### PR TITLE
Scope the Exfiltration Distance Check to real function boundaries (#102)

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -973,16 +973,12 @@ class StructuralExtractor:
             # ==============================================================================
 
 # galaxyscope:ignore sec_high_risk_execution
-            # 0a. The Exfiltration Distance Check
-            if "memory_scraping" in spatial_map and "exfiltration_camouflage" in spatial_map:
-                # Measures the physical call-path distance between the memory read and the socket
-                unmitigated, confirmed_exfiltration = self._correlate_signals(
-                    targets=spatial_map["memory_scraping"],
-                    dampeners=spatial_map["exfiltration_camouflage"],
-                    max_distance=200,  # If they happen within 200 chars of each other, it's a confirmed attack
-                )
-                counts["memory_scraping"] += confirmed_exfiltration * 100  # Massive penalty multiplier
-                mitigations["amplified_leaks"] += confirmed_exfiltration
+            # 0a. The Exfiltration Distance Check has been RELOCATED (#102) to
+            # apply_amplifier_correlations() in gitgalaxy.core.spatial_correlation,
+            # called from _function_slice() -- it was the one correlate() pair
+            # #346/#348 missed when they enumerated and migrated the other six,
+            # so it kept running flat/unscoped after everything else had moved
+            # to same-function scoping.
 
             # 0b. The RCE Funnel Amplifier
             if "rce_funnel" in spatial_map:

--- a/gitgalaxy/core/spatial_correlation.py
+++ b/gitgalaxy/core/spatial_correlation.py
@@ -198,8 +198,9 @@ def apply_amplifier_correlations(
     mitigations: Dict[str, int],
 ) -> None:
     """
-    Runs the two remaining in-segment amplifier-pair correlations (#348) scoped
-    to real function boundaries, for consistency with apply_dampener_correlations().
+    Runs the three remaining in-segment amplifier-pair correlations (#348, #102)
+    scoped to real function boundaries, for consistency with
+    apply_dampener_correlations().
 
     Unlike a wrong-scope dampener, a wrong-scope amplifier only costs one extra
     review item (a false positive) -- an accepted tradeoff for this project, not
@@ -209,6 +210,20 @@ def apply_amplifier_correlations(
 
     Mutates `counts`/`mitigations` in place, matching apply_dampener_correlations().
     """
+    # 0. The Exfiltration Distance Check (memory read -> outbound socket).
+    # The one correlate() pair #346/#348 missed when they enumerated and
+    # migrated the other six -- it kept running flat/unscoped in
+    # coding_analysis() until #102 closed out the last "sporadic" gap.
+    if "memory_scraping" in spatial_map and "exfiltration_camouflage" in spatial_map:
+        _, confirmed_exfiltration = correlate_scoped(
+            targets=spatial_map["memory_scraping"],
+            dampeners=spatial_map["exfiltration_camouflage"],
+            satellite_ranges=satellite_ranges,
+            max_distance=200,  # If they happen within 200 chars of each other, it's a confirmed attack
+        )
+        counts["memory_scraping"] += confirmed_exfiltration * 100  # Massive penalty multiplier
+        mitigations["amplified_leaks"] += confirmed_exfiltration
+
     # 1. Taint Tracking (RCE Weaponization)
     if "high_risk_execution" in spatial_map and "io" in spatial_map:
         _, corroborated_rce = correlate_scoped(

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -130,6 +130,35 @@ def test_detector_spatial_appsec_correlation():
     )
 
 
+def test_detector_exfiltration_check_does_not_cross_function_boundaries():
+    """
+    Regression test for #102: the Exfiltration Distance Check was the one
+    correlate() pair #346/#348 missed when they scoped the other six to real
+    function boundaries -- it kept running flat/unscoped in coding_analysis()
+    until now. A memory read in one function and a socket send in a
+    DIFFERENT, unrelated function must not correlate just because they're
+    within the old flat 200-char radius.
+    """
+    opt_detector = StructuralExtractor("c", MOCK_LANG_DEFS)
+    code = (
+        "void reads_memory() {\n"
+        "    memcpy(buffer, secret_key, 100);\n"
+        "}\n"
+        "\n"
+        "void sends_elsewhere() {\n"
+        "    send(socket, other_buffer, 100, 0);\n"
+        "}\n"
+    )
+
+    result = opt_detector.splice(code, "")
+
+    assert result["equations"]["memory_scraping"] == 1, (
+        "A socket send in a DIFFERENT function must not amplify this memory read -- "
+        "cross-function exfiltration correlation regressed!"
+    )
+    assert result["mitigation_telemetry"].get("amplified_leaks", 0) == 0
+
+
 def test_detector_silencer_region():
     """
     Proves the Spatial Map correctly neutralizes danger signals if a safety wrapper


### PR DESCRIPTION
## Summary
Closes out the last "sporadic" gap #102's epic body called out. #346/#348 enumerated and migrated six `correlate()` pairs in `detector.py` onto same-function scoping, but the **Exfiltration Distance Check** (`memory_scraping` -> `exfiltration_camouflage`, in `coding_analysis()`'s Phase 4 AppSec block) was a seventh pair that got missed, and kept running on the old flat 200-character radius after everything else in the file had moved off it.

Migrated it into `apply_amplifier_correlations()` in `spatial_correlation.py`, called from `_function_slice()` once real satellite ranges exist -- same treatment as the RCE taint corroboration and OOM Bomb pairs already there. Same amplifier-not-dampener tradeoff reasoning applies (a wrong-scope amplifier only costs one extra review item, not a false negative), so this was about consistency, not urgency: every `correlate()` call in the pipeline now shares the same scoping semantics.

Pure relocation, not a behavior change for same-function callers -- `counts["memory_scraping"]` and `mitigations["amplified_leaks"]` are still mutated identically when the memory read and the socket send share a function.

## Test plan
- [x] New cross-function regression test in `test_detector.py` (`test_detector_exfiltration_check_does_not_cross_function_boundaries`), mirroring the existing dampener cross-function tests, proving a memory read in one function no longer amplifies a socket send in a different, unrelated one.
- [x] Existing `test_detector_spatial_appsec_correlation` (same-function case) still passes unchanged.
- [x] `python -m pytest tests/ -q` -- full suite, 837 passed, 1 pre-existing xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)