### PR TITLE
fix(core): suppress final SAST false positives and clean CLI billboard

### DIFF
--- a/gitgalaxy/cobol_refractor_controller.py
+++ b/gitgalaxy/cobol_refractor_controller.py
@@ -6,7 +6,7 @@
 #          between high-speed RAM and SQLite3 to prevent OOM crashes.
 # ==============================================================================
 
-# galaxyscope:ignore sec_db_hooks
+# galaxyscope:ignore sec_db_hooks, sec_io, sec_high_risk_execution
 
 import argparse
 import sys

--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -7,6 +7,9 @@
 # A copy of the license can be found in the LICENSE file in the root directory
 # of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
 # ==============================================================================
+
+# galaxyscope:ignore sec_high_risk_execution
+
 import re
 import math
 import logging

--- a/gitgalaxy/core/guidestar_lens.py
+++ b/gitgalaxy/core/guidestar_lens.py
@@ -5,8 +5,11 @@
 # This source code is licensed under the PolyForm Noncommercial License 1.0.0.
 # You may not use this file except in compliance with the License.
 # A copy of the license can be found in the LICENSE file in the root directory
-# of this project, or at [https://polyformproject.org/licenses/noncommercial/1.0.0/](https://polyformproject.org/licenses/noncommercial/1.0.0/)
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
 # ==============================================================================
+
+# galaxyscope:ignore sec_io, llm_hooks
+
 import re
 import os
 import json

--- a/gitgalaxy/core/state_rehydrator.py
+++ b/gitgalaxy/core/state_rehydrator.py
@@ -8,6 +8,8 @@
 # of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
 # ==============================================================================
 
+# galaxyscope:ignore sec_db_hooks, sec_high_risk_execution
+
 import sqlite3
 from pathlib import Path
 from typing import Dict, Any

--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -8,7 +8,7 @@
 # of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
 # ==============================================================================
 
-# galaxyscope:ignore sec_high_risk_execution, sec_hardcoded_secrets
+# galaxyscope:ignore sec_high_risk_execution, sec_hardcoded_secrets, sec_io, safety_bypasses
 
 import logging
 import time
@@ -1179,7 +1179,7 @@ class Orchestrator:
                 print(" 🌌 READY FOR VISUALIZATION (100% LOCAL / ZERO UPLOAD)")
 
             print("=" * 75)
-            print(" 1. Open your browser to: \033[94m\033[4m[https://gitgalaxy.io/](https://gitgalaxy.io/)\033[0m")
+            print(" 1. Open your browser to: \033[94m\033[4mhttps://gitgalaxy.io/\033[0m")
             print(f" 2. Drag and drop '{gpu_output}'")
             print("\n * PRIVACY SECURED: Your data never leaves your machine.")
             print("   All architectural rendering executes locally in your browser.")

--- a/gitgalaxy/metrics/chronometer.py
+++ b/gitgalaxy/metrics/chronometer.py
@@ -8,7 +8,7 @@
 # of this project, or at [https://polyformproject.org/licenses/noncommercial/1.0.0/](https://polyformproject.org/licenses/noncommercial/1.0.0/)
 # ==============================================================================
 
-# galaxyscope:ignore sec_high_risk_execution
+# galaxyscope:ignore sec_high_risk_execution, sec_io, llm_hooks
 
 import os
 import subprocess


### PR DESCRIPTION
- Updated inline `# galaxyscope:ignore` directives across core engines (detector, guidestar, state_rehydrator, chronometer, galaxyscope, cobol_refractor).
- Silenced remaining false-positive alerts for RCE (`sec_high_risk_execution`), network I/O (`sec_io`), DB hooks (`sec_db_hooks`), LLM triggers (`llm_hooks`), and safety bypasses (`safety_bypasses`).
- Stripped rogue Markdown brackets from the CLI billboard URL in `galaxyscope.py` to ensure a clean, natively clickable ANSI-formatted link in the terminal.

### Description of Structural Changes
### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [ ] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
