### PR TITLE
Make Aperture's file-size gate tiered and Intent-aware

### DIFF
--- a/gitgalaxy/core/aperture.py
+++ b/gitgalaxy/core/aperture.py
@@ -168,6 +168,18 @@ class ApertureFilter:
             self.logger.info(f"NEURAL SHUNT: Routing {path_obj.name} away from standard regex engines.")
             return False, size_bytes, reason
 
+        # --- Gate 1.2.5: Absolute Mass Ceiling (Zero-I/O Memory Backstop) ---
+        # DEFENSIVE DESIGN: Checked here, before the file is ever opened for
+        # reading, using the os.stat() size already gathered above. This is an
+        # unconditional, Intent-blind physical safety net against truly extreme
+        # artifacts (multi-GB dumps) -- distinct from the *soft* MAX_FILE_SIZE_MB
+        # ceiling in is_in_scope(), which content-based classification and an
+        # Intent Lock can override. Nothing overrides this one.
+        hard_max_mb = self.config.get("MAX_FILE_SIZE_HARD_MB", 250)
+        if size_bytes > (hard_max_mb * 1024 * 1024):
+            reason = f"Blocked (File size exceeds absolute {hard_max_mb}MB safety ceiling)"
+            return False, size_bytes, reason
+
         # --- Gate 1.3: Explicit Extension Firewall ---
         if ext.lower() in self.ignored_extensions and ext.lower() not in self.whitelisted_extensions:
             reason = f"Blocked (Explicitly Denied Extension: '{ext}')"
@@ -228,16 +240,20 @@ class ApertureFilter:
             stats = path_obj.stat()
             result["size_bytes"] = stats.st_size
 
-            # --- Gate 2.1: Mass Saturation Limit ---
-            # DEFENSIVE DESIGN: Uses os.stat to check file size before allocating RAM. 
-            # A hard 10MB limit prevents a single massive log or SQL dump from consuming 
-            # all available RAM and triggering an OOM kill from the OS.
-            max_mb = self.config.get("MAX_FILE_SIZE_MB", 10)
-            if stats.st_size > (max_mb * 1024 * 1024):
+            # --- Gate 2.1: Mass Saturation Limit (Soft Ceiling) ---
+            # DEFENSIVE DESIGN: Above this size, raw byte count alone no longer decides
+            # exclusion -- the content-based classifiers below (binary/minified/monotony/
+            # array shields) are usually a better judge of "is this actual noise" than a
+            # blunt threshold, so an Intent-Locked file (GuideStar-recognized as
+            # important) is allowed through to them. The absolute, Intent-blind backstop
+            # against truly extreme artifacts lives in evaluate_path_integrity (Gate
+            # 1.2.5), checked before any disk read even happens.
+            soft_max_mb = self.config.get("MAX_FILE_SIZE_MB", 50)
+            if stats.st_size > (soft_max_mb * 1024 * 1024) and not active_intent:
                 result.update(
                     {
                         "classification": "oversized_minified",
-                        "reason": f"Blocked (File size exceeds {max_mb}MB limit)",
+                        "reason": f"Blocked (File size exceeds {soft_max_mb}MB limit without Intent Lock)",
                     }
                 )
                 return result

--- a/gitgalaxy/standards/config_resolver.py
+++ b/gitgalaxy/standards/config_resolver.py
@@ -77,6 +77,7 @@ APERTURE_CONFIG_SPEC: Dict[str, str] = {
     "MAX_LINE_LENGTH": REPLACE,
     "MINIFICATION_SCAN_LIMIT": REPLACE,
     "MAX_FILE_SIZE_MB": REPLACE,
+    "MAX_FILE_SIZE_HARD_MB": REPLACE,
     # BANDS is an internal label taxonomy, not user-overridable -- omitted
     # on purpose so a YAML BANDS key raises ConfigError.
 }

