### PR TITLE
Wire opt-in network-centrality risk weighting into the firewall

### DIFF
--- a/gitgalaxy/standards/gitgalaxy_config.py
+++ b/gitgalaxy/standards/gitgalaxy_config.py
@@ -33,6 +33,17 @@ BLACKLISTED_IMPORTS = [
     # Known compromised, malicious, or troll packages
 ]
 
+# ------------------------------------------------------------------
+# NETWORK-CENTRALITY RISK WEIGHTING (Supply Chain Firewall)
+# When True, a file's Downstream Exposure / Blast Radius (Phase 4 network
+# topology) amplifies its behavioral risk score before the firewall's block
+# threshold is applied -- a highly central "hub" file gets less tolerance
+# for the same embedded threat signal than a peripheral one.
+# Off by default: this previously never actually ran in production (it was
+# reading a key nothing ever wrote), so it ships opt-in rather than
+# silently changing what existing pipelines block on.
+# ------------------------------------------------------------------
+FIREWALL_NETWORK_WEIGHTING = False
 
 # ------------------------------------------------------------------
 # GLOBAL DENYLIST

--- a/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py
+++ b/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py
@@ -54,12 +54,14 @@ try:
         STRICT_IMPORT_MODE,
         APPROVED_IMPORTS,
         BLACKLISTED_IMPORTS,
+        FIREWALL_NETWORK_WEIGHTING,
     )
 except ImportError:
     ALLOWLIST_PATHS = []
     STRICT_IMPORT_MODE = False
     APPROVED_IMPORTS = []
     BLACKLISTED_IMPORTS = []
+    FIREWALL_NETWORK_WEIGHTING = False
 
 
 def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> dict:
@@ -191,6 +193,21 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
         ]:
             build_time_multiplier = 10.0
 
+        # DEFENSIVE DESIGN (NETWORK-CENTRALITY MULTIPLIER, opt-in):
+        # A highly central "hub" file (large Downstream Exposure / Blast Radius from
+        # Phase 4's network topology) gets less tolerance for the same embedded threat
+        # signal than a peripheral file. Only ever amplifies -- a low-centrality file
+        # is still judged on its own merits, never given a discount for being obscure.
+        network_multiplier = 1.0
+        if FIREWALL_NETWORK_WEIGHTING:
+            network_metrics = file_node.get("telemetry", {}).get("network_metrics", {})
+            blast_radius = network_metrics.get("normalized_blast_radius", 0.0)
+            betweenness = network_metrics.get("betweenness_score", 0.0)
+            if blast_radius > 1.0:
+                network_multiplier += blast_radius * 0.5
+            if betweenness > 0.05:
+                network_multiplier += 0.5
+
         # Read the risk scores SignalProcessor already computed for this file back in
         # Phase 3, rather than recomputing risk from raw hit counts (single source of truth).
         risk_vector = file_node.get("risk_vector", [])
@@ -201,7 +218,7 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
             raw_score = risk_vector[schema_idx]
             if not isinstance(raw_score, (int, float)) or raw_score <= 0.0:
                 continue
-            scaled_score = min(raw_score * build_time_multiplier, 100.0)
+            scaled_score = min(raw_score * build_time_multiplier * network_multiplier, 100.0)
             if scaled_score >= _FIREWALL_BLOCK_THRESHOLD:
                 exposures[risk_label] = scaled_score
 

--- a/tests/security_auditing/test_supply_chain_firewall.py
+++ b/tests/security_auditing/test_supply_chain_firewall.py
@@ -503,3 +503,107 @@ def test_memory_corruption_detection(tmp_path, monkeypatch):
     with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
         with pytest.raises(SystemExit):
             firewall_module.main()
