### PR TITLE
Implement the Spatial Radar for DB injection funnels (#105)

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -487,6 +487,37 @@ def _process_file_worker(rel_path: str) -> Dict[str, Any]:
                             logic_data["mitigation_telemetry"].get("amplified_leaks", 0) + active_leaks
                         )
 
+                # --- The DB Injection Funnel (#105) ---
+                # A public API route ("api", detector.py-side) that directly
+                # invokes a raw DB sink ("sec_db_hooks", security_lens.py-side,
+                # folded into threat_locs above) within the SAME function is a
+                # deterministically proven injection funnel -- reuses the exact
+                # ledger/primitive #348 built for post-hoc correlation instead
+                # of #105's original flat-radius proposal. correlate_against_
+                # ledger()'s same-function scoping does the real precision
+                # work here; max_distance=5 mirrors the Active Hemorrhage's own
+                # char->line conversion just above (150 chars -> 5 lines,
+                # applied here to #105's originally-proposed 100-char radius)
+                # and exists only to guard against sprawling functions.
+                if "api" in threat_locs and "sec_db_hooks" in threat_locs:
+                    _, amplified_sql_injection = correlate_against_ledger(
+                        threat_locs,
+                        logic_data.get("functions", []),
+                        "api",
+                        "sec_db_hooks",
+                        max_distance=5,
+                    )
+                    if amplified_sql_injection:
+                        logic_data["equations"]["sec_amplified_sql_injection"] = (
+                            logic_data["equations"].get("sec_amplified_sql_injection", 0)
+                            + amplified_sql_injection
+                        )
+                        logic_data.setdefault("mitigation_telemetry", {})
+                        logic_data["mitigation_telemetry"]["amplified_sql_injection"] = (
+                            logic_data["mitigation_telemetry"].get("amplified_sql_injection", 0)
+                            + amplified_sql_injection
+                        )
+
             if is_file_profiling:
                 phase_times["5.5_Security_Lens"] = time.perf_counter() - t_security
             # ----------------------------------------------------

--- a/gitgalaxy/metrics/signal_processor.py
+++ b/gitgalaxy/metrics/signal_processor.py
@@ -1988,11 +1988,25 @@ class SignalProcessor:
         if taint_confirmed > 0:
             injection_mass += taint_confirmed * 500.0  # Massive gravity spike
 
+        # ---> CONFIRMED DB INJECTION FUNNEL (#105) <---
+        # A public API route spatially proven (via correlate_against_ledger,
+        # same function, #348's persisted ledger) to directly invoke a raw DB
+        # sink is just as deterministic as sec_tainted_injection above, not a
+        # flat probabilistic guess -- same gravity spike, same dampener bypass.
+        sql_injection_confirmed = raw_signals.get("sec_amplified_sql_injection", 0)
+        if sql_injection_confirmed > 0:
+            injection_mass += sql_injection_confirmed * 500.0
+
         if injection_mass == 0:
             return 0.0
 
         explicit_threats = raw_signals.get("sec_high_risk_execution", 0) + raw_signals.get("sec_io", 0)
-        if explicit_threats == 0 and taint_confirmed == 0 and not getattr(self, "is_paranoid", False):
+        if (
+            explicit_threats == 0
+            and taint_confirmed == 0
+            and sql_injection_confirmed == 0
+            and not getattr(self, "is_paranoid", False)
+        ):
             injection_mass *= 0.10
 
         # Fetch tuning parameters

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -863,6 +863,77 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         self.assertEqual(result["data"]["mitigation_telemetry"].get("amplified_leaks", 0), 1)
 
     # ==============================================================================
+    # TEST 13.8: THE DB INJECTION FUNNEL (#105)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.ApertureFilter")
+    @patch("gitgalaxy.galaxyscope.Prism")
+    @patch("gitgalaxy.galaxyscope.LanguageDetector")
+    @patch("gitgalaxy.galaxyscope.SecurityLens")
+    @patch("gitgalaxy.galaxyscope.Path.is_file", return_value=True)
+    def test_worker_amplifies_db_injection_funnel_post_hoc(
+        self, mock_is_file, MockSecurity, MockDetector, MockPrism, MockAperture
+    ):
+        """
+        Regression test for #105: a public API route ("api", a real
+        detector.py-side hit) that directly invokes a raw DB sink
+        ("sec_db_hooks", a mocked security_lens.py-side finding, folded into
+        the shared threat_locations ledger by #348) must deterministically
+        register as amplified_sql_injection via correlate_against_ledger(),
+        exactly like the Active Hemorrhage's post-hoc reimplementation above.
+        """
+        from gitgalaxy.galaxyscope import _init_worker, _process_file_worker
+        from unittest.mock import mock_open
+        import logging
+
+        mock_aperture_inst = MockAperture.return_value
+        mock_aperture_inst.evaluate_path_integrity.return_value = (True, 1024, "Passed")
+        mock_aperture_inst.is_in_scope.return_value = {"is_in_scope": True, "reason": None}
+
+        mock_detector_inst = MockDetector.return_value
+        mock_detector_inst.inspect.return_value = {
+            "lang_id": "python", "intensity": 0.99, "lock_tier": 1, "source_proof": "Test"
+        }
+
+        code = "app_route(x)\ncursor.execute(query)"
+        mock_prism_inst = MockPrism.return_value
+        mock_prism_inst.split_streams.return_value = {
+            "code_stream": code, "comment_stream": "", "coding_loc": 2, "doc_loc": 0
+        }
+
+        # security_lens.py independently reports a raw DB sink on line 2.
+        mock_sec_inst = MockSecurity.return_value
+        mock_sec_inst.scan_content.return_value = {
+            "counts": {"db_hooks": 1},
+            "snippets": {},
+            "positions": {"db_hooks": [2]},
+        }
+
+        # Real rule so detector.py's OWN parsing produces a genuine "api"
+        # threat_locations entry on line 1 -- this is the source half of the
+        # correlation, and it must come from real detector.py output, not a mock.
+        self.mock_config["LANGUAGE_DEFINITIONS"] = {
+            "python": {
+                "extensions": [".py"],
+                "rules": {"api": re.compile(r"app_route")},
+            }
+        }
+        _init_worker(
+            root_str=".",
+            config=self.mock_config,
+            ext_tally={".py": 1},
+            log_level=logging.INFO,
+            git_tracked={"src/main.py"},
+            census={"main"},
+        )
+
+        with patch("builtins.open", mock_open(read_data=code)):
+            result = _process_file_worker("src/main.py")
+
+        self.assertEqual(result["status"], "success", "Worker failed to successfully parse the file!")
+        self.assertEqual(result["data"]["equations"].get("sec_amplified_sql_injection", 0), 1)
+        self.assertEqual(result["data"]["mitigation_telemetry"].get("amplified_sql_injection", 0), 1)
+
+    # ==============================================================================
     # TEST 14: THE MEMORY HOLE (SARIF Sanitization & Inline Suppressions)
     # ==============================================================================
     @patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")

