### PR TITLE
Scope dampener correlation to real function boundaries (#346 phase 1)

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -21,6 +21,10 @@ import time
 import bisect
 from typing import Dict, List, Any, TypedDict, Optional, Tuple
 from gitgalaxy.standards.analysis_lens import RECORDING_SCHEMAS
+from gitgalaxy.core.spatial_correlation import (
+    correlate_signals as _correlate_signals_impl,
+    apply_dampener_correlations,
+)
 
 HAS_TIKTOKEN = False
 try:
@@ -88,6 +92,8 @@ class FunctionNode(TypedDict, total=False):
 
     start_line: int
     end_line: int
+    start_idx: int
+    end_idx: int
 
     big_o_depth: int
     is_recursive: bool
@@ -452,6 +458,8 @@ class StructuralExtractor:
             functions, sum_fxn_impact = self._function_slice(
                 segments,
                 segment_spatial_maps,
+                equations,
+                mitigation_telemetry,
                 regex_telemetry if profile_regex else None,
             )
 
@@ -847,30 +855,12 @@ class StructuralExtractor:
         """
         Sweeps two sorted lists of indices to find how many targets are within
         'max_distance' of a dampener. Runs in O(N) linear time.
+
+        Extracted to gitgalaxy.core.spatial_correlation (#346) so the same
+        primitive is reusable outside this class; kept here as a thin
+        delegating wrapper for backward compatibility with existing callers.
         """
-        if not targets:
-            return 0, 0
-        if not dampeners:
-            return len(targets), 0
-
-        unmitigated_count = 0
-        mitigated_count = 0
-
-        damp_idx = 0
-        damp_len = len(dampeners)
-
-        for t_pos in targets:
-            # Move the dampener pointer forward until it is somewhat near the target
-            while damp_idx < damp_len and dampeners[damp_idx] < (t_pos - max_distance):
-                damp_idx += 1
-
-            # Check if the closest dampener is within the blast radius
-            if damp_idx < damp_len and abs(dampeners[damp_idx] - t_pos) <= max_distance:
-                mitigated_count += 1
-            else:
-                unmitigated_count += 1
-
-        return unmitigated_count, mitigated_count
+        return _correlate_signals_impl(targets, dampeners, max_distance)
 
     def coding_analysis(
         self, segments: List[Tuple[str, str, int]], regex_telemetry: Optional[dict] = None
@@ -1018,31 +1008,15 @@ class StructuralExtractor:
                 counts["sec_tainted_injection"] += corroborated_rce
                 mitigations["amplified_rce"] += corroborated_rce
 
-            # 2. The Silencer Region (True Safety)
-            if "high_risk_execution" in spatial_map and "safety" in spatial_map:
-                unmitigated_danger, mitigated_danger = self._correlate_signals(
-                    targets=spatial_map["high_risk_execution"],
-                    dampeners=spatial_map["safety"],
-                    max_distance=500,
-                )
-                counts["high_risk_execution"] -= mitigated_danger
-                mitigations["mitigated_danger"] += mitigated_danger
-
-            # 3. The Race Condition Radar
-            if "concurrency" in spatial_map and "state_mutation" in spatial_map:
-                unmitigated_flux, _ = self._correlate_signals(
-                    targets=spatial_map["state_mutation"],
-                    dampeners=spatial_map.get("sync_locks", []),
-                    max_distance=300,
-                )
-                if unmitigated_flux > 0:
-                    _, race_conditions = self._correlate_signals(
-                        targets=spatial_map["concurrency"],
-                        dampeners=spatial_map["state_mutation"],
-                        max_distance=150,
-                    )
-                    counts["concurrency"] += race_conditions * 5
-                    mitigations["amplified_race_conditions"] += race_conditions
+            # 2. The Silencer Region (True Safety), 3. The Race Condition Radar, and
+            # 5. The Memory Leak / UAF Tracker have all been RELOCATED (#346 phase 1)
+            # to _apply_dampener_correlations(), called from _function_slice() once
+            # real satellite/function boundaries exist. All three are dampener pairs
+            # -- a wrong-scope mitigation there silently suppresses real risk (a false
+            # negative), which the flat character-radius check here couldn't prevent.
+            # See _apply_dampener_correlations()'s docstring for the exact scoping
+            # rules and the module-level fallback that keeps this fully non-regressing
+            # for code outside any detected function.
 
             # 4. The Active Hemorrhage
             # NOTE (#344): unlike block 1, there is no unprefixed sibling to fall back
@@ -1064,19 +1038,6 @@ class StructuralExtractor:
                 )
                 counts["sec_hardcoded_secrets"] += active_leaks * 50
                 mitigations["amplified_leaks"] += active_leaks
-
-            # 5. The Memory Leak / UAF Tracker
-            if "memory_alloc" in spatial_map:
-                unmitigated_allocs, _ = self._correlate_signals(
-                    targets=spatial_map["memory_alloc"],
-                    dampeners=spatial_map.get("cleanup", []),
-                    max_distance=800,
-                )
-                original_allocs = len(spatial_map["memory_alloc"])
-                mitigated = original_allocs - unmitigated_allocs
-
-                counts["memory_alloc"] = unmitigated_allocs
-                mitigations["mitigated_memory_allocs"] += mitigated
 
             # 6. The OOM Bomb (Cascading State Flux)
             if "state_mutation" in spatial_map and "branch" in spatial_map:
@@ -1271,6 +1232,8 @@ class StructuralExtractor:
         self,
         segments: List[Tuple[str, str, int]],
         segment_spatial_maps: List[Dict[str, List[int]]],
+        counts: Dict[str, int],
+        mitigations: Dict[str, int],
         regex_telemetry: Optional[dict] = None,
     ) -> Tuple[List[FunctionNode], float]:
         """The Master Routing Dispatcher: Directs the structural signal into the correct integration mode."""
