### PR TITLE
Unify manifest-filename registries; fix mixed-ecosystem SBOM starvation

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -858,8 +858,18 @@ class Orchestrator:
             # ==========================================================
             logger.info("Phase 10: Executing Ecosystem Security Audits (X-Ray, Firewall, API Mapper)...")
 
+# NEW:
             # 1. Gather all manifests instantly using the Phase 0 stem_map (Zero Disk Walk)
-            target_manifests = set(GUIDESTAR_CONFIG.get("MANIFEST_MAP", {}).keys())
+            # Union of GuideStar's language-intent signals (Makefile, pyproject.toml,
+            # etc. -- files with no parseable dependency list, used only for its own
+            # Bayesian intent inference) with SUPPORTED_MANIFEST_FILENAMES, the
+            # canonical set UniversalManifestSlicer can actually parse. Without this
+            # union, ecosystems MANIFEST_MAP doesn't track (composer.json,
+            # requirements.txt) silently never reach the SBOM whenever any other
+            # manifest is also present in the repo.
+            from gitgalaxy.security.manifest_parser import ManifestParser, SUPPORTED_MANIFEST_FILENAMES
+
+            target_manifests = set(GUIDESTAR_CONFIG.get("MANIFEST_MAP", {}).keys()) | set(SUPPORTED_MANIFEST_FILENAMES)
             manifest_paths = [
                 str(self.root / rel_path)
                 for rel_path in self.stem_map.values()
@@ -867,8 +877,6 @@ class Orchestrator:
             ]
 
             # 2. Build the global translation map
