### PR TITLE
Clamp Tier 4 heuristic-discovery confidence to 1.0

### DIFF
--- a/gitgalaxy/standards/language_lens.py
+++ b/gitgalaxy/standards/language_lens.py
@@ -957,7 +957,7 @@ class LanguageDetector:
                     self.logger.warning(f"Tier 4 [Reconciliation]: TEMPORAL FRICTION ANOMALY on {top_id}...")
                     return "undeterminable", 0.0
 
-                return top_id, top_density
+                return top_id, min(top_density, 1.0)
 
             # 2. Friction Tie-Breaker (If margin is tight, penalize slow regex execution)
             elif density_margin >= self.thresholds.get("TIER_4_OUTLIER_MARGIN", 1.10):
@@ -967,7 +967,7 @@ class LanguageDetector:
                     )
                     return "undeterminable", 0.0
                 self.logger.debug(f"Tier 4 [Reconciliation]: Friction Tie-Breaker utilized for {top_id}.")
-                return top_id, top_density
+                return top_id, min(top_density, 1.0)
 
             # 3. Absolute Ambiguity Resolution
             else:
@@ -976,15 +976,15 @@ class LanguageDetector:
                         self.logger.debug(
                             f"Tier 4 [Reconciliation]: C/C++ Tie broken by Ecosystem Consensus -> {gravity_lang}"
                         )
-                        return gravity_lang, top_density
+                        return gravity_lang, min(top_density, 1.0)
                     # If no consensus exists, default to C as the lowest-level structural base
                     self.logger.debug("Tier 4 [Reconciliation]: C/C++ Tie broken by default architectural base -> c")
-                    return "c", top_density
+                    return "c", min(top_density, 1.0)
 
                 return "undeterminable", 0.0
 
         # 4. Single Candidate Victory
-        return top_id, top_density
+        return top_id, min(top_density, 1.0)
 
     def _forge_result(
         self,

--- a/tests/core_engine/test_language_lens.py
+++ b/tests/core_engine/test_language_lens.py
@@ -434,3 +434,34 @@ def test_corrupted_intent_vector_survival(isolated_detector):
     # The engine should ignore the garbage metadata and drop down to standard Heuristic Discovery
     assert result["lang_id"] in ["undeterminable", "plaintext", "python"]
     assert "Discovery" in result["source_proof"]
+
+
+# ==============================================================================
+# TEST 18: TIER 4 DENSITY CONFIDENCE CLAMP (ISSUE #257)
+# ==============================================================================
+@patch("gitgalaxy.standards.language_lens.time.time")
+def test_tier_4_density_confidence_is_clamped(mock_time, isolated_detector):
+    """
+    Proves Tier 4's `regex_hits / loc` density score is clamped to 1.0 before
+    being returned as a confidence value.
+
+    Unlike Tier 3 (`confidence = min(top_signal / 50.0, 1.0)`), Tier 4 used to
+    return `top_density` verbatim at every Phase 5 return point. Real files
+    routinely have more than one regex hit per physical line, so density
+    regularly exceeds 1.0 -- this payload deliberately hits "int main" three
+    times per line to drive raw density to ~2x, well past 1.0.
+    """
+    mock_time.side_effect = [float(i) for i in range(50)]
+
+    # 5 comment lines (to establish the standard_block lexical family) + 20
+    # lines with 3 "int main" hits each -> 60 hits over ~26 physical lines,
+    # a raw density of ~2.3 -- unclamped, this would flow straight into
+    # `intensity` in the final result.
+    c_payload = "// C file\n" * 5 + "int main(); int main(); int main();\n" * 20
+
+    result = isolated_detector.inspect("no_extension_file", c_payload)
+
+    assert result["lang_id"] == "c"
+    assert result["intensity"] <= 1.0, (
+        f"Tier 4 confidence must be clamped to <= 1.0, got {result['intensity']}"
+    )


### PR DESCRIPTION
_tier_3_lexical_scan normalizes its score before returning (confidence = min(top_signal / 50.0, 1.0)), but _tier_4_heuristic_discovery had no equivalent step: it returned raw top_density (regex_hits / loc) verbatim at every Phase 5 return point. Real source files routinely have more than one regex hit per line, so this regularly exceeded 1.0 and flowed straight into `intensity` in the final JSON/report/SARIF output with no clamping downstream -- visibly broken next to every other 0-1 confidence field, and it also meant FLOOR_TIER_4 (0.92) was trivially satisfied for real code, weakening the verification gate it's meant to enforce.

Fix: clamp with min(top_density, 1.0) at each of the 5 return points in Phase 5, while leaving the raw top_density used internally by the density_margin/friction_ratio tie-breaker math untouched, since clamping that would corrupt the reconciliation logic.

Added a regression test with a payload engineered to raw-density ~2.3x, verified it fails without the fix (asserts got 2.3076...) and passes with it.

Fixes #257

### Description of Structural Changes
### Visual Observatory Testing
- [x] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [x] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [x] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