@@ -1286,6 +1249,8 @@ class StructuralExtractor:
 
             t_mode_start = time.perf_counter()
             mode_name = "Unknown"
+            sats: List[FunctionNode] = []
+            impact = 0.0
 
             if integration_mode == "mode_d":
                 mode_name = "Mode_D_Keywords"
@@ -1296,39 +1261,50 @@ class StructuralExtractor:
             else:
                 # Fallback to standard structural heuristics (Modes A, B, C)
                 func_start = rules.get("func_start")
-                if not func_start:
-                    continue
-
-                # Routed via formal Lexical Family taxonomy
-                if lang_id in (
-                    "assembly",
-                    "agc_assembly",
-                    "cobol",
-                    "fortran",
-                ) or family in ("column_sensitive"):
-                    mode_name = "Mode_A_Labels"
-                    sats, impact = self._slice_by_labels(code, rules, offset, spatial_map)
-                elif family in ("single_line_only", "multi_style_dash") or lang_id in (
-                    "python",
-                    "yaml",
-                ):
-                    mode_name = "Mode_C_Indentation"
-                    sats, impact = self._slice_by_indentation(code, rules, offset, spatial_map)
-                else:
-                    mode_name = "Mode_B_Braces"
-                    sats, impact = self._slice_by_braces(code, lang_id, rules, offset, spatial_map, family=family)
+                if func_start:
+                    # Routed via formal Lexical Family taxonomy
+                    if lang_id in (
+                        "assembly",
+                        "agc_assembly",
+                        "cobol",
+                        "fortran",
+                    ) or family in ("column_sensitive"):
+                        mode_name = "Mode_A_Labels"
+                        sats, impact = self._slice_by_labels(code, rules, offset, spatial_map)
+                    elif family in ("single_line_only", "multi_style_dash") or lang_id in (
+                        "python",
+                        "yaml",
+                    ):
+                        mode_name = "Mode_C_Indentation"
+                        sats, impact = self._slice_by_indentation(code, rules, offset, spatial_map)
+                    else:
+                        mode_name = "Mode_B_Braces"
+                        sats, impact = self._slice_by_braces(code, lang_id, rules, offset, spatial_map, family=family)
+                # else: no func_start rule for this language at all -- sats stays [],
+                # and the dampener correlation below falls back to flat behavior for
+                # this segment (see apply_dampener_correlations()).
 
             # Record the telemetry if profiling is active
             if regex_telemetry is not None and mode_name != "Unknown":
                 key = f"{lang_id}::Cartography_{mode_name}"
                 regex_telemetry[key] = regex_telemetry.get(key, 0.0) + (time.perf_counter() - t_mode_start)
 