--- a/tests/core_engine/test_signal_processor.py
+++ b/tests/core_engine/test_signal_processor.py
@@ -624,6 +624,36 @@ def test_signal_processor_security_lenses(processor):
 
 
 # ==============================================================================
+# TEST 16.1: THE DB INJECTION FUNNEL (#105)
+# ==============================================================================
+def test_signal_processor_db_injection_funnel(processor):
+    """
+    sec_amplified_sql_injection (galaxyscope.py's post-hoc correlation of a
+    public API route against a raw DB sink via correlate_against_ledger(),
+    #105) must spike Injection Surface Exposure exactly like the deterministic
+    sec_tainted_injection signal does, even with no other io/exec signals
+    present -- it is proof of a real funnel, not a probabilistic guess.
+    """
+    idx_inj = processor.RISK_SCHEMA.index("injection_surface")
+
+    m_bare, sig_bare = create_synthetic_star(processor, "bare", 100, {})
+    m_funnel, sig_funnel = create_synthetic_star(
+        processor, "funnel", 100, {"sec_amplified_sql_injection": 1}
+    )
+
+    r_bare = processor.calculate_risk_vector(m_bare, sig_bare)
+    r_funnel = processor.calculate_risk_vector(m_funnel, sig_funnel)
+
+    assert r_bare["risk_vector"][idx_inj] == 0.0, (
+        "A file with zero signals should have zero injection surface exposure!"
+    )
+    assert r_funnel["risk_vector"][idx_inj] > 10.0, (
+        "A confirmed DB injection funnel must spike Injection Surface Exposure "
+        "even without a separate sec_high_risk_execution/sec_io signal!"
+    )
+
+
+# ==============================================================================
 # TEST 17: STRUCTURAL METRICS (Graveyard & Spec Match)
 # ==============================================================================
 def test_signal_processor_structural_metrics(processor):


### PR DESCRIPTION
## Summary
Closes #105. Landing order per the #102 epic (#344 -> #346 -> #105 -> #106): with #348's persisted, satellite-aware `threat_locations` ledger and its `correlate_against_ledger()` primitive already in place, this is a small, self-contained consumer of that infrastructure rather than a new correlation mechanism.

- **`galaxyscope.py`'s Phase 5.5**, right after the Active Hemorrhage block: correlates detector.py's `api` (public route) hits against security_lens.py's `sec_db_hooks` (raw DB sink) hits via `correlate_against_ledger()`, scoped to the **same function** -- a public API route directly invoking a DB query in its own body is deterministic proof of an injection funnel, not the flat probabilistic guess #105's original proposal described. Feeds a new `sec_amplified_sql_injection` signal, mirroring the `amplified_leaks`/`amplified_rce` telemetry pattern already established for the other post-hoc correlations.

  `max_distance=5` (lines) reuses the exact char->line conversion the Active Hemorrhage block just above it already established (150 chars -> 5 lines), applied here to #105's originally-proposed 100-char radius. Same-function scoping via `correlate_against_ledger()` does the real precision work; this just guards against sprawling functions where an unrelated DB call happens to share a function with an API route.

- **`signal_processor.py`'s `_calc_injection_surface()`**: `sec_amplified_sql_injection` is now treated as deterministic proof, exactly like `sec_tainted_injection` already is -- same +500 gravity spike, and it also exempts the score from the "unconfirmed guess" 90% dampener applied when no other explicit io/exec signal is present.

## Test plan
- [x] `test_galaxyscope.py`: `test_worker_amplifies_db_injection_funnel_post_hoc` -- a real detector.py `api` hit correlated against a mocked security_lens `db_hooks` position, driven through the full worker path.
- [x] `test_signal_processor.py`: `test_signal_processor_db_injection_funnel` -- proves the signal alone (no other io/exec signals) spikes `injection_surface`, matching `sec_tainted_injection`'s existing behavior.
- [x] `python -m pytest tests/ -q` -- full suite, 834 passed, 1 pre-existing xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)