### PR TITLE
Fix GuideStar IGNORED_DIRECTORIES pointing at wrong config dict

### DIFF
--- a/gitgalaxy/standards/gitgalaxy_config.py
+++ b/gitgalaxy/standards/gitgalaxy_config.py
@@ -415,6 +415,7 @@ PRIORITY_WHITELIST = [
 # ------------------------------------------------------------------------------
 # Defines the rules for Bayesian Intent inference used by the GuideStar Lens
 GUIDESTAR_CONFIG = {
+    "IGNORED_DIRECTORIES": APERTURE_CONFIG["IGNORED_DIRECTORIES"],
     "MANIFEST_MAP": {
         "package.json": "javascript",
         "Makefile": "makefile",


### PR DESCRIPTION
## Summary
- `GuideStarLens._gs_config` is bound to `GUIDESTAR_CONFIG`, which only defined `MANIFEST_MAP`, `INTENT_BIASED_SECTORS`, and `EXEC_PREFIX_MAP` — no `IGNORED_DIRECTORIES` key.
- `_calculate_documentation_coverage`'s `dirs[:]` pruning (`guidestar_lens.py:472`) reads `self._gs_config.get("IGNORED_DIRECTORIES", set())`, which therefore always fell back to an empty set, so the fix from #256 was silently a no-op and every scan walked `node_modules`, `.git`, `vendor`, `build`, etc.
- Fixed by adding `"IGNORED_DIRECTORIES": APERTURE_CONFIG["IGNORED_DIRECTORIES"]` to `GUIDESTAR_CONFIG`'s definition in `gitgalaxy_config.py`, giving a single source of truth instead of a second set that can drift.

Fixes #311

## Test plan
- [x] `python -m pytest tests/core_engine/test_guidestar_lens.py -q` — 5 passed
- [x] `python -m pytest tests/ -q` — 778 passed, 1 xfailed