-            all_satellites.extend(sats)
-            global_impact += impact
+            # --- SATELLITE-SCOPED DAMPENER CORRELATION (#346 phase 1) ---
+            # Runs for every segment unconditionally, using THIS segment's own
+            # satellite ranges. Deliberately placed before the MAX_SATELLITES
+            # truncation below: that cap only bounds stored function metadata,
+            # it must never silently disable risk correlation for the rest of
+            # an unusually large file.
+            sat_ranges = sorted(
+                (sat["start_idx"], sat["end_idx"]) for sat in sats if "start_idx" in sat and "end_idx" in sat
+            )
+            apply_dampener_correlations(spatial_map, sat_ranges, counts, mitigations)
 
-            if len(all_satellites) >= self.MAX_SATELLITES:
-                all_satellites = all_satellites[: self.MAX_SATELLITES]
-                break
+            if len(all_satellites) < self.MAX_SATELLITES:
+                all_satellites.extend(sats)
+                if len(all_satellites) > self.MAX_SATELLITES:
+                    all_satellites = all_satellites[: self.MAX_SATELLITES]
+            global_impact += impact
 
         all_satellites.sort(key=lambda x: x.get("mag", 0), reverse=True)
         return all_satellites, global_impact
@@ -2203,6 +2179,8 @@ class StructuralExtractor:
             "impact": round(magnitude, 1),
             "start_line": start_line,
             "end_line": end_line,
+            "start_idx": start_idx,
+            "end_idx": end_idx,
             "hit_vector": hit_vector,
             "keyword_density": round(keyword_density, 3),
             "coding_loc": coding_loc,

