### PR TITLE
Fix CLI/YAML sentinel-collision in the pipeline-flag interceptor

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -2455,13 +2455,27 @@ def main():
     # Required for safe execution limits with the multiprocessing pool on Windows
     multiprocessing.freeze_support()
 
+    # #247: every flag below that can ALSO be set via .galaxyscope.yaml's
+    # `galaxyscope:` section defaults to None here, not a real "off" value
+    # (False / 0.0 / a real int). argparse can't tell "flag not passed"
+    # apart from "flag explicitly passed with a value that happens to look
+    # like a default" -- an explicit `--max-risk-exposure 0.0` and simply
+    # never passing the flag both used to produce args.max_risk_exposure ==
+    # 0.0, so a YAML file setting the same key would silently clobber an
+    # explicit CLI opt-out. None is a value none of these flags can ever
+    # legitimately have from real parsing, so it's a safe "unset" sentinel.
+    # _ARG_REAL_DEFAULTS (below, applied right after the YAML merge) is
+    # where the actual default value gets substituted back in -- once, in
+    # one place -- so every downstream reader of args.*/full_config still
+    # sees a concrete value exactly as before.
     parser = argparse.ArgumentParser(description="GitGalaxy GalaxyScope v2")
     parser.add_argument("target", help="Path to repo or ZIP")
     parser.add_argument("--output", default=None, help="Optional output filename override")
-    parser.add_argument("--debug", action="store_true", help="Turn on verbose Analytical logging")
+    parser.add_argument("--debug", action="store_true", default=None, help="Turn on verbose Analytical logging")
     parser.add_argument(
         "--paranoid",
         action="store_true",
+        default=None,
         help="Lower security thresholds to flag more potential threats.",
     )
 
@@ -2469,20 +2483,21 @@ def main():
     parser.add_argument(
         "--shadow-patch-detected",
         action="store_true",
+        default=None,
         help="Indicates the payload hash mutated without a version bump.",
     )
 
     # --- EXCLUSIVE RECORDER FLAGS ---
-    parser.add_argument("--llm-only", action="store_true", help="Run ONLY the LLM recorder")
-    parser.add_argument("--gpu-only", action="store_true", help="Run ONLY the GPU recorder")
-    parser.add_argument("--audit-only", action="store_true", help="Run ONLY the Audit recorder")
-    parser.add_argument("--db-only", action="store_true", help="Run ONLY the native SQLite recorder")
-    parser.add_argument("--sarif-only", action="store_true", help="Run ONLY the SARIF exporter")
-    parser.add_argument("--sbom-only", action="store_true", help="Run ONLY the CycloneDX SBOM generator")
-    parser.add_argument("--fail-on-secrets", action="store_true", help="CI/CD Gate: Fail build if hardcoded secrets are detected")
-    parser.add_argument("--fail-on-malware", action="store_true", help="CI/CD Gate: Fail build if ML threat inference flags malware")
-    parser.add_argument("--max-risk-exposure", type=float, default=0.0, help="CI/CD Gate: Fail build if any file exceeds this risk percentage (0.0 to disable)")
-    parser.add_argument("--max-systemic-threat", type=float, default=0.0, help="CI/CD Gate: Fail build if systemic threat exceeds this limit (0.0 to disable)")
+    parser.add_argument("--llm-only", action="store_true", default=None, help="Run ONLY the LLM recorder")
+    parser.add_argument("--gpu-only", action="store_true", default=None, help="Run ONLY the GPU recorder")
+    parser.add_argument("--audit-only", action="store_true", default=None, help="Run ONLY the Audit recorder")
+    parser.add_argument("--db-only", action="store_true", default=None, help="Run ONLY the native SQLite recorder")
+    parser.add_argument("--sarif-only", action="store_true", default=None, help="Run ONLY the SARIF exporter")
+    parser.add_argument("--sbom-only", action="store_true", default=None, help="Run ONLY the CycloneDX SBOM generator")
+    parser.add_argument("--fail-on-secrets", action="store_true", default=None, help="CI/CD Gate: Fail build if hardcoded secrets are detected")
+    parser.add_argument("--fail-on-malware", action="store_true", default=None, help="CI/CD Gate: Fail build if ML threat inference flags malware")
+    parser.add_argument("--max-risk-exposure", type=float, default=None, help="CI/CD Gate: Fail build if any file exceeds this risk percentage (0.0 to disable)")
+    parser.add_argument("--max-systemic-threat", type=float, default=None, help="CI/CD Gate: Fail build if systemic threat exceeds this limit (0.0 to disable)")
     parser.add_argument("--incremental", type=str, metavar="DB_PATH", help="Path to baseline SQLite database for Delta Scanning")
 
     # --- DEPENDENCY AUDIT CACHE (incremental SBOM verification) ---
