### PR TITLE
Clamp Collision Resolved branch confidence to 1.0

### DIFF
--- a/gitgalaxy/standards/language_lens.py
+++ b/gitgalaxy/standards/language_lens.py
@@ -508,7 +508,7 @@ class LanguageDetector:
                 else:
                     if ext in self.COLLISION_FREQUENCIES:
                         best_lang = spectral_id
-                        best_conf = max(spec_intensity + 0.10, 0.92)
+                        best_conf = min(max(spec_intensity + 0.10, 0.92), 1.0)
                         lock_tier = 4
                         source_proof = f"Collision Resolved ({ext} -> {spectral_id})"
                     elif lock_tier == 4:

--- a/tests/core_engine/test_language_lens.py
+++ b/tests/core_engine/test_language_lens.py
@@ -465,3 +465,30 @@ def test_tier_4_density_confidence_is_clamped(mock_time, isolated_detector):
     assert result["intensity"] <= 1.0, (
         f"Tier 4 confidence must be clamped to <= 1.0, got {result['intensity']}"
     )
+
+
+# ==============================================================================
+# TEST 19: COLLISION-RESOLVED CONFIDENCE CLAMP (ISSUE #315)
+# ==============================================================================
+def test_collision_resolved_confidence_is_clamped(isolated_detector):
+    """
+    Proves the Tier-3 collision-resolution branch clamps
+    `spec_intensity + 0.10` to 1.0 before it becomes the final confidence.
+
+    ".h" is a COLLISION_FREQUENCIES extension shared by cpp/c/objective-c, so
+    Tier 1 refuses to lock it (undeterminable) and it falls through to the
+    lexical scan. This payload repeats "int main()" enough times on a single
+    short line to saturate `_tier_3_lexical_scan`'s score at exactly 1.0 --
+    unclamped, `max(1.0 + 0.10, 0.92)` would return 1.10.
+    """
+    content = "int main(); " * 6
+
+    result = isolated_detector.inspect(
+        file_path="test_collision_xyz.h", content_sample=content, ext_tally={}
+    )
+
+    assert result["lang_id"] == "c"
+    assert "Collision Resolved" in result["source_proof"]
+    assert result["intensity"] <= 1.0, (
+        f"Collision-resolved confidence must be clamped to <= 1.0, got {result['intensity']}"
+    )


### PR DESCRIPTION
Fixes #315. classify()'s Tier-3 collision-resolution branch computed best_conf = max(spec_intensity + 0.10, 0.92) with no upper clamp. Since spec_intensity is bounded to [0.0, 1.0], a saturated lexical scan (top_signal >= 50) on a COLLISION_FREQUENCIES extension pushed best_conf to 1.10, flowing unclamped into DetectorResult["intensity"] -- the same field every other branch in this file hard-caps at 0.999/0.95/0.92.

Same bug family as #257 (Tier 4 heuristic-discovery confidence), a different additive-bump root cause on a different code path.

Fix: min(max(spec_intensity + 0.10, 0.92), 1.0).

Added a regression test engineered to saturate the Tier-3 lexical scan score to exactly 1.0 on a COLLISION_FREQUENCIES (".h") extension, verified it fails without the fix (asserts got 1.1) and passes with it.

### Description of Structural Changes
### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

### The Differential Scan Acknowledgement
- [ ] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
