### PR TITLE
Aggregate duplicate_logic count into equations, mirroring orphaned_logic

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -527,6 +527,7 @@ class StructuralExtractor:
             token_counts = collections.Counter(re.findall(r"\b\w+\b", code_stream))
 
             orphan_count = 0
+            duplicate_count = 0
             func_names = [f.get("name", "") for f in functions]
             func_name_counts = collections.Counter(func_names)
 
@@ -537,6 +538,7 @@ class StructuralExtractor:
                 # Check for Duplicates (Defined multiple times in the same file)
                 if func_name and func_name_counts[func_name] > 1:
                     usage_status = 2  # 2 = Duplicate
+                    duplicate_count += 1
                 elif len(func_name) > 3 and func_name not in {
                     "Unknown_Sat",
                     "Anonymous_Block",
@@ -552,6 +554,8 @@ class StructuralExtractor:
 
             if orphan_count > 0:
                 equations["orphaned_logic"] = orphan_count
+            if duplicate_count > 0:
+                equations["duplicate_logic"] = duplicate_count
 
             # Calculate total file footprint, preferring the unshielded raw text if available
             file_token_mass = get_token_mass(raw_content if raw_content else code_stream)

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -277,7 +277,8 @@ def test_detector_atomic_literal_shield():
 def test_detector_orphan_and_duplicate_logic():
     """
     Proves the engine accurately identifies uncalled (orphan) functions
-    and duplicated function definitions within a single file.
+    and duplicated function definitions within a single file, and that both
+    counts are aggregated into equations (orphaned_logic / duplicate_logic).
     """
     opt_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
     code = (
@@ -285,6 +286,12 @@ def test_detector_orphan_and_duplicate_logic():
         "    return True\n"
         "\n"
         "def forgotten_orphan():\n"
+        "    pass\n"
+        "\n"
+        "def repeated_name():\n"
+        "    pass\n"
+        "\n"
+        "def repeated_name():\n"
         "    pass\n"
         "\n"
         "def main_process():\n"
@@ -296,12 +303,24 @@ def test_detector_orphan_and_duplicate_logic():
 
     # active_helper is used, forgotten_orphan is not, main_process is the entry point
     orphans = [f["name"] for f in result["functions"] if f.get("usage_status") == 1]
+    duplicates = [f["name"] for f in result["functions"] if f.get("usage_status") == 2]
 
     assert "forgotten_orphan" in orphans, (
         "Failed to flag the unused function as an orphan!"
     )
     assert "active_helper" not in orphans, (
         "Falsely flagged an active function as an orphan!"
+    )
+    assert duplicates.count("repeated_name") == 2, (
+        "Failed to flag both definitions of the duplicated function name!"
+    )
+
+    # forgotten_orphan and main_process (never called, name > 3 chars) both flag as orphans.
+    assert result["equations"].get("orphaned_logic", 0) == len(orphans), (
+        "orphan_count was not aggregated into equations['orphaned_logic']!"
+    )
+    assert result["equations"].get("duplicate_logic", 0) == 2, (
+        "duplicate_count was not aggregated into equations['duplicate_logic']!"
     )
 
 


### PR DESCRIPTION
## Summary
- The function-slicing loop in `detector.py` tagged each duplicately-defined function with `usage_status = 2`, but never accumulated a count or wrote it to `equations`, unlike its sibling `orphan_count`/`equations["orphaned_logic"]` write immediately below it.
- `duplicate_logic` was therefore a permanent zero going into `signal_processor._calc_tech_debt` (weighted 5.0x into `slop_stress`) and `security_auditor._construct_feature_matrix` (a constant-zero column in the XGBoost malware-inference feature matrix, for every file, on every repo).
- Fixed by accumulating `duplicate_count` in the same loop and writing `equations["duplicate_logic"] = duplicate_count` when nonzero, mirroring the `orphaned_logic` pattern exactly.
- Checked whether the recorders needed matching changes per the issue's ask: `record_keeper.py`'s `SHORT_KEY_MAP` and `llm_recorder.py`'s orphan/duplicate slop report already read `duplicate_logic` generically alongside `orphaned_logic` via `SIGNAL_SCHEMA`/`hit_vector` -- they were already fully wired and needed no changes, only a real producer feeding them.
- Extended `test_detector_orphan_and_duplicate_logic`, which asserted per-function `usage_status` but never actually exercised a duplicated function name or checked the aggregate, to cover both the duplicate case and the `equations["duplicate_logic"]` / `equations["orphaned_logic"]` aggregation.

Fixes #312

## Test plan
- [x] `python -m pytest tests/core_engine/test_detector.py tests/core_engine/test_signal_processor.py -q` — 110 passed
- [x] `python -m pytest tests/security_auditing/test_security_auditor.py tests/tools_recorders/test_llm_recorder.py tests/tools_recorders/test_record_keeper.py tests/core_engine/test_galaxyscope.py tests/core_engine/test_zero_dependency.py -q` — 61 passed
- [x] `python -m pytest tests/ -q` — 778 passed, 1 xfailed