### PR TITLE
Make shadow-API file-extension matching case-insensitive

### DIFF
--- a/gitgalaxy/tools/network_auditing/full_api_network_map.py
+++ b/gitgalaxy/tools/network_auditing/full_api_network_map.py
@@ -130,7 +130,7 @@ def auto_discover_swagger(target_dir: Path) -> list:
     }
 
     for filepath in target_dir.rglob("*"):
-        if not filepath.is_file() or filepath.suffix not in [".json", ".yaml", ".yml"]:
+        if not filepath.is_file() or filepath.suffix.lower() not in [".json", ".yaml", ".yml"]:
             continue
 
         # 1. Check filename first (Fast Path)
@@ -202,7 +202,7 @@ def map_physical_codebase(target_dir: Path) -> tuple:
             continue
 
         for framework, config in FRAMEWORK_SIGNATURES.items():
-            if filepath.suffix in config["ext"]:
+            if filepath.suffix.lower() in config["ext"]:
                 try:
                     content = filepath.read_text(encoding="utf-8", errors="ignore")
                     hits = config["regex"].findall(content)


### PR DESCRIPTION
## Summary
- `auto_discover_swagger` (line 133) and `map_physical_codebase` (line 205) in `full_api_network_map.py` both compared `Path.suffix` directly against lowercase literal lists, with no `.lower()`.
- Files like `Routes.JS`, `api.PY`, or `Config.YAML` were silently excluded from both Swagger/OpenAPI spec discovery and the physical-codebase API-endpoint extraction that the shadow-API diff depends on — a real endpoint could go undetected purely because of filename casing.
- `parse_official_swagger` already did this correctly (`swagger_path.suffix.lower()` at line 168), confirming the two unguarded sites were an oversight. Applied the same `.lower()` pattern at both.

Fixes #317

## Test plan
- [x] `python -m pytest tests/security_auditing/test_api_network_map.py -q` — 16 passed