### PR TITLE
Persist a satellite-aware spatial ledger for post-hoc correlation (#348)

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -24,6 +24,7 @@ from gitgalaxy.standards.analysis_lens import RECORDING_SCHEMAS
 from gitgalaxy.core.spatial_correlation import (
     correlate_signals as _correlate_signals_impl,
     apply_dampener_correlations,
+    apply_amplifier_correlations,
 )
 
 HAS_TIKTOKEN = False
@@ -991,64 +992,23 @@ class StructuralExtractor:
 
 # galaxyscope:ignore sec_high_risk_execution
 
-            # 1. Taint Tracking (RCE Weaponization)
-            # NOTE (#344): must key off the unprefixed "high_risk_execution"/"io" --
-            # these are detector.py's own rule hits, populated in THIS spatial_map.
-            # The "sec_" prefix belongs to the Passive Security Lens Observer family
-            # (analysis_lens.py's SIGNAL_SCHEMA), which security_lens.py only writes
-            # in galaxyscope.py's Phase 5.5, strictly after coding_analysis() returns
-            # -- those keys can never appear in this function's own spatial_map.
-            if "high_risk_execution" in spatial_map and "io" in spatial_map:
-                io_hits = sorted(spatial_map["io"])
-                _, corroborated_rce = self._correlate_signals(
-                    targets=spatial_map["high_risk_execution"],
-                    dampeners=io_hits,
-                    max_distance=250,
-                )
-                counts["sec_tainted_injection"] += corroborated_rce
-                mitigations["amplified_rce"] += corroborated_rce
-
-            # 2. The Silencer Region (True Safety), 3. The Race Condition Radar, and
-            # 5. The Memory Leak / UAF Tracker have all been RELOCATED (#346 phase 1)
-            # to _apply_dampener_correlations(), called from _function_slice() once
-            # real satellite/function boundaries exist. All three are dampener pairs
-            # -- a wrong-scope mitigation there silently suppresses real risk (a false
-            # negative), which the flat character-radius check here couldn't prevent.
-            # See _apply_dampener_correlations()'s docstring for the exact scoping
-            # rules and the module-level fallback that keeps this fully non-regressing
-            # for code outside any detected function.
-
-            # 4. The Active Hemorrhage
-            # NOTE (#344): unlike block 1, there is no unprefixed sibling to fall back
-            # to here -- "hardcoded_secrets" (unprefixed) is not a SIGNAL_SCHEMA member
-            # at all (only "sec_hardcoded_secrets", the Passive Security Lens Observer
-            # name, is registered), so detector.py has no rule of its own that could
-            # ever populate this spatial_map under either name. This block genuinely
-            # needs security_lens.py's data, which doesn't exist until galaxyscope.py's
-            # Phase 5.5, strictly after this function returns -- it can't be fixed with
-            # a key-name correction the way block 1 was. Left as still-dead pending the
-            # correlate-after-both-phases work in #346; do not "fix" this to a bare
-            # "hardcoded_secrets" check, that key will never be populated either.
-            if "sec_hardcoded_secrets" in spatial_map and ("telemetry" in spatial_map or "debug_prints" in spatial_map):
-                sinks = sorted(spatial_map.get("telemetry", []) + spatial_map.get("debug_prints", []))
-                _, active_leaks = self._correlate_signals(
-                    targets=spatial_map["sec_hardcoded_secrets"],
-                    dampeners=sinks,
-                    max_distance=150,
-                )
-                counts["sec_hardcoded_secrets"] += active_leaks * 50
-                mitigations["amplified_leaks"] += active_leaks
-
-            # 6. The OOM Bomb (Cascading State Flux)
-            if "state_mutation" in spatial_map and "branch" in spatial_map:
-                # Assuming 'branch' captures while/for loops
-                _, cascading_flux = self._correlate_signals(
-                    targets=spatial_map["state_mutation"],
-                    dampeners=spatial_map["branch"],
-                    max_distance=150,  # If state is mutated near heavy branching
-                )
-                counts["state_mutation"] += cascading_flux * 2  # Double the raw signal
-                mitigations["amplified_cascading_flux"] = mitigations.get("amplified_cascading_flux", 0) + cascading_flux
+            # 1. Taint Tracking (RCE Weaponization), 2. The Silencer Region,
+            # 3. The Race Condition Radar, 5. The Memory Leak / UAF Tracker, and
+            # 6. The OOM Bomb have all been RELOCATED (#346 phase 1, #348 phase 2)
+            # to apply_dampener_correlations()/apply_amplifier_correlations() in
+            # gitgalaxy.core.spatial_correlation, called from _function_slice()
+            # once real satellite/function boundaries exist -- coding_analysis()
+            # runs before those boundaries are computed, so none of these six
+            # pairs ever had real scope available to them here.
+            #
+            # 4. The Active Hemorrhage is NOT relocated to that same in-detector
+            # correlation step: its target key ("sec_hardcoded_secrets") is the
+            # Passive Security Lens Observer name, only ever populated by
+            # security_lens.py in galaxyscope.py's Phase 5.5 -- strictly after
+            # this function (and _function_slice()) have both already returned.
+            # It is instead reimplemented as a genuine post-hoc correlation in
+            # galaxyscope.py, against the persisted threat_locations ledger, via
+            # spatial_correlation.correlate_against_ledger() (#348).
 
             # Capture indentation signatures
             counts["indent_tabs"] += len(re.findall(r"^\t+(?=\S)", seg_code, flags=re.MULTILINE))
@@ -1289,7 +1249,7 @@ class StructuralExtractor:
                 key = f"{lang_id}::Cartography_{mode_name}"
                 regex_telemetry[key] = regex_telemetry.get(key, 0.0) + (time.perf_counter() - t_mode_start)
 
-            # --- SATELLITE-SCOPED DAMPENER CORRELATION (#346 phase 1) ---
+            # --- SATELLITE-SCOPED CORRELATION (#346 phase 1, #348 phase 2) ---
             # Runs for every segment unconditionally, using THIS segment's own
             # satellite ranges. Deliberately placed before the MAX_SATELLITES
             # truncation below: that cap only bounds stored function metadata,
@@ -1299,6 +1259,7 @@ class StructuralExtractor:
                 (sat["start_idx"], sat["end_idx"]) for sat in sats if "start_idx" in sat and "end_idx" in sat
             )
             apply_dampener_correlations(spatial_map, sat_ranges, counts, mitigations)
