### PR TITLE
Factor AI/LLM SDK detection into GLOBAL_ patterns

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -196,6 +196,25 @@ _DENSE_FRAGILE = (
 )
 GLOBAL_FRAGILE_DEBT = re.compile(f"{_SPACED_FRAGILE}|{_DENSE_FRAGILE}", re.I)
 
+
+# --- 3. AI / LLM & ML SDK DETECTION (split by SIGNAL_SCHEMA category) ---
+# Mirrors GLOBAL_PLANNED_DEBT/GLOBAL_FRAGILE_DEBT: compiled once here and
+# referenced identically by every language block that wants it, instead of
+# being hand-pasted per-language (see #322).
+_IMPORT_WRAPPER = r"\b(?:import|require|from)\b.*?(?:{names})\b"
+
+_LLM_API_NAMES = r"openai|anthropic"
+_LLM_ORCHESTRATOR_NAMES = r"langchain|llama_index"
+_LLM_VECTOR_STORE_NAMES = r"chromadb|pinecone"
+_ML_TRADITIONAL_NAMES = r"sklearn"
+_DL_FRAMEWORKS_NAMES = r"tensorflow|torch|keras"
+
+GLOBAL_LLM_API = re.compile(_IMPORT_WRAPPER.format(names=_LLM_API_NAMES))
+GLOBAL_LLM_ORCHESTRATOR = re.compile(_IMPORT_WRAPPER.format(names=_LLM_ORCHESTRATOR_NAMES))
+GLOBAL_LLM_VECTOR_STORE = re.compile(_IMPORT_WRAPPER.format(names=_LLM_VECTOR_STORE_NAMES))
+GLOBAL_ML_TRADITIONAL = re.compile(_IMPORT_WRAPPER.format(names=_ML_TRADITIONAL_NAMES))
+GLOBAL_DL_FRAMEWORKS = re.compile(_IMPORT_WRAPPER.format(names=_DL_FRAMEWORKS_NAMES))
+
 # ------------------------------------------------------------------------------
 # 4. LANGUAGE DEFINITIONS (The Structural Signature Matrix)
 # Consumed by: detector.py, language_lens.py, prism.py
@@ -362,9 +381,8 @@ LANGUAGE_DEFINITIONS = {
             ),
             # 21. comprehensions (Iterators / Comprehensions)
             "comprehensions": re.compile(r"\.(?:map|filter|reduce|flatMap|some|every|find|forEach|groupBy)\s*\("),