+
+# ==============================================================================
+# TEST 17: NETWORK-CENTRALITY WEIGHTING IS OFF BY DEFAULT
+# ==============================================================================
+def test_network_weighting_disabled_by_default():
+    """
+    Proves FIREWALL_NETWORK_WEIGHTING defaults to False, so a file with an
+    enormous blast radius but a below-threshold raw score does NOT block.
+    This is the regression guard for the opt-in rollout decision: existing
+    pipelines must see unchanged behavior until they explicitly flip the flag.
+    """
+    assert firewall_module.FIREWALL_NETWORK_WEIGHTING is False, (
+        "FIREWALL_NETWORK_WEIGHTING must default to False -- this feature was "
+        "previously inert in production and ships opt-in, not silently live."
+    )
+
+    mock_ram_graph = [
+        {
+            "path": "hub.py",
+            "raw_imports": [],
+            # 40.0 alone is well under the 50.0 block threshold.
+            "risk_vector": _risk_vector(logic_bomb=40.0),
+            "telemetry": {"network_metrics": {"normalized_blast_radius": 9.0, "betweenness_score": 0.5}},
+            "coding_loc": 50,
+        }
+    ]
+
+    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    assert result["threats_found"] == 0, "Network weighting fired despite being disabled by default."
+
+# ==============================================================================
+# TEST 18: NETWORK-CENTRALITY WEIGHTING AMPLIFIES HUB FILES (OPT-IN)
+# ==============================================================================
+def test_network_weighting_amplifies_high_centrality_hub(monkeypatch):
+    """
+    With FIREWALL_NETWORK_WEIGHTING enabled, a highly central "hub" file
+    (normalized_blast_radius=3.0 > 1.0) gets its risk score amplified enough
+    to cross the block threshold, while a peripheral file with the identical
+    raw score (normalized_blast_radius=0.5 <= 1.0) does not.
+
+    logic_bomb=40.0 alone stays under 50.0. The hub's multiplier is
+    1.0 + (3.0 * 0.5) = 2.5, so 40.0 * 2.5 = 100.0 (capped) clears it. This is
+    the "only-amplify" design: a low-centrality file is never given a
+    discount, it just isn't boosted.
+    """
+    monkeypatch.setattr(firewall_module, "FIREWALL_NETWORK_WEIGHTING", True)
+    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
+
+    mock_ram_graph = [
+        {
+            "path": "hub.py",
+            "raw_imports": [],
+            "risk_vector": _risk_vector(logic_bomb=40.0),
+            "telemetry": {"network_metrics": {"normalized_blast_radius": 3.0, "betweenness_score": 0.0}},
+            "coding_loc": 50,
+        },
+        {
+            "path": "leaf.py",
+            "raw_imports": [],
+            "risk_vector": _risk_vector(logic_bomb=40.0),
+            "telemetry": {"network_metrics": {"normalized_blast_radius": 0.5, "betweenness_score": 0.0}},
+            "coding_loc": 50,
+        },
+    ]
+
+    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    assert result["threats_found"] == 1, "Hub-file amplification failed to isolate the high-centrality file."
+
+# ==============================================================================
+# TEST 19: NETWORK-CENTRALITY WEIGHTING - BETWEENNESS BONUS (OPT-IN)
+# ==============================================================================
+def test_network_weighting_betweenness_bonus(monkeypatch):
+    """
+    With FIREWALL_NETWORK_WEIGHTING enabled, a file that sits on many shortest
+    paths between other files (betweenness_score=0.1 > 0.05) gets a flat +0.5
+    multiplier bonus even when its blast radius alone (0.5 <= 1.0) would not
+    have amplified it.
+
+    logic_bomb=40.0 alone stays under 50.0. Multiplier here is 1.0 + 0.5 = 1.5,
+    so 40.0 * 1.5 = 60.0 clears the threshold. The identical file without the
+    high betweenness score stays unblocked.
+    """
+    monkeypatch.setattr(firewall_module, "FIREWALL_NETWORK_WEIGHTING", True)
+    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
+
+    mock_ram_graph = [
+        {
+            "path": "bridge.py",
+            "raw_imports": [],
+            "risk_vector": _risk_vector(logic_bomb=40.0),
+            "telemetry": {"network_metrics": {"normalized_blast_radius": 0.5, "betweenness_score": 0.1}},
+            "coding_loc": 50,
+        },
+        {
+            "path": "isolated.py",
+            "raw_imports": [],
+            "risk_vector": _risk_vector(logic_bomb=40.0),
+            "telemetry": {"network_metrics": {"normalized_blast_radius": 0.5, "betweenness_score": 0.0}},
+            "coding_loc": 50,
+        },
+    ]
+
+    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    assert result["threats_found"] == 1, "Betweenness bonus failed to isolate the high-betweenness bridge file."


### PR DESCRIPTION
Follow-up to #302's discovery that the firewall's old evaluate_risk() read a "dependency_network" key nothing ever wrote, so network_multiplier was silently always 1.0 in production -- a previously-inert feature, never actually live. This wires it up for real, deliberately, as its own reviewed change rather than folding it into the #302 refactor.

Design decisions (both discussed and confirmed before implementing):

- Formula: reuse the old evaluate_risk multiplier shape -- starts at 1.0, += blast_radius * 0.5 if normalized_blast_radius > 1.0, += 0.5 if betweenness_score > 0.05 -- applied post-hoc to the risk_vector score (same pattern #302 established for build_time_multiplier). This is an only-amplify design: a peripheral, low-centrality file is judged on its own merits and never gets a discount; only high-centrality "hub" files get less tolerance for the same embedded threat signal.
- Rollout: opt-in via a new FIREWALL_NETWORK_WEIGHTING config flag (default False), mirroring Phase 10.5's MAX_SYSTEMIC_THREAT gate (also off-by-default). Since this feature never actually ran before, flipping it on unconditionally would be a silent behavior change for every existing firewall user the moment this ships -- opt-in keeps today's behavior unchanged until a repo explicitly turns it on.

Reads file_node["telemetry"]["network_metrics"] (normalized_blast_radius, betweenness_score), written by network_risk_sensor.build_dependency_graph() at Phase 4 -- well before the firewall runs at Phase 10, same ordering guarantee #302 relied on for risk_vector from Phase 3.

Added 3 tests: flag-off-by-default regression guard (proves the default itself, not just behavior under it), hub-file amplification crossing the block threshold vs. an identical peripheral file that doesn't, and the betweenness-only bonus in isolation. Full suite: 775 passed, 1 xfailed (pre-existing), 0 failures.

### Description of Structural Changes
### Visual Observatory Testing
- [x] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [x] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [x] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
