### PR TITLE
Wire supply chain firewall to SignalProcessor's risk_vector

### DIFF
--- a/gitgalaxy/security/security_lens.py
+++ b/gitgalaxy/security/security_lens.py
@@ -23,16 +23,6 @@ class SecurityLens:
     """
 
     def __init__(self, policy=None):
-        # ------------------------------------------------------------------
-        # DYNAMIC POLICY INJECTION
-        # ------------------------------------------------------------------
-        self.policy = policy or {
-            "secrets_risk_threshold": 0.001,
-            "hidden_malware_threshold": 0.60,
-            "logic_bomb_threshold": 0.50,
-            "injection_surface_threshold": 0.65,
-            "memory_corruption_threshold": 0.60,
-        }
 
         # DEFENSIVE GUARD: ReDoS Prevention
         # Extracts string literals for entropy scanning. Bounded to 64-1024 chars
@@ -387,73 +377,6 @@ class SecurityLens:
         snippets["agentic_rce"] = [s for s in taint_snippets if "RCE" in s]
 
         return {"counts": counts, "snippets": snippets}
-
-    def evaluate_risk(self, aggregated_hits, total_loc, network_metrics=None):
-        """
-        Evaluates vulnerability risk with Network Centrality awareness.
-        Highly central files (e.g., God Nodes with massive Downstream Exposures) have a
-        drastically lower tolerance for embedded threats, scaling their density multipliers.
-        """
-        loc_safe = total_loc if total_loc > 0 else 1
-        exposures = {}
-
-        # --- 1. NETWORK CENTRALITY & BLAST RADIUS MODIFIER ---
-        network_multiplier = 1.0
-        if network_metrics:
-            pr = network_metrics.get("normalized_blast_radius", 0.0)
-            btw = network_metrics.get("betweenness_score", 0.0)
-            if pr > 1.0:
-                network_multiplier += pr * 0.5
-            if btw > 0.05:
-                network_multiplier += 0.5
-
-        # 1. Hidden Malware Risk
-        malware_hits = (
-            aggregated_hits.get("reflection_metaprogramming", 0)
-            + aggregated_hits.get("bitwise_ops", 0)
-            + aggregated_hits.get("shadow_imports", 0)
-            + aggregated_hits.get("homoglyphs", 0)
-            + aggregated_hits.get("entropy", 0)
-        )
-        malware_density = (malware_hits / loc_safe) * network_multiplier
-        if malware_density >= self.policy["hidden_malware_threshold"]:
-            exposures["Hidden Malware Risk"] = malware_density
-
-        # 2. Logic Bomb / Sabotage Risk
-        sabotage_hits = aggregated_hits.get("dead_code", 0) + (aggregated_hits.get("high_risk_execution", 0) * 1.5)
-        sabotage_density = (sabotage_hits / loc_safe) * network_multiplier
-        if sabotage_density >= self.policy["logic_bomb_threshold"]:
-            exposures["Logic Bomb Risk"] = sabotage_density
-
-        # 3. Data Injection Risk
-        injection_hits = (
-            aggregated_hits.get("io", 0) + aggregated_hits.get("high_risk_execution", 0) + aggregated_hits.get("state_mutation", 0)
-        )
-        injection_density = (injection_hits / loc_safe) * network_multiplier
-        if injection_density >= self.policy["injection_surface_threshold"]:
-            exposures["Data Injection Risk"] = injection_density
-
-        # 4. Memory Corruption Risk
-        memory_hits = aggregated_hits.get("memory_corruption", 0)
-        memory_density = (memory_hits / loc_safe) * network_multiplier
-        if memory_density >= self.policy["memory_corruption_threshold"]:
-            exposures["Memory Corruption Risk"] = memory_density
-
-        # 5. Secrets Risk
-        secrets_hits = aggregated_hits.get("hardcoded_secrets", 0)
-        secrets_density = (secrets_hits / loc_safe) * network_multiplier
-        if secrets_density >= self.policy["secrets_risk_threshold"]:
-            exposures["Secrets Leak Risk"] = secrets_density
-
-        # 6. Advanced Agentic Threats
-        prompt_inj = aggregated_hits.get("prompt_injection", 0)
-        agentic_rce = aggregated_hits.get("agentic_rce", 0)
-        if agentic_rce > 0:
-            exposures["Autonomous Execution Vector (Critical)"] = 100.0
-        elif prompt_inj > 0:
-            exposures["Prompt Injection Surface Risk"] = min((prompt_inj / loc_safe) * network_multiplier * 100.0, 100.0)
-
-        return exposures
 
     def scan_binary(self, raw_bytes: bytes, ext: str) -> dict:
         """

