### PR TITLE
Fix schema drift in FunctionNode TypedDict

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -56,9 +56,12 @@ class FunctionNode(TypedDict, total=False):
     """Metadata for a surgically extracted functional logic block."""
 
     name: str
+    parent_class_name: str
+    usage_status: int
 
     # Dual-Key mapping to ensure compatibility with all pipeline versions
     semantic_type: str
+    texture: str
     type_id: str
 
     loc: int
@@ -72,12 +75,14 @@ class FunctionNode(TypedDict, total=False):
     args_count: int
 
     control_flow_angle: float
+    logic_angle: float
     angle: float
 
     control_flow_ratio: float
     cf_ratio: float
 
     structural_weight: float
+    magnitude: float
     mag: float
     impact: float
 
@@ -90,7 +95,7 @@ class FunctionNode(TypedDict, total=False):
     docstring: str
     calls_out_to: List[str]
     hit_vector: Dict[str, int]
-    token_mass: int
+    token_mass: Optional[int]
 
 
 class LogicData(TypedDict, total=False):


### PR DESCRIPTION
Resolves mypy type errors by adding parent_class_name, usage_status, texture, logic_angle, and magnitude to the FunctionNode schema to match the runtime dictionaries being generated. Also updates token_mass to Optional[int].

### Description of Structural Changes
### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [ ] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
