### PR TITLE
Remove ai_tools, ai_memory, ai_logic_loop from SIGNAL_SCHEMA -- not realistically detectable via regex

### DIFF
--- a/gitgalaxy/metrics/signal_processor.py
+++ b/gitgalaxy/metrics/signal_processor.py
@@ -974,14 +974,15 @@ class SignalProcessor:
             }
 
         # --- NEW: AI TOPOLOGY & LLM INTELLIGENCE ---
+        # ai_tools/ai_memory/ai_logic_loop removed from this list (#323):
+        # they were removed from SIGNAL_SCHEMA entirely -- see
+        # analysis_lens.py for why (behavioral patterns a lexical regex
+        # engine can't detect, unlike the import-identity categories below).
         ai_sensor_keys = [
             "llm_api",
             "llm_orchestrator",
             "llm_vector_store",
             "llm_local_compute",
-            "ai_tools",
-            "ai_memory",
-            "ai_logic_loop",
             "ml_traditional",
             "dl_frameworks",
         ]
@@ -1032,35 +1033,6 @@ class SignalProcessor:
             for f in parsed_files
         )
 
-        # Agentic Sensors
-        ai_tools_total = sum(
-            (
-                f.get("hit_vector", [])[self.SIGNAL_SCHEMA.index("ai_tools")]
-                if "ai_tools" in self.SIGNAL_SCHEMA
-                and len(f.get("hit_vector", [])) > self.SIGNAL_SCHEMA.index("ai_tools")
-                else 0
-            )
-            for f in parsed_files
-        )
-        ai_memory_total = sum(
-            (
-                f.get("hit_vector", [])[self.SIGNAL_SCHEMA.index("ai_memory")]
-                if "ai_memory" in self.SIGNAL_SCHEMA
-                and len(f.get("hit_vector", [])) > self.SIGNAL_SCHEMA.index("ai_memory")
-                else 0
-            )
-            for f in parsed_files
-        )
-        ai_loop_total = sum(
-            (
-                f.get("hit_vector", [])[self.SIGNAL_SCHEMA.index("ai_logic_loop")]
-                if "ai_logic_loop" in self.SIGNAL_SCHEMA
-                and len(f.get("hit_vector", [])) > self.SIGNAL_SCHEMA.index("ai_logic_loop")
-                else 0
-            )
-            for f in parsed_files
-        )
-
         # ML/DL Sensors
         ml_total = sum(
             (
@@ -1087,30 +1059,18 @@ class SignalProcessor:
             + llm_orch_total
             + llm_vector_total
             + llm_local_total
-            + ai_tools_total
-            + ai_memory_total
-            + ai_loop_total
             + ml_total
             + dl_total
         )
 
         if total_ai_mass > 0:
-            # Assess Agentic Autonomy First (Highest Complexity)
-            if ai_loop_total > 0 and ai_tools_total > 0:
-                ai_topology["classification"] = "Autonomous Agentic Fleet (Level 4)"
-                ai_topology["insights"].append(
-                    "High density of bound tools and cyclic reasoning loops (ReAct). Agents possess autonomy to execute code. Critical risk of non-deterministic runtime behavior."
-                )
-                if ai_memory_total == 0:
-                    ai_topology["insights"].append(
-                        "WARNING: High autonomy but low memory density. Agents may suffer from context amnesia between loops."
-                    )
-            elif ai_tools_total > 0:
-                ai_topology["classification"] = "Tool-Augmented LLM (Level 3)"
-                ai_topology["insights"].append(
-                    "LLM is explicitly bound to external functions/tools. High blast radius if prompt injection occurs."
-                )
-            elif llm_local_total > 0:
+            # #323: the "Autonomous Agentic Fleet (Level 4)" / "Tool-Augmented
+            # LLM (Level 3)" branches that used to sit here (keyed off
+            # ai_loop_total/ai_tools_total/ai_memory_total) were removed
+            # along with those signals -- they were never reachable against
+            # real source code (zero producers in language_standards.py),
+            # only against synthetic hand-built hit_vector fixtures.
+            if llm_local_total > 0:
                 ai_topology["classification"] = "Local Sovereignty (Heavy Compute)"
                 ai_topology["insights"].append(
                     "Repository contains local model execution or tensor math. Expect heavy GPU memory allocation."
@@ -1178,9 +1138,6 @@ class SignalProcessor:
                 "Orchestrators": llm_orch_total,
                 "Vector Stores": llm_vector_total,
                 "Local Compute": llm_local_total,
-                "Agent Tools": ai_tools_total,
-                "Agent Memory": ai_memory_total,
-                "Agent Loops": ai_loop_total,
                 "Traditional ML": ml_total,
                 "Deep Learning": dl_total,
             }
@@ -2004,9 +1961,9 @@ class SignalProcessor:
         execution_vectors = (raw_signals.get("sec_high_risk_execution", 0) * 4.0) + (raw_signals.get("sec_safety_bypasses", 0) * 2.0)
 
         # ---> LLM EXECUTION VULNERABILITY (Prompt Injection to Exec) <---
-        if raw_signals.get("sec_high_risk_execution", 0) > 0 and (
-            raw_signals.get("llm_orchestrator", 0) > 0 or raw_signals.get("ai_tools", 0) > 0
-        ):
+        # ai_tools removed from this check (#323) -- it was removed from
+        # SIGNAL_SCHEMA entirely, so raw_signals never carries that key.
+        if raw_signals.get("sec_high_risk_execution", 0) > 0 and raw_signals.get("llm_orchestrator", 0) > 0:
             # If an AI can trigger eval/exec/OS commands, it's a massive vulnerability
             execution_vectors *= 10.0
             input_vectors += 5.0  # Treat the LLM itself as a hostile input vector

--- a/gitgalaxy/standards/analysis_lens.py
+++ b/gitgalaxy/standards/analysis_lens.py
@@ -1127,13 +1127,21 @@ RECORDING_SCHEMAS = {
         "regex_execution",
         "time_date_logic",
         # --- NEW: AI & LLM SENSORS ---
+        # ai_tools/ai_memory/ai_logic_loop removed (#323): unlike the other
+        # 6 categories here, which just need "does this file import X" (a
+        # lexical pattern regex can do that), these 3 were trying to detect
+        # BEHAVIOR -- agent tool-calling, agent memory/state management,
+        # autonomous ReAct-style execution loops. No regex-based Structural
+        # Signature engine can reliably tell "this file imports langchain"
+        # apart from "this file implements an autonomous execution loop";
+        # the latter is a semantic/structural pattern, not a lexical one.
+        # They had zero producers anywhere in language_standards.py --
+        # always-zero dead weight, not a functioning (if imperfect)
+        # detector, and permanently unfixable via this engine's approach.
         "llm_api",
         "llm_orchestrator",
         "llm_vector_store",
         "llm_local_compute",
-        "ai_tools",
-        "ai_memory",
-        "ai_logic_loop",
         "ml_traditional",
         "dl_frameworks",
         # --- NEW: ADVANCED ALGORITHMIC SENSORS ---
@@ -1271,9 +1279,6 @@ RECORDING_SCHEMAS = {
         "llm_orchestrator": "AI Orchestration Frameworks",
         "llm_vector_store": "Vector Databases (RAG)",
         "llm_local_compute": "Local Inference & Tensor Math",
-        "ai_tools": "Agentic Tool & Function Calling",
-        "ai_memory": "Agentic State & Memory Management",
-        "ai_logic_loop": "Autonomous Execution Loops (ReAct)",
         "ml_traditional": "Traditional Machine Learning (Stats/Trees)",
         "dl_frameworks": "Deep Learning & Neural Networks",
         "lazy_evaluation": "Lazy Evaluation & Generators (O(1) Memory)",

--- a/tests/core_engine/test_signal_processor.py
+++ b/tests/core_engine/test_signal_processor.py
@@ -393,21 +393,24 @@ def test_signal_processor_memory_exhaustion_spatial(processor):
 # TEST 14: AI TOPOLOGY & NETWORK POSTURE
 # ==============================================================================
 def test_signal_processor_ai_topology(processor):
-    """Proves the aggregator correctly classifies Autonomous Fleets and RAG pipelines."""
-    # Level 4 Agent (Tools + Logic Loops, but NO memory)
-    m1, sig1 = create_synthetic_star(
-        processor,
-        "agent",
-        100,
-        {"ai_logic_loop": 10, "ai_tools": 10, "ai_memory": 0},
-    )
+    """
+    Proves the AI Network Posture insights (PageRank blast radius,
+    Betweenness choke-point) fire for any file that registers nonzero AI
+    mass, using llm_orchestrator as the trigger signal.
 
-    # RAG Pipeline
-    m2, sig2 = create_synthetic_star(
-        processor, "rag", 100, {"llm_api": 10, "llm_vector_store": 10}
-    )
+    #323: this test used to exercise ai_logic_loop/ai_tools/ai_memory
+    ("Autonomous Agentic Fleet (Level 4)" + "context amnesia" insight) --
+    those 3 categories were removed from SIGNAL_SCHEMA entirely (they
+    detect BEHAVIOR, not import identity, which a regex engine can't do;
+    they had zero producers in language_standards.py and were permanently
+    unreachable against real source). RAG Pipeline / Cloud API Wrapper
+    classification coverage lives in
+    test_signal_processor_ai_topology_rag_cloud below; this test now only
+    needs to prove the network-posture insight logic itself still works
+    off a signal that's actually still real.
+    """
+    m1, sig1 = create_synthetic_star(processor, "orchestrator", 100, {"llm_orchestrator": 10})
 
-    # Process files
     tel1 = processor.calculate_risk_vector(m1, sig1)
     m1["telemetry"] = tel1["telemetry"]
     m1["hit_vector"] = tel1["hit_vector"]  # Essential for the AI sensor!
@@ -420,20 +423,14 @@ def test_signal_processor_ai_topology(processor):
         "ecosystem_role": "Core Hub",
     }
 
-    tel2 = processor.calculate_risk_vector(m2, sig2)
-    m2["telemetry"] = tel2["telemetry"]
-    m2["hit_vector"] = tel2["hit_vector"]
-
-    parsed = [m1, m2]
-    summary = processor.summarize_galaxy_metrics(parsed, [])
+    summary = processor.summarize_galaxy_metrics([m1], [])
 
     topology = summary.get("ai_topology", {})
-    assert topology["classification"] == "Autonomous Agentic Fleet (Level 4)", (
-        "Failed to classify Level 4 Agent!"
+    assert topology["classification"] == "Framework-Heavy Orchestration", (
+        "Failed to classify orchestration-heavy repo!"
     )
 
     insights = " ".join(topology["insights"])
-    assert "context amnesia" in insights, "Failed to detect missing Agent Memory!"
     assert "catastrophically across the system" in insights, (
         "Failed to detect high PageRank blast radius!"
     )
@@ -954,11 +951,15 @@ def test_signal_processor_llm_execution_vulnerability(processor):
     )
 
     # 2. Agentic dynamic execution
+    # #323: ai_tools removed here -- it was removed from SIGNAL_SCHEMA
+    # entirely, so it was already inert dead data in this fixture even
+    # before that (calculate_risk_vector never read it directly; only
+    # llm_orchestrator drives the amplification this test verifies).
     m_agent, sig_agent = create_synthetic_star(
         processor,
         "agent_exec",
         100,
-        {"sec_high_risk_execution": 10, "llm_orchestrator": 5, "ai_tools": 5},
+        {"sec_high_risk_execution": 10, "llm_orchestrator": 5},
     )
 
     r_std = processor.calculate_risk_vector(m_std, sig_std)


### PR DESCRIPTION
## Summary
Closes #323.

## Decision: hard removal, not a stub
The issue asked for a deliberate choice between hard removal and an explicit-unsupported stub. Went with **hard removal**:

- Audited every consumer of `SIGNAL_SCHEMA` across the repo (Python and JS). Nothing hardcodes its length or these 3 categories' index positions -- every consumer allocates/reads vectors via `len(SIGNAL_SCHEMA)` or `.index(name)` dynamically. Removal doesn't shift anything.
- `SIGNAL_SCHEMA` and `SignalProcessor.RISK_SCHEMA` (used by `supply_chain_firewall.py`) are two separate, unrelated arrays -- confirmed no positional contract between them, so this change can't touch firewall risk-gating logic at all.
- Confirmed the issue's "zero prior art" claim: `language_standards.py` has zero producers for **all 9** AI/LLM/ML categories today, not just the 3 disputed ones (only `llm_local_compute` gets a value, and only via a special-cased synthetic-binary check in `galaxyscope.py`, never real source). #313 previously investigated this same area and was closed as "resolved by #326" -- but #326 only fixed an unrelated consumer-wiring bug (`AIAppSecSensor` reading from a phantom `telemetry` namespace); it never added the missing regex producers #313 asked for. There's no precedent to follow.
- A stub ("keep the key, always output 0, document as unsupported") would misrepresent reality here: these 3 aren't "not yet implemented" the way the other 6 currently are (those just need someone to write producer regexes) -- they're architecturally impossible for a regex-based engine per the issue's own thesis. A permanent always-zero stub for something that can never be real is worse than removing it, not safer.

## Changes
- **`gitgalaxy/standards/analysis_lens.py`**: removed the 3 keys from `SIGNAL_SCHEMA` and their entries from `FRIENDLY_MAP`, with a comment explaining why (behavioral pattern vs. lexical pattern, zero producers, permanently unfixable via this approach).
- **`gitgalaxy/metrics/signal_processor.py`**: removed all downstream dead code this exposed:
  - `ai_tools_total`/`ai_memory_total`/`ai_loop_total` sum blocks and their entry in `ai_sensor_keys`.
  - The "Autonomous Agentic Fleet (Level 4)" and "Tool-Augmented LLM (Level 3)" classification branches -- these were only ever reachable via hand-built synthetic test fixtures, never real source (zero producers).
  - The "context amnesia" warning tied to `ai_memory_total == 0`.
  - The corresponding `ai_topology["signal_mass"]` entries (`"Agent Tools"`, `"Agent Memory"`, `"Agent Loops"`).
  - The `ai_tools` half of an `or` condition in `_calc_injection_surface` -- `llm_orchestrator` alone still satisfies it, so this is a no-op removal, not a behavior change.

## Explicitly not touched
`gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py`'s "Over-Permissioned Agent" rule still reads `equations.get("ai_tools", 0)` with a safe default. That key will now never be populated -- functionally identical to today, since nothing has ever populated it. The rule becomes formally, permanently dead rather than just currently dead. The issue itself flags this as a downstream consequence tracked by a companion issue (the `AIAppSecSensor` work in #324/#326), not something #323 asks this PR to change.

## Test plan
- [x] Rewrote `test_signal_processor_ai_topology` (the one test with real semantic dependencies on the removed classification logic) to test the still-valid "Framework-Heavy Orchestration" classification + AI Network Posture insights (PageRank blast radius, betweenness choke-point) using `llm_orchestrator` instead of the removed keys -- this is genuinely non-redundant coverage vs. the existing `test_signal_processor_ai_topology_rag_cloud` and `test_signal_processor_ai_topology_dl_ml` tests, which already cover RAG/Cloud/DL/ML classification.
- [x] Cleaned up a stale, now-inert `"ai_tools": 5"` entry in `test_signal_processor_llm_execution_vulnerability`'s synthetic fixture (was never read by name in that code path; `llm_orchestrator` alone drives the assertion).
- [x] `pytest tests/core_engine/test_signal_processor.py` -- 50 passed.
- [x] `pytest tests/security_auditing/test_ai_appsec_sensor.py tests/core_engine/test_galaxyscope.py tests/security_auditing/test_security_auditor.py` -- 54 passed (these mock their own `SIGNAL_SCHEMA`/`equations` and don't depend on the real list).
- [x] Full repo suite: `pytest tests/` -- **809 passed**, 1 xfailed (pre-existing, unrelated) -- identical count to before this change (no tests added/removed, only rewritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)