### PR TITLE
[Config Phase 1] Add config_resolver.py: single ResolvedConfig merge point

### DIFF
--- a/gitgalaxy/standards/config_resolver.py
+++ b/gitgalaxy/standards/config_resolver.py
@@ -1,0 +1,297 @@
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+
+"""
+config_resolver.py
+Phase 1 of the config-override rework (issue #333; decisions in #332).
+
+Single entry point for merging gitgalaxy_config.py defaults with
+.galaxyscope.yaml overrides and CLI overrides, replacing the 3 previously
+independent, inconsistent inline mechanisms in galaxyscope.py's main()
+(a generic args.* interceptor that reached nothing, a hand-coded merge
+covering only 4 of APERTURE_CONFIG's keys, and no path at all for the
+other ~15 gitgalaxy_config.py constants).
+
+Precedence (decided in #332): CLI overrides > .galaxyscope.yaml > the
+gitgalaxy_config.py default. An unrecognized key -- in either the YAML
+file's `galaxyscope:` section or in `cli_overrides` -- is a hard
+ConfigError, not a warning: a typo'd security-policy key (e.g.
+STRICT_IMPORT_MDOE) must not silently no-op. This is distinct from a
+malformed/unreadable YAML *file*, which degrades to defaults with a logged
+warning (matching pre-existing CLI behavior).
+
+PROJECT_OVERRIDES (in language_standards.py) is deliberately NOT handled
+here. Per #332 it is a separate, Python-only, maintainer-curated
+per-project dialect-patch mechanism (it also patches LANGUAGE_DEFINITIONS,
+which is outside gitgalaxy_config.py's domain entirely) -- callers apply it
+as its own step, after this resolver has run, not as a 4th precedence tier.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from gitgalaxy.standards import gitgalaxy_config as _defaults
+
+logger = logging.getLogger("GalaxyScope.config_resolver")
+
+
+class ConfigError(ValueError):
+    """Raised when a config source names a key this resolver doesn't recognize."""
+
+
+# ------------------------------------------------------------------
+# Merge semantics registry
+# ------------------------------------------------------------------
+# "replace" -- the highest-precedence source that sets this key wins
+#              outright (scalars, booleans, thresholds).
+# "extend"  -- sources are unioned/merged rather than replacing each other:
+#              sets union, lists concatenate, dicts update key-by-key. This
+#              is the right default for policy allow/deny lists -- a user
+#              adding one entry to BLACKLISTED_IMPORTS should not silently
+#              wipe out the built-in ones.
+# A nested dict (see APERTURE_CONFIG_SPEC / GUIDESTAR_CONFIG_SPEC) declares
+# its own sub-key registry, so a typo'd sub-key is caught too, not just a
+# typo'd top-level key.
+
+REPLACE = "replace"
+EXTEND = "extend"
+
+APERTURE_CONFIG_SPEC: Dict[str, str] = {
+    "SECRETS_EXTENSIONS": EXTEND,
+    "SECRETS_EXACT": EXTEND,
+    "IGNORED_DIRECTORIES": EXTEND,
+    "IGNORED_EXTENSIONS": EXTEND,
+    "CONTRABAND_PATTERNS": EXTEND,
+    "VENDOR_MINIFICATION_PATHS": EXTEND,
+    "MAX_LINE_LENGTH": REPLACE,
+    "MINIFICATION_SCAN_LIMIT": REPLACE,
+    "MAX_FILE_SIZE_MB": REPLACE,
+    # BANDS is an internal label taxonomy, not user-overridable -- omitted
+    # on purpose so a YAML BANDS key raises ConfigError.
+}
+
+GUIDESTAR_CONFIG_SPEC: Dict[str, str] = {
+    "MANIFEST_MAP": EXTEND,
+    "INTENT_BIASED_SECTORS": EXTEND,
+    "EXEC_PREFIX_MAP": EXTEND,
+    # IGNORED_DIRECTORIES is a same-object reference to APERTURE_CONFIG's
+    # copy (see gitgalaxy_config.py) -- override it via APERTURE_CONFIG so
+    # the two can't drift out of sync.
+}
+
+# Every gitgalaxy_config.py constant this resolver knows how to merge, and
+# how. A key not listed here is not user-overridable: an attempt to set it
+# from YAML or CLI raises ConfigError rather than silently doing nothing.
+#
+# LEXICAL_FAMILY_HEURISTICS is intentionally omitted -- it's a fixed
+# heuristic table, not a user-facing policy knob, and nothing has ever
+# asked to override it.
+TOP_LEVEL_SPEC: Dict[str, Any] = {
+    "STRICT_IMPORT_MODE": REPLACE,
+    "APPROVED_IMPORTS": EXTEND,
+    "BLACKLISTED_IMPORTS": EXTEND,
+    "FIREWALL_NETWORK_WEIGHTING": REPLACE,
+    "DENYLIST_PATTERNS": EXTEND,
+    "ALLOWLIST_PATHS": EXTEND,
+    "XRAY_BYPASS_EXTENSIONS": EXTEND,
+    "XRAY_BYPASS_PATHS": EXTEND,
+    "APERTURE_CONFIG": APERTURE_CONFIG_SPEC,
+    "PRIORITY_WHITELIST": EXTEND,
+    "GUIDESTAR_CONFIG": GUIDESTAR_CONFIG_SPEC,
+    "EXACT_FILE_MATCH": EXTEND,
+    "TEST_NAMING_CONVENTIONS": EXTEND,
+    "CHRONOMETER_CONFIG": EXTEND,
+    "PROJECT_STORIES": EXTEND,
+    # These two have no gitgalaxy_config.py default at all -- they're
+    # YAML-only, matching the pre-existing precedent already in this
+    # repo's own .galaxyscope.yaml (main() has read them straight out of
+    # config_file_data with no compiled-in default since before this
+    # resolver existed).
+    "SARIF_IGNORED_RULES": EXTEND,
+    "SARIF_IGNORED_PATHS": EXTEND,
+}
+
+# Keys with no gitgalaxy_config.py constant backing them (see comment above).
+_NO_DEFAULT_KEYS = {"SARIF_IGNORED_RULES", "SARIF_IGNORED_PATHS"}
+
+# Which top-level keys a CLI flag may set. CLI flags only make sense for
+# scalars/booleans -- list/dict-valued policy keys are YAML-only (#332).
+# Empty for now: no argparse flag maps to a gitgalaxy_config.py key yet.
+# Phase 2 adds the flags and extends this set; resolve_config() enforces it
+# either way so a miswired future flag fails loudly instead of silently
+# matching nothing (the original bug this whole effort started from).
+CLI_OVERRIDABLE_KEYS: set = {
+    "STRICT_IMPORT_MODE",
+    "FIREWALL_NETWORK_WEIGHTING",
+}
+
+
+@dataclass
+class ResolvedConfig:
+    """
+    Final, merged configuration for a single scan run.
+
+    Exposes every key both as an attribute (`getattr(config, "X", default)`)
+    and as a dict item (`config["X"]` / `config.get("X")`), so it is a
+    drop-in replacement for both calling conventions currently in use
+    across the codebase: the `from gitgalaxy.standards import
+    gitgalaxy_config as config` + `getattr(config, ...)` pattern (
+    chronometer.py, gpu_recorder.py) and the `full_config` plain-dict
+    pattern galaxyscope.py's main() builds today.
+    """
+
+    _values: Dict[str, Any] = field(default_factory=dict)
+
+    def __getattr__(self, name: str) -> Any:
+        # Only called when normal attribute lookup fails, i.e. never for
+        # `_values` itself -- safe against recursion.
+        try:
+            return self._values[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def get(self, name: str, default: Any = None) -> Any:
+        return self._values.get(name, default)
+
+    def __getitem__(self, name: str) -> Any:
+        return self._values[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._values
+
+    def to_dict(self) -> Dict[str, Any]:
+        return copy.deepcopy(self._values)
+
+
+def _get_default(key: str) -> Any:
+    if key in _NO_DEFAULT_KEYS:
+        return {} if isinstance(TOP_LEVEL_SPEC[key], dict) else []
+    if not hasattr(_defaults, key):
+        raise ConfigError(
+            f"config_resolver.TOP_LEVEL_SPEC references '{key}', but "
+            f"gitgalaxy_config.py defines no such constant."
+        )
+    return copy.deepcopy(getattr(_defaults, key))
+
+
+def _merge_collection(base: Any, override: Any) -> Any:
+    if isinstance(base, set):
+        return base | set(override)
+    if isinstance(base, dict):
+        merged = dict(base)
+        merged.update(override)
+        return merged
+    if isinstance(base, list):
+        return [*base, *override]
+    # Shouldn't happen for real gitgalaxy_config.py values, but degrade
+    # sensibly for a no-default key whose shape isn't known ahead of time.
+    if isinstance(override, dict):
+        return {**(base or {}), **override}
+    return [*(base or []), *override]
+
+
+def _merge_value(base: Any, override: Any, spec: Any, *, path: str) -> Any:
+    if isinstance(spec, dict):
+        if not isinstance(override, dict):
+            raise ConfigError(
+                f"'{path}' must be a mapping in .galaxyscope.yaml, got "
+                f"{type(override).__name__}."
+            )
+        merged = copy.deepcopy(base) if isinstance(base, dict) else {}
+        for sub_key, sub_val in override.items():
+            if sub_key not in spec:
+                raise ConfigError(
+                    f"Unrecognized key '{sub_key}' under '{path}' in "
+                    f".galaxyscope.yaml. Known keys: {sorted(spec)}"
+                )
+            merged[sub_key] = (
+                sub_val if spec[sub_key] == REPLACE
+                else _merge_collection(merged.get(sub_key), sub_val)
+            )
+        return merged
+
+    if spec == REPLACE:
+        return override
+    return _merge_collection(base, override)
+
+
+def _load_yaml_section(yaml_path: str) -> Dict[str, Any]:
+    """
+    Returns the `galaxyscope:` section of the YAML file, or {} if the file
+    is missing, unreadable, or contains malformed YAML syntax -- that class
+    of failure degrades to defaults with a logged error rather than
+    raising, matching the pre-existing CLI behavior (see
+    test_yaml_config_load_failure). It is NOT the same thing as an
+    unrecognized *key* inside an otherwise-valid file, which is a
+    ConfigError raised by the caller.
+    """
+    try:
+        import yaml
+    except ImportError:
+        logger.warning("pyyaml not installed -- ignoring --config %s", yaml_path)
+        return {}
+
+    try:
+        with open(yaml_path, "r") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as exc:
+        logger.error("Failed to load config file %s: %s", yaml_path, exc)
+        return {}
+
+    section = data.get("galaxyscope", {}) if isinstance(data, dict) else {}
+    return section or {}
+
+
+def resolve_config(
+    yaml_path: Optional[str] = None,
+    cli_overrides: Optional[Dict[str, Any]] = None,
+) -> ResolvedConfig:
+    """
+    Merge, in the precedence decided in #332:
+        gitgalaxy_config.py defaults -> .galaxyscope.yaml -> cli_overrides
+
+    `cli_overrides` should contain only keys the user actually specified on
+    the command line (the tri-state fix from #332/#334 -- omit a key
+    entirely rather than passing its argparse default, so this function can
+    tell "not specified" from "explicitly set").
+
+    Raises ConfigError for any key in `yaml_path`'s `galaxyscope:` section
+    or in `cli_overrides` that isn't in TOP_LEVEL_SPEC (or, for nested
+    dict-valued keys, isn't in that key's own sub-key spec).
+    """
+    resolved: Dict[str, Any] = {key: _get_default(key) for key in TOP_LEVEL_SPEC}
+
+    if yaml_path:
+        yaml_data = _load_yaml_section(yaml_path)
+        for key, val in yaml_data.items():
+            if key not in TOP_LEVEL_SPEC:
+                raise ConfigError(
+                    f"Unrecognized key '{key}' in .galaxyscope.yaml's "
+                    f"'galaxyscope:' section. Known keys: "
+                    f"{sorted(TOP_LEVEL_SPEC)}"
+                )
+            resolved[key] = _merge_value(
+                resolved[key], val, TOP_LEVEL_SPEC[key], path=key
+            )
+
+    if cli_overrides:
+        for key, val in cli_overrides.items():
+            if key not in CLI_OVERRIDABLE_KEYS:
+                raise ConfigError(
+                    f"'{key}' is not a CLI-overridable config key. Known "
+                    f"CLI keys: {sorted(CLI_OVERRIDABLE_KEYS)}"
+                )
+            resolved[key] = val
+
+    return ResolvedConfig(_values=resolved)

--- a/tests/core_engine/test_config_resolver.py
+++ b/tests/core_engine/test_config_resolver.py
@@ -1,0 +1,276 @@
+import pytest
+
+from gitgalaxy.standards import gitgalaxy_config as defaults
+from gitgalaxy.standards.config_resolver import (
+    ConfigError,
+    ResolvedConfig,
+    resolve_config,
+)
+
+
+# ==============================================================================
+# DEFAULTS ONLY (no yaml, no CLI)
+# ==============================================================================
+
+
+def test_defaults_only_mirrors_gitgalaxy_config():
+    resolved = resolve_config()
+
+    assert resolved.STRICT_IMPORT_MODE == defaults.STRICT_IMPORT_MODE
+    assert resolved.APERTURE_CONFIG["IGNORED_DIRECTORIES"] == defaults.APERTURE_CONFIG["IGNORED_DIRECTORIES"]
+    assert resolved.PRIORITY_WHITELIST == defaults.PRIORITY_WHITELIST
+
+
+def test_defaults_only_does_not_mutate_source_module(tmp_path):
+    # Regression guard: the resolver must deep-copy, not alias, the
+    # gitgalaxy_config.py collections -- otherwise one run's YAML merge
+    # would permanently pollute the process-wide default for every run
+    # after it (import-time singletons are shared across the whole process).
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  APERTURE_CONFIG:\n"
+        "    IGNORED_DIRECTORIES:\n"
+        "      - some_totally_new_dir\n"
+    )
+    before = set(defaults.APERTURE_CONFIG["IGNORED_DIRECTORIES"])
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    assert "some_totally_new_dir" in resolved.APERTURE_CONFIG["IGNORED_DIRECTORIES"]
+    assert defaults.APERTURE_CONFIG["IGNORED_DIRECTORIES"] == before
+
+
+# ==============================================================================
+# PRECEDENCE: CLI > YAML > default
+# ==============================================================================
+
+
+def test_yaml_overrides_default(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text("galaxyscope:\n  STRICT_IMPORT_MODE: true\n")
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    assert resolved.STRICT_IMPORT_MODE is True
+
+
+def test_cli_overrides_yaml(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text("galaxyscope:\n  STRICT_IMPORT_MODE: true\n")
+
+    resolved = resolve_config(
+        yaml_path=str(yaml_path),
+        cli_overrides={"STRICT_IMPORT_MODE": False},
+    )
+
+    # This is the store_true-can't-force-False footgun #332 was raised to
+    # fix: an explicit CLI False must be able to beat a YAML True.
+    assert resolved.STRICT_IMPORT_MODE is False
+
+
+def test_cli_overrides_default_with_no_yaml():
+    resolved = resolve_config(cli_overrides={"FIREWALL_NETWORK_WEIGHTING": True})
+
+    assert resolved.FIREWALL_NETWORK_WEIGHTING is True
+
+
+# ==============================================================================
+# MERGE SEMANTICS: extend vs. replace
+# ==============================================================================
+
+
+def test_yaml_extends_set_valued_key_instead_of_replacing(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  APERTURE_CONFIG:\n"
+        "    IGNORED_DIRECTORIES:\n"
+        "      - my_custom_build_dir\n"
+    )
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+    merged = resolved.APERTURE_CONFIG["IGNORED_DIRECTORIES"]
+
+    assert "my_custom_build_dir" in merged
+    # The large built-in default set must still be present -- extend, not
+    # replace. node_modules is one of the original entries.
+    assert "node_modules" in merged
+
+
+def test_yaml_extends_list_valued_key(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  BLACKLISTED_IMPORTS:\n"
+        "    - evil-pkg\n"
+    )
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    assert "evil-pkg" in resolved.BLACKLISTED_IMPORTS
+
+
+def test_yaml_replaces_scalar_valued_key(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  APERTURE_CONFIG:\n"
+        "    MAX_LINE_LENGTH: 123\n"
+    )
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    # Replace, not extend -- there's no sensible way to "merge" a threshold.
+    assert resolved.APERTURE_CONFIG["MAX_LINE_LENGTH"] == 123
+
+
+def test_yaml_extends_dict_valued_key(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  GUIDESTAR_CONFIG:\n"
+        "    MANIFEST_MAP:\n"
+        "      mix.exs: elixir\n"
+    )
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+    manifest_map = resolved.GUIDESTAR_CONFIG["MANIFEST_MAP"]
+
+    assert manifest_map["mix.exs"] == "elixir"
+    # Built-in entries survive -- dict.update semantics, not replacement.
+    assert manifest_map["package.json"] == "javascript"
+
+
+# ==============================================================================
+# UNKNOWN-KEY HANDLING: hard error (#332)
+# ==============================================================================
+
+
+def test_unknown_top_level_yaml_key_raises(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text("galaxyscope:\n  STRICT_IMPORT_MDOE: true\n")  # typo
+
+    with pytest.raises(ConfigError, match="STRICT_IMPORT_MDOE"):
+        resolve_config(yaml_path=str(yaml_path))
+
+
+def test_unknown_nested_yaml_key_raises(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  APERTURE_CONFIG:\n"
+        "    IGNORED_DIRECTORES:\n"  # typo: missing an I
+        "      - build\n"
+    )
+
+    with pytest.raises(ConfigError, match="IGNORED_DIRECTORES"):
+        resolve_config(yaml_path=str(yaml_path))
+
+
+def test_internal_only_key_rejected_from_yaml(tmp_path):
+    # BANDS is an internal label taxonomy, deliberately not overridable.
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  APERTURE_CONFIG:\n"
+        "    BANDS:\n"
+        "      IGNORED: nope\n"
+    )
+
+    with pytest.raises(ConfigError, match="BANDS"):
+        resolve_config(yaml_path=str(yaml_path))
+
+
+def test_unknown_cli_key_raises():
+    with pytest.raises(ConfigError, match="NOT_A_REAL_KEY"):
+        resolve_config(cli_overrides={"NOT_A_REAL_KEY": True})
+
+
+# ==============================================================================
+# MALFORMED / MISSING YAML FILE: degrade to defaults, don't raise
+# ==============================================================================
+# This is a distinct failure mode from an unrecognized *key* above -- a
+# corrupted file degrades (matches pre-existing CLI behavior tested by
+# test_yaml_config_load_failure in test_galaxyscope.py), it does not raise.
+
+
+def test_malformed_yaml_file_degrades_to_defaults(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text("[invalid yaml struct {")
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    assert resolved.STRICT_IMPORT_MODE == defaults.STRICT_IMPORT_MODE
+
+
+def test_missing_yaml_file_degrades_to_defaults(tmp_path):
+    missing_path = tmp_path / "does_not_exist.yaml"
+
+    resolved = resolve_config(yaml_path=str(missing_path))
+
+    assert resolved.STRICT_IMPORT_MODE == defaults.STRICT_IMPORT_MODE
+
+
+def test_yaml_file_with_no_galaxyscope_section_degrades_to_defaults(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text("unrelated_tool:\n  some_key: 1\n")
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    assert resolved.STRICT_IMPORT_MODE == defaults.STRICT_IMPORT_MODE
+
+
+# ==============================================================================
+# NO-DEFAULT KEYS (SARIF_IGNORED_RULES / SARIF_IGNORED_PATHS)
+# ==============================================================================
+
+
+def test_no_default_key_defaults_to_empty_list():
+    resolved = resolve_config()
+
+    assert resolved.SARIF_IGNORED_RULES == []
+    assert resolved.SARIF_IGNORED_PATHS == []
+
+
+def test_no_default_key_extends_from_yaml(tmp_path):
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(
+        "galaxyscope:\n"
+        "  SARIF_IGNORED_RULES:\n"
+        "    - GH-1022\n"
+    )
+
+    resolved = resolve_config(yaml_path=str(yaml_path))
+
+    assert resolved.SARIF_IGNORED_RULES == ["GH-1022"]
+
+
+# ==============================================================================
+# ResolvedConfig ACCESS PATTERNS
+# ==============================================================================
+# Must support both calling conventions already in use across the codebase:
+# getattr(config, "X", default) (chronometer.py, gpu_recorder.py today) and
+# dict-style config["X"] / config.get("X") (galaxyscope.py's full_config).
+
+
+def test_resolved_config_supports_getattr_with_default():
+    resolved = resolve_config()
+
+    assert getattr(resolved, "PROJECT_STORIES", "fallback") == defaults.PROJECT_STORIES
+    assert getattr(resolved, "NOT_A_KEY", "fallback") == "fallback"
+
+
+def test_resolved_config_supports_dict_style_access():
+    resolved = resolve_config()
+
+    assert resolved["STRICT_IMPORT_MODE"] == defaults.STRICT_IMPORT_MODE
+    assert resolved.get("NOT_A_KEY", "fallback") == "fallback"
+    assert "APERTURE_CONFIG" in resolved
+
+
+def test_resolved_config_attribute_access_raises_attribute_error_for_unknown_key():
+    resolved = resolve_config()
+
+    with pytest.raises(AttributeError):
+        resolved.NOT_A_KEY

--- a/tests/core_engine/test_config_resolver.py
+++ b/tests/core_engine/test_config_resolver.py
@@ -3,7 +3,6 @@ import pytest
 from gitgalaxy.standards import gitgalaxy_config as defaults
 from gitgalaxy.standards.config_resolver import (
     ConfigError,
-    ResolvedConfig,
     resolve_config,
 )
 


### PR DESCRIPTION
## Summary
- Adds `gitgalaxy/standards/config_resolver.py` with a single `resolve_config()` entry point, replacing the 3 independent, inconsistent inline config-merge mechanisms in `galaxyscope.py`'s `main()` identified in #332.
- Implements the precedence decided in #332: `CLI overrides > .galaxyscope.yaml > gitgalaxy_config.py default`.
- Per-key merge semantics (extend for policy lists/sets/dicts, replace for scalars/thresholds), driven by an explicit registry (`TOP_LEVEL_SPEC`) covering every gitgalaxy_config.py key identified as overridable in #332's inventory.
- Unrecognized keys in either the YAML `galaxyscope:` section or `cli_overrides` raise `ConfigError` — a typo'd security-policy key (e.g. `STRICT_IMPORT_MDOE`) now fails loudly instead of silently no-opping.
- A malformed/unreadable YAML *file* still degrades to defaults with a logged error (unchanged pre-existing behavior, covered by `test_yaml_config_load_failure`) — that's a distinct failure mode from an unrecognized key inside an otherwise-valid file.
- `ResolvedConfig` supports both calling conventions already in use across the codebase: `getattr(config, "X", default)` (needed by `chronometer.py`, `gpu_recorder.py` once migrated in Phase 3) and dict-style `config["X"]` / `config.get("X")` (the `full_config` pattern `galaxyscope.py` uses today).
- `PROJECT_OVERRIDES` is intentionally **not** handled here — per #332's decision it stays a separate, Python-only, project-name-keyed mechanism (it also patches `LANGUAGE_DEFINITIONS`, outside this resolver's domain) applied as its own step after this resolver runs, not a 4th precedence tier.

Closes #333.

## Test plan
- [x] `pytest tests/core_engine/test_config_resolver.py` — 21 new tests covering precedence (CLI > YAML > default), extend-vs-replace merge semantics per key shape, unknown top-level/nested/CLI key rejection, malformed/missing YAML file degradation, and both `ResolvedConfig` access patterns.
- [x] `pytest tests/core_engine/test_galaxyscope.py tests/core_engine/test_aperture.py` — no regressions.
- [ ] Phase 2 (#334) wires `galaxyscope.py`'s `main()` to actually call `resolve_config()` — this PR only adds the resolver in isolation, nothing calls it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)