### PR TITLE
chore: bump Muninn to v0.3.4

### DIFF
--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run Muninn
         # zizmor: ignore[github_action_from_unverified_creator_used]
-        uses: skaldlab/muninn@de7174d6a498900ad104cd1e09f0077ac600a588 # v0.3.3
+        uses: skaldlab/muninn@c3b5b13e4599d1c3f68280d24d64e403a306f542 # v0.3.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail-on: info


### PR DESCRIPTION
## Summary

Updates the Muninn security scan workflow to the latest release (`v0.3.4`).

- Action pin: `skaldlab/muninn@v0.3.3` → `skaldlab/muninn@v0.3.4`
- Brings in updated scanner versions in the Muninn Docker image (osv-scanner, trivy, semgrep, zizmor)

## Why

Stay current with Muninn releases for improved scanner coverage and bug fixes.

## Test plan

- [x] Muninn workflow runs successfully on this PR
- [ ] PR comment and SARIF upload complete as expected