--- a/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py
+++ b/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py
@@ -23,9 +23,29 @@ import logging
 from pathlib import Path
 
 # Import exclusively from the GitGalaxy Hub
-from gitgalaxy.security.security_lens import SecurityLens
-from gitgalaxy.standards.analysis_lens import ThreatPolicy
+from gitgalaxy.metrics.signal_processor import SignalProcessor
 from typing import Optional
+
+# The five behavioral categories this firewall gates on, mapped to their names
+# in SignalProcessor.RISK_SCHEMA -- Phase 3 computes these once; the firewall
+# reads them back instead of recomputing risk from raw hit counts.
+_FIREWALL_RISK_MAP = {
+    "Hidden Malware Risk": "obscured_payload",
+    "Data Injection Risk": "injection_surface",
+    "Secrets Leak Risk": "secrets_risk",
+    "Logic Bomb Risk": "logic_bomb",
+    "Memory Corruption Risk": "memory_corruption",
+}
+_FIREWALL_RISK_INDEXES = {
+    label: SignalProcessor.RISK_SCHEMA.index(key)
+    for label, key in _FIREWALL_RISK_MAP.items()
+    if key in SignalProcessor.RISK_SCHEMA
+}
+
+# risk_vector entries are 0-100 sigmoid outputs from SignalProcessor; 50.0 is
+# the sigmoid's own midpoint, so using it as the block cutoff defers entirely
+# to SignalProcessor's judgment instead of maintaining a second threshold.
+_FIREWALL_BLOCK_THRESHOLD = 50.0
 
 # Safely import the config, falling back if the user hasn't configured exceptions yet
 try:
