### PR TITLE
Clamp _calc_concurrency and _calc_state_flux to 0-100 exposure scale

### DIFF
--- a/gitgalaxy/metrics/signal_processor.py
+++ b/gitgalaxy/metrics/signal_processor.py
@@ -1760,7 +1760,7 @@ class SignalProcessor:
         threshold = tuning.get("threshold_base", 4.0)  # Matches your config!
         slope = tuning.get("sigmoid_slope", 0.4)
 
-        return self._sigmoid(density, threshold, slope) * 100.0 * mp
+        return min(self._sigmoid(density, threshold, slope) * 100.0 * mp, 100.0)
 
     def _calc_state_flux(self, loc: int, raw_signals: Dict[str, int], irc: int, mp: float) -> float:
         """
@@ -1786,7 +1786,7 @@ class SignalProcessor:
         threshold = tuning.get("threshold_base", 15.0)
         slope = tuning.get("sigmoid_slope", 0.2)
 
-        return self._sigmoid(density, threshold, slope) * 100.0 * mp
+        return min(self._sigmoid(density, threshold, slope) * 100.0 * mp, 100.0)
 
     def _calc_spec_alignment(self, raw_signals: Dict[str, int], mp: float) -> float:
         entities = max(raw_signals.get("func_start", 0) + raw_signals.get("class_start", 0), 1)


### PR DESCRIPTION
## Summary
- `_calc_concurrency` and `_calc_state_flux` in `gitgalaxy/metrics/signal_processor.py` applied the path-modifier multiplier (`mp`) after the sigmoid's `[0, 1]` bound, with no final clamp — unlike every other `_calc_*` risk-exposure method, which wraps its return in `min(x, 100.0)`.
- A saturated concurrency sigmoid on a path matching `stores?/states?/reducers?/contexts?/` (mp=1.20) could yield 120.0; a saturated state-flux sigmoid on `configs?/envs?/globals?/constants?/settings?/` (mp=1.25) could yield 125.0 — both written unclamped into `exposure_vector`/`risk_vector_ordered`, violating the documented 0-100 range.
- Wrapped both return statements in `min(..., 100.0)` to match the sibling `_calc_*` methods.

Fixes #314

## Test plan
- [x] `python -m pytest tests/core_engine/test_signal_processor.py -q` — 50 passed