-            from gitgalaxy.security.manifest_parser import ManifestParser
-
             alias_map = ManifestParser(parent_logger=logger).build_resolution_map(manifest_paths)
 
             ecosystem_audits = {

--- a/gitgalaxy/recorders/sbom_recorder.py
+++ b/gitgalaxy/recorders/sbom_recorder.py
@@ -26,8 +26,7 @@ from gitgalaxy.standards.language_lens import LanguageDetector
 # UniversalManifestSlicer now lives in the canonical manifest module (PR A of
 # the dependency-audit overhaul). Re-imported here so existing consumers and
 # tests importing it from this module keep working unchanged.
-from gitgalaxy.security.manifest_parser import UniversalManifestSlicer
-
+from gitgalaxy.security.manifest_parser import UniversalManifestSlicer, SUPPORTED_MANIFEST_FILENAMES
 
 class SbomRecorder:
     """
@@ -354,9 +353,8 @@ class SbomRecorder:
 
         return trust_status, anomaly_notes, coverage
     
-    # Manifest filenames recognized across all supported ecosystems.
-    _MANIFEST_NAMES = (
-        "package.json", "composer.json", "requirements.txt",
-        "Cargo.toml", "go.mod", "Gemfile", "pom.xml",
-    )
+    # Single source of truth: manifest_parser.SUPPORTED_MANIFEST_FILENAMES.
+    # Only used by the root-only fallback below when a caller doesn't pass
+    # manifest_paths.
+    _MANIFEST_NAMES = SUPPORTED_MANIFEST_FILENAMES
 

--- a/gitgalaxy/security/manifest_parser.py
+++ b/gitgalaxy/security/manifest_parser.py
@@ -178,6 +178,20 @@ class ManifestParser:
                             resolution_map[f"INSECURE_REGISTRY_{filepath.name}"] = url
 
 
+# NEW:
+# Filenames UniversalManifestSlicer.slice_manifest() below knows how to parse
+# into an actual dependency list. This is the single source of truth for
+# "what is a project dependency manifest" across the codebase -- both
+# SbomRecorder (_MANIFEST_NAMES) and galaxyscope's Phase 10 discovery import
+# this instead of maintaining their own copies. Keep this in sync with the
+# filename checks inside slice_manifest() itself; they must never drift
+# from each other either.
+SUPPORTED_MANIFEST_FILENAMES = (
+    "package.json", "composer.json", "requirements.txt",
+    "Cargo.toml", "go.mod", "Gemfile", "pom.xml",
+)
+
+
 class UniversalManifestSlicer:
     """
     Uses regex and standard parsing to slice dependencies from any ecosystem.

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -1334,64 +1334,64 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         self.assertIn("Complete Hardware Memory Failure", str(context.exception))
     
     # ==============================================================================
-# TEST 33: MANIFEST REGISTRY ALIGNMENT (Phase 10)
-# ==============================================================================
-@patch("gitgalaxy.recorders.sbom_recorder.SbomRecorder.generate_report")
-@patch("gitgalaxy.galaxyscope.Orchestrator._calculate_risk_exposures")
-@patch("gitgalaxy.galaxyscope.Orchestrator._resolve_dependency_graph")
-@patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
-@patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")
-def test_phase_10_manifest_paths_includes_all_supported_ecosystems(
-    self, mock_census, mock_extract, mock_resolve, mock_risk, mock_sbom
-):
-    """
-    Regression: GUIDESTAR_CONFIG["MANIFEST_MAP"] (language-intent inference)
-    and SUPPORTED_MANIFEST_FILENAMES (what UniversalManifestSlicer can parse)
-    are two different lists for two different purposes, and have historically
-    drifted -- MANIFEST_MAP never tracked composer.json or requirements.txt.
-    Phase 10 must UNION both when building manifest_paths, or any repo that
-    also contains a MANIFEST_MAP-recognized file (package.json, Makefile,
-    etc.) silently starves SbomRecorder of Python/PHP manifests, even
-    though UniversalManifestSlicer is fully capable of parsing them.
-    """
-    config = self.mock_config.copy()
-    scope = Orchestrator(".", config)
+    # TEST 33: MANIFEST REGISTRY ALIGNMENT (Phase 10)
+    # ==============================================================================
+    @patch("gitgalaxy.recorders.sbom_recorder.SbomRecorder.generate_report")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._calculate_risk_exposures")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._resolve_dependency_graph")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")
+    def test_phase_10_manifest_paths_includes_all_supported_ecosystems(
+        self, mock_census, mock_extract, mock_resolve, mock_risk, mock_sbom
+    ):
+        """
+        Regression: GUIDESTAR_CONFIG["MANIFEST_MAP"] (language-intent inference)
+        and SUPPORTED_MANIFEST_FILENAMES (what UniversalManifestSlicer can parse)
+        are two different lists for two different purposes, and have historically
+        drifted -- MANIFEST_MAP never tracked composer.json or requirements.txt.
+        Phase 10 must UNION both when building manifest_paths, or any repo that
+        also contains a MANIFEST_MAP-recognized file (package.json, Makefile,
+        etc.) silently starves SbomRecorder of Python/PHP manifests, even
+        though UniversalManifestSlicer is fully capable of parsing them.
+        """
+        config = self.mock_config.copy()
+        scope = Orchestrator(".", config)
 
-    # Simulate a mixed-ecosystem repo: package.json (in MANIFEST_MAP) sits
-    # alongside requirements.txt (NOT in MANIFEST_MAP, only in
-    # SUPPORTED_MANIFEST_FILENAMES) in a different directory.
-    scope.stem_map = {
-        "package.json": "frontend/package.json",
-        "requirements.txt": "backend/requirements.txt",
-    }
-    scope.ram_cache = {}
-    scope.parsed_files = []
-    scope.unparsable_files = []
-    scope.network_sensor = MagicMock()
-    scope.network_sensor.build_dependency_graph.return_value = ([], {})
-    scope.processor = MagicMock()
-    scope.processor.summarize_galaxy_metrics.return_value = {}
-    scope.auditor = MagicMock()
-    scope.auditor.audit.return_value = ([], [])
-    scope.model_auditor = MagicMock()
-    scope.model_auditor.audit_repository.return_value = []
-    scope.gpu_recorder = MagicMock()
+        # Simulate a mixed-ecosystem repo: package.json (in MANIFEST_MAP) sits
+        # alongside requirements.txt (NOT in MANIFEST_MAP, only in
+        # SUPPORTED_MANIFEST_FILENAMES) in a different directory.
+        scope.stem_map = {
+            "package.json": "frontend/package.json",
+            "requirements.txt": "backend/requirements.txt",
+        }
+        scope.ram_cache = {}
+        scope.parsed_files = []
+        scope.unparsable_files = []
+        scope.network_sensor = MagicMock()
+        scope.network_sensor.build_dependency_graph.return_value = ([], {})
+        scope.processor = MagicMock()
+        scope.processor.summarize_galaxy_metrics.return_value = {}
+        scope.auditor = MagicMock()
+        scope.auditor.audit.return_value = ([], [])
+        scope.model_auditor = MagicMock()
+        scope.model_auditor.audit_repository.return_value = []
+        scope.gpu_recorder = MagicMock()
 