@@ -47,7 +67,6 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
     Programmatic entry point for GalaxyScope (Zero-Disk I/O).
     Operates exclusively on the pre-tokenized, anomaly-checked RAM graph from Phase 1.
     """
-    security = SecurityLens(policy=ThreatPolicy.get_policy("paranoid"))
     logger = logging.getLogger("GalaxyScope.firewall")
     safe_alias_map = alias_map or {}
 
@@ -156,21 +175,11 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
         if "/test/" in safe_path or "/tests/" in safe_path or "test_" in Path(safe_path).name or "_test" in Path(safe_path).name:
             continue
 
-        # Extract the raw structural signatures calculated natively by the Structural Signature Analysis Engine in Phase 1
-        equations = file_node.get("equations", {})
-        loc = file_node.get("coding_loc", 1)
-
-        # Clone the dictionary and strip the 'sec_' prefix for the security evaluator
-        local_counts = {}
-        for k, v in equations.items():
-            clean_key = k[4:] if k.startswith("sec_") else k
-            local_counts[clean_key] = v
-
         # DEFENSIVE DESIGN (BUILD-TIME EXECUTION MULTIPLIER):
-        # Configuration scripts (like setup.py or package.json) are executed by CI/CD 
+        # Configuration scripts (like setup.py or package.json) are executed by CI/CD
         # runners at build time. RCE here compromises the host before the app even runs.
-        # We apply an artificial density multiplier to manifest triggers so any I/O or 
-        # Danger signatures instantly trigger a blocking action from the firewall.
+        # We amplify SignalProcessor's already-computed risk scores for these files so
+        # any I/O or Danger signal instantly trips the firewall's block threshold.
         build_time_multiplier = 1.0
         filename = Path(rel_path_str).name
         if filename in [
@@ -182,29 +191,27 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
         ]:
             build_time_multiplier = 10.0
 
-        if build_time_multiplier > 1.0:
-            for k in local_counts:
-                if isinstance(local_counts[k], (int, float)):
-                    local_counts[k] = int(local_counts[k] * build_time_multiplier)
+        # Read the risk scores SignalProcessor already computed for this file back in
+        # Phase 3, rather than recomputing risk from raw hit counts (single source of truth).
+        risk_vector = file_node.get("risk_vector", [])
+        exposures = {}
+        for risk_label, schema_idx in _FIREWALL_RISK_INDEXES.items():
+            if schema_idx >= len(risk_vector):
+                continue
+            raw_score = risk_vector[schema_idx]
+            if not isinstance(raw_score, (int, float)) or raw_score <= 0.0:
+                continue
+            scaled_score = min(raw_score * build_time_multiplier, 100.0)
+            if scaled_score >= _FIREWALL_BLOCK_THRESHOLD:
+                exposures[risk_label] = scaled_score
 
-        # Evaluate risk using Phase 1 network topography context (e.g., Downstream Exposure)
-        network_metrics = file_node.get("dependency_network", {})
-        exposures = security.evaluate_risk(local_counts, loc, network_metrics)
-
-        if (
-            "Hidden Malware Risk" in exposures
-            or "Data Injection Risk" in exposures
-            or "Secrets Leak Risk" in exposures
-            or "Logic Bomb Risk" in exposures
-            or "Memory Corruption Risk" in exposures
-        ):
+        if exposures:
             if is_whitelisted:
                 threats_allowed += 1
             else:
-                logger.warning(f"🚨 [THREAT DETECTED] Density Threshold Breached in: {rel_path_str}")
-                for risk, density in exposures.items():
-                    capped_density = min(density * 100.0, 100.0)
-                    logger.warning(f"   -> {risk}: {capped_density:.1f}%")
+                logger.warning(f"🚨 [THREAT DETECTED] Risk Threshold Breached in: {rel_path_str}")
+                for risk, score in exposures.items():
+                    logger.warning(f"   -> {risk}: {score:.1f}%")
                 threats_found += 1
 
     return {

--- a/tests/security_auditing/test_supply_chain_firewall.py
+++ b/tests/security_auditing/test_supply_chain_firewall.py
@@ -5,6 +5,15 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import gitgalaxy.tools.supply_chain_security.supply_chain_firewall as firewall_module
+from gitgalaxy.metrics.signal_processor import SignalProcessor
+
+
+def _risk_vector(**scores):
+    """Builds a risk_vector fixture, e.g. _risk_vector(obscured_payload=70.0)."""
+    vector = [0.0] * len(SignalProcessor.RISK_SCHEMA)
+    for key, value in scores.items():
+        vector[SignalProcessor.RISK_SCHEMA.index(key)] = value
+    return vector
 
 # ==============================================================================
 # TEST 1: Dependency Graph Import Verification
@@ -131,12 +140,13 @@ def test_strict_mode_enforcement(tmp_path, monkeypatch):
         assert exc.value.code == 1, "Strict import policy enforcement failed to block an unknown package."
 
 # ==============================================================================
-# TEST 5: Behavioral Threat Density Evaluation (Updated Schema)
+# TEST 5: Behavioral Threat Score Evaluation (risk_vector Schema)
 # ==============================================================================
 def test_behavioral_threat_evaluation(tmp_path, monkeypatch):
     """
-    Validates that artifacts exhibiting high-density threat indicators
-    (calculated during Phase 1) trigger a firewall block.
+    Validates that a file whose Phase 3 risk_vector score for a gated category
+    is at/above the firewall's block threshold (50.0, SignalProcessor's own
+    sigmoid midpoint) triggers a firewall block.
     """
     monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
     monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", [])
@@ -147,7 +157,7 @@ def test_behavioral_threat_evaluation(tmp_path, monkeypatch):
                 "Files": {
                     "logic.js": {
                         "raw_imports": [],
-                        "equations": {"sec_homoglyphs": 500, "sec_high_risk_execution": 50},
+                        "risk_vector": _risk_vector(obscured_payload=70.0),
                         "coding_loc": 50,
                     }
                 }
@@ -163,29 +173,35 @@ def test_behavioral_threat_evaluation(tmp_path, monkeypatch):
     with patch.object(sys, "argv", test_args):
         with pytest.raises(SystemExit) as exc:
             firewall_module.main()
-        assert exc.value.code == 1, "Behavioral threat density evaluation failed to trigger pipeline failure."
+        assert exc.value.code == 1, "Behavioral threat score evaluation failed to trigger pipeline failure."
 
 # ==============================================================================
 # TEST 6: Build-Time Execution Multiplier (Static Sandbox)
 # ==============================================================================
 def test_build_time_execution_multiplier(monkeypatch):
     """
