### PR TITLE
Fix detector.py's dead RCE-taint corroboration and the sec_ merge overwrite

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -1002,10 +1002,16 @@ class StructuralExtractor:
 # galaxyscope:ignore sec_high_risk_execution
 
             # 1. Taint Tracking (RCE Weaponization)
-            if "sec_high_risk_execution" in spatial_map and ("sec_io" in spatial_map or "io" in spatial_map):
-                io_hits = sorted(spatial_map.get("sec_io", []) + spatial_map.get("io", []))
+            # NOTE (#344): must key off the unprefixed "high_risk_execution"/"io" --
+            # these are detector.py's own rule hits, populated in THIS spatial_map.
+            # The "sec_" prefix belongs to the Passive Security Lens Observer family
+            # (analysis_lens.py's SIGNAL_SCHEMA), which security_lens.py only writes
+            # in galaxyscope.py's Phase 5.5, strictly after coding_analysis() returns
+            # -- those keys can never appear in this function's own spatial_map.
+            if "high_risk_execution" in spatial_map and "io" in spatial_map:
+                io_hits = sorted(spatial_map["io"])
                 _, corroborated_rce = self._correlate_signals(
-                    targets=spatial_map["sec_high_risk_execution"],
+                    targets=spatial_map["high_risk_execution"],
                     dampeners=io_hits,
                     max_distance=250,
                 )
@@ -1039,6 +1045,16 @@ class StructuralExtractor:
                     mitigations["amplified_race_conditions"] += race_conditions
 
             # 4. The Active Hemorrhage