@@ -2496,35 +2511,61 @@ def main():
     parser.add_argument(
         "--no-dependency-cache",
         action="store_true",
+        default=None,
         help="Disable the dependency-audit cache entirely (legacy capped-sampling SBOM audit)",
     )
     parser.add_argument(
         "--full-dependency-scan",
         action="store_true",
+        default=None,
         help="Ignore the per-package fresh-scan budget and verify every dependency file this run",
     )
     parser.add_argument(
         "--dependency-scan-budget",
         type=int,
         metavar="N",
-        default=25,
+        default=None,
         help="Max cache-miss files freshly scanned per package per run (default 25; deferred files are disclosed and picked up next run)",
     )
     parser.add_argument("--config", type=str, help="Path to project-level configuration file (e.g., .galaxyscope.yaml)")
     parser.add_argument(
         "--splicing-speed",
         action="store_true",
+        default=None,
         help="Profile regex and file processing speeds (capped at 5000 files)",
     )
     parser.add_argument(
         "--file-speed",
         action="store_true",
+        default=None,
         help="Profile the macro lifecycle phases of file processing",
     )
 
-    args = parser.parse_args()
+    # The real default for each flag above once the YAML merge runs and it's
+    # still unset -- kept as one table so adding a new overridable flag means
+    # adding one line here, not re-deriving the sentinel-collision fix.
+    _ARG_REAL_DEFAULTS = {
+        "debug": False,
+        "paranoid": False,
+        "shadow_patch_detected": False,
+        "llm_only": False,
+        "gpu_only": False,
+        "audit_only": False,
+        "db_only": False,
+        "sarif_only": False,
+        "sbom_only": False,
+        "fail_on_secrets": False,
+        "fail_on_malware": False,
+        "max_risk_exposure": 0.0,
+        "max_systemic_threat": 0.0,
+        "no_dependency_cache": False,
+        "full_dependency_scan": False,
+        "dependency_scan_budget": 25,
+        "splicing_speed": False,
+        "file_speed": False,
+    }
 
-    log_level = logging.DEBUG if args.debug else logging.INFO
+    args = parser.parse_args()
 
     # ---------------------------------------------------------
     # YAML Configuration File Interceptor
@@ -2538,13 +2579,30 @@ def main():
             logging.info(f"⚙️ Loaded repository configuration from {args.config}")
         except Exception as e:
             logging.error(f"Failed to load config file {args.config}: {e}")
-    
-    # Map YAML configurations directly to argparse attributes if not overridden via CLI
+
+    # Map YAML configurations directly to argparse attributes if not overridden via CLI.
+    # #247: `is None` -- not a truthy/falsy check -- because None is the only
+    # value that means "the CLI didn't set this" now that every affected flag
+    # above defaults to None instead of a real off-value.
     if 'galaxyscope' in config_file_data:
         for key, val in config_file_data['galaxyscope'].items():
             arg_key = key.replace('-', '_')
-            if hasattr(args, arg_key) and getattr(args, arg_key) in (None, False, 0.0, ""):
+            if hasattr(args, arg_key) and getattr(args, arg_key) is None:
                 setattr(args, arg_key, val)
