### PR TITLE
Fix summary and composition type mutations in galaxyscope.py

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -2171,7 +2171,7 @@ class Orchestrator:
         a binary saturation threshold, or a regex timeout, this method captures the diagnostic
         string and appends it to the global anomalies array for the final Audit Recorder payload.
         """
-        summary = {"size_limit": 0, "binary": 0, "unparsable": 0, "os_permissions": 0}
+        summary: Dict[str, Any] = {"size_limit": 0, "binary": 0, "unparsable": 0, "os_permissions": 0}
         unparsable_artifacts: List[str] = []
 
         # 1. Maintain the physical error tallies (I/O, Binary, OS)
@@ -2193,7 +2193,7 @@ class Orchestrator:
             summary["unparsable_artifacts"] = unparsable_artifacts
 
         # 2. Build the hierarchical composition_by_extension_and_reason
-        composition = {}
+        composition: Dict[str, Dict[str, int]] = {}
         for unparsable in total_unparsable:
             path = unparsable.get("path", "")
             reason = unparsable.get("reason", "Unknown Reason")


### PR DESCRIPTION
### Description of Structural Changes
- Explicitly annotated `summary` as `Dict[str, Any]` inside `_summarize_anomalies` to prevent `mypy` from inferring it as `Dict[str, int]` and crashing when lists are appended downstream.
- Explicitly annotated `composition` as `Dict[str, Dict[str, int]]` to clear up annotation debt and allow nested string/integer mapping.

### Visual Observatory Testing
- [x] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [x] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [x] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.