-    Ensures that critical build files (like setup.py) have their risk equations
-    artificially multiplied to make them hyper-sensitive to anomalous logic.
+    Ensures that critical build files (like setup.py) have their already-computed
+    risk_vector score scaled by the 10x build-time multiplier post-hoc, making
+    them hyper-sensitive to anomalous logic that a normal file would not block on.
+
+    injection_surface=8.0 is chosen deliberately: below the 50.0 block threshold
+    on its own (8.0 < 50.0), but 8.0 * 10.0 = 80.0 clears it. This is a real
+    numeric re-verification of the post-hoc-scalar design (scaling the sigmoid
+    OUTPUT), not a mechanical port of the old pre-sigmoid density multiplier.
     """
     monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-    
+
     mock_ram_graph = [
         {
             "path": "setup.py",
             "raw_imports": [],
-            "equations": {"sec_high_risk_execution": 20},
+            "risk_vector": _risk_vector(injection_surface=8.0),
             "coding_loc": 1000,
         },
         {
             "path": "standard_app.py",
             "raw_imports": [],
-            "equations": {"sec_high_risk_execution": 20},
+            "risk_vector": _risk_vector(injection_surface=8.0),
             "coding_loc": 1000,
         }
     ]
@@ -283,10 +299,19 @@ def test_firewall_allowlist_loophole_guard(monkeypatch):
 
 
 # ==============================================================================
-# TEST 11: ISSUE #156 - THE 'SEC_' PREFIX STRIPPING BUG
+# TEST 11: LOGIC BOMB RISK CATEGORY EVALUATION
 # ==============================================================================
 def test_behavioral_threat_evaluation_strips_prefix(tmp_path, monkeypatch):
-    """Proves the firewall correctly strips the 'sec_' prefix from Phase 1 equations."""
+    """
+    Proves the firewall correctly blocks on the 'logic_bomb' risk_vector category.
+
+    Historically this test guarded a bug where the firewall's clone-and-strip of
+    the 'sec_' prefix from Phase 1 equations silently dropped keys. That whole
+    translation step is gone now -- the firewall reads risk_vector[idx] directly,
+    keyed off SignalProcessor.RISK_SCHEMA, with no prefix involved. Kept as a
+    distinct regression test (separate risk category from TEST 5) rather than
+    deleted, since it's still real coverage of the schema-index lookup.
+    """
     monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
 
     mock_ram_graph = {
@@ -295,7 +320,7 @@ def test_behavioral_threat_evaluation_strips_prefix(tmp_path, monkeypatch):
                 "Files": {
                     "logic.js": {
                         "raw_imports": [],
-                        "equations": {"sec_logic_bomb": 100, "sec_high_risk_execution": 50},
+                        "risk_vector": _risk_vector(logic_bomb=65.0),
                         "coding_loc": 50,
                     }
                 }
@@ -305,7 +330,7 @@ def test_behavioral_threat_evaluation_strips_prefix(tmp_path, monkeypatch):
 
     graph_file = tmp_path / "results.json"
     graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
-    
+
     with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
         with pytest.raises(SystemExit):
             firewall_module.main()
@@ -414,10 +439,20 @@ def test_directory_group_schema_parsing(tmp_path, monkeypatch, capsys):
     assert "Files Evaluated      : 2" in captured.out
 
 # ==============================================================================
-# TEST 15: ISSUE #160 - DENSITY DILUTION BUG
+# TEST 15: BUILD-TIME MULTIPLIER ON A SMALL BUILD SCRIPT (END-TO-END)
 # ==============================================================================
 def test_density_dilution_fix_for_build_scripts(tmp_path, monkeypatch):
-    """Proves that small build scripts are NOT diluted by +150 LOC padding."""
+    """
+    Proves a small build-time script still blocks via main()'s full JSON-loading
+    path, not just via run_firewall_audit() directly (TEST 6 covers that unit).
+
+    Historically this guarded against LOC-padding diluting a small file's raw
+    hit density. LOC-based dilution is now internal to SignalProcessor's own
+    sigmoid scoring (out of the firewall's scope) -- the firewall-level concern
+    that remains is that build_time_multiplier still amplifies a below-threshold
+    score (secrets_risk=7.0, below 50.0) past the block threshold (7.0 * 10.0 =
+    70.0) for a recognized build-time filename, even at tiny file sizes.
+    """
     monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
 
     mock_ram_graph = {
@@ -426,8 +461,8 @@ def test_density_dilution_fix_for_build_scripts(tmp_path, monkeypatch):
                 "Files": {
                     "postinstall.js": {
                         "raw_imports": [],
-                        "equations": {"sec_high_risk_execution": 10},
-                        "coding_loc": 5, 
+                        "risk_vector": _risk_vector(secrets_risk=7.0),
+                        "coding_loc": 5,
                     }
                 }
             }
@@ -436,7 +471,7 @@ def test_density_dilution_fix_for_build_scripts(tmp_path, monkeypatch):
 
     graph_file = tmp_path / "results.json"
     graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
-    
+
     with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
         with pytest.raises(SystemExit):
             firewall_module.main()
@@ -454,7 +489,7 @@ def test_memory_corruption_detection(tmp_path, monkeypatch):
                 "Files": {
                     "payload.c": {
                         "raw_imports": [],
-                        "equations": {"sec_memory_corruption": 500},
+                        "risk_vector": _risk_vector(memory_corruption=80.0),
                         "coding_loc": 50,
                     }
                 }
@@ -464,7 +499,7 @@ def test_memory_corruption_detection(tmp_path, monkeypatch):
 
     graph_file = tmp_path / "results.json"
     graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
-    
+
     with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
         with pytest.raises(SystemExit):
             firewall_module.main()


### PR DESCRIPTION
The firewall's behavioral scoring (evaluate_risk on SecurityLens) and SignalProcessor's risk scoring were two independent, disagreeing engines computing risk from the same underlying signals. SecurityLens.evaluate_risk() and its self.policy/ThreatPolicy plumbing are now dead, so run_firewall_audit reads the risk score SignalProcessor already computed at Phase 3 instead of recomputing density from raw equations counts.

- Replace the equations -> local_counts -> evaluate_risk() block with a one-time schema-index lookup (_FIREWALL_RISK_INDEXES) into SignalProcessor.RISK_SCHEMA, keyed by the same five risk categories the firewall previously gated on.
- Block threshold is 50.0 (SignalProcessor's own sigmoid midpoint), so the firewall defers to SignalProcessor's judgment rather than maintaining a second, independently-tuned threshold.
- build_time_multiplier (10x for setup.py/package.json/etc.) now scales the post-sigmoid score rather than pre-sigmoid hit counts, since multiplying raw counts pre-sigmoid and multiplying the sigmoid's output are not equivalent (saturates differently). Treated as a deliberate, tested behavior change rather than an assumed equivalence.
- The firewall previously read a "dependency_network" key that nothing in the codebase ever wrote (network_multiplier was silently always 1.0 in production); this drops that dead read rather than reproducing it.

Rewrote the 5 tests that exercised the old density-based scoring (test_behavioral_threat_evaluation[_strips_prefix], build/density multiplier tests, memory_corruption_detection) against risk_vector fixtures, with the threshold-crossing math spelled out in each docstring. The other 11 tests in the file exercise only import logic and needed no changes.

Not in this change: the SecurityLens(policy=...)/ThreatPolicy cleanup cascade at the remaining call sites (galaxyscope.py x3, vault_sentinel.py, sbom_recorder.py) and actually wiring up network-centrality/blast-radius weighting (previously inert, so out of scope for a behavior-preserving fix).

### Description of Structural Changes
### Visual Observatory Testing
- [x] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [x] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [x] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
