### PR TITLE
[Config Phase 2] Migrate galaxyscope.py main() to use the ResolvedConfig resolver

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -54,12 +54,9 @@ from gitgalaxy.security.security_auditor import SecurityAuditor, ML_AVAILABLE
 from gitgalaxy.tools.ai_guardrails.dev_agent_firewall import DevAgentFirewall
 from gitgalaxy.tools.ai_guardrails.ai_appsec_sensor import AIAppSecSensor
 from gitgalaxy.standards.gitgalaxy_config import (
-    APERTURE_CONFIG,
-    PRIORITY_WHITELIST,
     LEXICAL_FAMILY_HEURISTICS,
-    GUIDESTAR_CONFIG,
-    TEST_NAMING_CONVENTIONS,
 )
+from gitgalaxy.standards.config_resolver import resolve_config
 from gitgalaxy.standards.language_standards import (
     LANGUAGE_DEFINITIONS,
     PROJECT_OVERRIDES,
@@ -856,7 +853,8 @@ class Orchestrator:
             # manifest is also present in the repo.
             from gitgalaxy.security.manifest_parser import ManifestParser, SUPPORTED_MANIFEST_FILENAMES
 
-            target_manifests = set(GUIDESTAR_CONFIG.get("MANIFEST_MAP", {}).keys()) | set(SUPPORTED_MANIFEST_FILENAMES)
+            guidestar_config = self.config.get("GUIDESTAR_CONFIG", {})
+            target_manifests = set(guidestar_config.get("MANIFEST_MAP", {}).keys()) | set(SUPPORTED_MANIFEST_FILENAMES)
             manifest_paths = [
                 str(self.root / rel_path)
                 for rel_path in self.stem_map.values()
@@ -2579,37 +2577,32 @@ def main():
                 final_output = f"{project_name}_galaxy.json"
 
         # ---------------------------------------------------------
-        # 2. The Domain Dialect Pre-Flight Patch
+        # 2. Config Resolution (#332/#333: gitgalaxy_config.py defaults ->
+        #    .galaxyscope.yaml -> CLI, replacing the old 4-key-only
+        #    APERTURE_CONFIG hand-merge) + the Domain Dialect Pre-Flight
+        #    Patch (PROJECT_OVERRIDES, deliberately kept separate from the
+        #    resolver per #332 -- it also patches LANGUAGE_DEFINITIONS,
+        #    which is outside gitgalaxy_config.py's domain).
         # ---------------------------------------------------------
         base_langs = LANGUAGE_DEFINITIONS
         project_overrides = PROJECT_OVERRIDES
-        base_aperture = APERTURE_CONFIG
+
+        # The pipeline-flag interceptor above already claims any YAML key
+        # that matches an argparse dest (paranoid, fail-on-secrets, ...).
+        # Strip those out before handing the rest to resolve_config(), so a
+        # genuine gitgalaxy_config.py key typo still hard-errors (#332)
+        # instead of colliding with pipeline flags living in the same
+        # `galaxyscope:` YAML section.
+        yaml_section = config_file_data.get('galaxyscope', {}) if isinstance(config_file_data, dict) else {}
+        resolver_yaml_data = {
+            key: val for key, val in yaml_section.items()
+            if not hasattr(args, key.replace('-', '_'))
+        }
+
+        resolved = resolve_config(yaml_data=resolver_yaml_data)
 
         merged_langs = copy.deepcopy(base_langs)
-        merged_aperture = copy.deepcopy(base_aperture)
-
-        if 'galaxyscope' in config_file_data and 'APERTURE_CONFIG' in config_file_data['galaxyscope']:
-            yaml_aperture = config_file_data['galaxyscope']['APERTURE_CONFIG']
-            
-            if 'IGNORED_DIRECTORIES' in yaml_aperture:
-                if "IGNORED_DIRECTORIES" not in merged_aperture:
-                    merged_aperture["IGNORED_DIRECTORIES"] = set()
-                merged_aperture["IGNORED_DIRECTORIES"].update(yaml_aperture['IGNORED_DIRECTORIES'])
-            
-            if 'CONTRABAND_PATTERNS' in yaml_aperture:
-                if "CONTRABAND_PATTERNS" not in merged_aperture:
-                    merged_aperture["CONTRABAND_PATTERNS"] = []
-                merged_aperture["CONTRABAND_PATTERNS"].extend(yaml_aperture['CONTRABAND_PATTERNS'])
-
-            if 'VENDOR_MINIFICATION_PATHS' in yaml_aperture:
-                if "VENDOR_MINIFICATION_PATHS" not in merged_aperture:
-                    merged_aperture["VENDOR_MINIFICATION_PATHS"] = []
-                merged_aperture["VENDOR_MINIFICATION_PATHS"].extend(yaml_aperture['VENDOR_MINIFICATION_PATHS'])
-                
-            if 'SECRETS_EXACT' in yaml_aperture:
-                if "SECRETS_EXACT" not in merged_aperture:
-                    merged_aperture["SECRETS_EXACT"] = set()
-                merged_aperture["SECRETS_EXACT"].update(yaml_aperture['SECRETS_EXACT'])
+        merged_aperture = resolved.APERTURE_CONFIG
 
         if project_name in project_overrides:
             logging.info(f"🌌 DIALECT DETECTED: Injecting Project Overrides for '{project_name}'")
@@ -2655,12 +2648,20 @@ def main():
         # 3. Assemble the Final Configuration
         # ---------------------------------------------------------
         full_config = {
+            # Every gitgalaxy_config.py-backed key resolve_config() knows
+            # about (APERTURE_CONFIG, GUIDESTAR_CONFIG, PRIORITY_WHITELIST,
+            # STRICT_IMPORT_MODE, SARIF_IGNORED_RULES/PATHS, ...) -- see
+            # config_resolver.TOP_LEVEL_SPEC for the full list. This is
+            # what makes those keys reachable by Orchestrator/its workers
+            # at all; the per-file migration to actually *read* them from
+            # here instead of a direct gitgalaxy_config.py import is #335.
+            **resolved.to_dict(),
             "LANGUAGE_DEFINITIONS": merged_langs,
             "LEXICAL_FAMILY_HEURISTICS": LEXICAL_FAMILY_HEURISTICS,
+            # Overrides the resolved.to_dict() copy above with the version
+            # that also has the PROJECT_OVERRIDES dialect shield applied.
             "APERTURE_CONFIG": merged_aperture,
             "PATH_MODIFIERS": PATH_MODIFIERS,
-            "PRIORITY_WHITELIST": PRIORITY_WHITELIST,
-            "TEST_NAMING_CONVENTIONS": TEST_NAMING_CONVENTIONS,
             "DOCUMENTATION_LANGUAGES": ASSET_MASKS.get("DOCUMENTATION_LANGUAGES", set()),
             "PARANOID_MODE": args.paranoid,
             "SHADOW_PATCH_DETECTED": args.shadow_patch_detected,
@@ -2676,8 +2677,6 @@ def main():
             "MAX_SYSTEMIC_THREAT": args.max_systemic_threat,
             "SPLICING_SPEED": args.splicing_speed,
             "FILE_SPEED": args.file_speed,
-            "SARIF_IGNORED_RULES": config_file_data.get("galaxyscope", {}).get("SARIF_IGNORED_RULES", []),
-            "SARIF_IGNORED_PATHS": config_file_data.get("galaxyscope", {}).get("SARIF_IGNORED_PATHS", []),
             "DEPENDENCY_CACHE_PATH": args.dependency_cache,
             "NO_DEPENDENCY_CACHE": args.no_dependency_cache,
             "FULL_DEPENDENCY_SCAN": args.full_dependency_scan,

--- a/gitgalaxy/standards/config_resolver.py
+++ b/gitgalaxy/standards/config_resolver.py
@@ -255,25 +255,42 @@ def _load_yaml_section(yaml_path: str) -> Dict[str, Any]:
 
 def resolve_config(
     yaml_path: Optional[str] = None,
+    yaml_data: Optional[Dict[str, Any]] = None,
     cli_overrides: Optional[Dict[str, Any]] = None,
 ) -> ResolvedConfig:
     """
     Merge, in the precedence decided in #332:
         gitgalaxy_config.py defaults -> .galaxyscope.yaml -> cli_overrides
 
+    `yaml_data`, if given, is used directly as the already-parsed contents
+    of the `galaxyscope:` section -- `yaml_path` is not re-read in that
+    case. This lets a caller that has already parsed the file for its own
+    purposes (galaxyscope.py's main() does, for the separate pipeline-flag
+    interceptor) hand over a pre-filtered dict instead of paying for a
+    second parse. Pass `yaml_path` alone when there's no reason to
+    pre-parse -- e.g. direct/programmatic callers and this module's own
+    tests.
+
     `cli_overrides` should contain only keys the user actually specified on
     the command line (the tri-state fix from #332/#334 -- omit a key
     entirely rather than passing its argparse default, so this function can
     tell "not specified" from "explicitly set").
 
-    Raises ConfigError for any key in `yaml_path`'s `galaxyscope:` section
-    or in `cli_overrides` that isn't in TOP_LEVEL_SPEC (or, for nested
-    dict-valued keys, isn't in that key's own sub-key spec).
+    Raises ConfigError for any key in the YAML `galaxyscope:` section or in
+    `cli_overrides` that isn't in TOP_LEVEL_SPEC (or, for nested
+    dict-valued keys, isn't in that key's own sub-key spec). Callers whose
+    YAML section may also contain keys with no relation to
+    gitgalaxy_config.py (e.g. galaxyscope.py's pipeline flags like
+    `paranoid`) must filter those out before passing `yaml_data` -- this
+    function has no way to know about them and will treat any key it
+    doesn't recognize as a typo, by design (#332).
     """
     resolved: Dict[str, Any] = {key: _get_default(key) for key in TOP_LEVEL_SPEC}
 
-    if yaml_path:
+    if yaml_data is None and yaml_path:
         yaml_data = _load_yaml_section(yaml_path)
+
+    if yaml_data:
         for key, val in yaml_data.items():
             if key not in TOP_LEVEL_SPEC:
                 raise ConfigError(

--- a/tests/core_engine/test_config_resolver.py
+++ b/tests/core_engine/test_config_resolver.py
@@ -221,6 +221,25 @@ def test_yaml_file_with_no_galaxyscope_section_degrades_to_defaults(tmp_path):
 
 
 # ==============================================================================
+# PRE-PARSED yaml_data (bypasses yaml_path file read entirely)
+# ==============================================================================
+
+
+def test_yaml_data_is_used_directly_without_reading_yaml_path():
+    resolved = resolve_config(
+        yaml_path="/nonexistent/path/should/not/be/opened.yaml",
+        yaml_data={"STRICT_IMPORT_MODE": True},
+    )
+
+    assert resolved.STRICT_IMPORT_MODE is True
+
+
+def test_yaml_data_unknown_key_still_raises():
+    with pytest.raises(ConfigError, match="NOT_A_REAL_KEY"):
+        resolve_config(yaml_data={"NOT_A_REAL_KEY": True})
+
+
+# ==============================================================================
 # NO-DEFAULT KEYS (SARIF_IGNORED_RULES / SARIF_IGNORED_PATHS)
 # ==============================================================================
 

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -1395,3 +1395,84 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
             any(p.endswith("package.json") for p in manifest_paths),
             f"package.json missing from manifest_paths! Got: {manifest_paths}",
         )
+
+    # ==============================================================================
+    # TEST 34: CONFIG RESOLVER WIRING (#333/#334)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.Orchestrator")
+    @patch("gitgalaxy.licensing.enforce_licensing_guard")
+    def test_yaml_gitgalaxy_config_key_reaches_full_config(self, mock_license, mock_orchestrator):
+        """
+        Before #333/#334, a gitgalaxy_config.py key other than the 4
+        APERTURE_CONFIG sub-keys the old hand-merge covered (e.g.
+        STRICT_IMPORT_MODE, BLACKLISTED_IMPORTS) had no path from
+        .galaxyscope.yaml into the config ignited into the Orchestrator at
+        all -- main() never looked at it. Now that main() calls
+        resolve_config(), those keys must actually show up in full_config.
+        """
+        import sys
+        from gitgalaxy.galaxyscope import main
+
+        yaml_payload = """
+        galaxyscope:
+          STRICT_IMPORT_MODE: true
+          BLACKLISTED_IMPORTS:
+            - evil-pkg
+        """
+        fd, temp_yaml_path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, 'w') as f:
+            f.write(yaml_payload)
+
+        test_args = ["galaxyscope", ".", "--config", temp_yaml_path]
+
+        try:
+            with patch.object(sys, 'argv', test_args):
+                mock_orchestrator.return_value.policy_failed = False
+                main()
+
+            args, _ = mock_orchestrator.call_args
+            ignited_config = args[1]
+
+            self.assertTrue(
+                ignited_config.get("STRICT_IMPORT_MODE"),
+                "YAML STRICT_IMPORT_MODE never reached the ignited config!",
+            )
+            self.assertIn(
+                "evil-pkg",
+                ignited_config.get("BLACKLISTED_IMPORTS", []),
+                "YAML BLACKLISTED_IMPORTS never reached the ignited config!",
+            )
+        finally:
+            os.remove(temp_yaml_path)
+
+    @patch("gitgalaxy.galaxyscope.Orchestrator")
+    @patch("gitgalaxy.licensing.enforce_licensing_guard")
+    def test_yaml_typo_in_gitgalaxy_config_key_aborts_run(self, mock_license, mock_orchestrator):
+        """
+        #332's hard-error decision: a typo'd gitgalaxy_config.py-style key
+        (e.g. STRICT_IMPORT_MDOE) must abort the run rather than silently
+        matching nothing -- that silent-drop-on-typo behavior is exactly
+        what this whole effort exists to close.
+        """
+        import sys
+        from gitgalaxy.galaxyscope import main
+
+        yaml_payload = """
+        galaxyscope:
+          STRICT_IMPORT_MDOE: true
+        """
+        fd, temp_yaml_path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, 'w') as f:
+            f.write(yaml_payload)
+
+        test_args = ["galaxyscope", ".", "--config", temp_yaml_path]
+
+        try:
+            with patch.object(sys, 'argv', test_args):
+                mock_orchestrator.return_value.policy_failed = False
+                with self.assertRaises(SystemExit):
+                    main()
+
+            mock_orchestrator.assert_not_called()
+        finally:
+            os.remove(temp_yaml_path)


### PR DESCRIPTION
## Summary
Builds on #336 (Phase 1, already merged).

- Replaces the old 4-key-only `APERTURE_CONFIG` hand-merge and the ad hoc `SARIF_IGNORED_RULES`/`SARIF_IGNORED_PATHS` reads in `galaxyscope.py`'s `main()` with a single `resolve_config()` call.
- The pipeline-flag YAML interceptor (`paranoid`, `fail-on-secrets`, `max-risk-exposure`, etc.) is left **untouched** — those are argparse-driven pipeline flags, not `gitgalaxy_config.py` constants, and are outside the resolver's declared scope. `test_yaml_configuration_and_cli_priority` (which locks in that exact behavior) still passes unchanged.
- Because the existing YAML schema puts both kinds of keys in the same `galaxyscope:` section, `main()` now filters out any YAML key that matches an existing argparse dest before handing the rest to `resolve_config()` — so a real `gitgalaxy_config.py` key typo (e.g. `STRICT_IMPORT_MDOE`) still hard-errors per #332, without colliding with legitimate pipeline-flag keys.
- `full_config` now spreads every resolver-owned key (`**resolved.to_dict()`), not just the handful `main()` happened to read before — this closes part of the reachability gap #332 found. `STRICT_IMPORT_MODE`, `BLACKLISTED_IMPORTS`, `GUIDESTAR_CONFIG`, etc. now actually reach the config object passed to `Orchestrator`, even though most of their downstream consumers don't read it from there yet (that's #335).
- Found and fixed one more direct-import bypass while wiring this up: `Orchestrator.execute_pipeline()` read `GUIDESTAR_CONFIG["MANIFEST_MAP"]` straight from the module import instead of `self.config`, silently ignoring any override. Fixed to read from `self.config.get("GUIDESTAR_CONFIG", {})`.
- Extended `config_resolver.resolve_config()` with an optional `yaml_data` parameter (pre-parsed dict, bypassing a second file read), needed so `main()` can pass its already-parsed, pipeline-flag-filtered dict directly.

Closes #334.

## Test plan
- [x] `pytest tests/core_engine/test_config_resolver.py` — 23 tests (2 new, covering the `yaml_data` parameter), all passing.
- [x] `pytest tests/core_engine/test_galaxyscope.py` — 35 tests (2 new: one proving a YAML `gitgalaxy_config.py` key now actually reaches the ignited config, one proving a typo'd key aborts the run via `SystemExit`), all passing. No regressions in the pre-existing YAML/CLI-precedence and malformed-YAML tests.
- [x] Full repo suite: `pytest tests/` — 804 passed, 1 xfailed (pre-existing, unrelated). No regressions anywhere.
- [ ] #335 will prove the *downstream* consumers (`chronometer.py`, `guidestar_lens.py`, `supply_chain_firewall.py`, etc.) actually read from this resolved config instead of their own direct imports — this PR only makes the config reachable at the `Orchestrator` boundary, it doesn't migrate the consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)