+
+    # Neither the CLI nor the YAML file set these -- fall back to each
+    # flag's real default now, in one place, so every downstream reader of
+    # args.*/full_config sees a concrete value exactly as before #247.
+    for arg_key, real_default in _ARG_REAL_DEFAULTS.items():
+        if getattr(args, arg_key, None) is None:
+            setattr(args, arg_key, real_default)
+
+    # Computed after the YAML merge + real-default resolution above (not
+    # before, as previously) so a .galaxyscope.yaml `debug: true` with no
+    # --debug on the CLI actually takes effect instead of being silently
+    # ignored because log_level had already been fixed before the YAML
+    # value was ever applied to args.debug.
+    log_level = logging.DEBUG if args.debug else logging.INFO
 
     logging.basicConfig(
         level=log_level,

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -283,6 +283,127 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
             os.remove(temp_yaml_path)
 
     # ==============================================================================
+    # TEST 7b: #247 -- EXPLICIT FALSY-LOOKING CLI VALUE SURVIVES A YAML OVERRIDE
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.Orchestrator")
+    @patch("gitgalaxy.licensing.enforce_licensing_guard")
+    def test_explicit_cli_sentinel_value_not_clobbered_by_yaml(self, mock_license, mock_orchestrator):
+        """
+        The exact reproduction steps from #247: a .galaxyscope.yaml sets
+        max-risk-exposure: 25.0, and the CLI explicitly passes
+        --max-risk-exposure 0.0 (a real, intentional "disable this gate"
+        value, not "I forgot to set it"). Before the #247 fix, argparse
+        could not tell "flag not passed" apart from "flag passed with a
+        value that happens to equal the old truthy/falsy sentinel", so the
+        YAML value silently won. The explicit CLI value must win instead.
+        """
+        import sys
+        import tempfile
+        from gitgalaxy.galaxyscope import main
+
+        fd, temp_yaml_path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, 'w') as f:
+            f.write("galaxyscope:\n  max-risk-exposure: 25.0\n")
+
+        test_args = [
+            "galaxyscope",
+            ".",
+            "--config", temp_yaml_path,
+            "--max-risk-exposure", "0.0",
+        ]
+
+        try:
+            with patch.object(sys, 'argv', test_args):
+                mock_orchestrator.return_value.policy_failed = False
+                main()
+
+            args, _ = mock_orchestrator.call_args
+            ignited_config = args[1]
+
+            self.assertEqual(
+                ignited_config["MAX_RISK_EXPOSURE"], 0.0,
+                "YAML silently overwrote an explicit CLI value that looked like a default -- #247 regression!",
+            )
+        finally:
+            os.remove(temp_yaml_path)
+
+    # ==============================================================================
+    # TEST 7c: #247 -- A FLAG WITH A TRUTHY DEFAULT IS NOW REACHABLE FROM YAML AT ALL
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.Orchestrator")
+    @patch("gitgalaxy.licensing.enforce_licensing_guard")
+    def test_yaml_can_set_flag_with_previously_truthy_default(self, mock_license, mock_orchestrator):
+        """
+        --dependency-scan-budget defaulted to 25 (truthy) before #247's fix,
+        which meant the OLD interceptor's `in (None, False, 0.0, "")` check
+        could NEVER match it -- YAML could never set this flag even when
+        the CLI never touched it at all. Proves the flip side of the same
+        bug is also fixed: a real default no longer permanently blocks a
+        YAML override.
+        """
+        import sys
+        import tempfile
+        from gitgalaxy.galaxyscope import main
+
+        fd, temp_yaml_path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, 'w') as f:
+            f.write("galaxyscope:\n  dependency-scan-budget: 5\n")
+
+        test_args = ["galaxyscope", ".", "--config", temp_yaml_path]
+
+        try:
+            with patch.object(sys, 'argv', test_args):
+                mock_orchestrator.return_value.policy_failed = False
+                main()
+
+            args, _ = mock_orchestrator.call_args
+            ignited_config = args[1]
+
+            self.assertEqual(
+                ignited_config["DEPENDENCY_SCAN_BUDGET"], 5,
+                "YAML failed to reach a flag whose CLI default used to be truthy!",
+            )
+        finally:
+            os.remove(temp_yaml_path)
+
+    # ==============================================================================
+    # TEST 7d: #247 -- YAML `debug: true` ACTUALLY TAKES EFFECT
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.Orchestrator")
+    @patch("gitgalaxy.licensing.enforce_licensing_guard")
+    def test_yaml_debug_flag_actually_sets_log_level(self, mock_license, mock_orchestrator):
+        """
+        log_level used to be computed from args.debug BEFORE the YAML merge
+        ran, so a .galaxyscope.yaml `debug: true` with no --debug on the
+        CLI was silently a no-op -- log_level had already been fixed to
+        INFO by the time the YAML value was applied to args.debug. Fixed by
+        computing log_level after the YAML merge + real-default resolution.
+        """
+        import sys
+        import tempfile
+        import logging
+        from gitgalaxy.galaxyscope import main
+
+        fd, temp_yaml_path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, 'w') as f:
+            f.write("galaxyscope:\n  debug: true\n")
+
+        test_args = ["galaxyscope", ".", "--config", temp_yaml_path]
+
+        try:
+            with patch.object(sys, 'argv', test_args):
+                mock_orchestrator.return_value.policy_failed = False
+                main()
+
+            self.assertEqual(
+                logging.getLogger().getEffectiveLevel(), logging.DEBUG,
+                "YAML debug: true failed to actually raise the log level -- #247 ordering regression!",
+            )
+        finally:
+            os.remove(temp_yaml_path)
+            logging.getLogger().setLevel(logging.INFO)
+
+    # ==============================================================================
     # TEST 8: THE TYPOSQUATTING DOPPELGÄNGER (Supply Chain Radar)
     # ==============================================================================
     @patch("gitgalaxy.galaxyscope.logger")


