### PR TITLE
Remove dead ThreatPolicy/SecurityLens.policy plumbing

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -65,7 +65,6 @@ from gitgalaxy.standards.language_standards import (
     PROJECT_OVERRIDES,
 )
 from gitgalaxy.standards.analysis_lens import (
-    ThreatPolicy,
     PATH_MODIFIERS,
     ASSET_MASKS,
 )
@@ -141,12 +140,6 @@ def _init_worker(
         if lang_id not in detector_cache:
             detector_cache[lang_id] = OpticalDetector(lang_id, lang_defs, parent_logger=worker_logger)
 
-    # --- NEW: Decide the Rules of Engagement before booting the engines ---
-    if config.get("PARANOID_MODE", False):
-        _active_policy = ThreatPolicy.get_policy("paranoid")
-    else:
-        _active_policy = ThreatPolicy.get_policy("baseline")
-
     _worker_state.update(
         {
             "root": root,
@@ -165,7 +158,7 @@ def _init_worker(
             # --- NEW: Boot the Analysis Engines into worker memory ---
             "chronometer": Chronometer(root, parent_logger=worker_logger),
             "signal": SignalProcessor(aperture_config=config, parent_logger=worker_logger),
-            "security": SecurityLens(policy=_active_policy),
+            "security": SecurityLens(),
             # --------------------------------------------------------
         }
     )
@@ -682,14 +675,8 @@ class Orchestrator:
             fresh_scan_budget=_budget,
         )
         
-        # --- NEW: THE SMART THREAT SWITCH (MAIN THREAD) ---
-        if self.config.get("PARANOID_MODE", False):
-            _active_policy = ThreatPolicy.get_policy("paranoid")
-        else:
-            _active_policy = ThreatPolicy.get_policy("baseline")
-
         # Zero-Trust execution validation
-        self.security_analyzer = SecurityLens(policy=_active_policy)
+        self.security_analyzer = SecurityLens()
 
         # Multi-class XGBoost threat classification model
         self.model_auditor = SecurityAuditor(model_path="gitgalaxy_malware_xgb_multiclass.json", parent_logger=logger)
@@ -2657,12 +2644,9 @@ def main():
 
         # --- THE SMART THREAT SWITCH ---
         if args.paranoid:
-            _active_policy = ThreatPolicy.get_policy("paranoid")
             logging.getLogger("GalaxyScope").info(
                 "🔒 ZERO-TRUST MODE: Security Lens thresholds set to maximum sensitivity."
             )
-        else:
-            _active_policy = ThreatPolicy.get_policy("baseline")
         # -------------------------------
 
         # ---------------------------------------------------------

--- a/gitgalaxy/recorders/sbom_recorder.py
+++ b/gitgalaxy/recorders/sbom_recorder.py
@@ -18,7 +18,6 @@ from typing import Dict, List, Any, Optional
 
 # Import exclusively from the GitGalaxy Hub
 from gitgalaxy.security.security_lens import SecurityLens
-from gitgalaxy.standards.analysis_lens import ThreatPolicy
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 from gitgalaxy.standards.gitgalaxy_config import LEXICAL_FAMILY_HEURISTICS
 from gitgalaxy.standards.language_lens import LanguageDetector
@@ -68,7 +67,7 @@ class SbomRecorder:
 
         self.logger.info(f"SBOM: Engaging Universal Zero-Trust Generation on {target_path.name}...")
 
-        security = SecurityLens(policy=ThreatPolicy.get_policy("paranoid"))
+        security = SecurityLens()
         detector = LanguageDetector(LANGUAGE_DEFINITIONS, LEXICAL_FAMILY_HEURISTICS)
         slicer = UniversalManifestSlicer()
 

--- a/gitgalaxy/tools/supply_chain_security/vault_sentinel.py
+++ b/gitgalaxy/tools/supply_chain_security/vault_sentinel.py
@@ -16,7 +16,6 @@ from pathlib import Path
 # Import exclusively from the GitGalaxy Hub
 from gitgalaxy.core.aperture import ApertureFilter
 from gitgalaxy.security.security_lens import SecurityLens
-from gitgalaxy.standards.analysis_lens import ThreatPolicy
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 
 # Safely import the config, falling back if the user hasn't added exceptions yet
@@ -51,7 +50,7 @@ def main():
 
     # Initialize lightweight filters
     filter_engine = ApertureFilter(target_path, LANGUAGE_DEFINITIONS, APERTURE_CONFIG)
-    security = SecurityLens(policy=ThreatPolicy.get_policy("paranoid"))
+    security = SecurityLens()
 
     # SENSOR OPTIMIZATION: Only evaluate keys and dead-code logic for maximum performance
     security.THREAT_SIGNATURES = {


### PR DESCRIPTION
Follow-up to #302 (which deleted SecurityLens.evaluate_risk() and self.policy). ThreatPolicy existed solely to build the policy dict that evaluate_risk() consumed; with that method gone, every _active_policy / ThreatPolicy.get_policy(...) call site is dead code, and SecurityLens's policy kwarg is silently ignored (the constructor no longer stores or reads it).

Re-ran a repo-wide grep for ThreatPolicy/SecurityLens(policy= before touching anything, per the original cleanup plan, to confirm scope:

- galaxyscope.py (3 sites): worker init, Orchestrator.__init__, and the CLI args.paranoid path. Dropped the ThreatPolicy import and the _active_policy if/else blocks; SecurityLens(policy=_active_policy) -> SecurityLens(). The CLI site's "ZERO-TRUST MODE" log line stays under args.paranoid -- PARANOID_MODE is still live via SignalProcessor.is_paranoid, only the now-dead policy computation goes.
- vault_sentinel.py, sbom_recorder.py: same import + constructor simplification. These call SecurityLens.scan_content(), never evaluate_risk(), so they were never broken -- just carrying a policy kwarg with no effect.

ThreatPolicy the class itself is left in analysis_lens.py; the grep confirms it's now only self-referential (the class body and its own get_policy() classmethod), but deleting the class is a separate call from cleaning up its callers.

Full test suite: 772 passed, 1 xfailed (pre-existing), 0 failures.

### Description of Structural Changes
### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [ ] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
