### PR TITLE
Fix zero_dependency_mode under-reporting in incremental scans

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -2409,8 +2409,10 @@ class Orchestrator:
                 "missing_dependencies": {
                     "networkx": not HAS_NETWORKX,
                     "tiktoken": not HAS_TIKTOKEN,
+                    "xgboost": not ML_AVAILABLE,
+                    "pyyaml": not HAS_PYYAML,
                 },
-                "zero_dependency_mode": (not HAS_NETWORKX or not HAS_TIKTOKEN),
+                "zero_dependency_mode": (not HAS_NETWORKX or not HAS_TIKTOKEN or not ML_AVAILABLE or not HAS_PYYAML),
             }
 
             self.db_recorder.record_mission(


### PR DESCRIPTION
execute_incremental_scan only checked HAS_NETWORKX/HAS_TIKTOKEN, but the delta path also calls model_auditor.audit_repository (XGBoost) and can load YAML config. A runner missing xgboost/pandas or pyyaml silently skipped malware inference while reporting zero_dependency_mode: false.

Fixes #251

### Description of Structural Changes
### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [ ] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