-            # Expanded to include LLM orchestration tools for the Agentic Shield
             "scientific": re.compile(
-                r"\b(?:import|require|from)\b.*?(?:tensorflow|torch|keras|numpy|pandas|scipy|sklearn|matplotlib|opencv|cv2|langchain|openai|anthropic|llama_index|chromadb|pinecone)\b"
+                r"\b(?:import|require|from)\b.*?(?:numpy|pandas|scipy|matplotlib|opencv|cv2)\b"
             ),
             "hardware_bridge": re.compile(
                 r"\b(?:import|require|from)\b.*?(?:serialport|usb|bluetooth|socket\.io|websocket|printer|webgl)\b"
@@ -377,6 +395,12 @@ LANGUAGE_DEFINITIONS = {
             "reflection_metaprogramming": re.compile(
                 r"__(?:getattr|setattr|del|call|new|metaclass|dict|dir|import)__|@(?:staticmethod|classmethod|property)|\b(?:getattr|setattr|inspect\.)\b"
             ),
+            # --- AI & LLM SDK SENSORS (GLOBAL_, see #322) ---
+            "llm_api": GLOBAL_LLM_API,
+            "llm_orchestrator": GLOBAL_LLM_ORCHESTRATOR,
+            "llm_vector_store": GLOBAL_LLM_VECTOR_STORE,
+            "ml_traditional": GLOBAL_ML_TRADITIONAL,
+            "dl_frameworks": GLOBAL_DL_FRAMEWORKS,
             # 24. import (Dependency Inclusions)
             "import": re.compile(
                 r"\b(?:from\s+[a-zA-Z0-9_.]+\s+import\b|import\s+[a-zA-Z0-9_., \t]+|\b__import__\s*\(|\bimportlib\.import_module\s*\()",
@@ -632,9 +656,8 @@ LANGUAGE_DEFINITIONS = {
             "generics": re.compile(r"@template\s+\w+|/\*\*\s*@type\s*(?:\{|<\w+)"),
             # 21. comprehensions (Iterators / Comprehensions)
             "comprehensions": re.compile(r"\.(?:map|filter|reduce|flatMap|some|every|find|forEach|groupBy)\s*\("),
-            # Expanded to include LLM orchestration tools for the Agentic Shield
             "scientific": re.compile(
-                r"\b(?:import|require|from)\b.*?(?:tensorflow|torch|keras|numpy|pandas|scipy|sklearn|matplotlib|opencv|cv2|langchain|openai|anthropic|llama_index|chromadb|pinecone)\b"
+                r"\b(?:import|require|from)\b.*?(?:numpy|pandas|scipy|matplotlib|opencv|cv2)\b"
             ),
             "hardware_bridge": re.compile(
                 r"\b(?:import|require|from)\b.*?(?:serialport|usb|bluetooth|socket\.io|websocket|printer|webgl)\b"
@@ -646,6 +669,12 @@ LANGUAGE_DEFINITIONS = {
             "reflection_metaprogramming": re.compile(
                 r"\b(arguments\.|prototype|__proto__|Object\.assign|Reflect|Proxy|Object\.defineProperty|\.bind\(|\.call\(|\.apply\()\b"
             ),
+            # --- AI & LLM SDK SENSORS (GLOBAL_, see #322) ---
+            "llm_api": GLOBAL_LLM_API,
+            "llm_orchestrator": GLOBAL_LLM_ORCHESTRATOR,
+            "llm_vector_store": GLOBAL_LLM_VECTOR_STORE,
+            "ml_traditional": GLOBAL_ML_TRADITIONAL,
+            "dl_frameworks": GLOBAL_DL_FRAMEWORKS,
             # 24. import (Dependency Inclusions)
             "import": re.compile(
                 r"\b(?:import|export)\b[^;]*?\bfrom\b|\brequire\s*\(|\bimport\s*\(",
@@ -916,6 +945,12 @@ LANGUAGE_DEFINITIONS = {
             "reflection_metaprogramming": re.compile(
                 r"\b(arguments\.|prototype|__proto__|Object\.assign|Reflect|Proxy|Object\.defineProperty|\.bind\(|\.call\(|\.apply\()\b"
             ),
+            # --- AI & LLM SDK SENSORS (GLOBAL_, see #322) ---
+            "llm_api": GLOBAL_LLM_API,
+            "llm_orchestrator": GLOBAL_LLM_ORCHESTRATOR,
+            "llm_vector_store": GLOBAL_LLM_VECTOR_STORE,
+            "ml_traditional": GLOBAL_ML_TRADITIONAL,
+            "dl_frameworks": GLOBAL_DL_FRAMEWORKS,
             # 24. import (Dependency Inclusions)
             "import": re.compile(
                 r"\b(?:import(?:\s+type)?|export(?:\s+type)?)\b[^;]*?\bfrom\b|\brequire\s*\(|\bimport\s*\(",


### PR DESCRIPTION
## Summary
- The AI/LLM SDK name list (tensorflow, torch, keras, sklearn, langchain, openai, anthropic, llama_index, chromadb, pinecone) was hand-pasted, character-for-character identical, into the `scientific` key of exactly 2 of 57 language blocks (`python`, `javascript`) instead of using the `GLOBAL_` reference-not-redefine pattern `GLOBAL_PLANNED_DEBT`/`GLOBAL_FRAGILE_DEBT` already establish.
- Split the SDK names into five `GLOBAL_` constants matching the existing `SIGNAL_SCHEMA` categories: `GLOBAL_LLM_API`, `GLOBAL_LLM_ORCHESTRATOR`, `GLOBAL_LLM_VECTOR_STORE`, `GLOBAL_ML_TRADITIONAL`, `GLOBAL_DL_FRAMEWORKS`.
- Wired these in as new rule keys (`llm_api`, `llm_orchestrator`, `llm_vector_store`, `ml_traditional`, `dl_frameworks`) in `python`, `javascript`, **and `typescript`** — typescript shares the same import syntax and was the language silently missed when the list was copy-pasted into javascript's block.
- Removed the AI/LLM names from `scientific` in `python` and `javascript`, leaving it genuine scientific-computing only again (numpy, pandas, scipy, matplotlib, opencv, cv2).
- Left the secondary-tier language question (java/kotlin via LangChain4j/DJL, csharp via Semantic Kernel) untouched, per the issue's explicit note that it's a separate follow-up decision, not part of this fix.

Closes #322.

## Test plan
- [x] `pytest tests/core_engine/test_language_standards_strict.py tests/core_engine/test_signal_processor.py tests/core_engine/test_detector.py` — 119 passed
- [x] `pytest tests/core_engine/test_language_lens.py tests/core_engine/test_prism.py tests/security_auditing/ tests/core_engine/test_guidestar_lens.py tests/extraction/` — 368 passed
- [x] Full suite: `pytest -q` — 809 passed, 1 xfailed (pre-existing, unrelated)
- [x] Manual regex checks confirming AI/LLM imports now hit the new categories (not `scientific`) in python, javascript, and typescript samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)