### PR DESCRIPTION
## Summary
Closes #247 -- the piece left unaddressed by #332-#338 (see the status comment on #247 for why those didn't cover this).

`main()`'s generic `args.*` <- `.galaxyscope.yaml` interceptor decided "did the CLI set this?" by checking whether the parsed value looked like a default: `getattr(args, arg_key) in (None, False, 0.0, "")`. argparse has no way to distinguish "flag not passed" from "flag explicitly passed with a value that happens to equal the sentinel" -- both look identical after parsing. Two concrete failure modes, both from the same root cause:

1. **Explicit falsy CLI value silently overwritten.** `--max-risk-exposure 0.0` (a real, intentional "disable this CI/CD gate" value) parses to the same `0.0` as never passing the flag. A checked-in YAML with `max-risk-exposure: 25.0` would silently win, re-enabling a gate the caller explicitly turned off -- the exact scenario #247 reported.
2. **The inverse: a truthy default permanently blocked YAML.** `--dependency-scan-budget` defaulted to `25` (truthy), so the sentinel check could *never* match it -- YAML could never set this flag at all, even when the CLI never touched it.

## Fix
- Every affected flag (`--debug`, `--paranoid`, `--shadow-patch-detected`, the 6 `--*-only` exclusive-mode flags, `--fail-on-secrets`, `--fail-on-malware`, `--max-risk-exposure`, `--max-systemic-threat`, `--no-dependency-cache`, `--full-dependency-scan`, `--dependency-scan-budget`, `--splicing-speed`, `--file-speed`) now defaults to `None` in argparse -- the one value none of them can produce from real CLI parsing.
- The interceptor now checks `is None`, not truthiness.
- A `_ARG_REAL_DEFAULTS` table substitutes each flag's actual default back in immediately after the YAML merge runs, in one place, so every downstream reader of `args.*`/`full_config` sees a concrete value exactly as before -- this is purely an "unset" sentinel fix, not a behavior change for anyone who was already getting correct results.
- Found and fixed one more bug in the same code while I was in there: `log_level` was computed from `args.debug` **before** the YAML merge ran, so `.galaxyscope.yaml`'s `debug: true` was silently a no-op regardless of anything else. Moved the computation to after the merge + real-default resolution.

This is a distinct code path from the `gitgalaxy_config.py` resolver work (#332-#338) -- these are pipeline/CI-gate flags, not `gitgalaxy_config.py` constants -- and was explicitly left untouched during that migration, which is why the bug survived it.

## Test plan
- [x] `test_explicit_cli_sentinel_value_not_clobbered_by_yaml` -- reproduces #247's exact steps (`--max-risk-exposure 0.0` CLI + YAML `max-risk-exposure: 25.0`), asserts the CLI value wins.
- [x] `test_yaml_can_set_flag_with_previously_truthy_default` -- proves YAML can now set `--dependency-scan-budget` when the CLI doesn't touch it (impossible before this fix).
- [x] `test_yaml_debug_flag_actually_sets_log_level` -- proves the `--debug`/`log_level` ordering fix.
- [x] `test_yaml_configuration_and_cli_priority` (pre-existing) -- still passes unchanged, confirming normal CLI-wins/YAML-fills-in behavior is preserved.
- [x] `pytest tests/core_engine/test_galaxyscope.py` -- 38 passed (35 baseline + 3 new).
- [x] Full repo suite: `pytest tests/` -- **809 passed**, 1 xfailed (pre-existing, unrelated). Baseline before this PR was 806; net +3 matches the 3 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)