-    with patch("gitgalaxy.galaxyscope.run_api_audit", return_value={}), \
-         patch("gitgalaxy.galaxyscope.run_xray_audit", return_value={}), \
-         patch("gitgalaxy.galaxyscope.run_firewall_audit", return_value={}):
-        scope.execute_pipeline("fake_output.json")
+        with patch("gitgalaxy.galaxyscope.run_api_audit", return_value={}), \
+            patch("gitgalaxy.galaxyscope.run_xray_audit", return_value={}), \
+            patch("gitgalaxy.galaxyscope.run_firewall_audit", return_value={}):
+            scope.execute_pipeline("fake_output.json")
 
-    mock_sbom.assert_called_once()
-    _, sbom_kwargs = mock_sbom.call_args
-    manifest_paths = sbom_kwargs.get("manifest_paths") or []
+        mock_sbom.assert_called_once()
+        _, sbom_kwargs = mock_sbom.call_args
+        manifest_paths = sbom_kwargs.get("manifest_paths") or []
 
-    self.assertTrue(
-        any(p.endswith("requirements.txt") for p in manifest_paths),
-        f"requirements.txt missing from manifest_paths -- MANIFEST_MAP/"
-        f"SUPPORTED_MANIFEST_FILENAMES drifted again! Got: {manifest_paths}",
-    )
-    self.assertTrue(
-        any(p.endswith("package.json") for p in manifest_paths),
-        f"package.json missing from manifest_paths! Got: {manifest_paths}",
-    )
+        self.assertTrue(
+            any(p.endswith("requirements.txt") for p in manifest_paths),
+            f"requirements.txt missing from manifest_paths -- MANIFEST_MAP/"
+            f"SUPPORTED_MANIFEST_FILENAMES drifted again! Got: {manifest_paths}",
+        )
+        self.assertTrue(
+            any(p.endswith("package.json") for p in manifest_paths),
+            f"package.json missing from manifest_paths! Got: {manifest_paths}",
+        )

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -1332,3 +1332,66 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
             scope.execute_pipeline("out.json")
             
         self.assertIn("Complete Hardware Memory Failure", str(context.exception))