+            # NOTE (#344): unlike block 1, there is no unprefixed sibling to fall back
+            # to here -- "hardcoded_secrets" (unprefixed) is not a SIGNAL_SCHEMA member
+            # at all (only "sec_hardcoded_secrets", the Passive Security Lens Observer
+            # name, is registered), so detector.py has no rule of its own that could
+            # ever populate this spatial_map under either name. This block genuinely
+            # needs security_lens.py's data, which doesn't exist until galaxyscope.py's
+            # Phase 5.5, strictly after this function returns -- it can't be fixed with
+            # a key-name correction the way block 1 was. Left as still-dead pending the
+            # correlate-after-both-phases work in #346; do not "fix" this to a bare
+            # "hardcoded_secrets" check, that key will never be populated either.
             if "sec_hardcoded_secrets" in spatial_map and ("telemetry" in spatial_map or "debug_prints" in spatial_map):
                 sinks = sorted(spatial_map.get("telemetry", []) + spatial_map.get("debug_prints", []))
                 _, active_leaks = self._correlate_signals(

--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -422,8 +422,14 @@ def _process_file_worker(rel_path: str) -> Dict[str, Any]:
                 # Handle the new nested dictionary
                 sec_results = security.scan_content(content_buffer, filter_res.get("total_loc", 0))
 
+                # Additive, not an overwrite (#344): detector.py's own coding_analysis()
+                # can independently corroborate some of these same "sec_" keys (e.g.
+                # sec_tainted_injection, sec_hardcoded_secrets) via its in-segment
+                # spatial correlation. A plain assignment here would silently discard
+                # that contribution the moment security_lens's own scan ran second.
                 for sec_key, hit_count in sec_results["counts"].items():
-                    logic_data["equations"][f"sec_{sec_key}"] = hit_count
+                    mapped_key = f"sec_{sec_key}"
+                    logic_data["equations"][mapped_key] = logic_data["equations"].get(mapped_key, 0) + hit_count
 
                 # Pass the snippets into the payload
                 logic_data["threat_snippets"] = sec_results["snippets"]

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -42,10 +42,9 @@ MOCK_LANG_DEFS = {
             ),
             "memory_scraping": re.compile(r"\b(memcpy|VirtualRead)\b"),
             "exfiltration_camouflage": re.compile(r"\b(send|socket)\b"),
-            "high_risk_execution": re.compile(r"\b(strcpy|gets)\b"),
+            "high_risk_execution": re.compile(r"\b(strcpy|gets|system)\b"),
             "safety": re.compile(r"\b(strncpy|fgets)\b"),
-            "sec_high_risk_execution": re.compile(r"system"),
-            "sec_io": re.compile(r"request_get"),
+            "io": re.compile(r"request_get"),
             "concurrency": re.compile(r"std::thread"),
             "state_mutation": re.compile(r"shared_state"),
             "sync_locks": re.compile(r"mutex_lock"),
@@ -590,7 +589,7 @@ def test_detector_advanced_appsec_sensors():
     eqs = result["equations"]
     mits = result["mitigation_telemetry"]
 
-    # 1. RCE Weaponization: sec_danger spatially overlapping with sec_io
+    # 1. RCE Weaponization: high_risk_execution spatially overlapping with io (#344)
     assert eqs.get("sec_tainted_injection", 0) >= 1, (
         "Failed to spatially correlate Tainted RCE Injection!"
     )

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import os
+import re
 import tempfile
 from pathlib import Path
 
@@ -636,6 +637,84 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         self.assertEqual(result["status"], "success", "Worker failed to successfully parse the file!")
         self.assertEqual(result["data"]["lang_id"], "python", "Worker failed to assign language ID!")
         self.assertEqual(result["data"]["equations"]["sec_high_risk_execution"], 1, "Worker dropped security equations!")
+
+    # ==============================================================================
+    # TEST 13.5: THE DOUBLE CORROBORATION (Additive sec_ Merge, #344)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.ApertureFilter")
+    @patch("gitgalaxy.galaxyscope.Prism")
+    @patch("gitgalaxy.galaxyscope.LanguageDetector")
+    @patch("gitgalaxy.galaxyscope.SecurityLens")
+    @patch("gitgalaxy.galaxyscope.Path.is_file", return_value=True)
+    def test_worker_merges_sec_tainted_injection_additively(
+        self, mock_is_file, MockSecurity, MockDetector, MockPrism, MockAperture
+    ):
+        """
+        Regression test for #344: detector.py's own in-segment proximity check
+        (block 1, "Taint Tracking") and security_lens.py's independent variable-echo
+        check both contribute to the same "sec_tainted_injection" signal. Before the
+        fix, galaxyscope.py's Phase 5.5 merge used a plain assignment, so whichever
+        of the two ran second silently discarded the other's finding entirely.
+        This drives a real detector.py contribution (via a genuine
+        high_risk_execution/io proximity hit) together with a mocked
+        security_lens.py contribution, and asserts the final count is their SUM,
+        not just security_lens.py's value alone.
+        """
+        from gitgalaxy.galaxyscope import _init_worker, _process_file_worker
+        from unittest.mock import mock_open
+        import logging
+
+        mock_aperture_inst = MockAperture.return_value
+        mock_aperture_inst.evaluate_path_integrity.return_value = (True, 1024, "Passed")
+        mock_aperture_inst.is_in_scope.return_value = {"is_in_scope": True, "reason": None}
+
+        mock_detector_inst = MockDetector.return_value
+        mock_detector_inst.inspect.return_value = {
+            "lang_id": "python", "intensity": 0.99, "lock_tier": 1, "source_proof": "Test"
+        }
+
+        code = "eval(input())"
+        mock_prism_inst = MockPrism.return_value
+        mock_prism_inst.split_streams.return_value = {
+            "code_stream": code, "comment_stream": "", "coding_loc": 1, "doc_loc": 0
+        }
+
+        # security_lens.py independently reports its own variable-echo-based hit.
+        mock_sec_inst = MockSecurity.return_value
+        mock_sec_inst.scan_content.return_value = {"counts": {"tainted_injection": 3}, "snippets": {}}
+
+        # Real per-language rules so detector.py's own block 1 correlation fires for
+        # real: "eval(" is high_risk_execution, "input(" is io, well within the
+        # 250-char proximity radius -- this should corroborate to exactly 1 hit.
+        self.mock_config["LANGUAGE_DEFINITIONS"] = {
+            "python": {
+                "extensions": [".py"],
+                "rules": {
+                    "high_risk_execution": re.compile(r"\beval\b"),
+                    "io_ops": re.compile(r"\binput\b"),
+                },
+            }
+        }
+        _init_worker(
+            root_str=".",
+            config=self.mock_config,
+            ext_tally={".py": 1},
+            log_level=logging.INFO,
+            git_tracked={"src/main.py"},
+            census={"main"},
+        )
+
+        with patch("builtins.open", mock_open(read_data=code)):
+            result = _process_file_worker("src/main.py")
+
+        self.assertEqual(result["status"], "success", "Worker failed to successfully parse the file!")
+        self.assertEqual(
+            result["data"]["equations"]["sec_tainted_injection"],
+            4,
+            "Additive merge regressed: detector.py's own corroboration (1) and "
+            "security_lens.py's independent finding (3) must both survive (1 + 3 = 4), "
+            "not just whichever system ran last.",
+        )
 
     # ==============================================================================
     # TEST 14: THE MEMORY HOLE (SARIF Sanitization & Inline Suppressions)


### PR DESCRIPTION
## Summary
Fixes #344. The originally-filed issue described the bug as a merge overwrite (`security_lens.py`'s count silently clobbering `detector.py`'s own corroborated count); implementing it surfaced a more fundamental issue underneath, corrected in a follow-up comment on #344 before this PR.

- `detector.py::coding_analysis()`'s "1. Taint Tracking (RCE Weaponization)" block checked `spatial_map` for `"sec_high_risk_execution"`/`"sec_io"` — keys that belong exclusively to the Passive Security Lens Observer family (`SIGNAL_SCHEMA`), populated only by `security_lens.py` during `galaxyscope.py`'s Phase 5.5, which runs *after* `coding_analysis()` has already returned. `spatial_map` is local to a single `coding_analysis()` call and can never contain a `sec_`-prefixed key. **The block's guard was always `False` — this correlation has never actually executed.**
- Fixed by pointing the block at the keys `detector.py`'s own rules really produce at this stage: `"high_risk_execution"`/`"io"` (both real, unprefixed `SIGNAL_SCHEMA` members).
- The sibling block, "4. The Active Hemorrhage", has the same wrong-key shape but **no equivalent fix is available yet**: `"hardcoded_secrets"` (unprefixed) isn't a `SIGNAL_SCHEMA` member at all, so there's no key `detector.py`'s own rules could ever populate it under. Left intentionally dead, annotated in place, pending #346 (moving correlation to run after `security_lens.py` has actually populated its data).
- Once block 1 computes a real value, `galaxyscope.py`'s Phase 5.5 merge loop would have erased it again on the next line — it did `equations[f"sec_{key}"] = hit_count` unconditionally. Made the merge additive so `detector.py`'s proximity-based corroboration and `security_lens.py`'s independent variable-echo corroboration both survive.
- Two existing tests (`test_detector_advanced_appsec_sensors`, and its `MOCK_LANG_DEFS`) had been quietly papering over the dead-code bug by injecting fake rules literally named `sec_high_risk_execution`/`sec_io` — updated them to use the real unprefixed rule names, matching how `language_standards.py` actually names these rules in production.

## Test plan
- [x] Added `test_worker_merges_sec_tainted_injection_additively` in `test_galaxyscope.py`, driving a real `detector.py` corroboration (1 hit) together with a mocked `security_lens.py` contribution (3 hits) through the full worker path, asserting the merged result is `4`, not `3`. Verified it fails (`3 != 4`) on the pre-fix code and passes after.
- [x] `python -m pytest tests/core_engine/test_detector.py tests/core_engine/test_galaxyscope.py tests/core_engine/test_signal_processor.py tests/security_auditing/test_security_lens.py -q` — all pass.
- [x] `python -m pytest tests/ -q` — full suite, 812 passed, 1 xfailed (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)