### PR TITLE
[Config Phase 3] Migrate guidestar_lens.py, language_lens.py, supply_chain_firewall.py, and 4 more off direct gitgalaxy_config.py imports

### DIFF
--- a/gitgalaxy/core/guidestar_lens.py
+++ b/gitgalaxy/core/guidestar_lens.py
@@ -44,13 +44,6 @@ class GuideStarLens:
     This guarantees accurate language detection and bypasses expensive inference checks.
     """
 
-    # Fetch intelligence dictionaries directly from the configuration
-    _gs_config = GUIDESTAR_CONFIG
-
-    MANIFEST_MAP = _gs_config.get("MANIFEST_MAP", {})
-    INTENT_BIASED_SECTORS = set(_gs_config.get("INTENT_BIASED_SECTORS", []))
-    EXEC_PREFIX_MAP = _gs_config.get("EXEC_PREFIX_MAP", {})
-
     # Compiled regex for extracting target headers from README files
     README_TARGET_HEADERS = re.compile(
         r"^#+\s+(Usage|Structure|File|Layout|Getting\s+Started|Installation|Architecture|Scripts|CLI)",
@@ -62,6 +55,7 @@ class GuideStarLens:
         root_path: Union[str, Path],
         priority_whitelist: Optional[List[str]] = None,
         parent_logger: Optional[logging.Logger] = None,
+        guidestar_config: Optional[Dict[str, Any]] = None,
     ):
         """Initializes the Intelligence Engine and calibrates the lock maps."""
         if parent_logger:
@@ -73,6 +67,15 @@ class GuideStarLens:
 
         self.root = Path(root_path).resolve()
         self.whitelist = set(priority_whitelist or [])
+
+        # #335: was a class-level `GUIDESTAR_CONFIG` module import, which
+        # meant no YAML/CLI override (#332) could ever reach this lens.
+        # Falls back to the raw default only when the caller doesn't
+        # already have a resolved config to hand over (e.g. direct/test use).
+        self._gs_config = guidestar_config if guidestar_config is not None else GUIDESTAR_CONFIG
+        self.MANIFEST_MAP = self._gs_config.get("MANIFEST_MAP", {})
+        self.INTENT_BIASED_SECTORS = set(self._gs_config.get("INTENT_BIASED_SECTORS", []))
+        self.EXEC_PREFIX_MAP = self._gs_config.get("EXEC_PREFIX_MAP", {})
 
         # Internal Lock Map: Dict[filename, {lang, confidence, proof}]
         self.intent_locks: Dict[str, Dict[str, Any]] = {}

--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -147,13 +147,15 @@ def _init_worker(
             "git_tracked": git_tracked,
             "census": census,
             "filter": ApertureFilter(root, lang_defs, aperture_cfg, parent_logger=worker_logger),
-            "guidestar": GuideStarLens(root, priority_whitelist, parent_logger=worker_logger),
-            "detector": LanguageDetector(lang_defs, lexical_heuristics),
+            "guidestar": GuideStarLens(
+                root, priority_whitelist, parent_logger=worker_logger, guidestar_config=config.get("GUIDESTAR_CONFIG")
+            ),
+            "detector": LanguageDetector(lang_defs, lexical_heuristics, exact_file_match=config.get("EXACT_FILE_MATCH")),
             "prism": Prism(lexical_heuristics, lang_defs, parent_logger=worker_logger),
             "detector_cache": detector_cache,
             "word_tokenizer": re.compile(r"\b\w+\b"),
             # --- NEW: Boot the Analysis Engines into worker memory ---
-            "chronometer": Chronometer(root, parent_logger=worker_logger),
+            "chronometer": Chronometer(root, parent_logger=worker_logger, resolved_config=config),
             "signal": SignalProcessor(aperture_config=config, parent_logger=worker_logger),
             "security": SecurityLens(),
             # --------------------------------------------------------
@@ -596,10 +598,12 @@ class Orchestrator:
         self.filter = ApertureFilter(self.root, lang_defs, aperture_cfg, parent_logger=logger)
 
         # Bayesian prior injector (evaluates intent via Manifests, Readmes, .gitattributes)
-        self.guidestar = GuideStarLens(self.root, priority_whitelist, parent_logger=logger)
+        self.guidestar = GuideStarLens(
+            self.root, priority_whitelist, parent_logger=logger, guidestar_config=config.get("GUIDESTAR_CONFIG")
+        )
 
         # Temporal engine extracting Git volatility, churn velocity, and ownership entropy
-        self.chronometer = Chronometer(self.root, parent_logger=logger)
+        self.chronometer = Chronometer(self.root, parent_logger=logger, resolved_config=config)
         self.spatial_mapper = SpatialMapper(parent_logger=logger)
 
         # The primary heuristic math engine converting raw Structural Signatures to risk exposure vectors
@@ -866,9 +870,9 @@ class Orchestrator:
 
             ecosystem_audits = {
                 "api_mapper": run_api_audit(self.root),
-                "xray": run_xray_audit(self.root),
+                "xray": run_xray_audit(self.root, config=self.config),
                 # 3. Pass the RAM graph and the alias map to the Firewall
-                "firewall": run_firewall_audit(repository_graph, alias_map=alias_map),
+                "firewall": run_firewall_audit(repository_graph, alias_map=alias_map, config=self.config),
             }
 
             # Attach it to the summary payload
@@ -1194,6 +1198,7 @@ class Orchestrator:
                     forensic_report=report,
                     repo_name=self.root.name,
                     session_meta=session_meta,
+                    resolved_config=self.config,
                 )
 
                 payload["meta"]["session"] = session_meta

--- a/gitgalaxy/metrics/chronometer.py
+++ b/gitgalaxy/metrics/chronometer.py
@@ -20,7 +20,7 @@ import logging
 import time
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
-from gitgalaxy.standards import gitgalaxy_config as config
+from gitgalaxy.standards.config_resolver import resolve_config
 
 # ==============================================================================
 
@@ -51,7 +51,12 @@ class Chronometer:
        finalization to prevent zombie processes and FD leaks.
     """
 
-    def __init__(self, root_path: Path, parent_logger: Optional[logging.Logger] = None):
+    def __init__(
+        self,
+        root_path: Path,
+        parent_logger: Optional[logging.Logger] = None,
+        resolved_config=None,
+    ):
         """Initializes the Time-Series Analyzer and ignites the Bulk Survey Pass."""
         if parent_logger:
             self.logger = parent_logger.getChild("chronometer")
@@ -63,9 +68,20 @@ class Chronometer:
         self.root = Path(root_path).resolve()
         self.is_git_enabled = False
 
-        # Pull configurations safely
-        self.chrono_config = getattr(config, "CHRONOMETER_CONFIG", {})
-        self.aperture_config = getattr(config, "APERTURE_CONFIG", {})
+        # #335: was `from gitgalaxy.standards import gitgalaxy_config as
+        # config`, the raw unmerged module -- meant no YAML/CLI override
+        # (#332) could ever reach the Chronometer, even the APERTURE_CONFIG
+        # keys galaxyscope.py's main() already merges correctly. Falls back
+        # to an unconfigured resolve_config() only when the caller doesn't
+        # already have a resolved config to hand over (e.g. direct/test
+        # use). Uses .get() rather than getattr() because the caller may
+        # hand over either a ResolvedConfig or Orchestrator's plain
+        # full_config dict -- both support .get(), but getattr() on a
+        # plain dict silently always returns the default, which is exactly
+        # the reachability bug this migration exists to close.
+        config_source = resolved_config if resolved_config is not None else resolve_config()
+        self.chrono_config = config_source.get("CHRONOMETER_CONFIG", {})
+        self.aperture_config = config_source.get("APERTURE_CONFIG", {})
 
         # --- INTERNAL STATE (The Sensor Cache) ---
         self.churn_map: Dict[str, int] = {}

--- a/gitgalaxy/recorders/gpu_recorder.py
+++ b/gitgalaxy/recorders/gpu_recorder.py
@@ -20,7 +20,7 @@ import gc
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from gitgalaxy.standards import analysis_lens
-from gitgalaxy.standards import gitgalaxy_config
+from gitgalaxy.standards.config_resolver import resolve_config
 
 # ==============================================================================
 
@@ -85,6 +85,7 @@ class GPURecorder:
         session_meta: Optional[Dict] = None,
         commit_hash: str = "untracked_local",
         branch_name: str = "unknown_branch",