+    
+    # ==============================================================================
+# TEST 33: MANIFEST REGISTRY ALIGNMENT (Phase 10)
+# ==============================================================================
+@patch("gitgalaxy.recorders.sbom_recorder.SbomRecorder.generate_report")
+@patch("gitgalaxy.galaxyscope.Orchestrator._calculate_risk_exposures")
+@patch("gitgalaxy.galaxyscope.Orchestrator._resolve_dependency_graph")
+@patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
+@patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")
+def test_phase_10_manifest_paths_includes_all_supported_ecosystems(
+    self, mock_census, mock_extract, mock_resolve, mock_risk, mock_sbom
+):
+    """
+    Regression: GUIDESTAR_CONFIG["MANIFEST_MAP"] (language-intent inference)
+    and SUPPORTED_MANIFEST_FILENAMES (what UniversalManifestSlicer can parse)
+    are two different lists for two different purposes, and have historically
+    drifted -- MANIFEST_MAP never tracked composer.json or requirements.txt.
+    Phase 10 must UNION both when building manifest_paths, or any repo that
+    also contains a MANIFEST_MAP-recognized file (package.json, Makefile,
+    etc.) silently starves SbomRecorder of Python/PHP manifests, even
+    though UniversalManifestSlicer is fully capable of parsing them.
+    """
+    config = self.mock_config.copy()
+    scope = Orchestrator(".", config)
+
+    # Simulate a mixed-ecosystem repo: package.json (in MANIFEST_MAP) sits
+    # alongside requirements.txt (NOT in MANIFEST_MAP, only in
+    # SUPPORTED_MANIFEST_FILENAMES) in a different directory.
+    scope.stem_map = {
+        "package.json": "frontend/package.json",
+        "requirements.txt": "backend/requirements.txt",
+    }
+    scope.ram_cache = {}
+    scope.parsed_files = []
+    scope.unparsable_files = []
+    scope.network_sensor = MagicMock()
+    scope.network_sensor.build_dependency_graph.return_value = ([], {})
+    scope.processor = MagicMock()
+    scope.processor.summarize_galaxy_metrics.return_value = {}
+    scope.auditor = MagicMock()
+    scope.auditor.audit.return_value = ([], [])
+    scope.model_auditor = MagicMock()
+    scope.model_auditor.audit_repository.return_value = []
+    scope.gpu_recorder = MagicMock()
+
+    with patch("gitgalaxy.galaxyscope.run_api_audit", return_value={}), \
+         patch("gitgalaxy.galaxyscope.run_xray_audit", return_value={}), \
+         patch("gitgalaxy.galaxyscope.run_firewall_audit", return_value={}):
+        scope.execute_pipeline("fake_output.json")
+
+    mock_sbom.assert_called_once()
+    _, sbom_kwargs = mock_sbom.call_args
+    manifest_paths = sbom_kwargs.get("manifest_paths") or []
+
+    self.assertTrue(
+        any(p.endswith("requirements.txt") for p in manifest_paths),
+        f"requirements.txt missing from manifest_paths -- MANIFEST_MAP/"
+        f"SUPPORTED_MANIFEST_FILENAMES drifted again! Got: {manifest_paths}",
+    )
+    self.assertTrue(
+        any(p.endswith("package.json") for p in manifest_paths),
+        f"package.json missing from manifest_paths! Got: {manifest_paths}",
+    )

--- a/tests/core_engine/test_manifest_parser.py
+++ b/tests/core_engine/test_manifest_parser.py
@@ -312,3 +312,28 @@ def test_unsupported_manifest_bypass(parser, tmp_path):
     resolution_map = parser.build_resolution_map([str(random_file)])
     
     assert resolution_map == {}, "Parser hallucinated resolutions from an unsupported file type!"
+
+def test_manifest_parser_scope_is_npm_and_pypi_only(parser, tmp_path):
+    """
+    Documents current scope, not a bug: ManifestParser.build_resolution_map
+    only builds an alias/registry-spoofing map for npm and PyPI-family files.
+    It does NOT recognize composer.json, Cargo.toml, Gemfile, or pom.xml --
+    even though UniversalManifestSlicer (this module's OTHER class, used for
+    the SBOM) parses all of those. Since galaxyscope's Phase 10 now feeds the
+    SAME manifest_paths list to both consumers, these filenames silently
+    no-op here. Locking this in so a future contributor extending
+    SUPPORTED_MANIFEST_FILENAMES doesn't assume ManifestParser gained
+    matching coverage for free.
+    """
+    cargo_file = tmp_path / "Cargo.toml"
+    cargo_file.write_text('[dependencies]\nserde = "1.0"')
+    composer_file = tmp_path / "composer.json"
+    composer_file.write_text(json.dumps({"require": {"monolog/monolog": "npm:evil@1.0"}}))
+
+    resolution_map = parser.build_resolution_map([str(cargo_file), str(composer_file)])
+
+    assert resolution_map == {}, (
+        "ManifestParser started resolving Cargo.toml/composer.json -- if this "
+        "is intentional, great, but SUPPORTED_MANIFEST_FILENAMES coverage "
+        "claims in sbom_recorder/galaxyscope comments should be revisited too."
+    )

