### PR TITLE
Fix missing positional arguments in _slice_by_braces

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -1656,7 +1656,7 @@ class StructuralExtractor:
         self.logger.debug(f"[DIAGNOSTIC] Mode D: Initiating _slice_by_keywords for {lang_id}")
         config = ScopeParsingRegistry.get_config(lang_id)
         if not config:
-            return self._slice_by_braces(code, rules, offset)
+            return self._slice_by_braces(code, lang_id, rules, offset, spatial_map)
 
         flags = re.IGNORECASE if config.get("ignore_case") else 0
         open_pattern = re.compile("|".join(config["openers"]), flags)
@@ -1813,7 +1813,7 @@ class StructuralExtractor:
         """[INTEGRATION MODE E] - Terminator Cleaving (SQL, Erlang, Prolog)."""
         config = ScopeParsingRegistry.get_config(lang_id)
         if not config:
-            return self._slice_by_braces(code, rules, offset)
+            return self._slice_by_braces(code, lang_id, rules, offset, spatial_map)
 
         terminator_pattern = re.compile(config["terminator"])
         igniter_pattern = re.compile(config["igniter"], re.IGNORECASE)

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -1620,3 +1620,54 @@ def test_detector_docstring_harvest_not_contaminated_by_harvest_above():
     assert "return 3" not in docstring, (
         "Pre-existing 'harvest above' content contaminated the below-docstring scan!"
     )
+
+# ==============================================================================
+# TEST 47: FALLBACK SIGNATURE ALIGNMENT (_slice_by_braces)
+# ==============================================================================
+@patch.object(StructuralExtractor, "_slice_by_braces")
+def test_detector_fallback_slice_by_braces_arguments(mock_slice_by_braces):
+    """
+    Proves that the fallback paths in _slice_by_keywords and _slice_by_terminator
+    pass the correct number of positional arguments (code, lang_id, rules, offset, spatial_map)
+    to _slice_by_braces to prevent silent structural corruption.
+    """
+    opt_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
+
+    # 1. Trigger Mode D's Fallback (Pass an unregistered language to force it to fail)
+    opt_detector._slice_by_keywords(
+        code="def test(): pass",
+        lang_id="unregistered_alien_lang",
+        rules={"mock": "rule"},
+        offset=42,
+        spatial_map={"branch": [10, 20]}
+    )
+    
+    # Assert all 5 arguments were passed in the exact correct order
+    mock_slice_by_braces.assert_called_with(
+        "def test(): pass", 
+        "unregistered_alien_lang", 
+        {"mock": "rule"}, 
+        42, 
+        {"branch": [10, 20]}
+    )
+
+    # Reset the mock for the next test
+    mock_slice_by_braces.reset_mock()
+
+    # 2. Trigger Mode E's Fallback
+    opt_detector._slice_by_terminator(
+        code="SELECT * FROM table;",
+        lang_id="unregistered_sql_dialect",
+        rules={"io": "rule"},
+        offset=99,
+        spatial_map={"io": [5]}
+    )
+    
+    # Assert all 5 arguments were passed in the exact correct order
+    mock_slice_by_braces.assert_called_with(
+        "SELECT * FROM table;", 
+        "unregistered_sql_dialect", 
+        {"io": "rule"}, 
+        99, 
+        {"io": [5]}
+    )


### PR DESCRIPTION
Resolves #290 

### Description of Structural Changes
- The fallback paths in `_slice_by_keywords` and `_slice_by_terminator` were passing three arguments to `_slice_by_braces` instead of the required five.
- Fixed the call sites to pass `code`, `lang_id`, `rules`, `offset`, and `spatial_map` in the correct order to prevent silent structural corruption in the heuristic parsing.
- Added Test 47 to enforce fallback signature alignment.

### Visual Observatory Testing
- [x] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [x] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [x] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.