### PR TITLE
Wire the dead key auditor into CI as a baseline-gated required check (#325)

### DIFF
--- a/.github/workflows/dead-key-audit.yml
+++ b/.github/workflows/dead-key-audit.yml
@@ -1,0 +1,29 @@
+name: Dead Key Audit
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dead-key-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      # No pip install: dead_key_audit.py is stdlib-only (ast/json/argparse)
+      # by design, so this check stays fast and dependency-free.
+      - name: Run baseline-gated regression check (#325)
+        run: python tests/dead_key_audit.py --ci

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ tests/telemetry_out/
 
 # Force tracking of the Golden Master despite global *.json ignore
 !tests/golden_master_audit.json*.vsix
+
+# Force tracking of the Dead Key Auditor baseline (#325) despite global *.json ignore
+!tests/dead_key_audit_baseline.json

--- a/tests/dead_key_audit.py
+++ b/tests/dead_key_audit.py
@@ -11,11 +11,26 @@ later without updating the consumer -- was found six independent times by
 hand (see #325); this is the "automate the manual diff" half of that issue.
 
 USAGE
-    python tests/dead_key_audit.py
+    python tests/dead_key_audit.py          # full report, exits 1 if anything
+                                             # un-allowlisted is found -- use
+                                             # this to re-tune ALLOWLIST or to
+                                             # refresh the baseline below.
+    python tests/dead_key_audit.py --ci      # baseline-gated regression check
+                                             # (see BASELINE below) -- this is
+                                             # what CI runs.
 
-This is a standalone report script, not a pytest test: it is deliberately
-NOT wired into CI yet (that is #325's separate sub-task 3). Run it by hand
-and read the report.
+BASELINE (#325 sub-task 3)
+This repo had 15 confirmed-real, not-yet-fixed instances of this pattern the
+day this check was wired into CI (see dead_key_audit_baseline.json). Hard
+failing on those immediately would block every unrelated PR until all 15
+were fixed first, so `--ci` mode is a REGRESSION gate, not a zero-tolerance
+one: it fails only on keys not already in the baseline. Fixing a baselined
+key doesn't fail the build either -- shrinking the baseline is a deliberate,
+reviewable edit you make yourself (matching #330's "deliberate, reviewable
+updates instead of silent overwrite" philosophy for golden_master.json),
+not something this script does automatically. `--ci` prints anything it
+notices has already been fixed as an FYI, so the baseline doesn't silently
+go stale, but it does not fail the build over it.
 
 SCOPE & LIMITATIONS (read before treating a hit as a confirmed bug)
 This is a purely syntactic, whole-repo string-literal cross-reference. It
@@ -34,13 +49,16 @@ External-schema keys (parsed YAML/JSON config, third-party API responses,
 lockfile fields, etc.) are real reads with no producer *in this repo* by
 design -- those go in ALLOWLIST below, with a comment saying why.
 """
+import argparse
 import ast
+import json
 import sys
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Set, Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCAN_ROOTS = [REPO_ROOT / "gitgalaxy"]
+BASELINE_PATH = Path(__file__).resolve().parent / "dead_key_audit_baseline.json"
 
 # ==============================================================================
 # ALLOWLIST -- tuned from a real run against this repo, not guessed in
@@ -272,13 +290,15 @@ def find_dead_keys() -> Dict[str, List[KeyUsage]]:
     return dead
 
 
-def main() -> int:
-    dead = find_dead_keys()
-    if not dead:
-        print("Dead Key Auditor: no un-allowlisted read-without-write keys found.")
-        return 0
+def load_baseline() -> Dict[str, str]:
+    """Returns {key: reason} for every already-known, not-yet-fixed lead."""
+    if not BASELINE_PATH.exists():
+        return {}
+    with open(BASELINE_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
 
-    print(f"Dead Key Auditor: {len(dead)} key(s) read but never written anywhere in gitgalaxy/:\n")
+
+def _print_dead_keys(dead: Dict[str, List[KeyUsage]]) -> None:
     for key in sorted(dead, key=lambda k: (-len(dead[k]), k)):
         usages = dead[key]
         print(f'  "{key}"  ({len(usages)} read site(s))')
@@ -288,11 +308,67 @@ def main() -> int:
             print(f"      ... and {len(usages) - 5} more")
         print()
 
+
+def run_full_report() -> int:
+    dead = find_dead_keys()
+    if not dead:
+        print("Dead Key Auditor: no un-allowlisted read-without-write keys found.")
+        return 0
+
+    print(f"Dead Key Auditor: {len(dead)} key(s) read but never written anywhere in gitgalaxy/:\n")
+    _print_dead_keys(dead)
     print(
         "Each hit above is a LEAD, not a confirmed bug -- see the module docstring's "
         "\"SCOPE & LIMITATIONS\" section before filing an issue."
     )
     return 1
+
+
+def run_ci_check() -> int:
+    """
+    Baseline-gated regression check (#325 sub-task 3): fails only on keys
+    NOT already in dead_key_audit_baseline.json. See the module docstring's
+    BASELINE section for why this isn't a zero-tolerance check.
+    """
+    dead = find_dead_keys()
+    baseline = load_baseline()
+
+    new_keys = {key: usages for key, usages in dead.items() if key not in baseline}
+    resolved_keys = sorted(set(baseline) - set(dead))
+
+    if resolved_keys:
+        print("Dead Key Auditor: FYI -- these baselined keys are no longer flagged (fixed, or now allowlisted).")
+        print("Consider removing them from dead_key_audit_baseline.json in this PR:\n")
+        for key in resolved_keys:
+            print(f'  "{key}"  -- {baseline[key]}')
+        print()
+
+    if not new_keys:
+        print(f"Dead Key Auditor: no NEW read-without-write keys beyond the {len(baseline)}-key baseline.")
+        return 0
+
+    print(f"Dead Key Auditor: {len(new_keys)} NEW key(s) read but never written anywhere in gitgalaxy/:\n")
+    _print_dead_keys(new_keys)
+    print(
+        "Each hit above is a LEAD, not a confirmed bug -- see the module docstring's "
+        "\"SCOPE & LIMITATIONS\" section. From here:\n"
+        "  - Confirmed false positive (walker limitation)? Add it to ALLOWLIST with a reason.\n"
+        "  - Confirmed real instance of #325's pattern, not fixing it in this PR? Add it to\n"
+        "    dead_key_audit_baseline.json with a reason, and consider filing an issue.\n"
+        "  - Otherwise, fix the actual read/write mismatch."
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="Baseline-gated regression check (what CI runs) instead of the full report.",
+    )
+    args = parser.parse_args()
+    return run_ci_check() if args.ci else run_full_report()
 
 
 if __name__ == "__main__":

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,0 +1,17 @@
+{
+  "AI Threat Score": "6 read sites across every recorder; real producer key is 'AI Threat Confidence' (security_auditor.py) -- near-miss rename",
+  "aperture_reason": "signal_processor.py, audit_recorder.py; #325's own pre-documented instance #3 -- real key is 'reason'",
+  "repo_z_score": "record_keeper.py/llm_recorder.py read it flat off per-file telemetry; real value is nested at summary['repo_macro_species']['z_score'] and never threaded down",
+  "max_big_o": "dev_agent_firewall.py reads it off file_data directly; only producer sets it as a networkx graph node attribute (network_risk_sensor.py), never copied back",
+  "is_malware": "record_keeper.py SQLite column always 0; no producer -- security_auditor.py's actual output key is 'is_ml_threat' (near-miss)",
+  "has_credentials": "record_keeper.py SQLite column always 0; no producer anywhere",
+  "binary_anomaly": "record_keeper.py SQLite column always 0; no producer anywhere",
+  "glassworm_flag": "record_keeper.py SQLite column always 0; no producer anywhere",
+  "house_of_cards": "llm_recorder.py's 'House of Cards' report section always empty; real bottleneck-detector key is 'fragile_dependency_chain' (signal_processor.py)",
+  "has_tests": "dev_agent_firewall.py's Silent Mutation Risk dampener can never be satisfied by real test coverage; nothing writes telemetry['has_tests']",
+  "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
+  "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",
+  "disqualifiers": "language_lens.py's toxic-contributor penalty is fully dead; zero of the 57 language definitions set this key (vs. 'discriminators', set 57 times)",
+  "ai_tools": "already documented dead per #323 (removed from SIGNAL_SCHEMA); ai_appsec_sensor.py still reads it",
+  "mechanical_families": "prism.py; not chased down to a confirmed verdict -- open lead"
+}

--- a/tests/test_dead_key_audit.py
+++ b/tests/test_dead_key_audit.py
@@ -1,7 +1,6 @@
 import ast
 import json
 
-import dead_key_audit
 from dead_key_audit import KeyVisitor, find_dead_keys, ALLOWLIST, run_ci_check
 
 

--- a/tests/test_dead_key_audit.py
+++ b/tests/test_dead_key_audit.py
@@ -1,12 +1,12 @@
 import ast
 import json
 
-from dead_key_audit import KeyVisitor, find_dead_keys, ALLOWLIST, run_ci_check
+import dead_key_audit
 
 
-def _visit(source: str) -> KeyVisitor:
+def _visit(source: str) -> "dead_key_audit.KeyVisitor":
     tree = ast.parse(source)
-    visitor = KeyVisitor("synthetic.py")
+    visitor = dead_key_audit.KeyVisitor("synthetic.py")
     visitor.visit(tree)
     return visitor
 
@@ -74,17 +74,17 @@ def test_fstring_with_no_leading_literal_yields_no_prefix():
 # ==============================================================================
 def test_find_dead_keys_flags_read_without_any_write(tmp_path, monkeypatch):
     _write_scan_root(tmp_path, "mod.py", "x.get('orphan_key')\n")
-    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
 
-    dead = find_dead_keys()
+    dead = dead_key_audit.find_dead_keys()
     assert "orphan_key" in dead
 
 
 def test_find_dead_keys_does_not_flag_a_read_with_a_matching_write(tmp_path, monkeypatch):
     _write_scan_root(tmp_path, "mod.py", "x.get('k')\nx['k'] = 1\n")
-    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
 
-    dead = find_dead_keys()
+    dead = dead_key_audit.find_dead_keys()
     assert "k" not in dead
 
 
@@ -92,18 +92,18 @@ def test_find_dead_keys_honors_prefix_writes_across_files(tmp_path, monkeypatch)
     """A read of "sec_foo" must be covered by a DIFFERENT file's f"sec_{...}" write."""
     _write_scan_root(tmp_path, "producer.py", 'k = "foo"\nx[f"sec_{k}"] = 1\n')
     _write_scan_root(tmp_path, "consumer.py", "y.get('sec_foo')\n")
-    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
 
-    dead = find_dead_keys()
+    dead = dead_key_audit.find_dead_keys()
     assert "sec_foo" not in dead
 
 
 def test_find_dead_keys_respects_the_allowlist(tmp_path, monkeypatch):
-    allowlisted_key = next(iter(ALLOWLIST))
+    allowlisted_key = next(iter(dead_key_audit.ALLOWLIST))
     _write_scan_root(tmp_path, "mod.py", f"x.get('{allowlisted_key}')\n")
-    monkeypatch.setattr("dead_key_audit.SCAN_ROOTS", [tmp_path])
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
 
-    dead = find_dead_keys()
+    dead = dead_key_audit.find_dead_keys()
     assert allowlisted_key not in dead
 
 
@@ -125,7 +125,7 @@ def test_ci_check_passes_when_findings_exactly_match_baseline(tmp_path, monkeypa
     monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
     _write_baseline(tmp_path, monkeypatch, {"known_lead": "already tracked"})
 
-    assert run_ci_check() == 0
+    assert dead_key_audit.run_ci_check() == 0
 
 
 def test_ci_check_fails_on_a_key_not_in_the_baseline(tmp_path, monkeypatch, capsys):
@@ -133,7 +133,7 @@ def test_ci_check_fails_on_a_key_not_in_the_baseline(tmp_path, monkeypatch, caps
     monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
     _write_baseline(tmp_path, monkeypatch, {})
 
-    assert run_ci_check() == 1
+    assert dead_key_audit.run_ci_check() == 1
     assert "brand_new_lead" in capsys.readouterr().out
 
 
@@ -143,7 +143,7 @@ def test_ci_check_does_not_fail_when_a_baselined_key_gets_fixed(tmp_path, monkey
     monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
     _write_baseline(tmp_path, monkeypatch, {"now_fixed_key": "used to be a lead"})
 
-    assert run_ci_check() == 0
+    assert dead_key_audit.run_ci_check() == 0
     assert "now_fixed_key" in capsys.readouterr().out  # still surfaced as an FYI
 
 
@@ -152,7 +152,7 @@ def test_ci_check_with_no_baseline_file_treats_everything_as_new(tmp_path, monke
     monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
     monkeypatch.setattr(dead_key_audit, "BASELINE_PATH", tmp_path / "does_not_exist.json")
 
-    assert run_ci_check() == 1
+    assert dead_key_audit.run_ci_check() == 1
 
 
 # ==============================================================================
@@ -164,4 +164,4 @@ def test_real_repo_baseline_has_no_new_regressions():
     gitgalaxy/ -- this is the one test in this file that scans the real repo,
     not a synthetic fixture, mirroring exactly what `--ci` does.
     """
-    assert run_ci_check() == 0
+    assert dead_key_audit.run_ci_check() == 0

--- a/tests/test_dead_key_audit.py
+++ b/tests/test_dead_key_audit.py
@@ -1,6 +1,8 @@
 import ast
+import json
 
-from dead_key_audit import KeyVisitor, find_dead_keys, ALLOWLIST
+import dead_key_audit
+from dead_key_audit import KeyVisitor, find_dead_keys, ALLOWLIST, run_ci_check
 
 
 def _visit(source: str) -> KeyVisitor:
@@ -108,3 +110,59 @@ def test_find_dead_keys_respects_the_allowlist(tmp_path, monkeypatch):
 
 def _write_scan_root(tmp_path, filename: str, source: str) -> None:
     (tmp_path / filename).write_text(source, encoding="utf-8")
+
+
+def _write_baseline(tmp_path, monkeypatch, baseline: dict) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+    monkeypatch.setattr(dead_key_audit, "BASELINE_PATH", baseline_path)
+
+
+# ==============================================================================
+# TEST 5: run_ci_check() -- baseline-gated regression check (#325 sub-task 3)
+# ==============================================================================
+def test_ci_check_passes_when_findings_exactly_match_baseline(tmp_path, monkeypatch):
+    _write_scan_root(tmp_path, "mod.py", "x.get('known_lead')\n")
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
+    _write_baseline(tmp_path, monkeypatch, {"known_lead": "already tracked"})
+
+    assert run_ci_check() == 0
+
+
+def test_ci_check_fails_on_a_key_not_in_the_baseline(tmp_path, monkeypatch, capsys):
+    _write_scan_root(tmp_path, "mod.py", "x.get('brand_new_lead')\n")
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
+    _write_baseline(tmp_path, monkeypatch, {})
+
+    assert run_ci_check() == 1
+    assert "brand_new_lead" in capsys.readouterr().out
+
+
+def test_ci_check_does_not_fail_when_a_baselined_key_gets_fixed(tmp_path, monkeypatch, capsys):
+    """Fixing a baselined key must not fail the build -- only regressions should."""
+    _write_scan_root(tmp_path, "mod.py", "pass\n")  # the old read is gone
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
+    _write_baseline(tmp_path, monkeypatch, {"now_fixed_key": "used to be a lead"})
+
+    assert run_ci_check() == 0
+    assert "now_fixed_key" in capsys.readouterr().out  # still surfaced as an FYI
+
+
+def test_ci_check_with_no_baseline_file_treats_everything_as_new(tmp_path, monkeypatch):
+    _write_scan_root(tmp_path, "mod.py", "x.get('some_key')\n")
+    monkeypatch.setattr(dead_key_audit, "SCAN_ROOTS", [tmp_path])
+    monkeypatch.setattr(dead_key_audit, "BASELINE_PATH", tmp_path / "does_not_exist.json")
+
+    assert run_ci_check() == 1
+
+
+# ==============================================================================
+# TEST 6: the real baseline file matches what a fresh scan actually finds
+# ==============================================================================
+def test_real_repo_baseline_has_no_new_regressions():
+    """
+    Guards against the baseline file itself silently drifting out of sync with
+    gitgalaxy/ -- this is the one test in this file that scans the real repo,
+    not a synthetic fixture, mirroring exactly what `--ci` does.
+    """
+    assert run_ci_check() == 0


### PR DESCRIPTION
## Summary
Closes out #325's sub-task 3 (and, with it, the epic itself if you're happy with this). The tool already reports 15 confirmed-real, not-yet-fixed leads from the tuning pass in #362 -- a zero-tolerance "fail on any finding" gate would immediately block every future PR on fixing all 15 first, so this is a **regression gate**, not a zero-tolerance one: CI fails only on keys not already recorded in the new `tests/dead_key_audit_baseline.json`, via a new `--ci` mode (`run_ci_check()`).

Fixing a baselined key doesn't fail the build either -- `--ci` prints it as an FYI ("consider removing this from the baseline") so the baseline doesn't silently drift stale, but shrinking it stays a deliberate, reviewable edit a human makes, same "deliberate, reviewable updates instead of silent overwrite" philosophy #330 established for `golden_master.json`.

Wired in two places:
- **`tests/test_dead_key_audit.py::test_real_repo_baseline_has_no_new_regressions`** runs the real check against `gitgalaxy/` (not a synthetic fixture, unlike every other test in this file) as part of the normal `pytest tests/ -v` `smoke-test.yml` step every PR already runs.
- **`.github/workflows/dead-key-audit.yml`**: a small dedicated workflow running `python tests/dead_key_audit.py --ci` directly, for a distinctly-labeled required check in the PR UI rather than a failure buried inside one giant pytest step -- matching this repo's existing convention of single-purpose workflows (CodeQL, Muninn, Vault Sentinel, X-Ray Inspector, golden-crucible). Zero new dependencies: the script is stdlib-only by design, so this check stays fast.

**Side fix**: `.gitignore`'s blanket `*.json` rule was silently swallowing the new baseline file (the existing `golden_master_audit.json` exception is itself a malformed single-line merge of two unrelated patterns -- left as-is, out of scope here -- but the same category of problem would have made this baseline file un-addable). Added a correctly-formed negation line for it.

## Test plan
- [x] 4 new tests on `run_ci_check()` covering the four real code paths: exact baseline match (pass), a genuinely new key (fail), a baselined key that's since been fixed (still passes, prints FYI), and a missing baseline file (everything treated as new).
- [x] Verified all four manually against the real baseline too (temporarily removing/adding an entry and confirming the exit code flips), not just via the synthetic-fixture unit tests.
- [x] `python -m pytest tests/ -q` -- full suite, 853 passed, 1 pre-existing xfail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)