### PR TITLE
chore: bump Muninn to v0.3.6

### DIFF
--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run Muninn
         # zizmor: ignore[github_action_from_unverified_creator_used]
-        uses: skaldlab/muninn@365628a795478e870417bf9e395a0ecc63685442 # v0.3.5
+        uses: skaldlab/muninn@daf98872b5748d015ed5bd828296175f6bc0115d # v0.3.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail-on: info


### PR DESCRIPTION
## Summary

Updates the Muninn security scan workflow to the latest release (`v0.3.6`).

- Action pin: `skaldlab/muninn@v0.3.5` → `skaldlab/muninn@v0.3.6`
- Brings in scanner image updates: zizmor 1.28.0 (replaces yanked 1.27.0), GitPython floor for checkov-transitive GHSA highs, Go toolchain 1.26.5

## Why

Stay current with Muninn releases for improved scanner coverage and bug fixes.

## Test plan

- [ ] Muninn workflow runs successfully on this PR