--- a/gitgalaxy/standards/gitgalaxy_config.py
+++ b/gitgalaxy/standards/gitgalaxy_config.py
@@ -346,7 +346,14 @@ APERTURE_CONFIG = {
     # --- 4. Integrity Thresholds ---
     "MAX_LINE_LENGTH": 500,
     "MINIFICATION_SCAN_LIMIT": 50,
+    # Soft ceiling: content-based classifiers (binary/minified/monotony/array
+    # shields) decide whether a file over this size is real signal or noise.
+    # An Intent-Locked file (GuideStar-recognized as important) bypasses it.
     "MAX_FILE_SIZE_MB": 50,
+    # Absolute ceiling: an unconditional, Intent-blind memory-safety backstop
+    # checked before the file is ever opened for reading (see Aperture Gate
+    # 1.0 in evaluate_path_integrity). Nothing bypasses this one.
+    "MAX_FILE_SIZE_HARD_MB": 250,
     "VENDOR_MINIFICATION_PATHS": [
         "/vendor/",
         "/node_modules/",

--- a/tests/core_engine/test_aperture.py
+++ b/tests/core_engine/test_aperture.py
@@ -19,6 +19,7 @@ MOCK_CONFIG = {
     "SECRETS_EXACT": {"id_rsa", ".env"},
     "SECRETS_EXTENSIONS": {".pem", ".key"},
     "MAX_FILE_SIZE_MB": 10,
+    "MAX_FILE_SIZE_HARD_MB": 100,
     "MAX_LINE_LENGTH": 500,
     "IGNORED_DIRECTORIES": {"node_modules", ".git"},
     "IGNORED_EXTENSIONS": {".exe", ".dll"},
@@ -197,7 +198,7 @@ def test_aperture_system_guardrails(filter_engine, tmp_path):
     assert result["is_in_scope"] is False
     assert "Protocol Violation: Missing content buffer" in result["reason"]
 
-    # 3. Size Cap Exceeded (Mocking stat to simulate an 11MB file)
+    # 3. Size Cap Exceeded (Mocking stat to simulate a 15MB file, no Intent Lock)
     big_file = tmp_path / "huge.py"
     big_file.write_text("x")
 
@@ -207,7 +208,53 @@ def test_aperture_system_guardrails(filter_engine, tmp_path):
 
         assert result["is_in_scope"] is False
         assert result["classification"] == "oversized_minified"
-        assert "File size exceeds 10MB limit" in result["reason"]
+        assert "File size exceeds 10MB limit without Intent Lock" in result["reason"]
+
+
+# ==============================================================================
+# TEST 13: TIERED MASS CEILING (SOFT vs. HARD, ISSUE #245-followup)
+# ==============================================================================
+def test_aperture_tiered_mass_ceiling(filter_engine, tmp_path):
+    """
+    Proves the file-size gate is no longer a single flat cutoff:
+      - Below the soft ceiling (MAX_FILE_SIZE_MB): always passes.
+      - Above the soft ceiling but below the hard ceiling: blocked UNLESS the
+        file carries a GuideStar Intent Lock, in which case it's handed to the
+        content-based classifiers instead of being excluded on size alone.
+      - Above the hard ceiling (MAX_FILE_SIZE_HARD_MB): blocked unconditionally,
+        even with an Intent Lock, and rejected at evaluate_path_integrity
+        (zero-I/O, pre-read) rather than is_in_scope.
+    """
+    mid_file = tmp_path / "generated_schema.py"
+    mid_file.write_text("x", encoding="utf-8")
+
+    # 1. Above soft (10MB), below hard (100MB), NO intent -> blocked
+    with patch("pathlib.Path.stat") as mock_stat:
+        mock_stat.return_value.st_size = 20 * 1024 * 1024  # 20MB
+        result = filter_engine.is_in_scope(mid_file, content="x", has_intent=False)
+        assert result["is_in_scope"] is False
+        assert "without Intent Lock" in result["reason"]
+
+    # 2. Above soft (10MB), below hard (100MB), WITH intent -> passes the size
+    #    gate and reaches content classification
+    with patch("pathlib.Path.stat") as mock_stat:
+        mock_stat.return_value.st_size = 20 * 1024 * 1024  # 20MB
+        result = filter_engine.is_in_scope(mid_file, content="x", has_intent=True)
+        assert result["is_in_scope"] is True
+
+    # 3. Above hard ceiling (100MB) -> blocked even WITH intent, and caught by
+    #    the zero-I/O pre-read gate (evaluate_path_integrity), not is_in_scope.
+    with patch("pathlib.Path.stat") as mock_stat:
+        mock_stat.return_value.st_size = 150 * 1024 * 1024  # 150MB
+        is_valid, _, reason = filter_engine.evaluate_path_integrity(
+            mid_file, has_intent=True
+        )
+        assert is_valid is False
+        assert "absolute 100MB safety ceiling" in reason
+
+        result = filter_engine.is_in_scope(mid_file, content="x", has_intent=True)
+        assert result["is_in_scope"] is False
+        assert "safety ceiling" in result["reason"]
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
- `MAX_FILE_SIZE_MB` was a single flat, Intent-blind cutoff (50MB) enforced only *after* the entire file had already been read into memory (`galaxyscope.py` reads the file before `ApertureFilter.is_in_scope()` ever checks its size) — unlike every other size-related gate in `ApertureFilter` (static-asset LOC cap, machine-gen source check, lexical monotony shield), which already carve out an exception for GuideStar's Intent Lock.
- Net effect: large but legitimate/important files (e.g. a generated schema someone explicitly cares about) were silently excluded purely on byte count, while the size check itself did nothing to actually bound memory use on a truly giant file, since the read had already happened by the time it ran.
- Fix: split the single cutoff into two tiers:
  - **`MAX_FILE_SIZE_MB` (soft, 50MB, unchanged default)** — above this, an Intent-Locked file now bypasses the gate and is handed to the existing content-based classifiers (binary/minified/monotony/embedded-array shields) instead of being excluded on size alone.
  - **`MAX_FILE_SIZE_HARD_MB` (new, absolute, 250MB default)** — an unconditional, Intent-blind backstop checked in `evaluate_path_integrity` *before* the file is ever opened for reading, so it's a real memory bound regardless of Intent Lock or content.
- Both are user-overridable via the existing YAML/CLI config resolver (`config_resolver.py`).

## Test plan
- [x] Updated `test_aperture_system_guardrails` for the new "without Intent Lock" message text.
- [x] Added `test_aperture_tiered_mass_ceiling`, covering: soft-blocked without intent, soft-bypassed with intent, and hard-blocked even with intent (verified caught at the pre-read `evaluate_path_integrity` gate).
- [x] `python -m pytest tests/core_engine/test_aperture.py -q` — 12 passed, 1 xfailed (pre-existing, unrelated).
- [x] `python -m pytest tests/ -q` — full suite, 811 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)