### PR TITLE
Spatially verify Metaprogramming Hallucination Risk in Dev Agent Firewall (#106)

### DIFF
--- a/gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py
+++ b/gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py
@@ -17,6 +17,7 @@ import logging
 from typing import List, Dict, Any
 
 from gitgalaxy.standards.analysis_lens import RECORDING_SCHEMAS
+from gitgalaxy.core.spatial_correlation import correlate_against_ledger
 
 class DevAgentFirewall:
     """
@@ -30,13 +31,11 @@ class DevAgentFirewall:
         self.logger.info("Executing Autonomous Agent Firewall & Token Density Validation...")
 
         risk_schema = RECORDING_SCHEMAS.get("RISK_SCHEMA", [])
-        signal_schema = RECORDING_SCHEMAS.get("SIGNAL_SCHEMA", [])
 
         for file_data in parsed_files:
             token_mass = file_data.get("token_mass", 0)
             network_metrics = file_data.get("telemetry", {}).get("network_metrics", {})
             risk_vector = file_data.get("risk_vector", [])  # Assuming standard 0-100 risk scores
-            hit_vector = file_data.get("hit_vector", [])
 
             # Extract relevant structural metrics, safely handling None values from Zero-Dependency Mode
             pagerank = network_metrics.get("normalized_blast_radius") or 0.0
@@ -55,10 +54,6 @@ class DevAgentFirewall:
             if "state_flux" in risk_schema and len(risk_vector) > risk_schema.index("state_flux"):
                 state_flux = risk_vector[risk_schema.index("state_flux")]
 
-            meta_count = 0
-            if "reflection_metaprogramming" in signal_schema and len(hit_vector) > signal_schema.index("reflection_metaprogramming"):
-                meta_count = hit_vector[signal_schema.index("reflection_metaprogramming")]
-
             # 1. Context Window Exhaustion (Agentic Black Hole)
             # If a file exceeds token limits AND has severe algorithmic complexity, the AI will lose context.
             if token_mass is not None and token_mass > 8000 and max_big_o >= 3:
@@ -74,14 +69,35 @@ class DevAgentFirewall:
                     "WARNING [HITL Mandate]: High Downstream Exposure combined with severe risk debt. Human-in-the-Loop required for structural modifications."
                 )
 
-            # 3. Metaprogramming Hallucination Risk
-            meta_heavy = meta_count > 2
-            doc_density = file_data.get("telemetry", {}).get("doc_density", 1.0)
-
-            if meta_heavy and doc_density < 0.2:
+            # 3. Metaprogramming Hallucination Risk (#106)
+            # Replaces the old global-average check (file-wide doc_density vs.
+            # file-wide metaprogramming count), which was fully dead code -- no
+            # producer ever wrote telemetry["doc_density"] (#345) -- and, even
+            # if it had, a global average has two documented blind spots: it
+            # misses undocumented metaprogramming buried in an otherwise
+            # well-documented file, and it false-positives on well-documented
+            # metaprogramming just because the REST of the file is sparse.
+            #
+            # correlate_against_ledger() (#348) proves proximity directly: a
+            # "reflection_metaprogramming" hit is only flagged if no "doc" hit
+            # falls within max_distance=10 lines AND the same function/satellite
+            # -- reusing #106's own anticipated fixture value, matching
+            # test_spatial_correlation.py's existing correlate_against_ledger
+            # coverage for this exact signal pair.
+            undocumented_metaprogramming, _ = correlate_against_ledger(
+                file_data.get("threat_locations", {}),
+                file_data.get("functions", []),
+                "reflection_metaprogramming",
+                "doc",
+                max_distance=10,
+            )
+            if undocumented_metaprogramming > 0:
+                guardrails["undocumented_metaprogramming"] = undocumented_metaprogramming
                 guardrails["hallucination_zone"] = True
                 guardrails["warnings"].append(
-                    "DANGER [Hallucination Risk]: Dynamic metaprogramming detected combined with severe Documentation Risk Exposure (< 20% density). Autonomous agents are highly likely to hallucinate missing methods."
+                    f"DANGER [Hallucination Risk]: {undocumented_metaprogramming} undocumented metaprogramming "
+                    "construct(s) found with no surrounding documentation in the same function. Autonomous "
+                    "agents are highly likely to hallucinate missing methods."
                 )
 
             # 4. Cascading State Flux (Silent Mutation Risk)

--- a/tests/security_auditing/test_dev_agent_firewall.py
+++ b/tests/security_auditing/test_dev_agent_firewall.py
@@ -68,19 +68,19 @@ def test_hitl_mandate_detection(firewall):
 
 
 # ==============================================================================
-# TEST 3: The Hallucination Zone (Schema Drift Fix)
+# TEST 3: The Hallucination Zone (#106 -- spatially verified, not global-average)
 # ==============================================================================
 def test_hallucination_zone_detection(firewall):
     """
-    Proves that high dynamic execution (pulled from hit_vector) and poor documentation
-    triggers the Hallucination Zone warning.
+    Proves that a "reflection_metaprogramming" hit with no nearby "doc" hit --
+    in the SAME function -- triggers the Hallucination Zone warning, via the
+    persisted threat_locations ledger and correlate_against_ledger() (#348),
+    not the old dead doc_density global average (#345).
     """
     mock_files = [
         {
-            "hit_vector": [0, 3],  # ☢️ Index 1 is reflection_metaprogramming (> 2 triggers)
-            "telemetry": {
-                "doc_density": 0.15,  # ☢️ < 0.20 density
-            }
+            "threat_locations": {"reflection_metaprogramming": [50]},
+            "functions": [{"start_line": 40, "end_line": 60}],
         }
     ]
 
@@ -88,7 +88,60 @@ def test_hallucination_zone_detection(firewall):
     guardrails = result[0]["telemetry"]["ai_guardrails"]
 
     assert guardrails["hallucination_zone"] is True, "Failed to detect the Hallucination Zone!"
+    assert guardrails["undocumented_metaprogramming"] == 1
     assert any("Hallucination Risk" in warning for warning in guardrails["warnings"])
+
+
+def test_hallucination_zone_spares_locally_documented_metaprogramming(firewall):
+    """
+    #106's second documented blind spot: metaprogramming that IS documented
+    right where it lives must NOT be flagged, even though this is exactly the
+    shape the old dead doc_density check would have gotten wrong if it had
+    ever fired (a low file-wide average could still block a well-documented
+    function).
+    """
+    mock_files = [
+        {
+            "threat_locations": {
+                "reflection_metaprogramming": [45],
+                "doc": [40],
+            },
+            "functions": [{"start_line": 40, "end_line": 60}],
+        }
+    ]
+
+    result = firewall.evaluate_ecosystem(mock_files)
+    guardrails = result[0]["telemetry"]["ai_guardrails"]
+
+    assert guardrails["hallucination_zone"] is False
+    assert "undocumented_metaprogramming" not in guardrails
+
+
+def test_hallucination_zone_ignores_documentation_in_a_different_function(firewall):
+    """
+    #106's first documented blind spot: a doc comment concentrated in one
+    function (e.g. a class docstring near the top) must not paper over
+    undocumented metaprogramming in a totally different function -- this is
+    exactly the false negative the old GLOBAL doc_density average produced.
+    """
+    mock_files = [
+        {
+            "threat_locations": {
+                "reflection_metaprogramming": [50],
+                "doc": [5],
+            },
+            "functions": [
+                {"start_line": 1, "end_line": 10},
+                {"start_line": 40, "end_line": 60},
+            ],
+        }
+    ]
+
+    result = firewall.evaluate_ecosystem(mock_files)
+    guardrails = result[0]["telemetry"]["ai_guardrails"]
+
+    assert guardrails["hallucination_zone"] is True
+    assert guardrails["undocumented_metaprogramming"] == 1
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
Closes #106, and resolves #345. Landing order per the #102 epic (#344 -> #346 -> #105 -> #106): with #348's persisted `threat_locations` ledger and `correlate_against_ledger()` already proven out by #105, this is a second, even simpler consumer -- both signals it needs (`reflection_metaprogramming` and `doc`) are native `detector.py` rules, not security_lens-only, so there's no cross-worker merge dependency at all.

Replaces `dev_agent_firewall.py`'s rule 3 (Metaprogramming Hallucination Risk), which was fully dead code per #345: it read `file_data["telemetry"]["doc_density"]`, a key no producer anywhere ever wrote, so the check could never fire. Even a working version of the old check had two structural blind spots #106 called out: a global per-file doc-density average (a) misses undocumented metaprogramming buried in an otherwise well-documented file, and (b) false-positives on well-documented metaprogramming just because the rest of the file is sparse.

`correlate_against_ledger()` fixes both by proving proximity directly: a `reflection_metaprogramming` hit only flags `hallucination_zone` if no `doc` hit falls within the **same function** and `max_distance=10` lines -- reusing the exact fixture value `test_spatial_correlation.py` already anticipated for this signal pair. Also drops the now-fully-unused `signal_schema`/`hit_vector` reads in `evaluate_ecosystem`, and exposes the raw count as `guardrails["undocumented_metaprogramming"]` per #106's proposed telemetry export.

### Architectural integration, confirmed rather than assumed
Before landing, I traced the underlying data path end to end:
- Satellite ranges are guaranteed non-overlapping by construction -- `_slice_by_braces`/`_slice_by_indentation` track `last_end_idx` and skip any `func_start` match nested inside the previous satellite, so `correlate_scoped()`'s "sorted, non-overlapping" assumption is structurally enforced, not just documented.
- `threat_locations`/`functions` demonstrably survive from the per-file worker through `_calculate_risk_exposures` (Phase 3, spread via `**meta`) and `build_dependency_graph` (Phase 4, confirmed in-place mutation -- it already reads `f.get("functions", [])` itself) into the `parsed_files` list `DevAgentFirewall` consumes in Phase 5.

## Test plan
- [x] `test_dev_agent_firewall.py`'s hallucination-zone test rewritten to drive the ledger instead of the dead `doc_density` key.
- [x] Two new tests proving both of #106's blind spots are fixed: locally-documented metaprogramming is spared (`test_hallucination_zone_spares_locally_documented_metaprogramming`), and a doc comment in a *different* function does not paper over undocumented metaprogramming in another (`test_hallucination_zone_ignores_documentation_in_a_different_function`).
- [x] `python -m pytest tests/ -q` -- full suite, 836 passed, 1 pre-existing xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)