### PR TITLE
Remove dead func_empty/keyword_debt reads from tech-debt scoring

### DIFF
--- a/docs/wiki/08-08-technical-debt.md
+++ b/docs/wiki/08-08-technical-debt.md
@@ -17,7 +17,6 @@ The heuristic scanning has been entirely decoupled from the core deterministic e
 | :--- | :--- | :--- | :--- |
 | `planned_debt_hits` | `TODO`, `WIP`, `STUB`, `REFACTOR` | 1.0x | **The Promise.** Future work that doesn't necessarily imply current brokenness. |
 | `fragile_debt_hits` | `HACK`, `FIXME`, `XXX`, `UGLY` | 3.0x | **The Fracture.** An explicit admission that the current logic is fragile or dangerous. |
-| `func_empty` | Empty functions `{}` | 0.5x | **The Skeleton.** Placeholder logic independent of comments. |
 | `irc` | Implicit Language Penalty | 0.5x | **The Fog.** Implicit languages hide debt better, so we add a weighted baseline load to the stress sum. |
 
 ## Universal Framework Integration
@@ -36,7 +35,7 @@ We calculate the Density of Debt per line of code.
 **Step A: Calculate Stress Sum**
 We sum the markers, applying weights to distinguish "Planned Work" (Good Debt) from "Broken Logic" (Bad Debt). We also add the Implicit Risk Correction ($Irc$), dampened by its own weight multiplier ($0.5$).
 
-$$Stress = (GoodDebt \times 1.0) + (BadDebt \times 3.0) + (Stubs \times 0.5) + (Irc \times 0.5)$$
+$$Stress = (GoodDebt \times 1.0) + (BadDebt \times 3.0) + (Irc \times 0.5)$$
 
 **Step B: Calculate Stress Density**
 We normalize against the file size to calculate the stress points per 100 lines. A 1,000-line file with 1 `TODO` is fine. A 10-line file with 1 `HACK` is structurally critical.
@@ -58,16 +57,14 @@ from typing import Dict
 def _calc_tech_debt(self, loc: int, eq: Dict[str, int], irc: int, mp: float) -> float:
     t = self.risk_tuning.get("tech_debt", {})
     good_debt = eq.get("planned_debt", 0)
-    bad_debt = eq.get("fragile_debt", eq.get("keyword_debt", 0))
-    stubs = eq.get("func_empty", 0)
+    bad_debt = eq.get("fragile_debt", 0)
     
-    if good_debt == 0 and bad_debt == 0 and stubs == 0:
+    if good_debt == 0 and bad_debt == 0:
         return 0.0
     
     # Step A: Stress Sum
     stress = (good_debt * t.get("good_debt_weight", 1.0)) + \
              (bad_debt * t.get("bad_debt_weight", 3.0)) + \
-             (stubs * t.get("stub_weight", 0.5)) + \
              (irc * t.get("irc_weight", 0.5))
              
     # Step B: Density Calculation

--- a/gitgalaxy/metrics/signal_processor.py
+++ b/gitgalaxy/metrics/signal_processor.py
@@ -1469,14 +1469,13 @@ class SignalProcessor:
     def _calc_tech_debt(self, loc: int, raw_signals: Dict[str, int], irc: int, mp: float) -> float:
         t = self.risk_tuning.get("tech_debt", {})
         good_debt = raw_signals.get("planned_debt", 0)
-        bad_debt = raw_signals.get("fragile_debt", raw_signals.get("keyword_debt", 0))
-        stubs = raw_signals.get("func_empty", 0)
+        bad_debt = raw_signals.get("fragile_debt", 0)
 
         # --- NEW: UNTRACKED COMPLEXITY (SLOP) ---
         orphans = raw_signals.get("orphaned_logic", 0)
         duplicates = raw_signals.get("duplicate_logic", 0)
 
-        if good_debt == 0 and bad_debt == 0 and stubs == 0 and orphans == 0 and duplicates == 0:
+        if good_debt == 0 and bad_debt == 0 and orphans == 0 and duplicates == 0:
             return 0.0
 
         # Implicit debt carries a heavier baseline penalty because it is invisible to standard linters
@@ -1485,7 +1484,6 @@ class SignalProcessor:
         stress = (
             (good_debt * t.get("good_debt_weight", 1.0))
             + (bad_debt * t.get("bad_debt_weight", 3.0))
-            + (stubs * t.get("stub_weight", 0.5))
             + (irc * t.get("irc_weight", 0.5))
             + slop_stress
         )

--- a/gitgalaxy/standards/analysis_lens.py
+++ b/gitgalaxy/standards/analysis_lens.py
@@ -771,7 +771,6 @@ RISK_EQUATION_TUNING = {
     "tech_debt": {
         "good_debt_weight": 1.0,
         "bad_debt_weight": 3.0,
-        "stub_weight": 0.5,
         "irc_weight": 0.5,
         "threshold": 5.0,
         "sigmoid_slope": 0.5,


### PR DESCRIPTION
_calc_tech_debt read raw_signals["func_empty"] and fell back to raw_signals["keyword_debt"], but no producer in the extraction pipeline ever writes either key, so the "Empty Stubs" dimension of tech-debt scoring was permanently dead at 0. Since implementing real stub detection would require new per-language regex across the whole language_standards.py catalog, remove the dead read paths and the unused stub_weight tuning constant instead, and update the docs' equation/reference implementation to match.

Fixes #252

### Description of Structural Changes
### Visual Observatory Testing
- [x] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [x] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [x] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
