### PR TITLE
Make SBOM malware-scan candidate selection case-insensitive

### DIFF
--- a/gitgalaxy/recorders/sbom_recorder.py
+++ b/gitgalaxy/recorders/sbom_recorder.py
@@ -215,7 +215,7 @@ class SbomRecorder:
         candidates = []
         for root, _, files in os.walk(pkg_path):
             for file in files:
-                if file.endswith((".js", ".py", ".ts", ".php", ".rs")):
+                if file.lower().endswith((".js", ".py", ".ts", ".php", ".rs")):
                     candidates.append(Path(root) / file)
 
         def _priority(p: Path):
@@ -264,7 +264,7 @@ class SbomRecorder:
         for root, _, files in os.walk(pkg_path):
             scanned_in_dir = 0
             for file in files:
-                if not file.endswith((".js", ".py", ".ts", ".php", ".rs")):
+                if not file.lower().endswith((".js", ".py", ".ts", ".php", ".rs")):
                     continue
                 total_candidates += 1
                 if scanned_in_dir >= 5:


### PR DESCRIPTION
## Summary
- Both candidate-selection loops in `sbom_recorder.py` (lines 218 and 267) filtered filenames with `file.endswith((".js", ".py", ".ts", ".php", ".rs"))` — a lowercase literal tuple compared against the raw on-disk filename.
- Files like `Handler.PY`, `component.JS`, or `worker.RS` silently failed the check and were skipped entirely by the supply-chain malware/anomaly scan for that package.
- Normalized both sites with `file.lower().endswith(...)`.

Fixes #316

## Test plan
- [x] `python -m pytest tests/tools_recorders/test_sbom_generator.py tests/core_engine/test_galaxyscope.py tests/core_engine/test_manifest_parser.py tests/security_auditing/test_dependency_audit_cache.py -q` — 66 passed