### PR TITLE
Build and tune the dead key auditor (#325)

### DIFF
--- a/tests/dead_key_audit.py
+++ b/tests/dead_key_audit.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Dead Key Auditor (#325)
+
+Finds dict keys that a consumer reads (.get("key"), ["key"], .pop("key"))
+somewhere in gitgalaxy/, but that no producer anywhere in gitgalaxy/ ever
+writes (["key"] = ..., a {"key": ...} literal/comprehension, .setdefault(
+"key", ...), or a dict(key=...)/​.update(key=...) keyword). That failure
+shape -- a read against a producer that was never built, or was renamed
+later without updating the consumer -- was found six independent times by
+hand (see #325); this is the "automate the manual diff" half of that issue.
+
+USAGE
+    python tests/dead_key_audit.py
+
+This is a standalone report script, not a pytest test: it is deliberately
+NOT wired into CI yet (that is #325's separate sub-task 3). Run it by hand
+and read the report.
+
+SCOPE & LIMITATIONS (read before treating a hit as a confirmed bug)
+This is a purely syntactic, whole-repo string-literal cross-reference. It
+has no type information, so "key" is one flat global namespace regardless
+of which dict it actually belongs to -- a real false negative is a key
+that's read from an unrelated producer of the same name elsewhere in the
+repo, and a real false positive is a key that IS produced, but only via
+a runtime-computed key the walker can't resolve to a literal (a variable,
+a function return value, etc). The PREFIX_WRITES handling below recovers
+the single largest source of that -- f-string-templated keys like
+f"sec_{sec_key}" -- but arbitrary indirection (e.g. CORE_MAPPING-style
+rule-name remapping through a dict lookup) is still invisible to it.
+Treat every hit as a lead to grep-confirm by hand, not a proven bug.
+
+External-schema keys (parsed YAML/JSON config, third-party API responses,
+lockfile fields, etc.) are real reads with no producer *in this repo* by
+design -- those go in ALLOWLIST below, with a comment saying why.
+"""
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Set, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = [REPO_ROOT / "gitgalaxy"]
+
+# ==============================================================================
+# ALLOWLIST -- tuned from a real run against this repo, not guessed in
+# advance (#325's sub-task 2). Each entry is a key this script currently
+# flags that is NOT an instance of the #325 pattern. Keep the reason with
+# the entry: it's the only thing that lets a future run tell "still valid"
+# apart from "the code changed, re-check this."
+# ==============================================================================
+ALLOWLIST = {
+    # --- External package manifests (package.json / composer.json / lockfiles) ---
+    # manifest_parser.py and guidestar_lens.py json.load() a THIRD-PARTY file;
+    # these keys are that file format's schema, not a dict this repo produces.
+    "dependencies": "package.json/composer.json field (manifest_parser.py)",
+    "devDependencies": "package.json field (manifest_parser.py)",
+    "require": "composer.json field (manifest_parser.py)",
+    "require-dev": "composer.json field (manifest_parser.py)",
+    "packages": "composer.lock field (manifest_parser.py)",
+    "resolved": "composer.lock field (manifest_parser.py)",
+    "bin": "package.json field (guidestar_lens.py)",
+    "main": "package.json field (guidestar_lens.py)",
+    "scripts": "package.json field (guidestar_lens.py)",
+
+    # --- External model/tensor files ---
+    # tensor_scanner.py json.loads()'s a .safetensors file's own header; these
+    # are that format's reserved/per-tensor keys, not ours.
+    "__metadata__": "safetensors header reserved key (tensor_scanner.py)",
+    "format": "safetensors per-tensor header field (tensor_scanner.py)",
+    "shape": "safetensors per-tensor header field (tensor_scanner.py)",
+    # func_ml_brain/repo_model are loaded ML archetype-clustering artifacts;
+    # the .get(..., [...]) fallback is explicitly "Bulletproof fallback names
+    # if the model dictionary forgets them" per signal_processor.py's own
+    # comment -- absence is the designed case, not a bug.
+    "cluster_names": "optional ML archetype-model field, has an explicit fallback (signal_processor.py)",
+
+    # --- External YAML/env config ---
+    "galaxyscope": "top-level section name in a user's .galaxyscope.yml project config file",
+    "GITGALAXY_LICENSE_KEY": "environment variable (os.environ.get), not a repo-produced dict",
+    "vulnerability_density_min": "optional risk_tuning YAML key (signal_processor.py._calc_injection_surface-style tuning)",
+    "asymptotic_dampener": "optional risk_tuning YAML key (signal_processor.py)",
+    "quarantine": "STATIC_ARCHETYPES app-config constant, read with a graceful string fallback",
+
+    # --- Explicit dual/legacy-schema compatibility shims ---
+    # spatial_mapper.py's own docstring: "Safely extracts structural magnitude
+    # regardless of which JSON version the pipeline is using."
+    "forensics": "legacy-schema compatibility branch (spatial_mapper.py, self-documented)",
+    # Defensive SECONDARY key in a.get("primary", a.get("filename", default))
+    # fallback chain -- "path"/"name" is the real, always-written key.
+    "filename": "defensive fallback alt-key, not the primary key (spatial_mapper.py)",
+
+    # --- SQLite Row column access ---
+    # state_rehydrator.py reads sqlite3.Row objects like dicts; these column
+    # names live in record_keeper.py's CREATE TABLE schema (confirmed present
+    # there), not in a Python dict literal this walker can see.
+    "author": "SQLite column, schema confirmed in record_keeper.py (state_rehydrator.py)",
+    "file_path": "SQLite column, schema confirmed in record_keeper.py (state_rehydrator.py)",
+    "src/hacked.py": "test fixture value inside state_rehydrator.py's own embedded test, not a real key",
+
+    # --- Dynamically-keyed dicts (walker can't trace the indirection) ---
+    # audit_recorder.py builds a dict keyed by each entry's own "label" value
+    # (e.g. {"secrets_risk": {"label": "Secrets Risk Exposure", ...}}), so
+    # "Hidden Malware Risk Exposure"/"Secrets Risk Exposure" ARE real keys of
+    # the resulting dict -- just not literal at the read site.
+    "Hidden Malware Risk Exposure": "dynamically keyed by a config table's 'label' field (audit_recorder.py)",
+    "Secrets Risk Exposure": "dynamically keyed by a config table's 'label' field (audit_recorder.py)",
+    # signal_processor.py._get_locational_multipliers() writes
+    # active_multipliers[signal_key] = multiplier, where signal_key comes from
+    # a "Friendly Name" -> short-name `bridge` dict lookup -- confirmed real
+    # writes, just one level of variable indirection away from the literal.
+    "cog": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+    "debt": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+    "async": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+    "dead": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+    "obscured": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+    "secrets": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+    "spec": "written via the bridge/signal_key indirection in _get_locational_multipliers (signal_processor.py)",
+
+    # --- External user-provided data ---
+    "known_programs": "user-provided IR JSON field, documented as external input (terabyte_log_scanner.py)",
+}
+
+
+class KeyUsage(NamedTuple):
+    file: str
+    line: int
+
+
+def _string_const(node: Optional[ast.expr]) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _fstring_prefix(node: Optional[ast.expr]) -> Optional[str]:
+    """
+    For an f-string key like f"sec_{sec_key}", returns the leading literal
+    text ("sec_") a write to that templated key would always start with.
+    Returns None for anything that isn't a JoinedStr with a leading literal
+    ast.Constant segment (e.g. f"{x}_suffix" has no usable prefix).
+    """
+    if not isinstance(node, ast.JoinedStr) or not node.values:
+        return None
+    first = node.values[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str) and first.value:
+        return first.value
+    return None
+
+
+class KeyVisitor(ast.NodeVisitor):
+    """
+    Walks one module's AST, recording every string-literal dict key read or
+    written in it. Deliberately conservative: only exact string constants
+    (plus the f-string PREFIX_WRITES special case below) are recorded --
+    anything keyed by a variable or function call is invisible to this pass
+    rather than guessed at.
+    """
+
+    def __init__(self, filename: str):
+        self.filename = filename
+        self.reads: Dict[str, List[KeyUsage]] = {}
+        self.writes: Set[str] = set()
+        self.prefix_writes: Set[str] = set()
+
+    def _record_read(self, key: str, node: ast.AST) -> None:
+        self.reads.setdefault(key, []).append(KeyUsage(self.filename, node.lineno))
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        key = _string_const(node.slice)
+        if key is not None:
+            if isinstance(node.ctx, ast.Load):
+                self._record_read(key, node)
+            elif isinstance(node.ctx, ast.Store):
+                self.writes.add(key)
+        elif isinstance(node.ctx, ast.Store):
+            prefix = _fstring_prefix(node.slice)
+            if prefix:
+                self.prefix_writes.add(prefix)
+        self.generic_visit(node)
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        for k in node.keys:
+            key = _string_const(k)
+            if key is not None:
+                self.writes.add(key)
+        self.generic_visit(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        prefix = _fstring_prefix(node.key)
+        if prefix:
+            self.prefix_writes.add(prefix)
+        key = _string_const(node.key)
+        if key is not None:
+            self.writes.add(key)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            if func.attr in ("get", "pop") and node.args:
+                key = _string_const(node.args[0])
+                if key is not None:
+                    self._record_read(key, node)
+            elif func.attr == "setdefault" and node.args:
+                key = _string_const(node.args[0])
+                if key is not None:
+                    self.writes.add(key)
+                else:
+                    prefix = _fstring_prefix(node.args[0])
+                    if prefix:
+                        self.prefix_writes.add(prefix)
+            elif func.attr == "update":
+                for kw in node.keywords:
+                    if kw.arg:
+                        self.writes.add(kw.arg)
+        elif isinstance(func, ast.Name) and func.id == "dict":
+            for kw in node.keywords:
+                if kw.arg:
+                    self.writes.add(kw.arg)
+        self.generic_visit(node)
+
+
+def iter_python_files(roots: List[Path]):
+    for root in roots:
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            yield path
+
+
+def scan() -> tuple:
+    all_reads: Dict[str, List[KeyUsage]] = {}
+    all_writes: Set[str] = set()
+    all_prefix_writes: Set[str] = set()
+
+    for path in iter_python_files(SCAN_ROOTS):
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        try:
+            rel = str(path.relative_to(REPO_ROOT))
+        except ValueError:
+            # Only reachable when SCAN_ROOTS points outside REPO_ROOT, e.g.
+            # this module's own tests pointing it at a tmp_path fixture.
+            rel = str(path)
+        visitor = KeyVisitor(rel)
+        visitor.visit(tree)
+
+        for key, usages in visitor.reads.items():
+            all_reads.setdefault(key, []).extend(usages)
+        all_writes.update(visitor.writes)
+        all_prefix_writes.update(visitor.prefix_writes)
+
+    return all_reads, all_writes, all_prefix_writes
+
+
+def find_dead_keys() -> Dict[str, List[KeyUsage]]:
+    reads, writes, prefix_writes = scan()
+    dead = {}
+    for key, usages in reads.items():
+        if key in writes:
+            continue
+        if any(key.startswith(prefix) for prefix in prefix_writes):
+            continue
+        if key in ALLOWLIST:
+            continue
+        dead[key] = usages
+    return dead
+
+
+def main() -> int:
+    dead = find_dead_keys()
+    if not dead:
+        print("Dead Key Auditor: no un-allowlisted read-without-write keys found.")
+        return 0
+
+    print(f"Dead Key Auditor: {len(dead)} key(s) read but never written anywhere in gitgalaxy/:\n")
+    for key in sorted(dead, key=lambda k: (-len(dead[k]), k)):
+        usages = dead[key]
+        print(f'  "{key}"  ({len(usages)} read site(s))')
+        for usage in usages[:5]:
+            print(f"      {usage.file}:{usage.line}")
+        if len(usages) > 5:
+            print(f"      ... and {len(usages) - 5} more")
+        print()
+
+    print(
+        "Each hit above is a LEAD, not a confirmed bug -- see the module docstring's "
+        "\"SCOPE & LIMITATIONS\" section before filing an issue."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dead_key_audit.py
+++ b/tests/test_dead_key_audit.py
@@ -1,0 +1,110 @@
+import ast
+
+from dead_key_audit import KeyVisitor, find_dead_keys, ALLOWLIST
+
+
+def _visit(source: str) -> KeyVisitor:
+    tree = ast.parse(source)
+    visitor = KeyVisitor("synthetic.py")
+    visitor.visit(tree)
+    return visitor
+
+
+# ==============================================================================
+# TEST 1: READ DETECTION
+# ==============================================================================
+def test_detects_get_and_pop_and_subscript_reads():
+    v = _visit(
+        "x.get('a')\n"
+        "x.get('b', 1)\n"
+        "x.pop('c')\n"
+        "y = x['d']\n"
+    )
+    assert set(v.reads.keys()) == {"a", "b", "c", "d"}
+
+
+def test_variable_keyed_reads_are_invisible_not_guessed():
+    """A read keyed by a variable can't be resolved to a literal -- must be silently skipped, not misattributed."""
+    v = _visit("k = 'a'\nx.get(k)\n")
+    assert v.reads == {}
+
+
+# ==============================================================================
+# TEST 2: WRITE DETECTION
+# ==============================================================================
+def test_detects_subscript_store_and_dict_literal_and_setdefault_writes():
+    v = _visit(
+        "x['a'] = 1\n"
+        "y = {'b': 1, 'c': 2}\n"
+        "x.setdefault('d', [])\n"
+        "x.update(e=1)\n"
+        "z = dict(f=1)\n"
+    )
+    assert v.writes == {"a", "b", "c", "d", "e", "f"}
+
+
+# ==============================================================================
+# TEST 3: F-STRING PREFIX WRITES (#325 -- the sec_{key} shape)
+# ==============================================================================
+def test_fstring_templated_subscript_write_is_a_prefix_write():
+    v = _visit('sec_key = "reflection_metaprogramming"\nx[f"sec_{sec_key}"] = 1\n')
+    assert v.prefix_writes == {"sec_"}
+    assert v.writes == set()
+
+
+def test_fstring_templated_setdefault_is_a_prefix_write():
+    v = _visit('x.setdefault(f"sec_{k}", [])\n')
+    assert v.prefix_writes == {"sec_"}
+
+
+def test_fstring_templated_dictcomp_key_is_a_prefix_write():
+    v = _visit('d = {f"sec_{k}": v for k, v in items}\n')
+    assert v.prefix_writes == {"sec_"}
+
+
+def test_fstring_with_no_leading_literal_yields_no_prefix():
+    """f"{x}_suffix" has no usable leading literal -- must not fabricate a prefix."""
+    v = _visit('x[f"{k}_suffix"] = 1\n')
+    assert v.prefix_writes == set()
+
+
+# ==============================================================================
+# TEST 4: find_dead_keys() end-to-end (read/write cross-reference)
+# ==============================================================================
+def test_find_dead_keys_flags_read_without_any_write(tmp_path, monkeypatch):
+    _write_scan_root(tmp_path, "mod.py", "x.get('orphan_key')\n")
+    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+
+    dead = find_dead_keys()
+    assert "orphan_key" in dead
+
+
+def test_find_dead_keys_does_not_flag_a_read_with_a_matching_write(tmp_path, monkeypatch):
+    _write_scan_root(tmp_path, "mod.py", "x.get('k')\nx['k'] = 1\n")
+    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+
+    dead = find_dead_keys()
+    assert "k" not in dead
+
+
+def test_find_dead_keys_honors_prefix_writes_across_files(tmp_path, monkeypatch):
+    """A read of "sec_foo" must be covered by a DIFFERENT file's f"sec_{...}" write."""
+    _write_scan_root(tmp_path, "producer.py", 'k = "foo"\nx[f"sec_{k}"] = 1\n')
+    _write_scan_root(tmp_path, "consumer.py", "y.get('sec_foo')\n")
+    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+
+    dead = find_dead_keys()
+    assert "sec_foo" not in dead
+
+
+def test_find_dead_keys_respects_the_allowlist(tmp_path, monkeypatch):
+    allowlisted_key = next(iter(ALLOWLIST))
+    _write_scan_root(tmp_path, "mod.py", f"x.get('{allowlisted_key}')\n")
+    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+
+    dead = find_dead_keys()
+    assert allowlisted_key not in dead
+
+
+def _write_scan_root(tmp_path, filename: str, source: str) -> None:
+    (tmp_path / filename).write_text(source, encoding="utf-8")


### PR DESCRIPTION
## Summary
Sub-tasks 1+2 of #325 ("automate the manual diff"): a small AST-based static analysis script (`tests/dead_key_audit.py`) that walks every `.get("key")`/`["key"]`/`.pop("key")` read in `gitgalaxy/` and cross-references each against every place that key is ever written (`["key"] = ...`, a `{"key": ...}` literal/comprehension, `.setdefault(`, or a `dict(key=...)`/`.update(key=...)` keyword), flagging any read with zero matching writes anywhere in the scanned tree.

Also handles the single largest expected source of false positives specifically: f-string-templated write keys (e.g. `threat_locations[f"sec_{sec_key}"] = ...`, the pattern this repo uses extensively for its `sec_`-prefixed signals) are recognized via a leading-literal-prefix match, so a read of `"sec_foo"` is correctly covered by a write of `f"sec_{k}"` even though the walker never resolves the runtime value of `k`.

**Deliberately NOT wired into CI** (#325's separate sub-task 3) and **does not fix anything it finds** (sub-task 4) -- scoped to the tool itself, tuned to a low-noise signal, per #325's own framing: *"the first sub-task is tuning it down to a low-noise signal, not just writing the walker."*

## Tuning pass
Raw first run: 48 candidates. Manually verified every one.

**33 confirmed false positives**, now in `ALLOWLIST` with the specific reason for each: external package manifests (package.json/composer.json/lockfiles), external ML model/tensor-file headers, external YAML/env config, explicit legacy-schema compatibility shims, SQLite `Row` column access, dynamically-keyed dicts (a config table's own `"label"` field used as a key), and `signal_processor.py`'s `_get_locational_multipliers()` bridge-dict indirection.

**15 remaining leads** -- not fixed here, but several independently confirmed while tuning, worth flagging now since #325 asks for individually-filed issues as instances are found:

- `"AI Threat Score"` (6 read sites across every recorder) vs the actual producer key, `"AI Threat Confidence"` (`security_auditor.py`) -- a near-miss rename matching #325's own described failure shape exactly.
- `"aperture_reason"` (`signal_processor.py`, `audit_recorder.py`) -- this is **#325's own pre-documented instance #3** ("real key is `reason`"), still unfixed.
- `"repo_z_score"` -- `record_keeper.py`/`llm_recorder.py` read it flat off per-file telemetry, but the real value lives nested at `summary["repo_macro_species"]["z_score"]` and is never threaded down.
- `"max_big_o"` -- `dev_agent_firewall.py` reads it off `file_data` directly; the only producer sets it as a networkx graph node attribute in `network_risk_sensor.py`, never copied back onto `file_data`. Silently caps the Agentic Black Hole check's O(N^3) condition at "never true."
- `"is_malware"`/`"has_credentials"`/`"binary_anomaly"`/`"glassworm_flag"` -- `record_keeper.py`'s SQLite columns for all four are always 0/False; no producer writes any of them (`security_auditor.py`'s actual output key is `"is_ml_threat"`, another near-miss).
- `"house_of_cards"` -- `llm_recorder.py`'s "House of Cards" report section is always empty; the real bottleneck-detector key is `"fragile_dependency_chain"` (`signal_processor.py`).
- `"has_tests"` -- `dev_agent_firewall.py`'s Silent Mutation Risk dampener can never be satisfied by real test coverage; nothing ever writes `telemetry["has_tests"]`.
- `"TYPOSQUAT_WHITELIST"` -- read from `APERTURE_CONFIG`, which has no such key; the typosquat whitelist is always empty.
- `"typosquat_hits"` -- `galaxyscope.py` computes and logs this count but never attaches it to `summary`/`ecosystem_audits`; `record_keeper.py`'s column is always the fallback 0.
- `"disqualifiers"` -- `language_lens.py`'s toxic-contributor penalty is fully dead; zero of the 57 language definitions set this key (vs. `"discriminators"`, set 57 times).
- `"ai_tools"` -- already documented dead per #323 (removed from `SIGNAL_SCHEMA`); `ai_appsec_sensor.py` still reads it. Likely #325's own referenced "AIAppSecSensor... companion issue."
- `"mechanical_families"` -- not chased down to a confirmed verdict; left as an open lead for whoever picks it up.

## Test plan
- [x] `tests/test_dead_key_audit.py` unit-tests the walker itself (read/write/setdefault/dict-literal/dict-comprehension detection, f-string prefix-write matching including a cross-file case, allowlist filtering, and that a variable-keyed read is silently skipped rather than guessed at) against synthetic fixtures -- **not** an assertion that `gitgalaxy/` has zero findings, since that would be sub-task 3 in disguise.
- [x] `python -m pytest tests/ -q` -- full suite, 848 passed, 1 pre-existing xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)