--- a/gitgalaxy/core/spatial_correlation.py
+++ b/gitgalaxy/core/spatial_correlation.py
@@ -1,0 +1,192 @@
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at [https://polyformproject.org/licenses/noncommercial/1.0.0/](https://polyformproject.org/licenses/noncommercial/1.0.0/)
+# ==============================================================================
+"""
+Structural Colocalization: shared proximity-correlation primitives.
+
+Extracted from detector.py (#346) so the same distance-sweep can be reused
+outside the StructuralExtractor -- and, in this module, given real
+function-level scoping instead of a flat character radius as its only notion
+of "nearby".
+
+NAMING NOTE: this is proximity correlation between independent signal
+classes, not taint tracking. It never follows a specific value through
+assignment/parameter-binding; it only asks whether two kinds of regex hit
+occurred close together (optionally: within the same function). See the
+V2.5.0 epic (#102) discussion for why "taint tracker" overclaims what this
+does versus security_lens.py's actual variable-identity echo check.
+"""
+import bisect
+from typing import Dict, List, Optional, Sequence, Tuple
+
+
+def correlate_signals(targets: List[int], dampeners: List[int], max_distance: int = 500) -> Tuple[int, int]:
+    """
+    Sweeps two sorted lists of indices to find how many targets are within
+    'max_distance' of a dampener. Runs in O(N) linear time.
+    """
+    if not targets:
+        return 0, 0
+    if not dampeners:
+        return len(targets), 0
+
+    unmitigated_count = 0
+    mitigated_count = 0
+
+    damp_idx = 0
+    damp_len = len(dampeners)
+
+    for t_pos in targets:
+        # Move the dampener pointer forward until it is somewhat near the target
+        while damp_idx < damp_len and dampeners[damp_idx] < (t_pos - max_distance):
+            damp_idx += 1
+
+        # Check if the closest dampener is within the blast radius
+        if damp_idx < damp_len and abs(dampeners[damp_idx] - t_pos) <= max_distance:
+            mitigated_count += 1
+        else:
+            unmitigated_count += 1
+
+    return unmitigated_count, mitigated_count
+
+
+def filter_positions_in_range(positions: Sequence[int], start: int, end: int) -> List[int]:
+    """
+    Returns the subset of a SORTED position list falling within [start, end).
+    Same O(log N) bisect approach _calculate_block_metrics already uses to
+    build a satellite's own hit_vector -- reused here so correlation and
+    per-function metrics agree on what "inside this function" means.
+    """
+    left = bisect.bisect_left(positions, start)
+    right = bisect.bisect_left(positions, end)
+    return list(positions[left:right])
+
+
+def correlate_scoped(
+    targets: List[int],
+    dampeners: List[int],
+    satellite_ranges: Optional[List[Tuple[int, int]]],
+    max_distance: int = 500,
+) -> Tuple[int, int]:
+    """
+    Same contract as correlate_signals (returns unmitigated_count,
+    mitigated_count) but requires a target and its dampener to additionally
+    fall within the SAME satellite/function range to correlate.
+
+    A target that doesn't fall inside any known satellite range (module-level
+    code, or a segment where no functions were sliced at all) falls back to
+    the flat, distance-only behavior against the full dampener list -- this
+    is exactly today's pre-scoping behavior, so nothing that correlated
+    before stops correlating; code inside a detected function just gets the
+    stricter, more correct same-function requirement on top.
+
+    Assumes satellite_ranges are sorted by start and non-overlapping, which
+    holds for every existing slicer (_slice_by_braces, _slice_by_indentation,
+    etc. all track last_end_idx to skip overlapping matches).
+    """
+    if not targets:
+        return 0, 0
+    if not satellite_ranges:
+        return correlate_signals(targets, dampeners, max_distance)
+
+    starts = [r[0] for r in satellite_ranges]
+    covered_targets: Dict[int, List[int]] = {}
+    uncovered_targets: List[int] = []
+
+    for pos in targets:
+        idx = bisect.bisect_right(starts, pos) - 1
+        if idx >= 0 and satellite_ranges[idx][0] <= pos < satellite_ranges[idx][1]:
+            covered_targets.setdefault(idx, []).append(pos)
+        else:
+            uncovered_targets.append(pos)
+
+    total_unmitigated = 0
+    total_mitigated = 0
+
+    for sat_idx, sat_targets in covered_targets.items():
+        sat_start, sat_end = satellite_ranges[sat_idx]
+        scoped_dampeners = filter_positions_in_range(dampeners, sat_start, sat_end)
+        unmit, mit = correlate_signals(sat_targets, scoped_dampeners, max_distance)
+        total_unmitigated += unmit
+        total_mitigated += mit
+
+    if uncovered_targets:
+        unmit, mit = correlate_signals(uncovered_targets, dampeners, max_distance)
+        total_unmitigated += unmit
+        total_mitigated += mit
+
+    return total_unmitigated, total_mitigated
+
+
+def apply_dampener_correlations(
+    spatial_map: Dict[str, List[int]],
+    satellite_ranges: List[Tuple[int, int]],
+    counts: Dict[str, int],
+    mitigations: Dict[str, int],
+) -> None:
+    """
+    Runs the three dampener-pair correlations (#346 phase 1) scoped to real
+    function boundaries instead of a flat character radius: a target and its
+    dampener must fall within the SAME satellite to mitigate one another.
+
+    A target outside every known satellite range (module-level code, or a
+    segment where no functions were sliced at all) falls back to the
+    pre-scoping flat behavior -- see correlate_scoped()'s docstring. Nothing
+    that correlated before this change stops correlating; code inside a
+    detected function just gets the stricter, same-function requirement these
+    dampeners always should have had.
+
+    Mutates `counts`/`mitigations` in place, matching the style
+    detector.py's coding_analysis() already uses throughout.
+    """
+    # 2. The Silencer Region (True Safety)
+    if "high_risk_execution" in spatial_map and "safety" in spatial_map:
+        _, mitigated_danger = correlate_scoped(
+            targets=spatial_map["high_risk_execution"],
+            dampeners=spatial_map["safety"],
+            satellite_ranges=satellite_ranges,
+            max_distance=500,
+        )
+        counts["high_risk_execution"] -= mitigated_danger
+        mitigations["mitigated_danger"] += mitigated_danger
+
+    # 3. The Race Condition Radar. Only the dampener half (sync_locks
+    # mitigating state_mutation) is scoped here -- the amplifier half
+    # (concurrency near state_mutation) is a lower-urgency false-positive
+    # risk, not the false-negative class this phase targets, and is left on
+    # the flat radius pending #348.
+    if "concurrency" in spatial_map and "state_mutation" in spatial_map:
+        unmitigated_flux, _ = correlate_scoped(
+            targets=spatial_map["state_mutation"],
+            dampeners=spatial_map.get("sync_locks", []),
+            satellite_ranges=satellite_ranges,
+            max_distance=300,
+        )
+        if unmitigated_flux > 0:
+            _, race_conditions = correlate_signals(
+                targets=spatial_map["concurrency"],
+                dampeners=spatial_map["state_mutation"],
+                max_distance=150,
+            )
+            counts["concurrency"] += race_conditions * 5
+            mitigations["amplified_race_conditions"] += race_conditions
+
+    # 5. The Memory Leak / UAF Tracker
+    if "memory_alloc" in spatial_map:
+        unmitigated_allocs, _ = correlate_scoped(
+            targets=spatial_map["memory_alloc"],
+            dampeners=spatial_map.get("cleanup", []),
+            satellite_ranges=satellite_ranges,
+            max_distance=800,
+        )
+        original_allocs = len(spatial_map["memory_alloc"])
+        mitigated = original_allocs - unmitigated_allocs
+
+        counts["memory_alloc"] = unmitigated_allocs
+        mitigations["mitigated_memory_allocs"] += mitigated

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -609,6 +609,61 @@ def test_detector_advanced_appsec_sensors():
 
 
 # ==============================================================================
+# TEST 47: SATELLITE-SCOPED DAMPENER CORRELATION (#346 phase 1)
+# ==============================================================================
+def test_detector_dampeners_do_not_cross_function_boundaries():
+    """
+    Regression test for #346 phase 1: a safety/cleanup call in one function
+    must not silently cancel a danger/leak signal in a DIFFERENT function,
+    even though both are well within the old flat 500-char correlation
+    radius. Before this fix, the two functions below (under 150 total
+    characters apart) would have had their risk fully cancelled out.
+    """
+    opt_detector = StructuralExtractor("c", MOCK_LANG_DEFS)
+    code = (
+        "void dangerous_one() {\n"
+        "    strcpy(buf, input);\n"
+        "}\n"
+        "\n"
+        "void safe_two() {\n"
+        "    strncpy(buf2, input2, 10);\n"
+        "}\n"
+    )
+
+    result = opt_detector.splice(code, "")
+    eqs = result["equations"]
+    mits = result["mitigation_telemetry"]
+
+    assert eqs.get("high_risk_execution", 0) == 1, (
+        "A safety call in a DIFFERENT function must not mitigate this danger signal -- "
+        "cross-function dampening regressed!"
+    )
+    assert mits.get("mitigated_danger", 0) == 0, (
+        "mitigated_danger should be 0: the only safety call is in an unrelated function"
+    )
+
+
+def test_detector_dampeners_still_apply_within_same_function():
+    """The same safety/cleanup call, when it's genuinely inside the SAME function, still mitigates."""
+    opt_detector = StructuralExtractor("c", MOCK_LANG_DEFS)
+    code = (
+        "void guarded() {\n"
+        "    strcpy(buf, input);\n"
+        "    strncpy(buf2, input2, 10);\n"
+        "}\n"
+    )
+
+    result = opt_detector.splice(code, "")
+    eqs = result["equations"]
+    mits = result["mitigation_telemetry"]
+
+    assert eqs.get("high_risk_execution", 0) == 0, (
+        "Same-function safety call should still mitigate this danger signal"
+    )
+    assert mits.get("mitigated_danger", 0) == 1
+
+
+# ==============================================================================
 # TEST 12: CATASTROPHIC FALLBACKS (HARDWARE GUILLOTINES)
 # ==============================================================================
 def test_detector_catastrophic_fallbacks():

--- a/tests/core_engine/test_spatial_correlation.py
+++ b/tests/core_engine/test_spatial_correlation.py
@@ -1,0 +1,204 @@
+from gitgalaxy.core.spatial_correlation import (
+    correlate_signals,
+    correlate_scoped,
+    filter_positions_in_range,
+    apply_dampener_correlations,
+)
+
+
+# ==============================================================================
+# TEST 1: BASELINE CORRELATION (unchanged behavior, moved from detector.py)
+# ==============================================================================
+def test_correlate_signals_basic_proximity():
+    """Proves the extracted primitive still sweeps distance identically."""
+    # Target at 100 is within 50 of a dampener at 120 -> mitigated
+    unmit, mit = correlate_signals(targets=[100], dampeners=[120], max_distance=50)
+    assert (unmit, mit) == (0, 1)
+
+    # Target at 100 is NOT within 50 of a dampener at 500 -> unmitigated
+    unmit, mit = correlate_signals(targets=[100], dampeners=[500], max_distance=50)
+    assert (unmit, mit) == (1, 0)
+
+    # No dampeners at all -> everything unmitigated
+    unmit, mit = correlate_signals(targets=[10, 20], dampeners=[], max_distance=50)
+    assert (unmit, mit) == (2, 0)
+
+    # No targets -> nothing to report
+    unmit, mit = correlate_signals(targets=[], dampeners=[10, 20], max_distance=50)
+    assert (unmit, mit) == (0, 0)
+
+
+# ==============================================================================
+# TEST 2: RANGE FILTERING (the satellite-scoping primitive)
+# ==============================================================================
+def test_filter_positions_in_range():
+    positions = [10, 50, 99, 100, 150, 200, 201]
+    assert filter_positions_in_range(positions, 100, 200) == [100, 150]
+    assert filter_positions_in_range(positions, 0, 10) == []
+    assert filter_positions_in_range(positions, 0, 11) == [10]
+    assert filter_positions_in_range([], 0, 100) == []
+
+
+# ==============================================================================
+# TEST 3: SATELLITE-SCOPED CORRELATION (#346 phase 1 -- the actual fix)
+# ==============================================================================
+def test_correlate_scoped_no_satellites_matches_flat_behavior():
+    """With no satellite data at all, correlate_scoped must equal correlate_signals."""
+    targets, dampeners = [100, 900], [120, 850]
+    flat = correlate_signals(targets, dampeners, max_distance=50)
+    scoped = correlate_scoped(targets, dampeners, satellite_ranges=None, max_distance=50)
+    assert scoped == flat
+
+    scoped_empty_list = correlate_scoped(targets, dampeners, satellite_ranges=[], max_distance=50)
+    assert scoped_empty_list == flat
+
+
+def test_correlate_scoped_rejects_cross_function_mitigation():
+    """
+    The core false-negative fix: a dampener in a DIFFERENT function must not
+    mitigate a target, even though it's well within the flat character radius.
+    """
+    # Two adjacent functions: [0, 200) and [200, 400).
+    satellites = [(0, 200), (200, 400)]
+
+    # Danger at offset 190 (function A), safety net at offset 210 (function B) --
+    # only 20 chars apart, well inside a 500-char flat radius.
+    targets = [190]
+    dampeners = [210]
+
+    flat_unmit, flat_mit = correlate_signals(targets, dampeners, max_distance=500)
+    assert (flat_unmit, flat_mit) == (0, 1), "Sanity check: flat correlation should mitigate this pair"
+
+    scoped_unmit, scoped_mit = correlate_scoped(targets, dampeners, satellites, max_distance=500)
+    assert (scoped_unmit, scoped_mit) == (1, 0), (
+        "Scoped correlation must NOT let a dampener in a different function "
+        "silently cancel real risk in this one"
+    )
+
+
+def test_correlate_scoped_allows_same_function_mitigation():
+    """A dampener in the SAME function still mitigates, exactly as today."""
+    satellites = [(0, 200), (200, 400)]
+    targets = [50]
+    dampeners = [60]  # Same function (A), 10 chars away
+
+    unmit, mit = correlate_scoped(targets, dampeners, satellites, max_distance=500)
+    assert (unmit, mit) == (0, 1)
+
+
+def test_correlate_scoped_falls_back_for_module_level_targets():
+    """
+    A target that falls OUTSIDE every known satellite range (module-level
+    code, or a segment with zero sliced functions) must fall back to the
+    flat, whole-segment behavior against the full dampener list -- this is
+    the "no regression for unsliced code" guarantee.
+    """
+    satellites = [(100, 200)]  # Only one function, at [100, 200)
+    targets = [900]  # Module-level code, far outside the only known function
+    dampeners = [910]  # Also module-level, right next to the target
+
+    unmit, mit = correlate_scoped(targets, dampeners, satellites, max_distance=50)
+    assert (unmit, mit) == (0, 1), (
+        "Module-level target/dampener pairs outside any satellite must still "
+        "correlate via the flat fallback, matching pre-scoping behavior"
+    )
+
+
+def test_correlate_scoped_mixed_covered_and_uncovered_targets():
+    """Covered and uncovered targets are handled independently in one call."""
+    satellites = [(0, 100)]
+    # in-function target, mitigated by an out-of-function dampener -> must NOT mitigate
+    # module-level target, mitigated by another module-level dampener -> must mitigate
+    targets = [50, 500]
+    dampeners = [500 + 10]  # far from the in-function target, close to the module-level one
+
+    unmit, mit = correlate_scoped(targets, dampeners, satellites, max_distance=50)
+    assert unmit == 1, "In-function target must not be mitigated by an out-of-function dampener"
+    assert mit == 1, "Module-level target must still be mitigated via the flat fallback"
+
+
+# ==============================================================================
+# TEST 4: apply_dampener_correlations (the three relocated blocks, #346)
+# ==============================================================================
+def _fresh_mitigations():
+    return {
+        "mitigated_danger": 0,
+        "mitigated_memory_allocs": 0,
+        "amplified_rce": 0,
+        "amplified_race_conditions": 0,
+        "amplified_leaks": 0,
+    }
+
+
+def test_apply_dampener_correlations_silencer_region_respects_scope():
+    """
+    Block 2 (The Silencer Region): a safety check in a DIFFERENT function
+    must not cancel out a danger signal in this one.
+    """
+    satellite_ranges = [(0, 200), (200, 400)]
+    spatial_map = {"high_risk_execution": [190], "safety": [210]}
+    counts = {"high_risk_execution": 1}
+    mitigations = _fresh_mitigations()
+
+    apply_dampener_correlations(spatial_map, satellite_ranges, counts, mitigations)
+
+    assert counts["high_risk_execution"] == 1, (
+        "Cross-function safety check must not silently mitigate this danger signal"
+    )
+    assert mitigations["mitigated_danger"] == 0
+
+
+def test_apply_dampener_correlations_silencer_region_same_function():
+    """A safety check in the SAME function still mitigates, as before."""
+    satellite_ranges = [(0, 200)]
+    spatial_map = {"high_risk_execution": [50], "safety": [60]}
+    counts = {"high_risk_execution": 1}
+    mitigations = _fresh_mitigations()
+
+    apply_dampener_correlations(spatial_map, satellite_ranges, counts, mitigations)
+
+    assert counts["high_risk_execution"] == 0, "Same-function safety check should still mitigate"
+    assert mitigations["mitigated_danger"] == 1
+
+
+def test_apply_dampener_correlations_memory_leak_scoped():
+    """Block 5: a cleanup() in a different function must not hide a real leak."""
+    satellite_ranges = [(0, 100), (100, 200)]
+    spatial_map = {"memory_alloc": [50], "cleanup": [150]}
+    counts = {"memory_alloc": 1}
+    mitigations = _fresh_mitigations()
+
+    apply_dampener_correlations(spatial_map, satellite_ranges, counts, mitigations)
+
+    assert counts["memory_alloc"] == 1, "Cross-function cleanup() must not hide this leak"
+    assert mitigations["mitigated_memory_allocs"] == 0
+
+
+def test_apply_dampener_correlations_race_condition_still_amplifies():
+    """
+    Block 3: unmitigated state flux (no sync_lock nearby, scoped) should
+    still trigger the (unscoped, phase-1-deferred) race condition amplifier.
+    """
+    satellite_ranges = [(0, 500)]
+    spatial_map = {"concurrency": [40], "state_mutation": [50]}  # no sync_locks at all
+    counts = {"concurrency": 0}
+    mitigations = _fresh_mitigations()
+
+    apply_dampener_correlations(spatial_map, satellite_ranges, counts, mitigations)
+
+    assert counts["concurrency"] == 5, "Race condition amplifier should have fired (unmitigated flux)"
+    assert mitigations["amplified_race_conditions"] == 1
+
+
+def test_apply_dampener_correlations_no_satellites_matches_pre_scoping_behavior():
+    """With zero known satellite ranges, behavior must match the old flat correlation exactly."""
+    spatial_map = {"high_risk_execution": [10], "safety": [20], "memory_alloc": [5], "cleanup": [15]}
+    counts = {"high_risk_execution": 1, "memory_alloc": 1}
+    mitigations = _fresh_mitigations()
+
+    apply_dampener_correlations(spatial_map, [], counts, mitigations)
+
+    assert counts["high_risk_execution"] == 0, "Flat fallback should still mitigate a nearby danger"
+    assert mitigations["mitigated_danger"] == 1
+    assert counts["memory_alloc"] == 0, "Flat fallback should still mitigate a nearby leak"
+    assert mitigations["mitigated_memory_allocs"] == 1


### PR DESCRIPTION
## Summary
Fixes #346 (phase 1 -- see the issue for the split; phase 2, persisting a satellite-aware ledger for post-hoc tools and scoping the amplifier pairs, is tracked separately in #348).

- `detector.py`'s three **dampener**-pair correlations -- "2. The Silencer Region" (`safety` mitigating `high_risk_execution`), the `sync_locks` half of "3. The Race Condition Radar", and "5. The Memory Leak / UAF Tracker" (`cleanup` mitigating `memory_alloc`) -- all used a flat character-radius proximity check as their only notion of "nearby". A `safety`/`cleanup` call in a **completely different function** could silently cancel real risk in this one, as long as it fell within the radius (500/300/800 chars respectively) -- a false negative, not just noise, since these blocks *reduce* reported risk rather than add to it.
- None of the six `correlate()` calls in `coding_analysis()` had access to real function boundaries, because `coding_analysis()` (where they ran) executed *before* `_function_slice()` (which computes satellite/function ranges) in `splice()`.
- Fixed by:
  - Extracting `_correlate_signals` into `gitgalaxy/core/spatial_correlation.py` as a shared, reusable primitive (`StructuralExtractor._correlate_signals` is now a thin delegating wrapper, kept for existing callers).
  - Adding a scope-aware `correlate_scoped()`: a target/dampener pair must fall within the same satellite range to correlate; a target outside every known satellite range falls back to the pre-scoping flat behavior, so nothing that correlated before this change stops correlating -- module-level/unsliced code is unaffected.
  - Relocating the three dampener blocks out of `coding_analysis()` into `apply_dampener_correlations()`, called from `_function_slice()`'s own per-segment loop right after that segment's satellites are computed -- the one place `spatial_map` and real satellite ranges already coexist, with no new cross-referencing needed.
  - Adding `start_idx`/`end_idx` to each satellite (`FunctionNode`), computed but previously discarded in `_calculate_block_metrics`.
  - Removing `_function_slice()`'s early `MAX_SATELLITES` break: that cap bounds stored function *metadata*, not which code gets correlated -- letting it silently skip correlating the remainder of an unusually large file would have been a regression this fix specifically exists to prevent. Only matters for files with 250+ functions.
- The three amplifier-only pairs (RCE/IO taint corroboration, active secret-leak amplification, and the concurrency-amplifying half of the Race Condition Radar) are intentionally left on the flat radius -- a false positive there costs one extra review item, an accepted tradeoff, not the false-negative risk this phase targets.

## Test plan
- [x] Added `tests/core_engine/test_spatial_correlation.py` (12 tests) covering the new primitives in isolation: baseline `correlate_signals` parity, `filter_positions_in_range`, `correlate_scoped` (cross-function rejection, same-function acceptance, module-level fallback, mixed covered/uncovered), and `apply_dampener_correlations` for all three relocated blocks.
- [x] Added `test_detector_dampeners_do_not_cross_function_boundaries` and `test_detector_dampeners_still_apply_within_same_function` in `test_detector.py`, exercising the fix through the real `StructuralExtractor.splice()` path. Verified the cross-function test fails on the pre-fix code (`0 == 1`, proving the false-negative) and passes after.
- [x] `python -m pytest tests/core_engine/ tests/security_auditing/ -q` -- 433 passed, 1 xfailed (pre-existing, unrelated).
- [x] `python -m pytest tests/ -q` -- full suite, 826 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)