### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -4320,8 +4320,8 @@ LANGUAGE_DEFINITIONS = {
             "_inline_comment": None,
             # Block comment start: Standard SGML/XML literature delimiter.
             "_block_start": re.compile(r"<!--"),
-            # Block comment end: Standard SGML/XML literature delimiter.
-            "_block_end": re.compile(r"-->"),
+            # Block comment end: Accept both --> and permissive HTML parser form --!>.
+            "_block_end": re.compile(r"--!?>"),
             # --- PHASE 1: PHYSICS ENGINE (Geometry & Structure) ---
             # 1. branch (The Forks in the Road)
             # User-driven branching and declarative framework conditionals.


### PR DESCRIPTION
Potential fix for [https://github.com/squid-protocol/gitgalaxy/security/code-scanning/1](https://github.com/squid-protocol/gitgalaxy/security/code-scanning/1)

General fix: update the HTML comment-end regex so it recognizes both standard `-->` and the permissive `--!>` form accepted by HTML parsers.

Best single fix here: in `gitgalaxy/standards/language_standards.py`, replace the `_block_end` pattern from `re.compile(r"-->")` to a regex that matches both forms, e.g. `re.compile(r"--!?>")`. This keeps existing behavior for `-->` while adding support for `--!>` with minimal functional change and no new dependencies/imports.

Scope of change:
- File: `gitgalaxy/standards/language_standards.py`
- Region: HTML rules block around lines 4322–4324
- No new imports, methods, or definitions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