+            apply_amplifier_correlations(spatial_map, sat_ranges, counts, mitigations)
 
             if len(all_satellites) < self.MAX_SATELLITES:
                 all_satellites.extend(sats)

--- a/gitgalaxy/core/spatial_correlation.py
+++ b/gitgalaxy/core/spatial_correlation.py
@@ -156,11 +156,9 @@ def apply_dampener_correlations(
         counts["high_risk_execution"] -= mitigated_danger
         mitigations["mitigated_danger"] += mitigated_danger
 
-    # 3. The Race Condition Radar. Only the dampener half (sync_locks
-    # mitigating state_mutation) is scoped here -- the amplifier half
-    # (concurrency near state_mutation) is a lower-urgency false-positive
-    # risk, not the false-negative class this phase targets, and is left on
-    # the flat radius pending #348.
+    # 3. The Race Condition Radar (both halves now scoped, #348: the sync_locks
+    # dampener check first, then the concurrency amplifier check only against
+    # the SAME-scoped state_mutation hits that survived it).
     if "concurrency" in spatial_map and "state_mutation" in spatial_map:
         unmitigated_flux, _ = correlate_scoped(
             targets=spatial_map["state_mutation"],
@@ -169,9 +167,10 @@ def apply_dampener_correlations(
             max_distance=300,
         )
         if unmitigated_flux > 0:
-            _, race_conditions = correlate_signals(
+            _, race_conditions = correlate_scoped(
                 targets=spatial_map["concurrency"],
                 dampeners=spatial_map["state_mutation"],
+                satellite_ranges=satellite_ranges,
                 max_distance=150,
             )
             counts["concurrency"] += race_conditions * 5
@@ -190,3 +189,84 @@ def apply_dampener_correlations(
 
         counts["memory_alloc"] = unmitigated_allocs
         mitigations["mitigated_memory_allocs"] += mitigated
+
+
+def apply_amplifier_correlations(
+    spatial_map: Dict[str, List[int]],
+    satellite_ranges: List[Tuple[int, int]],
+    counts: Dict[str, int],
+    mitigations: Dict[str, int],
+) -> None:
+    """
+    Runs the two remaining in-segment amplifier-pair correlations (#348) scoped
+    to real function boundaries, for consistency with apply_dampener_correlations().
+
+    Unlike a wrong-scope dampener, a wrong-scope amplifier only costs one extra
+    review item (a false positive) -- an accepted tradeoff for this project, not
+    the false-negative risk phase 1 targeted. These are migrated here mainly so
+    every correlate() call in the pipeline shares the same scoping semantics,
+    not because the flat radius was actively harmful the way the dampeners were.
+
+    Mutates `counts`/`mitigations` in place, matching apply_dampener_correlations().
+    """
+    # 1. Taint Tracking (RCE Weaponization)
+    if "high_risk_execution" in spatial_map and "io" in spatial_map:
+        _, corroborated_rce = correlate_scoped(
+            targets=spatial_map["high_risk_execution"],
+            dampeners=sorted(spatial_map["io"]),
+            satellite_ranges=satellite_ranges,
+            max_distance=250,
+        )
+        counts["sec_tainted_injection"] += corroborated_rce
+        mitigations["amplified_rce"] += corroborated_rce
+
+    # 6. The OOM Bomb (Cascading State Flux)
+    if "state_mutation" in spatial_map and "branch" in spatial_map:
+        _, cascading_flux = correlate_scoped(
+            targets=spatial_map["state_mutation"],
+            dampeners=spatial_map["branch"],
+            satellite_ranges=satellite_ranges,
+            max_distance=150,  # If state is mutated near heavy branching
+        )
+        counts["state_mutation"] += cascading_flux * 2  # Double the raw signal
+        mitigations["amplified_cascading_flux"] = mitigations.get("amplified_cascading_flux", 0) + cascading_flux
+
+
+def correlate_against_ledger(
+    threat_locations: Dict[str, List[int]],
+    functions: List[Dict[str, int]],
+    source_key: str,
+    sink_key: str,
+    max_distance: int = 10,
+) -> Tuple[int, int]:
+    """
+    Correlates two named signals from a POST-HOC pipeline stage -- outside
+    detector.py entirely, e.g. dev_agent_firewall.py or ai_appsec_sensor.py,
+    both of which run over fully-assembled parsed_files after coding_analysis()'s
+    transient spatial_map is long gone (#346/#348).
+
+    Reads only what already survives to that stage: file_data["threat_locations"]
+    (rule_name -> [line_numbers], persisted for every rule detector.py runs) and
+    file_data["functions"] (satellites, each carrying file-global start_line/
+    end_line). No new field or schema change is required on either -- this is a
+    query-time join, not a persisted association, which also means it can never
+    go stale relative to whichever satellites _function_slice() last computed.
+
+    `max_distance` here is in LINES, not characters -- these two lists are
+    line-indexed, not char-offset-indexed, unlike correlate_scoped().
+
+    Returns (unmitigated_count, mitigated_count), same contract as
+    correlate_scoped(): a dampener-style caller (e.g. "is metaprogramming
+    undocumented") wants the unmitigated count; a corroboration/amplifier-style
+    caller (e.g. "is this API route near a DB call") wants the mitigated count.
+    """
+    sources = sorted(threat_locations.get(source_key, []))
+    sinks = sorted(threat_locations.get(sink_key, []))
+
+    satellite_ranges = sorted(
+        (f["start_line"], f["end_line"] + 1)  # end_line is inclusive; correlate_scoped wants an exclusive upper bound
+        for f in functions
+        if "start_line" in f and "end_line" in f
+    )
+
+    return correlate_scoped(sources, sinks, satellite_ranges, max_distance)

--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -34,6 +34,7 @@ from gitgalaxy.core.guidestar_lens import GuideStarLens
 from gitgalaxy.standards.language_lens import LanguageDetector
 from gitgalaxy.core.prism import Prism
 from gitgalaxy.core.spatial_mapper import SpatialMapper
+from gitgalaxy.core.spatial_correlation import correlate_against_ledger
 from gitgalaxy.core.network_risk_sensor import NetworkRiskSensor
 from gitgalaxy.metrics.chronometer import Chronometer
 from gitgalaxy.metrics.signal_processor import SignalProcessor
@@ -433,6 +434,58 @@ def _process_file_worker(rel_path: str) -> Dict[str, Any]:
 
                 # Pass the snippets into the payload
                 logic_data["threat_snippets"] = sec_results["snippets"]
+
+                # Fold security_lens.py's own line positions into the same shared,
+                # persisted ledger detector.py's rules already populate (#348).
+                # security_lens.py tracks a handful of signals (e.g. db_hooks) that
+                # have no detector.py-side equivalent at all -- without this, that
+                # position data was computed (for security_lens's own internal
+                # taint check) and then simply discarded, leaving post-hoc tools
+                # outside detector.py (dev_agent_firewall.py, ai_appsec_sensor.py,
+                # #105's future db_hooks correlation) with nothing to correlate
+                # against for these signals.
+                logic_data.setdefault("threat_locations", {})
+                for pos_key, line_numbers in sec_results.get("positions", {}).items():
+                    mapped_key = f"sec_{pos_key}"
+                    logic_data["threat_locations"].setdefault(mapped_key, []).extend(line_numbers)
+
+                # --- The Active Hemorrhage, reimplemented post-hoc (#348) ---
+                # This correlation (secrets near a logging/print sink) used to live
+                # in detector.py's coding_analysis(), but its target key,
+                # "sec_hardcoded_secrets", is the Passive Security Lens Observer
+                # name -- only ever populated by security_lens.py, right above, in
+                # THIS phase. It could never run inside detector.py; it needed to
+                # move here, where that data (and detector.py's own "telemetry"/
+                # "debug_prints" threat_locations) finally coexist.
+                threat_locs = logic_data["threat_locations"]
+                sinks_present = "telemetry" in threat_locs or "debug_prints" in threat_locs
+                if "sec_hardcoded_secrets" in threat_locs and sinks_present:
+                    # correlate_against_ledger() takes one sink key; fold telemetry
+                    # and debug_prints into one synthetic entry in a throwaway copy
+                    # of the ledger, matching detector.py's original "telemetry OR
+                    # debug_prints" sink definition.
+                    ledger_for_query = dict(threat_locs)
+                    ledger_for_query["_active_hemorrhage_sinks"] = sorted(
+                        threat_locs.get("telemetry", []) + threat_locs.get("debug_prints", [])
+                    )
+                    # 5 lines, not detector.py's original 150 CHARS -- this ledger is
+                    # line-indexed, not char-offset-indexed, so the radius has to be
+                    # re-expressed in the new unit rather than reused as a raw number.
+                    _, active_leaks = correlate_against_ledger(
+                        ledger_for_query,
+                        logic_data.get("functions", []),
+                        "sec_hardcoded_secrets",
+                        "_active_hemorrhage_sinks",
+                        max_distance=5,
+                    )
+                    if active_leaks:
+                        logic_data["equations"]["sec_hardcoded_secrets"] = (
+                            logic_data["equations"].get("sec_hardcoded_secrets", 0) + active_leaks * 50
+                        )
+                        logic_data.setdefault("mitigation_telemetry", {})
+                        logic_data["mitigation_telemetry"]["amplified_leaks"] = (
+                            logic_data["mitigation_telemetry"].get("amplified_leaks", 0) + active_leaks
+                        )
 
             if is_file_profiling:
                 phase_times["5.5_Security_Lens"] = time.perf_counter() - t_security

--- a/gitgalaxy/security/security_lens.py
+++ b/gitgalaxy/security/security_lens.py
@@ -11,6 +11,7 @@ import re
 import math
 import bisect
 from collections import Counter, defaultdict
+from typing import Dict, List
 
 
 class SecurityLens:
@@ -218,6 +219,13 @@ class SecurityLens:
         # PERFORMANCE OPTIMIZATION: O(1) Offset Map for Taint Analysis
         # Only tracks lines where an actual threat signature triggered, skipping blank space.
         threat_lines = defaultdict(set)
+        # Line positions for the four signals below, keyed the same way
+        # detector.py's own threat_locations are (rule_name -> [1-indexed line
+        # numbers]) -- exposed via scan_content()'s return so galaxyscope.py can
+        # fold them into the shared, persisted ledger (#348). Previously this
+        # position data was computed (via threat_lines above) but only ever
+        # used internally for this function's own taint check, then discarded.
+        positions: Dict[str, List[int]] = defaultdict(list)
         if not is_auto_gen:
             line_starts = [0] + [m.end() for m in re.finditer(r"\n", safe_content)]
 
@@ -245,9 +253,11 @@ class SecurityLens:
                             "high_risk_execution",
                             "llm_hooks",
                             "db_hooks",
+                            "hardcoded_secrets",
                         }:
                             line_idx = bisect.bisect_right(line_starts, match.start()) - 1
                             threat_lines[line_idx].add(key)
+                            positions[key].append(line_idx + 1)  # 1-indexed, matching detector.py's convention
 
         # ---> 3. SHANNON ENTROPY (Obfuscation Detection) <---
         entropy_hits = 0
@@ -376,7 +386,7 @@ class SecurityLens:
         snippets["prompt_injection"] = [s for s in taint_snippets if "LLM" in s]
         snippets["agentic_rce"] = [s for s in taint_snippets if "RCE" in s]
 
-        return {"counts": counts, "snippets": snippets}
+        return {"counts": counts, "snippets": snippets, "positions": dict(positions)}
 
     def scan_binary(self, raw_bytes: bytes, ext: str) -> dict:
         """

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -1033,13 +1033,25 @@ def test_detector_explicit_type_override():
 
 
 # ==============================================================================
-# TEST 23: APPSEC ACTIVE HEMORRHAGE SENSOR
+# TEST 23: APPSEC ACTIVE HEMORRHAGE SENSOR (RELOCATED, #348)
 # ==============================================================================
-def test_detector_active_hemorrhage_leak():
-    """Proves the AppSec sensor detects secrets being passed to outbound logging/print streams."""
+def test_detector_active_hemorrhage_leak_no_longer_lives_in_detector():
+    """
+    "The Active Hemorrhage" (secrets correlated with a logging/print sink) has
+    moved out of detector.py entirely (#348): its target key,
+    "sec_hardcoded_secrets", is the Passive Security Lens Observer name, only
+    ever populated by security_lens.py in galaxyscope.py's Phase 5.5 -- data
+    that structurally cannot exist yet at the point detector.py's
+    coding_analysis() runs. The real, working amplification now lives in
+    galaxyscope.py's post-hoc correlation step; see
+    test_galaxyscope.py::test_worker_amplifies_active_hemorrhage_post_hoc.
+
+    This test only proves detector.py itself no longer touches this key at
+    all -- injecting a fake "sec_hardcoded_secrets" rule directly (as the old
+    version of this test did) now just produces a raw, unamplified count.
+    """
     opt_detector = StructuralExtractor("c", MOCK_LANG_DEFS)
-    
-    # Inject rules for the hemorrhage sensor
+
     opt_detector.primary_rules["sec_hardcoded_secrets"] = re.compile(r"password")
     opt_detector.primary_rules["telemetry"] = re.compile(r"console\.log|printf")
 
@@ -1049,16 +1061,14 @@ def test_detector_active_hemorrhage_leak():
         "    printf(password);                // Trigger: telemetry (sink)\n"
         "}\n"
     )
-    
+
     result = opt_detector.splice(code, "")
-    
-    # A single private_info hit is multiplied by 50 when correlated with a telemetry sink
-    assert result["equations"].get("sec_hardcoded_secrets", 0) >= 50, (
-        "AppSec Sensor failed to amplify the Active Hemorrhage penalty!"
+
+    assert result["equations"].get("sec_hardcoded_secrets", 0) == 2, (
+        "detector.py should report only the raw, unamplified hit count (2x 'password') -- "
+        "amplification is no longer computed here at all"
     )
-    assert result["mitigation_telemetry"].get("amplified_leaks", 0) >= 1, (
-        "Failed to log the active hemorrhage telemetry!"
-    )
+    assert result["mitigation_telemetry"].get("amplified_leaks", 0) == 0
 
 # ==============================================================================
 # TEST 24: HARVEST ABOVE (GHOST TETHER) & CLASS LINEAGE

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -717,6 +717,152 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         )
 
     # ==============================================================================
+    # TEST 13.6: THE FORGOTTEN LEDGER (security_lens positions survive, #348)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.ApertureFilter")
+    @patch("gitgalaxy.galaxyscope.Prism")
+    @patch("gitgalaxy.galaxyscope.LanguageDetector")
+    @patch("gitgalaxy.galaxyscope.SecurityLens")
+    @patch("gitgalaxy.galaxyscope.Path.is_file", return_value=True)
+    def test_worker_folds_security_lens_positions_into_threat_locations(
+        self, mock_is_file, MockSecurity, MockDetector, MockPrism, MockAperture
+    ):
+        """
+        Regression test for #348: security_lens.py computes line positions for
+        signals like db_hooks that detector.py has no rule of its own to ever
+        produce -- before this fix, that position data was discarded the moment
+        scan_content() returned, leaving nothing in threat_locations for a
+        post-hoc tool (outside detector.py entirely) to correlate db_hooks
+        against. This drives a mocked security_lens contribution through the
+        real worker path and asserts its positions survive into
+        result["data"]["threat_locations"], prefixed exactly like its counts.
+        """
+        from gitgalaxy.galaxyscope import _init_worker, _process_file_worker
+        from unittest.mock import mock_open
+        import logging
+
+        mock_aperture_inst = MockAperture.return_value
+        mock_aperture_inst.evaluate_path_integrity.return_value = (True, 1024, "Passed")
+        mock_aperture_inst.is_in_scope.return_value = {"is_in_scope": True, "reason": None}
+
+        mock_detector_inst = MockDetector.return_value
+        mock_detector_inst.inspect.return_value = {
+            "lang_id": "python", "intensity": 0.99, "lock_tier": 1, "source_proof": "Test"
+        }
+
+        code = "cursor.execute(query)"
+        mock_prism_inst = MockPrism.return_value
+        mock_prism_inst.split_streams.return_value = {
+            "code_stream": code, "comment_stream": "", "coding_loc": 1, "doc_loc": 0
+        }
+
+        mock_sec_inst = MockSecurity.return_value
+        mock_sec_inst.scan_content.return_value = {
+            "counts": {"db_hooks": 1},
+            "snippets": {},
+            "positions": {"db_hooks": [1]},
+        }
+
+        self.mock_config["LANGUAGE_DEFINITIONS"] = {"python": {"extensions": [".py"], "rules": {}}}
+        _init_worker(
+            root_str=".",
+            config=self.mock_config,
+            ext_tally={".py": 1},
+            log_level=logging.INFO,
+            git_tracked={"src/main.py"},
+            census={"main"},
+        )
+
+        with patch("builtins.open", mock_open(read_data=code)):
+            result = _process_file_worker("src/main.py")
+
+        self.assertEqual(result["status"], "success", "Worker failed to successfully parse the file!")
+        self.assertEqual(
+            result["data"]["threat_locations"].get("sec_db_hooks"),
+            [1],
+            "security_lens.py's db_hooks line positions must survive into the shared "
+            "threat_locations ledger, not be silently discarded after scan_content() returns.",
+        )
+
+    # ==============================================================================
+    # TEST 13.7: THE ACTIVE HEMORRHAGE, RELOCATED (#348)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.ApertureFilter")
+    @patch("gitgalaxy.galaxyscope.Prism")
+    @patch("gitgalaxy.galaxyscope.LanguageDetector")
+    @patch("gitgalaxy.galaxyscope.SecurityLens")
+    @patch("gitgalaxy.galaxyscope.Path.is_file", return_value=True)
+    def test_worker_amplifies_active_hemorrhage_post_hoc(
+        self, mock_is_file, MockSecurity, MockDetector, MockPrism, MockAperture
+    ):
+        """
+        Regression test for #348: "The Active Hemorrhage" (a hardcoded secret
+        correlated with a nearby logging/print sink) used to live in
+        detector.py, but its target key ("sec_hardcoded_secrets") never
+        existed there -- see test_detector.py's
+        test_detector_active_hemorrhage_leak_no_longer_lives_in_detector.
+        This drives the real post-hoc replacement: a mocked security_lens
+        secret-position finding, correlated against a REAL detector.py
+        "debug_prints" hit (from actual regex parsing) on the same line,
+        via the shared threat_locations ledger.
+        """
+        from gitgalaxy.galaxyscope import _init_worker, _process_file_worker
+        from unittest.mock import mock_open
+        import logging
+
+        mock_aperture_inst = MockAperture.return_value
+        mock_aperture_inst.evaluate_path_integrity.return_value = (True, 1024, "Passed")
+        mock_aperture_inst.is_in_scope.return_value = {"is_in_scope": True, "reason": None}
+
+        mock_detector_inst = MockDetector.return_value
+        mock_detector_inst.inspect.return_value = {
+            "lang_id": "python", "intensity": 0.99, "lock_tier": 1, "source_proof": "Test"
+        }
+
+        code = "print(password)"
+        mock_prism_inst = MockPrism.return_value
+        mock_prism_inst.split_streams.return_value = {
+            "code_stream": code, "comment_stream": "", "coding_loc": 1, "doc_loc": 0
+        }
+
+        # security_lens.py independently reports a hardcoded secret on line 1.
+        mock_sec_inst = MockSecurity.return_value
+        mock_sec_inst.scan_content.return_value = {
+            "counts": {"hardcoded_secrets": 1},
+            "snippets": {},
+            "positions": {"hardcoded_secrets": [1]},
+        }
+
+        # Real rule so detector.py's OWN parsing produces a genuine "debug_prints"
+        # threat_locations entry on the same line -- this is the sink half of the
+        # correlation, and it must come from real detector.py output, not a mock.
+        self.mock_config["LANGUAGE_DEFINITIONS"] = {
+            "python": {
+                "extensions": [".py"],
+                "rules": {"debug_prints": re.compile(r"\bprint\b")},
+            }
+        }
+        _init_worker(
+            root_str=".",
+            config=self.mock_config,
+            ext_tally={".py": 1},
+            log_level=logging.INFO,
+            git_tracked={"src/main.py"},
+            census={"main"},
+        )
+
+        with patch("builtins.open", mock_open(read_data=code)):
+            result = _process_file_worker("src/main.py")
+
+        self.assertEqual(result["status"], "success", "Worker failed to successfully parse the file!")
+        self.assertEqual(
+            result["data"]["equations"].get("sec_hardcoded_secrets", 0),
+            51,
+            "Active Hemorrhage amplification regressed: 1 raw hit + (1 corroborated * 50) = 51",
+        )
+        self.assertEqual(result["data"]["mitigation_telemetry"].get("amplified_leaks", 0), 1)
+
+    # ==============================================================================
     # TEST 14: THE MEMORY HOLE (SARIF Sanitization & Inline Suppressions)
     # ==============================================================================
     @patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")

--- a/tests/core_engine/test_spatial_correlation.py
+++ b/tests/core_engine/test_spatial_correlation.py
@@ -3,6 +3,7 @@ from gitgalaxy.core.spatial_correlation import (
     correlate_scoped,
     filter_positions_in_range,
     apply_dampener_correlations,
+    correlate_against_ledger,
 )
 
 
@@ -202,3 +203,56 @@ def test_apply_dampener_correlations_no_satellites_matches_pre_scoping_behavior(
     assert mitigations["mitigated_danger"] == 1
     assert counts["memory_alloc"] == 0, "Flat fallback should still mitigate a nearby leak"
     assert mitigations["mitigated_memory_allocs"] == 1
+
+
+# ==============================================================================
+# TEST 5: correlate_against_ledger (post-hoc, line-indexed, #348)
+# ==============================================================================
+def test_correlate_against_ledger_scopes_by_function_line_range():
+    """
+    Reflection/metaprogramming on line 50 of function A (lines 1-60) must not
+    be considered "documented" just because a doc comment sits on line 5 of a
+    totally different function.
+    """
+    threat_locations = {"reflection_metaprogramming": [50], "doc": [5]}
+    functions = [
+        {"name": "documented_helper", "start_line": 1, "end_line": 10},
+        {"name": "undocumented_reflector", "start_line": 40, "end_line": 60},
+    ]
+
+    unmit, mit = correlate_against_ledger(
+        threat_locations, functions, "reflection_metaprogramming", "doc", max_distance=10
+    )
+    assert unmit == 1, "Metaprogramming in a different, undocumented function must be flagged"
+    assert mit == 0
+
+
+def test_correlate_against_ledger_same_function_is_documented():
+    """Reflection/metaprogramming with a doc comment in the SAME function is not flagged."""
+    threat_locations = {"reflection_metaprogramming": [45], "doc": [40]}
+    functions = [{"name": "documented_reflector", "start_line": 40, "end_line": 60}]
+
+    unmit, mit = correlate_against_ledger(
+        threat_locations, functions, "reflection_metaprogramming", "doc", max_distance=10
+    )
+    assert unmit == 0
+    assert mit == 1
+
+
+def test_correlate_against_ledger_missing_keys_are_empty():
+    """Absent signal keys behave like empty lists, not a KeyError."""
+    unmit, mit = correlate_against_ledger({}, [], "reflection_metaprogramming", "doc")
+    assert (unmit, mit) == (0, 0)
+
+
+def test_correlate_against_ledger_corroboration_style_reads_mitigated():
+    """
+    The #105 shape (amplifier/corroboration, not a dampener): an API route and
+    a DB hook in the SAME function is the corroborated, deterministic signal --
+    read from the "mitigated" side of the same return contract.
+    """
+    threat_locations = {"api": [12], "db_hooks": [15]}
+    functions = [{"name": "user_route", "start_line": 10, "end_line": 20}]
+
+    _, corroborated = correlate_against_ledger(threat_locations, functions, "api", "db_hooks", max_distance=10)
+    assert corroborated == 1, "API route and DB hook in the same function should corroborate"


### PR DESCRIPTION
## Summary
Fixes #348 (phase 2 of #346/#102). This is the piece that actually unblocks #105 and #106.

- **`correlate_against_ledger()`** (new, in `spatial_correlation.py`): joins `file_data["threat_locations"]` (line numbers, persisted for every rule) against `file_data["functions"]` (satellites, which already carry file-global `start_line`/`end_line`) **at query time**. No schema change to `threat_locations` was made -- `sarif_recorder.py` reads `threat_locations[key][idx]` expecting a plain int line number, so embedding a literal satellite id in each entry would have broken SARIF output. The join uses data that already exists on both sides.
- **`security_lens.py`'s missing position data**: `scan_content()` computed line positions for `io`/`high_risk_execution`/`llm_hooks`/`db_hooks` (now also `hardcoded_secrets`) internally, for its own variable-echo taint check, then discarded them -- only counts and snippets were ever returned. Now returns `"positions"` too, folded into the shared `threat_locations` ledger by `galaxyscope.py`'s Phase 5.5 (additive, same pattern as the #344 counts merge). `db_hooks` position data -- needed for #105 -- exists in the persisted ledger for the first time.
- **The three amplifier-only `correlate()` pairs** (RCE/IO taint corroboration, the concurrency half of the Race Condition Radar, the OOM Bomb cascading-flux check) migrated onto the scope-aware primitive from phase 1, via a new `apply_amplifier_correlations()` -- for consistency, not urgency (a wrong-scope amplifier costs one review item, not the false-negative risk phase 1 targeted), and cheap now that satellite ranges are already threaded through `_function_slice()`.
- **"The Active Hemorrhage"** (hardcoded secrets near a logging/print sink) could never run inside `detector.py` at all -- its target key, `sec_hardcoded_secrets`, is only ever populated by `security_lens.py`, which hadn't run yet at that point in the pipeline (confirmed dead in #344/#346). Removed the dead block from `coding_analysis()` and reimplemented it as a genuine post-hoc correlation in `galaxyscope.py`, against the now-persisted ledger.

## Test plan
- [x] `test_spatial_correlation.py`: 4 new tests for `correlate_against_ledger()` (cross-function rejection, same-function acceptance, missing-key safety, corroboration-style read).
- [x] `test_galaxyscope.py`: `test_worker_folds_security_lens_positions_into_threat_locations` (verified failing pre-fix, passing post-fix) and `test_worker_amplifies_active_hemorrhage_post_hoc` (drives a real detector.py `debug_prints` hit against a mocked security_lens secret finding through the full worker path; verified failing pre-fix -- `1 != 51` -- passing post-fix).
- [x] `test_detector.py`: replaced the old in-detector Active Hemorrhage test (which tested a mechanism that no longer exists there) with one proving detector.py now reports only the raw, unamplified count for that key.
- [x] `python -m pytest tests/core_engine/ tests/security_auditing/ -q` -- 439 passed, 1 xfailed (pre-existing, unrelated).
- [x] `python -m pytest tests/ -q` -- full suite, 832 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)