### PR TITLE
Fix AIAppSecSensor reading its 8 inputs from a phantom telemetry namespace

### DIFF
--- a/gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py
+++ b/gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py
@@ -30,22 +30,31 @@ class AIAppSecSensor:
         self.logger.info("AI AppSec Sensor: Scanning for Agentic Vulnerabilities...")
 
         for file_data in parsed_files:
-            # Extract the raw structural signatures (assuming they are tallied in 'telemetry')
-            telemetry = file_data.get("telemetry", {})
+            # Extract the raw structural signatures. These are tallied in 'equations'
+            # (raw_signals keyed by SIGNAL_SCHEMA name), not 'telemetry' -- 'telemetry'
+            # only holds derived/computed metrics (network stats, popularity, etc.).
+            equations = file_data.get("equations", {})
 
             # Extract specific architectural signals
-            ai_orchestrator = telemetry.get("ai_orchestrator", 0) > 0
-            llm_api = telemetry.get("llm_api", 0) > 0
-            ai_tools = telemetry.get("ai_tools", 0) > 0
+            ai_orchestrator = equations.get("llm_orchestrator", 0) > 0
+            llm_api = equations.get("llm_api", 0) > 0
+            ai_tools = equations.get("ai_tools", 0) > 0
 
-            arch_api = telemetry.get("arch_api", 0) > 0  # Publicly exposed
-            arch_io = telemetry.get("arch_io", 0) > 0  # Network/Disk I/O
+            arch_api = equations.get("api", 0) > 0  # Publicly exposed
+            arch_io = (equations.get("io", 0) + equations.get("sec_io", 0)) > 0  # Network/Disk I/O
             db_complexity = file_data.get("max_db_complexity", 0)  # Data gravity
 
             # Security Structural Signatures
-            sec_danger = telemetry.get("sec_high_risk_execution", 0) > 0  # eval, exec, subprocess
-            sec_secrets = telemetry.get("sec_secrets", 0) > 0  # Hardcoded keys/env access
-            safety_density = telemetry.get("safety_density", 1.0)  # Defensive programming (try/catch, regex)
+            sec_danger = equations.get("sec_high_risk_execution", 0) > 0  # eval, exec, subprocess
+            sec_secrets = equations.get("sec_hardcoded_secrets", 0) > 0  # Hardcoded keys/env access
+
+            # Defensive programming density (try/catch, guards, regex validation) per LOC.
+            # No existing schema signal captures this ratio directly, so it's derived here
+            # from the raw 'safety' hit count, using the same doc_mult-style scaling
+            # SignalProcessor._calc_cog_load uses to turn sparse per-LOC hit counts into a
+            # meaningful 0-1 density.
+            safe_loc = max(file_data.get("coding_loc", 1), 1)
+            safety_density = min(1.0, (equations.get("safety", 0) * 10.0) / safe_loc)
 
             appsec_report = {
                 "is_rce_funnel": False,

--- a/tests/security_auditing/test_ai_appsec_sensor.py
+++ b/tests/security_auditing/test_ai_appsec_sensor.py
@@ -14,12 +14,12 @@ def test_autonomous_execution_vector_detection():
 
     mock_files = [
         {
-            "telemetry": {
+            "telemetry": {},
+            "equations": {
                 "llm_api": 1,  # AI is present
-                "arch_api": 1,  # Exposed to the public internet
+                "api": 1,  # Exposed to the public internet
                 "sec_high_risk_execution": 1,  # Contains eval() or subprocess execution
-                "safety_density": 0.9,
-            }
+            },
         }
     ]
 
@@ -45,9 +45,11 @@ def test_over_permissioned_agent_detection():
     mock_files = [
         {
             "max_db_complexity": 3,  # Heavy database write access
-            "telemetry": {
+            "coding_loc": 100,
+            "telemetry": {},
+            "equations": {
                 "ai_tools": 1,  # Agentic tool calling enabled
-                "safety_density": 0.2,  # Dangerously low defensive programming
+                "safety": 0,  # Dangerously low defensive programming -> density 0.0
             },
         }
     ]
@@ -75,11 +77,12 @@ def test_exfiltration_vector_detection():
 
     mock_files = [
         {
-            "telemetry": {
+            "telemetry": {},
+            "equations": {
                 "llm_api": 1,  # AI is present
-                "arch_io": 1,  # Can make outbound network requests
-                "sec_secrets": 1,  # Has access to AWS keys/passwords
-            }
+                "io": 1,  # Can make outbound network requests
+                "sec_hardcoded_secrets": 1,  # Has access to AWS keys/passwords
+            },
         }
     ]
 
@@ -108,12 +111,14 @@ def test_safe_baseline():
     mock_files = [
         {
             "max_db_complexity": 0,
-            "telemetry": {
+            "coding_loc": 50,
+            "telemetry": {},
+            "equations": {
                 "llm_api": 1,  # ✅ AI is present
-                "arch_api": 0,  # ✅ Not exposed to the public
+                "api": 0,  # ✅ Not exposed to the public
                 "sec_high_risk_execution": 0,  # ✅ No eval/subprocess
-                "sec_secrets": 0,  # ✅ No secrets exposed
-                "safety_density": 0.95,  # ✅ High defensive try/catch density
+                "sec_hardcoded_secrets": 0,  # ✅ No secrets exposed
+                "safety": 5,  # ✅ High defensive try/catch density (-> density 1.0)
             },
         }
     ]


### PR DESCRIPTION
## Summary
- `AIAppSecSensor.hunt_threats()` read all 8 inputs from `file_data["telemetry"]`, a namespace nothing populates with these keys. All three detection rules -- Autonomous Execution Vector, Over-Permissioned Agent, Agentic Exfiltration Vector -- have been permanently unreachable since this module was written.
- `ai_orchestrator`/`llm_api`/`ai_tools` now read from `file_data["equations"]` under their real SIGNAL_SCHEMA names (`llm_orchestrator`, `llm_api`, `ai_tools`) instead of a nonexistent/misnamed telemetry key.
- `arch_api`/`arch_io` now read `equations["api"]` / `equations["io"] + equations["sec_io"]`, matching the same api/io bridge keys `SignalProcessor` already uses elsewhere (e.g. `signal_processor.py:1941`, `2210`).
- `sec_danger`/`sec_secrets` now read `equations["sec_high_risk_execution"]` and `equations["sec_hardcoded_secrets"]`, their real schema names.
- `safety_density` had no real source anywhere in the codebase under any name -- a genuine gap, not just a misnamed read. Built one: a 0-1 defensive-programming density derived from the raw `"safety"` hit count over LOC, scaled the same way `SignalProcessor._calc_cog_load` turns sparse per-LOC hit counts into a density (its `doc_mult`-style scaling).
- Updated `test_ai_appsec_sensor.py`, which had been asserting against the same phantom telemetry fields the production code read from, so it was silently validating dead code. It now populates `file_data["equations"]` (and `coding_loc` for the density calc) to match what the sensor actually reads.

Fixes #324

## Test plan
- [x] `python -m pytest tests/security_auditing/test_ai_appsec_sensor.py -q` — 4 passed
- [x] `python -m pytest tests/security_auditing/ -q` — 139 passed