+        resolved_config=None,
     ) -> Dict:
         """
         Orchestrates the synthesis and implementation of Destructive RAM Eviction.
@@ -361,7 +362,18 @@ class GPURecorder:
         # ==============================================================================
 
 # galaxyscope:ignore sec_high_risk_execution
-        project_stories = getattr(gitgalaxy_config, "PROJECT_STORIES", {})
+        # #335: was `from gitgalaxy.standards import gitgalaxy_config`, the
+        # raw unmerged module -- meant no YAML/CLI override (#332) could
+        # ever reach this lookup. Falls back to an unconfigured
+        # resolve_config() only when the caller doesn't already have a
+        # resolved config to hand over (e.g. direct/test use). Uses .get()
+        # rather than getattr() because the caller may hand over either a
+        # ResolvedConfig or Orchestrator's plain full_config dict -- both
+        # support .get(), but getattr() on a plain dict silently always
+        # returns the default, which is exactly the reachability bug this
+        # migration exists to close.
+        config_source = resolved_config if resolved_config is not None else resolve_config()
+        project_stories = config_source.get("PROJECT_STORIES", {})
 
         story_payload = project_stories.get(
             repo_name,

--- a/gitgalaxy/standards/language_lens.py
+++ b/gitgalaxy/standards/language_lens.py
@@ -67,9 +67,15 @@ class LanguageDetector:
         language_definitions: Dict[str, Any],
         lexical_heuristics: Dict[str, Any],
         parent_logger: Optional[logging.Logger] = None,
+        exact_file_match: Optional[Dict[str, str]] = None,
     ):
         self.languages = language_definitions
         self.lexical_heuristics = lexical_heuristics
+        # #335: was a direct module-level EXACT_FILE_MATCH import, which
+        # meant no YAML/CLI override (#332) could ever reach it. Falls back
+        # to the raw default only when the caller doesn't already have a
+        # resolved config to hand over (e.g. direct/test use).
+        self.exact_file_match = exact_file_match if exact_file_match is not None else EXACT_FILE_MATCH
 
         if parent_logger:
             self.logger = parent_logger.getChild("lens")
@@ -214,9 +220,9 @@ class LanguageDetector:
         if not content_sample:
             content_sample = self._capture_raw_signal(file_path)
 
-        if name in EXACT_FILE_MATCH:
+        if name in self.exact_file_match:
             return self._forge_result(
-                lang_id=EXACT_FILE_MATCH[name],
+                lang_id=self.exact_file_match[name],
                 intensity=0.95,
                 tier=2,
                 proof="Single Indicator (Exact Match)",

--- a/gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py
+++ b/gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py
@@ -22,28 +22,13 @@ import os
 import time
 import fnmatch
 from pathlib import Path
+from typing import Optional
 
 # Import exclusively from the GitGalaxy Hub
 from gitgalaxy.core.aperture import ApertureFilter
 from gitgalaxy.security.security_lens import SecurityLens
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
-
-# Safely import the config, falling back if the user hasn't configured exceptions yet
-try:
-    from gitgalaxy.standards.gitgalaxy_config import (
-        APERTURE_CONFIG,
-        ALLOWLIST_PATHS,
-        DENYLIST_PATTERNS,
-        XRAY_BYPASS_EXTENSIONS,
-        XRAY_BYPASS_PATHS,
-    )
-except ImportError:
-    from gitgalaxy.standards.gitgalaxy_config import APERTURE_CONFIG
-
-    ALLOWLIST_PATHS = []
-    DENYLIST_PATTERNS = []
-    XRAY_BYPASS_EXTENSIONS = []
-    XRAY_BYPASS_PATHS = []
+from gitgalaxy.standards.config_resolver import ResolvedConfig, resolve_config
 
 
 def main():
@@ -53,7 +38,24 @@ def main():
 
     parser = argparse.ArgumentParser(description="Binary Anomaly Detector: Entropy & Magic Byte Scanner")
     parser.add_argument("target", help="Directory to scan")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to project-level configuration file (e.g., .galaxyscope.yaml) -- "
+        "same resolver galaxyscope.py uses, so standalone runs honor the same "
+        "ALLOWLIST_PATHS / DENYLIST_PATTERNS / XRAY_BYPASS_* overrides (#335).",
+    )
     args = parser.parse_args()
+
+    # #335: was a direct module-level gitgalaxy_config.py import, which meant
+    # no YAML/CLI override (#332) could ever reach this standalone detector.
+    resolved_config = resolve_config(yaml_path=args.config)
+    allowlist_paths = resolved_config.get("ALLOWLIST_PATHS", [])
+    denylist_patterns = resolved_config.get("DENYLIST_PATTERNS", [])
+    xray_bypass_extensions = resolved_config.get("XRAY_BYPASS_EXTENSIONS", [])
+    xray_bypass_paths = resolved_config.get("XRAY_BYPASS_PATHS", [])
+    aperture_config = resolved_config.get("APERTURE_CONFIG", {})
 
     target_path = Path(args.target).resolve()
     if not target_path.exists():
@@ -63,7 +65,7 @@ def main():
     print(f"🔍 Initializing Binary Anomaly Detector on {target_path.name}...")
 
     # Initialize lightweight filters
-    filter_engine = ApertureFilter(target_path, LANGUAGE_DEFINITIONS, APERTURE_CONFIG)
+    filter_engine = ApertureFilter(target_path, LANGUAGE_DEFINITIONS, aperture_config)
     security = SecurityLens()
 
     # ==============================================================================
@@ -109,8 +111,8 @@ def main():
             rel_path_str = str(file_path.relative_to(target_path)).replace("\\", "/")
 
             # Evaluate Global vs. Tool-Specific Bypasses
-            is_global_allow = any(approved in rel_path_str for approved in ALLOWLIST_PATHS)
-            is_xray_bypass = ext in XRAY_BYPASS_EXTENSIONS or any(b in rel_path_str for b in XRAY_BYPASS_PATHS)
+            is_global_allow = any(approved in rel_path_str for approved in allowlist_paths)
+            is_xray_bypass = ext in xray_bypass_extensions or any(b in rel_path_str for b in xray_bypass_paths)
 
             is_whitelisted = is_global_allow or is_xray_bypass
 
@@ -126,7 +128,7 @@ def main():
                 is_whitelisted = True
 
             # 1. DENYLIST ENFORCEMENT
-            is_forbidden = any(fnmatch.fnmatch(file, pattern) for pattern in DENYLIST_PATTERNS)
+            is_forbidden = any(fnmatch.fnmatch(file, pattern) for pattern in denylist_patterns)
             if is_forbidden and not is_whitelisted:
                 print(f"[DENYLIST MATCH] Unauthorized file pattern detected: {rel_path_str}")
                 forbidden_blocked += 1
@@ -234,14 +236,33 @@ def main():
     print("=" * 75 + "\n")
 
 
-def run_xray_audit(target_path: Path) -> dict:
-    """Programmatic entry point for GalaxyScope (orchestrator execution)."""
+def run_xray_audit(target_path: Path, config: Optional[ResolvedConfig] = None) -> dict:
+    """
+    Programmatic entry point for GalaxyScope (orchestrator execution).
+
+    `config` was previously a module-level `gitgalaxy_config.py` import
+    (#332/#335) -- that meant no YAML/CLI override could ever reach this
+    audit, regardless of what a user put in .galaxyscope.yaml. Defaults to
+    an unconfigured resolve_config() only when the caller doesn't already
+    have a resolved config to hand over (e.g. direct/test use).
+    """
     import logging
     # Mute the noisy Aperture Filter init during headless Phase 10 execution
     quiet_logger = logging.getLogger("GalaxyScope.xray")
     quiet_logger.setLevel(logging.WARNING)
-    
-    filter_engine = ApertureFilter(target_path, LANGUAGE_DEFINITIONS, APERTURE_CONFIG, parent_logger=quiet_logger)
+
+    # .get() rather than attribute access: the caller may hand over either
+    # a ResolvedConfig or Orchestrator's plain full_config dict, and only
+    # .get() works uniformly across both.
+    resolved_config = config if config is not None else resolve_config()
+    allowlist_paths = resolved_config.get("ALLOWLIST_PATHS", [])
+    denylist_patterns = resolved_config.get("DENYLIST_PATTERNS", [])
+    xray_bypass_extensions = resolved_config.get("XRAY_BYPASS_EXTENSIONS", [])
+    xray_bypass_paths = resolved_config.get("XRAY_BYPASS_PATHS", [])
+
+    filter_engine = ApertureFilter(
+        target_path, LANGUAGE_DEFINITIONS, resolved_config.get("APERTURE_CONFIG", {}), parent_logger=quiet_logger
+    )
     security = SecurityLens()
     security.THREAT_SIGNATURES = {
         "reflection_metaprogramming": security.THREAT_SIGNATURES["reflection_metaprogramming"],
@@ -264,15 +285,15 @@ def run_xray_audit(target_path: Path) -> dict:
             rel_path_str = str(file_path.relative_to(target_path)).replace("\\", "/")
             
             is_whitelisted = (
-                any(a in rel_path_str for a in ALLOWLIST_PATHS)
-                or file_path.suffix.lower() in XRAY_BYPASS_EXTENSIONS
-                or any(b in rel_path_str for b in XRAY_BYPASS_PATHS)
+                any(a in rel_path_str for a in allowlist_paths)
+                or file_path.suffix.lower() in xray_bypass_extensions
+                or any(b in rel_path_str for b in xray_bypass_paths)
             )
-            
+
             if "/test/" in rel_path_str.lower() or "/tests/" in rel_path_str.lower():
                 is_whitelisted = True
 
-            if any(fnmatch.fnmatch(file, p) for p in DENYLIST_PATTERNS) and not is_whitelisted:
+            if any(fnmatch.fnmatch(file, p) for p in denylist_patterns) and not is_whitelisted:
                 anomalies_found += 1
                 continue
 

--- a/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py
+++ b/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 # Import exclusively from the GitGalaxy Hub
 from gitgalaxy.metrics.signal_processor import SignalProcessor
+from gitgalaxy.standards.config_resolver import ResolvedConfig, resolve_config
 from typing import Optional
 
 # The five behavioral categories this firewall gates on, mapped to their names
@@ -47,30 +48,32 @@ _FIREWALL_RISK_INDEXES = {
 # to SignalProcessor's judgment instead of maintaining a second threshold.
 _FIREWALL_BLOCK_THRESHOLD = 50.0
 
-# Safely import the config, falling back if the user hasn't configured exceptions yet
-try:
-    from gitgalaxy.standards.gitgalaxy_config import (
-        ALLOWLIST_PATHS,
-        STRICT_IMPORT_MODE,
-        APPROVED_IMPORTS,
-        BLACKLISTED_IMPORTS,
-        FIREWALL_NETWORK_WEIGHTING,
-    )
-except ImportError:
-    ALLOWLIST_PATHS = []
-    STRICT_IMPORT_MODE = False
-    APPROVED_IMPORTS = []
-    BLACKLISTED_IMPORTS = []
-    FIREWALL_NETWORK_WEIGHTING = False
-
-
-def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> dict:
+def run_firewall_audit(
+    parsed_files: list,
+    alias_map: Optional[dict] = None,
+    config: Optional[ResolvedConfig] = None,
+) -> dict:
     """
     Programmatic entry point for GalaxyScope (Zero-Disk I/O).
     Operates exclusively on the pre-tokenized, anomaly-checked RAM graph from Phase 1.
+
+    `config` was previously a module-level `gitgalaxy_config.py` import
+    (#332/#335) -- that meant no YAML/CLI override could ever reach this
+    firewall, regardless of what a user put in .galaxyscope.yaml. Defaults
+    to an unconfigured resolve_config() only when the caller doesn't
+    already have a resolved config to hand over (e.g. direct/test use).
     """
     logger = logging.getLogger("GalaxyScope.firewall")
     safe_alias_map = alias_map or {}
+    # .get() rather than attribute access: the caller may hand over either
+    # a ResolvedConfig or Orchestrator's plain full_config dict, and only
+    # .get() works uniformly across both.
+    resolved_config = config if config is not None else resolve_config()
+    allowlist_paths = resolved_config.get("ALLOWLIST_PATHS", [])
+    strict_import_mode = resolved_config.get("STRICT_IMPORT_MODE", False)
+    approved_imports = resolved_config.get("APPROVED_IMPORTS", [])
+    blacklisted_imports = resolved_config.get("BLACKLISTED_IMPORTS", [])
+    firewall_network_weighting = resolved_config.get("FIREWALL_NETWORK_WEIGHTING", False)
 
     imports_whitelisted = 0
     imports_blacklisted = 0
@@ -89,7 +92,7 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
 
     for file_node in parsed_files:
         rel_path_str = file_node.get("path", "unknown")
-        is_whitelisted = any(approved in rel_path_str for approved in ALLOWLIST_PATHS)
+        is_whitelisted = any(approved in rel_path_str for approved in allowlist_paths)
 
         # =====================================================================
         # NEW: CONTEXTUAL ALIAS RESOLUTION
@@ -137,7 +140,7 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
             # where a malicious package masks itself behind a trusted internal alias.
             true_pkg = local_aliases.get(pkg, pkg)
 
-            if true_pkg in BLACKLISTED_IMPORTS:
+            if true_pkg in blacklisted_imports:
                 imports_blacklisted += 1
                 threats_found += 1
                 # The Allowlist Loophole Fix: A blacklisted import is ALWAYS a threat. Never suppress it.
@@ -145,11 +148,11 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
                     logger.critical(f"🚨 [BLACKLISTED IMPORT] Spoofed alias blocked: '{pkg}' -> '{true_pkg}' in: {rel_path_str}")
                 else:
                     logger.critical(f"🚨 [BLACKLISTED IMPORT] Unauthorized package '{pkg}' blocked in: {rel_path_str}")
-            elif true_pkg in APPROVED_IMPORTS:
+            elif true_pkg in approved_imports:
                 imports_whitelisted += 1
             else:
                 imports_unknown += 1
-                if STRICT_IMPORT_MODE and not is_whitelisted:
+                if strict_import_mode and not is_whitelisted:
                     threats_found += 1
                     if true_pkg != pkg:
                         logger.warning(
@@ -199,7 +202,7 @@ def run_firewall_audit(parsed_files: list, alias_map: Optional[dict] = None) -> 
         # signal than a peripheral file. Only ever amplifies -- a low-centrality file
         # is still judged on its own merits, never given a discount for being obscure.
         network_multiplier = 1.0
-        if FIREWALL_NETWORK_WEIGHTING:
+        if firewall_network_weighting:
             network_metrics = file_node.get("telemetry", {}).get("network_metrics", {})
             blast_radius = network_metrics.get("normalized_blast_radius", 0.0)
             betweenness = network_metrics.get("betweenness_score", 0.0)
@@ -252,7 +255,17 @@ def main():
 
     parser = argparse.ArgumentParser(description="Supply Chain Firewall (RAM-Exclusive Mode)")
     parser.add_argument("target", help="Path to the compiled GalaxyScope RAM graph (e.g., results.json)")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to project-level configuration file (e.g., .galaxyscope.yaml) -- "
+        "same resolver galaxyscope.py uses, so standalone runs honor the same "
+        "STRICT_IMPORT_MODE / BLACKLISTED_IMPORTS / etc. overrides (#335).",
+    )
     args = parser.parse_args()
+
+    resolved_config = resolve_config(yaml_path=args.config)
 
     target_path = Path(args.target).resolve()
     if not target_path.exists():
@@ -319,9 +332,9 @@ def main():
 
     # In standalone CLI mode, we bypass the dynamic manifest parsing for speed,
     # relying purely on strict exact-match dependencies and behavioral structural signatures.
-    results = run_firewall_audit(parsed_files, alias_map={})
+    results = run_firewall_audit(parsed_files, alias_map={}, config=resolved_config)
 
-    mode_str = "Strict (Exclude Blacklist and Unknown)" if STRICT_IMPORT_MODE else "Audit (Allow Whitelist + Unknown)"
+    mode_str = "Strict (Exclude Blacklist and Unknown)" if resolved_config.get("STRICT_IMPORT_MODE") else "Audit (Allow Whitelist + Unknown)"
 
     print("\n" + "=" * 75)
     print(" 🧱 SUPPLY CHAIN FIREWALL: SCAN SUMMARY")

--- a/gitgalaxy/tools/supply_chain_security/vault_sentinel.py
+++ b/gitgalaxy/tools/supply_chain_security/vault_sentinel.py
@@ -17,19 +17,7 @@ from pathlib import Path
 from gitgalaxy.core.aperture import ApertureFilter
 from gitgalaxy.security.security_lens import SecurityLens
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
-
-# Safely import the config, falling back if the user hasn't added exceptions yet
-try:
-    from gitgalaxy.standards.gitgalaxy_config import (
-        APERTURE_CONFIG,
-        ALLOWLIST_PATHS,
-        DENYLIST_PATTERNS,
-    )
-except ImportError:
-    from gitgalaxy.standards.gitgalaxy_config import APERTURE_CONFIG
-
-    ALLOWLIST_PATHS = []
-    DENYLIST_PATTERNS = []
+from gitgalaxy.standards.config_resolver import resolve_config
 
 
 def main():
@@ -39,7 +27,22 @@ def main():
 
     parser = argparse.ArgumentParser(description="Secrets Scanner: High-Speed Secrets Scanner")
     parser.add_argument("target", help="Directory or file to scan")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to project-level configuration file (e.g., .galaxyscope.yaml) -- "
+        "same resolver galaxyscope.py uses, so standalone runs honor the same "
+        "ALLOWLIST_PATHS / DENYLIST_PATTERNS / APERTURE_CONFIG overrides (#335).",
+    )
     args = parser.parse_args()
+
+    # #335: was a direct module-level gitgalaxy_config.py import, which meant
+    # no YAML/CLI override (#332) could ever reach this standalone scanner.
+    resolved_config = resolve_config(yaml_path=args.config)
+    allowlist_paths = resolved_config.ALLOWLIST_PATHS
+    denylist_patterns = resolved_config.DENYLIST_PATTERNS
+    aperture_config = resolved_config.APERTURE_CONFIG
 
     target_path = Path(args.target).resolve()
     if not target_path.exists():
@@ -49,7 +52,7 @@ def main():
     print(f"🛡️  Secrets Scanner engaging on {target_path.name}...")
 
     # Initialize lightweight filters
-    filter_engine = ApertureFilter(target_path, LANGUAGE_DEFINITIONS, APERTURE_CONFIG)
+    filter_engine = ApertureFilter(target_path, LANGUAGE_DEFINITIONS, aperture_config)
     security = SecurityLens()
 
     # SENSOR OPTIMIZATION: Only evaluate keys and dead-code logic for maximum performance
@@ -84,10 +87,10 @@ def main():
 
             # Create a normalized string for checking against lists
             rel_path_str = str(file_path.relative_to(target_path)).replace("\\", "/")
-            is_whitelisted = any(approved in rel_path_str for approved in ALLOWLIST_PATHS)
+            is_whitelisted = any(approved in rel_path_str for approved in allowlist_paths)
 
             # 1. DENYLIST ENFORCEMENT (Wildcard Pattern Matching)
-            is_forbidden = any(fnmatch.fnmatch(file, pattern) for pattern in DENYLIST_PATTERNS)
+            is_forbidden = any(fnmatch.fnmatch(file, pattern) for pattern in denylist_patterns)
             if is_forbidden and not is_whitelisted:
                 print(f"[DENYLIST MATCH] Unauthorized file pattern detected: {rel_path_str}")
                 forbidden_blocked += 1
@@ -163,7 +166,8 @@ def main():
     if leaks_found > 0:
         print(f" [BLOCKING ACTION] {leaks_found} unauthorized secrets exposed. Failing pipeline.")
         print(" TIP: If this is a false positive, add the file path to ALLOWLIST_PATHS")
-        print("         inside gitgalaxy/standards/gitgalaxy_config.py")
+        print("         in gitgalaxy/standards/gitgalaxy_config.py, or under 'galaxyscope:'")
+        print("         in a --config .galaxyscope.yaml")
         sys.exit(1)
     else:
         print(" [SUCCESS] No unauthorized secrets detected.")

--- a/tests/core_engine/test_guidestar_lens.py
+++ b/tests/core_engine/test_guidestar_lens.py
@@ -23,18 +23,7 @@ MOCK_GUIDESTAR_CONFIG = {
 @pytest.fixture
 def guidestar(tmp_path):
     """Initializes the GuideStar Lens with a mocked configuration."""
-    with patch(
-        "gitgalaxy.core.guidestar_lens.GuideStarLens._gs_config", MOCK_GUIDESTAR_CONFIG
-    ):
-        with patch(
-            "gitgalaxy.core.guidestar_lens.GuideStarLens.MANIFEST_MAP",
-            MOCK_GUIDESTAR_CONFIG["MANIFEST_MAP"],
-        ):
-            with patch(
-                "gitgalaxy.core.guidestar_lens.GuideStarLens.INTENT_BIASED_SECTORS",
-                set(MOCK_GUIDESTAR_CONFIG["INTENT_BIASED_SECTORS"]),
-            ):
-                return GuideStarLens(root_path=tmp_path)
+    return GuideStarLens(root_path=tmp_path, guidestar_config=MOCK_GUIDESTAR_CONFIG)
 
 
 # ==============================================================================
@@ -168,10 +157,10 @@ def test_guidestar_documentation_coverage_prunes_ignored_dirs(tmp_path):
     nested_dir.mkdir(parents=True)
     (nested_dir / "README.md").write_text("y" * 500, encoding="utf-8")
 
-    lens = GuideStarLens(root_path=tmp_path)
-    # Instance-attribute override (class-attribute patching doesn't survive past
-    # __init__ here, since nothing in __init__ captures _gs_config into self).
-    lens._gs_config = {**MOCK_GUIDESTAR_CONFIG, "IGNORED_DIRECTORIES": {"Node_Modules"}}
+    lens = GuideStarLens(
+        root_path=tmp_path,
+        guidestar_config={**MOCK_GUIDESTAR_CONFIG, "IGNORED_DIRECTORIES": {"Node_Modules"}},
+    )
 
     visited_roots = []
     real_walk = os.walk

--- a/tests/security_auditing/test_binary_anomaly_detector.py
+++ b/tests/security_auditing/test_binary_anomaly_detector.py
@@ -1,9 +1,34 @@
-import sys
 import pytest
-import importlib
+import yaml
 from unittest.mock import patch
 
 import gitgalaxy.tools.supply_chain_security.binary_anomaly_detector as xray_module
+from gitgalaxy.standards.config_resolver import ResolvedConfig, resolve_config
+
+
+def _make_config(**overrides):
+    """
+    Builds a ResolvedConfig for direct run_xray_audit() calls (#335): starts
+    from real gitgalaxy_config.py defaults and overlays just the keys a
+    given test cares about, replacing the old
+    monkeypatch.setattr(xray_module, "X", ...) pattern now that the
+    detector reads config off a passed-in object instead of module globals.
+    """
+    values = resolve_config().to_dict()
+    values.update(overrides)
+    return ResolvedConfig(_values=values)
+
+
+def _write_config_yaml(tmp_path, **overrides):
+    """
+    Writes a .galaxyscope.yaml for main()-based tests that need a
+    non-default gitgalaxy_config.py key. Exercises the real --config path
+    end-to-end instead of monkeypatching module-level constants that no
+    longer exist after the direct-import migration.
+    """
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(yaml.dump({"galaxyscope": overrides}))
+    return str(yaml_path)
 
 
 # ==============================================================================
@@ -12,11 +37,13 @@ import gitgalaxy.tools.supply_chain_security.binary_anomaly_detector as xray_mod
 @patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.ApertureFilter")
 def test_xray_routing_matrix(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch
+    mock_aperture_class, mock_security_class, tmp_path
 ):
-    monkeypatch.setattr(xray_module, "DENYLIST_PATTERNS", ["*.key", "*.pem", "id_rsa*"])
-    monkeypatch.setattr(xray_module, "XRAY_BYPASS_EXTENSIONS", [".gz", ".zip"])
-    monkeypatch.setattr(xray_module, "ALLOWLIST_PATHS", ["approved_keys/"])
+    config = _make_config(
+        DENYLIST_PATTERNS=["*.key", "*.pem", "id_rsa*"],
+        XRAY_BYPASS_EXTENSIONS=[".gz", ".zip"],
+        ALLOWLIST_PATHS=["approved_keys/"],
+    )
 
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
@@ -41,7 +68,7 @@ def test_xray_routing_matrix(
     # File C (Bypass Extension)
     (repo_dir / "compressed.zip").write_text("FAKE_ZIP_DATA", encoding="utf-8")
 
-    result = xray_module.run_xray_audit(repo_dir)
+    result = xray_module.run_xray_audit(repo_dir, config=config)
     assert result["anomalies_found"] == 1, (
         "Path filtering logic failed! Verify Denylist and Allowlist evaluation."
     )
@@ -156,10 +183,10 @@ def test_main_missing_target(capsys):
 @patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.ApertureFilter")
 def test_main_clean_run(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch, capsys
+    mock_aperture_class, mock_security_class, tmp_path, capsys
 ):
     """Proves a clean repository successfully logs completion without raising SystemExit."""
-    monkeypatch.setattr(xray_module, "ALLOWLIST_PATHS", ["approved/"])
+    config_path = _write_config_yaml(tmp_path, ALLOWLIST_PATHS=["approved/"])
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
 
@@ -183,7 +210,7 @@ def test_main_clean_run(
     approved_dir.mkdir()
     (approved_dir / "bypassed.key").write_text("bypassed", encoding="utf-8")
 
-    with patch("sys.argv", ["xray", str(repo_dir)]):
+    with patch("sys.argv", ["xray", str(repo_dir), "--config", config_path]):
         xray_module.main()
 
     captured = capsys.readouterr()
@@ -199,10 +226,10 @@ def test_main_clean_run(
 @patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.ApertureFilter")
 def test_main_anomaly_detected(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch, capsys
+    mock_aperture_class, mock_security_class, tmp_path, capsys
 ):
     """Proves the CLI detects active anomalies, blocks the commit, and logs the blocking action."""
-    monkeypatch.setattr(xray_module, "DENYLIST_PATTERNS", ["*.forbidden"])
+    config_path = _write_config_yaml(tmp_path, DENYLIST_PATTERNS=["*.forbidden"])
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
 
@@ -220,7 +247,7 @@ def test_main_anomaly_detected(
         else {"counts": {}}
     )
 
-    with patch("sys.argv", ["xray", str(repo_dir)]):
+    with patch("sys.argv", ["xray", str(repo_dir), "--config", config_path]):
         with pytest.raises(SystemExit) as exc_info:
             xray_module.main()
 
@@ -251,32 +278,13 @@ def test_main_file_read_exception(mock_aperture_class, mock_security_class, tmp_
 
 
 # ==============================================================================
-# TEST 9: Module Import Fallback Configuration
+# TEST 9 (removed, #335): the try/except ImportError module-level fallback
+# this test covered no longer exists -- binary_anomaly_detector.py now
+# reads config from resolve_config(), which always has real defaults
+# (gitgalaxy_config.py is a committed file, not an optional install-time
+# artifact). See test_yaml_config_flag_actually_changes_standalone_xray_behavior
+# below for the replacement "gap is closed" proof.
 # ==============================================================================
-def test_xray_import_fallback():
-    """Proves the module gracefully degrades if custom bypass arrays are missing from config."""
-    # Stash the original module
-    original_config = sys.modules.get("gitgalaxy.standards.gitgalaxy_config")
-
-    # Create a mock module that ONLY has APERTURE_CONFIG (simulating a fresh install)
-    mock_config = type(sys)("gitgalaxy.standards.gitgalaxy_config")
-    mock_config.APERTURE_CONFIG = {}
-    sys.modules["gitgalaxy.standards.gitgalaxy_config"] = mock_config
-
-    # Force a reload to trigger the ImportError bypass block
-    importlib.reload(xray_module)
-
-    assert xray_module.ALLOWLIST_PATHS == [], (
-        "Fallback failed to initialize empty Allowlist!"
-    )
-    assert xray_module.DENYLIST_PATTERNS == [], (
-        "Fallback failed to initialize empty Denylist!"
-    )
-
-    # Restore reality
-    if original_config:
-        sys.modules["gitgalaxy.standards.gitgalaxy_config"] = original_config
-    importlib.reload(xray_module)
 
 
 # ==============================================================================
@@ -312,3 +320,48 @@ def test_xray_test_folder_bypass(mock_aperture_class, mock_security_class, tmp_p
     captured = capsys.readouterr()
     assert "[SUCCESS] No obfuscated payloads or binary anomalies detected." in captured.out
     assert "known mock/safe files were bypassed via configuration." in captured.out
+
+
+# ==============================================================================
+# TEST 11: #335 -- .galaxyscope.yaml ACTUALLY REACHES STANDALONE MAIN()
+# ==============================================================================
+@patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.SecurityLens")
+@patch("gitgalaxy.tools.supply_chain_security.binary_anomaly_detector.ApertureFilter")
+def test_yaml_config_flag_actually_changes_standalone_xray_behavior(
+    mock_aperture_class, mock_security_class, tmp_path
+):
+    """
+    Before #335, binary_anomaly_detector.py imported DENYLIST_PATTERNS as a
+    module-level constant at load time -- no YAML file, no --config flag,
+    nothing could ever change what it blocked. This proves the gap is
+    closed: the IDENTICAL file, scanned via the IDENTICAL standalone
+    main() CLI entrypoint, passes clean with no --config and hard-blocks
+    once a .galaxyscope.yaml denylists its exact filename pattern.
+    """
+    mock_aperture = mock_aperture_class.return_value
+    mock_aperture._check_ignore_rules.return_value = True
+    mock_security_class.return_value.scan_binary.return_value = {}
+    mock_security_class.return_value.scan_content.return_value = {"counts": {"entropy": 0, "bitwise_ops": 0}}
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / "asset.blob").write_text("nothing anomalous here", encoding="utf-8")
+
+    # BEFORE: no --config -- DENYLIST_PATTERNS defaults to [], clean pass.
+    with patch("sys.argv", ["xray", str(repo_dir)]):
+        try:
+            xray_module.main()
+        except SystemExit:
+            pytest.fail("Detector blocked a file with no denylist config applied.")
+
+    # AFTER: identical file, identical CLI entrypoint, but a .galaxyscope.yaml
+    # now denylists this exact pattern -- must hard-block via SystemExit(1).
+    config_path = _write_config_yaml(tmp_path, DENYLIST_PATTERNS=["*.blob"])
+    with patch("sys.argv", ["xray", str(repo_dir), "--config", config_path]):
+        with pytest.raises(SystemExit) as exc:
+            xray_module.main()
+        assert exc.value.code == 1, (
+            "YAML DENYLIST_PATTERNS override never reached standalone "
+            "binary_anomaly_detector.py main() -- the #332/#335 "
+            "reachability gap is still open."
+        )

--- a/tests/security_auditing/test_supply_chain_firewall.py
+++ b/tests/security_auditing/test_supply_chain_firewall.py
@@ -1,11 +1,13 @@
 import pytest
 import sys
 import json
+import yaml
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import gitgalaxy.tools.supply_chain_security.supply_chain_firewall as firewall_module
 from gitgalaxy.metrics.signal_processor import SignalProcessor
+from gitgalaxy.standards.config_resolver import ResolvedConfig, resolve_config
 
 
 def _risk_vector(**scores):
@@ -15,17 +17,42 @@ def _risk_vector(**scores):
         vector[SignalProcessor.RISK_SCHEMA.index(key)] = value
     return vector
 
+
+def _make_config(**overrides):
+    """
+    Builds a ResolvedConfig for direct run_firewall_audit() calls (#335):
+    starts from real gitgalaxy_config.py defaults (via resolve_config()) and
+    overlays just the keys a given test cares about, replacing the old
+    monkeypatch.setattr(firewall_module, "X", ...) pattern now that the
+    firewall reads config off a passed-in object instead of module globals.
+    """
+    values = resolve_config().to_dict()
+    values.update(overrides)
+    return ResolvedConfig(_values=values)
+
+
+def _write_config_yaml(tmp_path, **overrides):
+    """
+    Writes a .galaxyscope.yaml for main()-based tests that need a
+    non-default gitgalaxy_config.py key. Exercises the real --config path
+    end-to-end (the same resolve_config() galaxyscope.py's main() uses)
+    instead of monkeypatching module internals that no longer exist.
+    """
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(yaml.dump({"galaxyscope": overrides}))
+    return str(yaml_path)
+
 # ==============================================================================
 # TEST 1: Dependency Graph Import Verification
 # ==============================================================================
-def test_zero_trust_import_verification(monkeypatch):
+def test_zero_trust_import_verification():
     """
     Validates that the firewall correctly segregates imports into approved,
     unknown, and blacklisted categories based on enterprise policy constraints.
     """
-    monkeypatch.setattr(firewall_module, "APPROVED_IMPORTS", ["react", "express"])
-    monkeypatch.setattr(
-        firewall_module, "BLACKLISTED_IMPORTS", ["event-stream-malware"]
+    config = _make_config(
+        APPROVED_IMPORTS=["react", "express"],
+        BLACKLISTED_IMPORTS=["event-stream-malware"],
     )
 
     mock_ram_graph = [
@@ -43,7 +70,7 @@ def test_zero_trust_import_verification(monkeypatch):
         },
     ]
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    result = firewall_module.run_firewall_audit(mock_ram_graph, config=config)
     assert result["imports_whitelisted"] == 1, "Failed to identify approved package."
     assert result["imports_blacklisted"] == 1, "Failed to identify blacklisted package."
     assert result["imports_unknown"] == 1, "Failed to identify unknown package."
@@ -52,13 +79,12 @@ def test_zero_trust_import_verification(monkeypatch):
 # ==============================================================================
 # TEST 2: Local Path and Sub-Module Truncation Shield
 # ==============================================================================
-def test_import_truncation_and_local_shield(monkeypatch):
+def test_import_truncation_and_local_shield():
     """
     Ensures that local relative imports are ignored, and deeply nested
     scoped packages (@org/pkg/module) are properly truncated for evaluation.
     """
-    monkeypatch.setattr(firewall_module, "APPROVED_IMPORTS", ["@angular/core", "lodash"])
-    monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", [])
+    config = _make_config(APPROVED_IMPORTS=["@angular/core", "lodash"])
 
     mock_ram_graph = [
         {
@@ -70,20 +96,19 @@ def test_import_truncation_and_local_shield(monkeypatch):
         }
     ]
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    result = firewall_module.run_firewall_audit(mock_ram_graph, config=config)
     assert result["imports_whitelisted"] == 2, "Failed to truncate and match scoped/nested dependencies."
     assert result["imports_unknown"] == 0, "Local relative import was erroneously evaluated."
 
 # ==============================================================================
 # TEST 3: Alias Spoofing Detection
 # ==============================================================================
-def test_alias_spoofing_detection(monkeypatch, caplog):
+def test_alias_spoofing_detection(caplog):
     """
     Validates that the firewall correctly detects when a safe alias is mapped
     to a blacklisted upstream package via the alias_map.
     """
-    monkeypatch.setattr(firewall_module, "APPROVED_IMPORTS", [])
-    monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", ["malicious-core"])
+    config = _make_config(BLACKLISTED_IMPORTS=["malicious-core"])
 
     mock_ram_graph = [
         {
@@ -93,13 +118,13 @@ def test_alias_spoofing_detection(monkeypatch, caplog):
             "coding_loc": 10,
         }
     ]
-    
+
     # Simulate an npm alias: "safe-utils": "npm:malicious-core@1.0"
     # Namespaced to the current directory (".")
     mock_alias_map = {".": {"safe-utils": "malicious-core"}}
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph, alias_map=mock_alias_map)
-    
+    result = firewall_module.run_firewall_audit(mock_ram_graph, alias_map=mock_alias_map, config=config)
+
     assert result["imports_blacklisted"] == 1, "Failed to dereference spoofed alias."
     assert result["threats_found"] == 1, "Spoofed alias did not increment threat counter."
     assert "Spoofed alias blocked" in caplog.text, "Missing spoofed alias log output."
@@ -107,14 +132,12 @@ def test_alias_spoofing_detection(monkeypatch, caplog):
 # ==============================================================================
 # TEST 4: Strict Policy Enforcement Mode (Updated Schema)
 # ==============================================================================
-def test_strict_mode_enforcement(tmp_path, monkeypatch):
+def test_strict_mode_enforcement(tmp_path):
     """
     Ensures that when STRICT_IMPORT_MODE is enabled, any unknown dependency
     causes the pipeline to fail with a SystemExit.
     """
-    monkeypatch.setattr(firewall_module, "APPROVED_IMPORTS", ["react"])
-    monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", [])
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", True)
+    config_path = _write_config_yaml(tmp_path, APPROVED_IMPORTS=["react"], STRICT_IMPORT_MODE=True)
 
     mock_ram_graph = {
         "6. Parsed Files (Scanned Artifacts)": {
@@ -133,7 +156,7 @@ def test_strict_mode_enforcement(tmp_path, monkeypatch):
     graph_file = tmp_path / "results.json"
     graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
 
-    test_args = ["supply_chain_firewall.py", str(graph_file)]
+    test_args = ["supply_chain_firewall.py", str(graph_file), "--config", config_path]
     with patch.object(sys, "argv", test_args):
         with pytest.raises(SystemExit) as exc:
             firewall_module.main()
@@ -142,15 +165,16 @@ def test_strict_mode_enforcement(tmp_path, monkeypatch):
 # ==============================================================================
 # TEST 5: Behavioral Threat Score Evaluation (risk_vector Schema)
 # ==============================================================================
-def test_behavioral_threat_evaluation(tmp_path, monkeypatch):
+def test_behavioral_threat_evaluation(tmp_path):
     """
     Validates that a file whose Phase 3 risk_vector score for a gated category
     is at/above the firewall's block threshold (50.0, SignalProcessor's own
     sigmoid midpoint) triggers a firewall block.
-    """
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-    monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", [])
 
+    STRICT_IMPORT_MODE=False and BLACKLISTED_IMPORTS=[] are gitgalaxy_config.py's
+    real defaults, so no --config override is needed here (#335) -- this test
+    only cares about the behavioral risk_vector path.
+    """
     mock_ram_graph_threat = {
         "6. Parsed Files (Scanned Artifacts)": {
             "root": {
@@ -178,7 +202,7 @@ def test_behavioral_threat_evaluation(tmp_path, monkeypatch):
 # ==============================================================================
 # TEST 6: Build-Time Execution Multiplier (Static Sandbox)
 # ==============================================================================
-def test_build_time_execution_multiplier(monkeypatch):
+def test_build_time_execution_multiplier():
     """
     Ensures that critical build files (like setup.py) have their already-computed
     risk_vector score scaled by the 10x build-time multiplier post-hoc, making
@@ -188,9 +212,10 @@ def test_build_time_execution_multiplier(monkeypatch):
     on its own (8.0 < 50.0), but 8.0 * 10.0 = 80.0 clears it. This is a real
     numeric re-verification of the post-hoc-scalar design (scaling the sigmoid
     OUTPUT), not a mechanical port of the old pre-sigmoid density multiplier.
-    """
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
 
+    STRICT_IMPORT_MODE=False is gitgalaxy_config.py's real default, so no
+    config override is needed here (#335).
+    """
     mock_ram_graph = [
         {
             "path": "setup.py",
@@ -241,19 +266,18 @@ def test_main_corrupted_json(tmp_path, capsys):
 # ==============================================================================
 # TEST 9: Monorepo Contextual Alias Resolution
 # ==============================================================================
-def test_monorepo_contextual_alias_resolution(monkeypatch, caplog):
+def test_monorepo_contextual_alias_resolution(caplog):
     """
-    Proves that the firewall resolves package aliases contextually based on the 
+    Proves that the firewall resolves package aliases contextually based on the
     physical directory of the audited file, traversing upwards to find the nearest
     authoritative manifest and preventing monorepo alias clobbering.
     """
-    monkeypatch.setattr(firewall_module, "APPROVED_IMPORTS", [])
-    monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", ["malicious-core", "rogue-ui"])
+    config = _make_config(BLACKLISTED_IMPORTS=["malicious-core", "rogue-ui"])
 
     mock_alias_map = {
         "frontend": {"lodash": "rogue-ui"},
         "backend/src": {"lodash": "malicious-core"},
-        "backend": {"express": "safe-express"} 
+        "backend": {"express": "safe-express"}
     }
 
     mock_ram_graph = [
@@ -264,7 +288,7 @@ def test_monorepo_contextual_alias_resolution(monkeypatch, caplog):
         {"path": "scripts/deploy.js", "raw_imports": ["lodash"], "equations": {}, "coding_loc": 10}
     ]
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph, alias_map=mock_alias_map)
+    result = firewall_module.run_firewall_audit(mock_ram_graph, alias_map=mock_alias_map, config=config)
 
     assert result["imports_blacklisted"] == 3, "Failed to resolve contextual aliases correctly!"
     assert result["threats_found"] == 3, "Failed to increment threats for contextually spoofed packages!"
@@ -274,14 +298,16 @@ def test_monorepo_contextual_alias_resolution(monkeypatch, caplog):
 # ==============================================================================
 # TEST 10: THE ALLOWLIST LOOPHOLE GUARD (UNHAPPY PATH)
 # ==============================================================================
-def test_firewall_allowlist_loophole_guard(monkeypatch):
+def test_firewall_allowlist_loophole_guard():
     """
-    Proves that a file residing in an ALLOWLIST_PATH can bypass strict mode 
+    Proves that a file residing in an ALLOWLIST_PATH can bypass strict mode
     for unknown imports, but is STILL blocked if it imports a known BLACKLISTED package.
     """
-    monkeypatch.setattr(firewall_module, "ALLOWLIST_PATHS", ["experiments/"])
-    monkeypatch.setattr(firewall_module, "BLACKLISTED_IMPORTS", ["known-malware"])
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", True)
+    config = _make_config(
+        ALLOWLIST_PATHS=["experiments/"],
+        BLACKLISTED_IMPORTS=["known-malware"],
+        STRICT_IMPORT_MODE=True,
+    )
 
     mock_ram_graph = [
         {
@@ -292,7 +318,7 @@ def test_firewall_allowlist_loophole_guard(monkeypatch):
         }
     ]
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    result = firewall_module.run_firewall_audit(mock_ram_graph, config=config)
     assert result["imports_unknown"] == 1
     assert result["imports_blacklisted"] == 1
     assert result["threats_found"] == 1, "Blacklisted import bypassed the firewall via the Allowlist Loophole!"
@@ -301,7 +327,7 @@ def test_firewall_allowlist_loophole_guard(monkeypatch):
 # ==============================================================================
 # TEST 11: LOGIC BOMB RISK CATEGORY EVALUATION
 # ==============================================================================
-def test_behavioral_threat_evaluation_strips_prefix(tmp_path, monkeypatch):
+def test_behavioral_threat_evaluation_strips_prefix(tmp_path):
     """
     Proves the firewall correctly blocks on the 'logic_bomb' risk_vector category.
 
@@ -312,8 +338,6 @@ def test_behavioral_threat_evaluation_strips_prefix(tmp_path, monkeypatch):
     distinct regression test (separate risk category from TEST 5) rather than
     deleted, since it's still real coverage of the schema-index lookup.
     """
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-
     mock_ram_graph = {
         "6. Parsed Files (Scanned Artifacts)": {
             "src": {
@@ -338,10 +362,8 @@ def test_behavioral_threat_evaluation_strips_prefix(tmp_path, monkeypatch):
 # ==============================================================================
 # TEST 12: ISSUE #157 - THE TUPLE CRASH
 # ==============================================================================
-def test_tuple_import_handling(tmp_path, monkeypatch):
+def test_tuple_import_handling(tmp_path):
     """Proves the firewall safely unpacks Phase 2 entity tuples from the imports array."""
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-    
     mock_ram_graph = {
         "6. Parsed Files (Scanned Artifacts)": {
             "root": {
@@ -358,7 +380,7 @@ def test_tuple_import_handling(tmp_path, monkeypatch):
 
     graph_file = tmp_path / "results.json"
     graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
-    
+
     with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
         try:
             firewall_module.main()
@@ -369,18 +391,17 @@ def test_tuple_import_handling(tmp_path, monkeypatch):
 # TEST 13: ISSUES #158 & #162 - STANDALONE DIRECTORY CRASH & GLOB MISMATCH
 # ==============================================================================
 @patch("subprocess.run")
-def test_directory_execution_and_globbing(mock_subprocess_run, tmp_path, monkeypatch):
+def test_directory_execution_and_globbing(mock_subprocess_run, tmp_path):
     """Proves passing a directory triggers the orchestrator and globs correctly."""
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
     target_dir = tmp_path / "mock_repo"
     target_dir.mkdir()
-    
+
     def mock_run_side_effect(*args, **kwargs):
         # Correctly extract the target output path from the subprocess call arguments
         call_args = args[0]
         out_target = Path(call_args[call_args.index("--output") + 1])
         audit_file = out_target.parent / "firewall_temp_audit.json"
-        
+
         mock_audit_content = {
             "6. Parsed Files (Scanned Artifacts)": {
                 "root": {
@@ -398,7 +419,7 @@ def test_directory_execution_and_globbing(mock_subprocess_run, tmp_path, monkeyp
             firewall_module.main()
         except SystemExit:
             pytest.fail("Firewall crashed during standalone directory execution.")
-            
+
     called_args = mock_subprocess_run.call_args[0][0]
     assert "--output" in called_args
     output_target = called_args[called_args.index("--output") + 1]
@@ -407,10 +428,8 @@ def test_directory_execution_and_globbing(mock_subprocess_run, tmp_path, monkeyp
 # ==============================================================================
 # TEST 14: ISSUE #159 - SILENT "0 FILES SCANNED" FAILURE (SCHEMA MISMATCH)
 # ==============================================================================
-def test_directory_group_schema_parsing(tmp_path, monkeypatch, capsys):
+def test_directory_group_schema_parsing(tmp_path, capsys):
     """Proves the firewall iterates nested directory groups to extract files."""
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-
     mock_ram_graph = {
         "6. Parsed Files (Scanned Artifacts)": {
             "src/backend": {
@@ -428,20 +447,20 @@ def test_directory_group_schema_parsing(tmp_path, monkeypatch, capsys):
 
     graph_file = tmp_path / "results.json"
     graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
-    
+
     with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
         try:
             firewall_module.main()
         except SystemExit:
             pytest.fail("Failed on clean schema test.")
-            
+
     captured = capsys.readouterr()
     assert "Files Evaluated      : 2" in captured.out
 
 # ==============================================================================
 # TEST 15: BUILD-TIME MULTIPLIER ON A SMALL BUILD SCRIPT (END-TO-END)
 # ==============================================================================
-def test_density_dilution_fix_for_build_scripts(tmp_path, monkeypatch):
+def test_density_dilution_fix_for_build_scripts(tmp_path):
     """
     Proves a small build-time script still blocks via main()'s full JSON-loading
     path, not just via run_firewall_audit() directly (TEST 6 covers that unit).
@@ -453,8 +472,6 @@ def test_density_dilution_fix_for_build_scripts(tmp_path, monkeypatch):
     score (secrets_risk=7.0, below 50.0) past the block threshold (7.0 * 10.0 =
     70.0) for a recognized build-time filename, even at tiny file sizes.
     """
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-
     mock_ram_graph = {
         "6. Parsed Files (Scanned Artifacts)": {
             "root": {
@@ -479,10 +496,8 @@ def test_density_dilution_fix_for_build_scripts(tmp_path, monkeypatch):
 # ==============================================================================
 # TEST 16: ISSUE #161 - MISSING THREAT VECTORS (MEMORY CORRUPTION)
 # ==============================================================================
-def test_memory_corruption_detection(tmp_path, monkeypatch):
+def test_memory_corruption_detection(tmp_path):
     """Proves 'Memory Corruption Risk' triggers a blocking action when detected."""
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
-
     mock_ram_graph = {
         "6. Parsed Files (Scanned Artifacts)": {
             "root": {
@@ -514,7 +529,7 @@ def test_network_weighting_disabled_by_default():
     This is the regression guard for the opt-in rollout decision: existing
     pipelines must see unchanged behavior until they explicitly flip the flag.
     """
-    assert firewall_module.FIREWALL_NETWORK_WEIGHTING is False, (
+    assert resolve_config().FIREWALL_NETWORK_WEIGHTING is False, (
         "FIREWALL_NETWORK_WEIGHTING must default to False -- this feature was "
         "previously inert in production and ships opt-in, not silently live."
     )
@@ -536,7 +551,7 @@ def test_network_weighting_disabled_by_default():
 # ==============================================================================
 # TEST 18: NETWORK-CENTRALITY WEIGHTING AMPLIFIES HUB FILES (OPT-IN)
 # ==============================================================================
-def test_network_weighting_amplifies_high_centrality_hub(monkeypatch):
+def test_network_weighting_amplifies_high_centrality_hub():
     """
     With FIREWALL_NETWORK_WEIGHTING enabled, a highly central "hub" file
     (normalized_blast_radius=3.0 > 1.0) gets its risk score amplified enough
@@ -548,8 +563,7 @@ def test_network_weighting_amplifies_high_centrality_hub(monkeypatch):
     the "only-amplify" design: a low-centrality file is never given a
     discount, it just isn't boosted.
     """
-    monkeypatch.setattr(firewall_module, "FIREWALL_NETWORK_WEIGHTING", True)
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
+    config = _make_config(FIREWALL_NETWORK_WEIGHTING=True)
 
     mock_ram_graph = [
         {
@@ -568,13 +582,13 @@ def test_network_weighting_amplifies_high_centrality_hub(monkeypatch):
         },
     ]
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    result = firewall_module.run_firewall_audit(mock_ram_graph, config=config)
     assert result["threats_found"] == 1, "Hub-file amplification failed to isolate the high-centrality file."
 
 # ==============================================================================
 # TEST 19: NETWORK-CENTRALITY WEIGHTING - BETWEENNESS BONUS (OPT-IN)
 # ==============================================================================
-def test_network_weighting_betweenness_bonus(monkeypatch):
+def test_network_weighting_betweenness_bonus():
     """
     With FIREWALL_NETWORK_WEIGHTING enabled, a file that sits on many shortest
     paths between other files (betweenness_score=0.1 > 0.05) gets a flat +0.5
@@ -585,8 +599,7 @@ def test_network_weighting_betweenness_bonus(monkeypatch):
     so 40.0 * 1.5 = 60.0 clears the threshold. The identical file without the
     high betweenness score stays unblocked.
     """
-    monkeypatch.setattr(firewall_module, "FIREWALL_NETWORK_WEIGHTING", True)
-    monkeypatch.setattr(firewall_module, "STRICT_IMPORT_MODE", False)
+    config = _make_config(FIREWALL_NETWORK_WEIGHTING=True)
 
     mock_ram_graph = [
         {
@@ -605,5 +618,55 @@ def test_network_weighting_betweenness_bonus(monkeypatch):
         },
     ]
 
-    result = firewall_module.run_firewall_audit(mock_ram_graph)
+    result = firewall_module.run_firewall_audit(mock_ram_graph, config=config)
     assert result["threats_found"] == 1, "Betweenness bonus failed to isolate the high-betweenness bridge file."
+
+# ==============================================================================
+# TEST 20: #335 -- .galaxyscope.yaml ACTUALLY REACHES STANDALONE MAIN()
+# ==============================================================================
+def test_yaml_config_flag_actually_changes_standalone_firewall_behavior(tmp_path):
+    """
+    Before #335, supply_chain_firewall.py imported BLACKLISTED_IMPORTS as a
+    module-level constant at load time -- no YAML file, no --config flag,
+    nothing could ever change what it saw, in standalone CLI mode or
+    otherwise. This proves the gap is actually closed: the IDENTICAL RAM
+    graph, run through the IDENTICAL standalone `main()` CLI entrypoint,
+    produces a clean pass with no --config and a hard block once a
+    .galaxyscope.yaml blacklists the offending package.
+    """
+    mock_ram_graph = {
+        "6. Parsed Files (Scanned Artifacts)": {
+            "root": {
+                "Files": {
+                    "app.js": {
+                        "raw_imports": ["totally-innocuous-package"],
+                        "equations": {},
+                        "coding_loc": 10,
+                    }
+                }
+            }
+        }
+    }
+    graph_file = tmp_path / "results.json"
+    graph_file.write_text(json.dumps(mock_ram_graph), encoding="utf-8")
+
+    # BEFORE: no --config at all -- unknown package, audit mode, clean pass.
+    with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file)]):
+        try:
+            firewall_module.main()
+        except SystemExit:
+            pytest.fail("Firewall blocked an unlisted package with no config applied.")
+
+    # AFTER: identical graph, identical CLI entrypoint, but a .galaxyscope.yaml
+    # now blacklists the exact package -- must hard-block via SystemExit(1).
+    config_path = _write_config_yaml(
+        tmp_path, BLACKLISTED_IMPORTS=["totally-innocuous-package"]
+    )
+    with patch.object(sys, "argv", ["supply_chain_firewall.py", str(graph_file), "--config", config_path]):
+        with pytest.raises(SystemExit) as exc:
+            firewall_module.main()
+        assert exc.value.code == 1, (
+            "YAML BLACKLISTED_IMPORTS override never reached standalone "
+            "supply_chain_firewall.py main() -- the #332/#335 reachability "
+            "gap is still open."
+        )

--- a/tests/security_auditing/test_vault_sentinel.py
+++ b/tests/security_auditing/test_vault_sentinel.py
@@ -1,8 +1,21 @@
 import pytest
 import sys
+import yaml
 from unittest.mock import patch
 
 import gitgalaxy.tools.supply_chain_security.vault_sentinel as sentinel_module
+
+
+def _write_config_yaml(tmp_path, **overrides):
+    """
+    Writes a .galaxyscope.yaml for main()-based tests that need a
+    non-default gitgalaxy_config.py key (#335). Exercises the real
+    --config path end-to-end instead of monkeypatching module-level
+    constants that no longer exist after the direct-import migration.
+    """
+    yaml_path = tmp_path / ".galaxyscope.yaml"
+    yaml_path.write_text(yaml.dump({"galaxyscope": overrides}))
+    return str(yaml_path)
 
 # ==============================================================================
 # TEST 1: Denylist Path Evaluation (Immediate Blocking)
@@ -10,14 +23,15 @@ import gitgalaxy.tools.supply_chain_security.vault_sentinel as sentinel_module
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.ApertureFilter")
 def test_sentinel_denylist_blocking(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch
+    mock_aperture_class, mock_security_class, tmp_path
 ):
     """
     Proves that files matching the DENYLIST_PATTERNS are instantly blocked
     and trigger a pipeline failure without requiring a deep content scan.
     """
-    monkeypatch.setattr(sentinel_module, "DENYLIST_PATTERNS", ["*.pem", "id_rsa*"])
-    monkeypatch.setattr(sentinel_module, "ALLOWLIST_PATHS", [])
+    config_path = _write_config_yaml(
+        tmp_path, DENYLIST_PATTERNS=["*.pem", "id_rsa*"], ALLOWLIST_PATHS=[]
+    )
 
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
@@ -26,7 +40,7 @@ def test_sentinel_denylist_blocking(
     repo_dir.mkdir()
     (repo_dir / "production.pem").write_text("FAKE_CERT_DATA", encoding="utf-8")
 
-    test_args = ["vault_sentinel.py", str(repo_dir)]
+    test_args = ["vault_sentinel.py", str(repo_dir), "--config", config_path]
     with patch.object(sys, "argv", test_args):
         with pytest.raises(SystemExit) as exc:
             sentinel_module.main()
@@ -38,14 +52,19 @@ def test_sentinel_denylist_blocking(
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.ApertureFilter")
 def test_sentinel_content_breach(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch
+    mock_aperture_class, mock_security_class, tmp_path
 ):
     """
     Proves that seemingly benign files are deeply scanned, and if the SAST engine
     detects private_info signatures, it successfully halts the pipeline.
+
+    DENYLIST_PATTERNS=[] and ALLOWLIST_PATHS=[] here happen to match
+    gitgalaxy_config.py's real defaults for this file's path (which doesn't
+    contain "tests/"), so no --config override is strictly required -- kept
+    explicit anyway via a written config for parity with the other tests in
+    this file and to pin the intent regardless of future default changes.
     """
-    monkeypatch.setattr(sentinel_module, "DENYLIST_PATTERNS", [])
-    monkeypatch.setattr(sentinel_module, "ALLOWLIST_PATHS", [])
+    config_path = _write_config_yaml(tmp_path, DENYLIST_PATTERNS=[], ALLOWLIST_PATHS=[])
 
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
@@ -63,7 +82,7 @@ def test_sentinel_content_breach(
         "AWS_KEY = 'AKIAIOSFODNN7EXAMPLE'", encoding="utf-8"
     )
 
-    test_args = ["vault_sentinel.py", str(repo_dir)]
+    test_args = ["vault_sentinel.py", str(repo_dir), "--config", config_path]
     with patch.object(sys, "argv", test_args):
         with pytest.raises(SystemExit) as exc:
             sentinel_module.main()
@@ -78,14 +97,15 @@ def test_sentinel_content_breach(
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.ApertureFilter")
 def test_sentinel_allowlist_bypass(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch, capsys
+    mock_aperture_class, mock_security_class, tmp_path, capsys
 ):
     """
     Proves that if a file resides explicitly inside an ALLOWLIST_PATH, it completely
     bypasses both Denylist path checks and Deep Content scanning triggers.
     """
-    monkeypatch.setattr(sentinel_module, "DENYLIST_PATTERNS", ["*.pem"])
-    monkeypatch.setattr(sentinel_module, "ALLOWLIST_PATHS", ["mock_keys/"])
+    config_path = _write_config_yaml(
+        tmp_path, DENYLIST_PATTERNS=["*.pem"], ALLOWLIST_PATHS=["mock_keys/"]
+    )
 
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
@@ -105,7 +125,7 @@ def test_sentinel_allowlist_bypass(
     mock_dir.mkdir()
     (mock_dir / "dummy_test.pem").write_text("FAKE_KEY_DATA", encoding="utf-8")
 
-    test_args = ["vault_sentinel.py", str(repo_dir)]
+    test_args = ["vault_sentinel.py", str(repo_dir), "--config", config_path]
 
     try:
         with patch.object(sys, "argv", test_args):
@@ -114,7 +134,7 @@ def test_sentinel_allowlist_bypass(
         pytest.fail(
             "The Allowlist evaluation failed. A designated test credential triggered a pipeline failure."
         )
-        
+
     captured = capsys.readouterr()
     assert "[ALLOWLIST BYPASS]" in captured.out
     assert "[SUCCESS] No unauthorized secrets detected." in captured.out
@@ -125,43 +145,42 @@ def test_sentinel_allowlist_bypass(
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.ApertureFilter")
 def test_ignore_rules_traversal(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch, capsys
+    mock_aperture_class, mock_security_class, tmp_path, capsys
 ):
     """
     Ensures that os.walk is properly mutated to completely skip directories
     like .git or node_modules that fail the ApertureFilter check.
     """
-    monkeypatch.setattr(sentinel_module, "DENYLIST_PATTERNS", [])
-    monkeypatch.setattr(sentinel_module, "ALLOWLIST_PATHS", [])
+    config_path = _write_config_yaml(tmp_path, DENYLIST_PATTERNS=[], ALLOWLIST_PATHS=[])
 
     mock_aperture = mock_aperture_class.return_value
-    
+
     # Configure the mock to reject any directory named '.git'
     def mock_check_ignore(rel_path):
         if ".git" in str(rel_path):
             return False
         return True
-        
+
     mock_aperture._check_ignore_rules.side_effect = mock_check_ignore
     mock_aperture.evaluate_path_integrity.return_value = (True, 100, None)
-    
+
     mock_security = mock_security_class.return_value
     mock_security.scan_content.return_value = {"counts": {"hardcoded_secrets": 0}}
 
     repo_dir = tmp_path / "ignore_repo"
     repo_dir.mkdir()
-    
+
     # Create a blocked directory with a file that would normally be scanned
     git_dir = repo_dir / ".git"
     git_dir.mkdir()
     (git_dir / "config").write_text("dummy", encoding="utf-8")
-    
+
     # Create an approved directory
     src_dir = repo_dir / "src"
     src_dir.mkdir()
     (src_dir / "main.py").write_text("dummy", encoding="utf-8")
 
-    test_args = ["vault_sentinel.py", str(repo_dir)]
+    test_args = ["vault_sentinel.py", str(repo_dir), "--config", config_path]
     with patch.object(sys, "argv", test_args):
         sentinel_module.main()
 
@@ -174,14 +193,13 @@ def test_ignore_rules_traversal(
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.SecurityLens")
 @patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.ApertureFilter")
 def test_unreadable_file_handling(
-    mock_aperture_class, mock_security_class, tmp_path, monkeypatch
+    mock_aperture_class, mock_security_class, tmp_path
 ):
     """
     Validates that a file generating an I/O or Permission error during reading
     is gracefully skipped without crashing the Sentinel.
     """
-    monkeypatch.setattr(sentinel_module, "DENYLIST_PATTERNS", [])
-    monkeypatch.setattr(sentinel_module, "ALLOWLIST_PATHS", [])
+    config_path = _write_config_yaml(tmp_path, DENYLIST_PATTERNS=[], ALLOWLIST_PATHS=[])
 
     mock_aperture = mock_aperture_class.return_value
     mock_aperture._check_ignore_rules.return_value = True
@@ -191,8 +209,8 @@ def test_unreadable_file_handling(
     repo_dir.mkdir()
     (repo_dir / "locked.dat").write_text("data", encoding="utf-8")
 
-    test_args = ["vault_sentinel.py", str(repo_dir)]
-    
+    test_args = ["vault_sentinel.py", str(repo_dir), "--config", config_path]
+
     try:
         with patch.object(sys, "argv", test_args):
             with patch("builtins.open", side_effect=PermissionError("Locked")):
@@ -212,3 +230,47 @@ def test_main_missing_target(capsys):
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert "Error: Target" in captured.out
+
+# ==============================================================================
+# TEST 7: #335 -- .galaxyscope.yaml ACTUALLY REACHES STANDALONE MAIN()
+# ==============================================================================
+@patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.SecurityLens")
+@patch("gitgalaxy.tools.supply_chain_security.vault_sentinel.ApertureFilter")
+def test_yaml_config_flag_actually_changes_standalone_sentinel_behavior(
+    mock_aperture_class, mock_security_class, tmp_path
+):
+    """
+    Before #335, vault_sentinel.py imported DENYLIST_PATTERNS as a
+    module-level constant at load time -- no YAML file, no --config flag,
+    nothing could ever change what it blocked. This proves the gap is
+    closed: the IDENTICAL file, scanned via the IDENTICAL standalone
+    main() CLI entrypoint, passes clean with no --config and hard-blocks
+    once a .galaxyscope.yaml denylists its exact filename pattern.
+    """
+    mock_aperture = mock_aperture_class.return_value
+    mock_aperture._check_ignore_rules.return_value = True
+    mock_aperture.evaluate_path_integrity.return_value = (True, 100, None)
+    mock_security_class.return_value.scan_content.return_value = {"counts": {"hardcoded_secrets": 0}}
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / "custom_notes.internal").write_text("nothing secret here", encoding="utf-8")
+
+    # BEFORE: no --config -- DENYLIST_PATTERNS defaults to [], clean pass.
+    with patch.object(sys, "argv", ["vault_sentinel.py", str(repo_dir)]):
+        try:
+            sentinel_module.main()
+        except SystemExit:
+            pytest.fail("Sentinel blocked a file with no denylist config applied.")
+
+    # AFTER: identical file, identical CLI entrypoint, but a .galaxyscope.yaml
+    # now denylists this exact pattern -- must hard-block via SystemExit(1).
+    config_path = _write_config_yaml(tmp_path, DENYLIST_PATTERNS=["*.internal"])
+    with patch.object(sys, "argv", ["vault_sentinel.py", str(repo_dir), "--config", config_path]):
+        with pytest.raises(SystemExit) as exc:
+            sentinel_module.main()
+        assert exc.value.code == 1, (
+            "YAML DENYLIST_PATTERNS override never reached standalone "
+            "vault_sentinel.py main() -- the #332/#335 reachability gap "
+            "is still open."
+        )


### PR DESCRIPTION
## Summary
Builds on #336 (Phase 1) and #337 (Phase 2), both merged. Closes #335.

Migrates all 7 files identified in #335 (the original issue named 3; audit found 7 -- see the #335 comment thread) off direct `gitgalaxy_config.py` imports:

- `gitgalaxy/core/guidestar_lens.py` -- was baking `MANIFEST_MAP`/`INTENT_BIASED_SECTORS`/`EXEC_PREFIX_MAP` into **class attributes** at module load time (worse than a simple import: even per-instance overrides were impossible before this). Now set in `__init__` from an optional `guidestar_config` param.
- `gitgalaxy/standards/language_lens.py` -- `EXACT_FILE_MATCH` now an optional `exact_file_match` constructor param.
- `gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py` -- `run_firewall_audit()` takes an optional `config` param; standalone `main()` gained a `--config` flag.
- `gitgalaxy/tools/supply_chain_security/vault_sentinel.py` -- standalone `main()` gained a `--config` flag (this tool has no separate programmatic entry point).
- `gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py` -- `run_xray_audit()` takes an optional `config` param; standalone `main()` gained a `--config` flag.
- `gitgalaxy/metrics/chronometer.py` -- was `from gitgalaxy.standards import gitgalaxy_config as config` at the top of the file (module-object `getattr` pattern). Now an optional `resolved_config` constructor param.
- `gitgalaxy/recorders/gpu_recorder.py` -- same `getattr`-on-module pattern for `PROJECT_STORIES`. Now an optional `resolved_config` param on `record_mission()`.

All 7 default to an unconfigured `resolve_config()` only when the caller doesn't already have one (direct/test use stays behavior-identical).

**Design note on `.get()` vs. attribute access:** `Orchestrator.self.config` is a plain dict (Phase 2's `full_config`), not a `ResolvedConfig` instance. `getattr()` on a plain dict silently *always* returns the default, regardless of the dict's contents -- that's the exact bug this whole effort exists to close, just one layer further down. So every one of the 7 files' new config parameter is read with `.get(key, default)`, never `getattr()`. `ResolvedConfig` (from #336) supports both, so this works uniformly whether a caller hands over the real `ResolvedConfig` (standalone CLI tools calling `resolve_config()` directly) or `Orchestrator`'s flattened dict (main pipeline and multiprocessing workers).

**Wiring `galaxyscope.py`:** `Orchestrator.__init__`, its multiprocessing worker bootstrap (`_process_file_worker` -- a separate code path from `Orchestrator.__init__` that constructs its own `GuideStarLens`/`LanguageDetector`/`Chronometer` instances for parallel file processing, easy to miss), and `execute_pipeline()`'s calls to `run_xray_audit`/`run_firewall_audit`/`GPURecorder.record_mission` all now pass `self.config`/`config` through. This closes the loop #334 opened but didn't finish: #334 made `STRICT_IMPORT_MODE`, `GUIDESTAR_CONFIG`, etc. reachable *in* `full_config`, but nothing was reading them back out yet.

## Also found and fixed
- `Orchestrator.execute_pipeline()`'s worker bootstrap had the same unreachable-config bug as the 7 files above, just not on anyone's radar -- fixed as part of the wiring pass.

## Found but explicitly NOT fixed here (flagged for follow-up)
- `gitgalaxy/recorders/sbom_recorder.py` also constructs a bare `LanguageDetector(LANGUAGE_DEFINITIONS, LEXICAL_FAMILY_HEURISTICS)` with zero config plumbing -- `SbomRecorder` doesn't hold a `self.config` at all today, so wiring this one through is a larger, separate refactor than the other 7. An 8th direct-import site, discovered but out of #335's original scope.

## Test plan
- [x] `pytest tests/core_engine/test_guidestar_lens.py` -- fixture switched from 3-level class-attribute `patch()` nesting to a single `guidestar_config=` constructor kwarg. 5 passed.
- [x] `pytest tests/security_auditing/test_supply_chain_firewall.py` -- all `monkeypatch.setattr(firewall_module, "X", ...)` calls replaced with either a `config=` object (direct `run_firewall_audit()` calls) or a real `--config .galaxyscope.yaml` (main()-based calls, now exercising the actual resolver path instead of monkeypatching internals). Added an explicit before/after test proving a YAML override changes standalone CLI behavior. 20 passed.
- [x] `pytest tests/security_auditing/test_vault_sentinel.py` -- same treatment, plus a before/after proof test. 7 passed.
- [x] `pytest tests/security_auditing/test_binary_anomaly_detector.py` -- same treatment, plus a before/after proof test. Deleted `test_xray_import_fallback`, which tested the `try/except ImportError` module-load fallback that no longer exists (config is now a parameter, not an import). 10 passed.
- [x] `pytest tests/core_engine/test_chronometer.py tests/core_engine/test_chronometer_timeout.py tests/tools_recorders/test_gpu_recorder.py` -- no monkeypatching existed for these; confirmed no regressions. 13 passed.
- [x] `pytest tests/core_engine/test_galaxyscope.py` -- confirms the `Orchestrator`/worker wiring changes don't regress existing pipeline behavior. 35 passed.
- [x] Full repo suite: `pytest tests/` -- **806 passed**, 1 xfailed (pre-existing, unrelated). Baseline before this PR was 804; net +2 accounts for 3 new "gap is closed" end-to-end tests minus the 1 deleted fallback test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)