--- a/tests/tools_recorders/test_sbom_generator.py
+++ b/tests/tools_recorders/test_sbom_generator.py
@@ -254,3 +254,40 @@ def test_zero_trust_sbom_clean_run(mock_detector_class, mock_security_class, tmp
 
     props = {p["name"]: p["value"] for p in bom_data["components"][0]["properties"]}
     assert props["gitgalaxy:trust_status"] == "VERIFIED_SAFE"
+
+# ==============================================================================
+# TEST 6: MANIFEST REGISTRY SYNC (drift guard)
+# ==============================================================================
+def test_manifest_names_match_slicer_support(tmp_path):
+    """
+    Regression: SbomRecorder._MANIFEST_NAMES (now an alias for
+    manifest_parser.SUPPORTED_MANIFEST_FILENAMES) must never drift from the
+    filenames UniversalManifestSlicer.slice_manifest() actually knows how to
+    parse. This is exactly the class of bug behind the
+    GUIDESTAR_CONFIG["MANIFEST_MAP"] drift: two independently-maintained
+    lists silently disagreeing.
+    """
+    slicer = UniversalManifestSlicer()
+    expected_ecosystems = {
+        "package.json": "npm",
+        "composer.json": "packagist",
+        "requirements.txt": "pypi",
+        "Cargo.toml": "cargo",
+        "go.mod": "golang",
+        "Gemfile": "rubygems",
+        "pom.xml": "maven",
+    }
+
+    assert set(SbomRecorder._MANIFEST_NAMES) == set(expected_ecosystems), (
+        "SbomRecorder._MANIFEST_NAMES no longer matches the known ecosystem set "
+        "-- update this test AND confirm slice_manifest() handles the change."
+    )
+
+    for filename, expected_eco in expected_ecosystems.items():
+        f = tmp_path / filename
+        f.write_text("")  # ecosystem is identified by filename before content is parsed
+        ecosystem, _ = slicer.slice_manifest(f)
+        assert ecosystem == expected_eco, (
+            f"{filename} is in _MANIFEST_NAMES but slice_manifest identified it as "
+            f"'{ecosystem}' instead of '{expected_eco}' -- the two are out of sync!"
+        )


### PR DESCRIPTION
GUIDESTAR_CONFIG['MANIFEST_MAP'] and SbomRecorder._MANIFEST_NAMES were two independently-maintained lists of 'what counts as a manifest,' built for different purposes (GuideStar's language-intent inference vs. what UniversalManifestSlicer can actually parse into dependencies), and they had drifted: MANIFEST_MAP never tracked composer.json or requirements.txt.

That drift was harmless on its own, but became a real bug once galaxyscope Phase 10 started feeding manifest_paths to SbomRecorder: Phase 10 filtered the census through MANIFEST_MAP alone, so composer.json/requirements.txt were silently dropped from manifest_paths whenever ANY other MANIFEST_MAP- recognized file (package.json, Makefile, etc.) also existed in the repo -- i.e. any mixed-ecosystem repo, which is the common case, not the edge case. GuideStarLens itself already had to runtime-patch around half of this same gap (dynamically injecting requirements.txt into its own local copy), independent evidence this was a real, previously-unnoticed problem.

Fix: added SUPPORTED_MANIFEST_FILENAMES to manifest_parser.py as the single canonical list of filenames UniversalManifestSlicer.slice_manifest() can parse. SbomRecorder._MANIFEST_NAMES now aliases it instead of hand-copying it. galaxyscope Phase 10 now unions MANIFEST_MAP with SUPPORTED_MANIFEST_FILENAMES when building manifest_paths, so GuideStar's intent-inference signals (Makefile, pyproject.toml, etc. -- harmless no-ops for the SBOM, which skips anything slice_manifest can't parse) and the SBOM's actual dependency-manifest coverage are no longer the same hand- maintained list pretending to serve two purposes at once.

Tests:
- test_galaxyscope.py: new Phase 10 test with a mixed package.json + requirements.txt stem_map, asserting manifest_paths passed to SbomRecorder actually contains both -- this is the scenario that was silently broken and had no prior coverage at all.
- test_sbom_generator.py: new drift guard asserting _MANIFEST_NAMES stays in exact sync with what slice_manifest() recognizes per ecosystem.
- test_manifest_parser.py: new test documenting (not fixing) that ManifestParser.build_resolution_map's alias-map scope is npm/PyPI-only and does not cover Cargo.toml/Gemfile/pom.xml/composer.json, now that it receives the same unioned manifest_paths list as the SBOM. Explicit boundary instead of an untested assumption.

### Description of Structural Changes
### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [ ] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
