### PR TITLE
Revive AIAppSecSensor's Over-Permissioned Agent rule with a real signal (#365)

### DIFF
--- a/gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py
+++ b/gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py
@@ -38,7 +38,6 @@ class AIAppSecSensor:
             # Extract specific architectural signals
             ai_orchestrator = equations.get("llm_orchestrator", 0) > 0
             llm_api = equations.get("llm_api", 0) > 0
-            ai_tools = equations.get("ai_tools", 0) > 0
 
             arch_api = equations.get("api", 0) > 0  # Publicly exposed
             arch_io = (equations.get("io", 0) + equations.get("sec_io", 0)) > 0  # Network/Disk I/O
@@ -72,8 +71,23 @@ class AIAppSecSensor:
                 )
 
             # 2. Over-Permissioned Agent Binding (Autonomous Escalation)
-            # AI Agent Tools + State Mutation (DB or Disk) + Low Defensive Safety
-            if ai_tools and (db_complexity >= 2 or arch_io) and safety_density < 0.5:
+            # Agent Orchestration Framework + State Mutation (DB or Disk) + Low Defensive Safety
+            #
+            # #365/#323: this used to gate on "ai_tools", a SIGNAL_SCHEMA category
+            # removed in #323 because agent tool-CALLING is behavior, not library
+            # identity -- a regex-based structural signature engine can't reliably
+            # detect it, so the category was deliberately dropped rather than left
+            # as a permanent false negative. That silently broke this rule (it
+            # could never fire again) until #365 found it via #325's dead key audit.
+            #
+            # ai_orchestrator (langchain/llama_index imports) is the closest thing
+            # this engine CAN honestly detect: those are specifically the frameworks
+            # whose entire purpose is binding an LLM to tools/actions, so "this file
+            # imports an agent orchestration framework" is a reasonable, lexically-
+            # detectable proxy for "this file has agentic tool-binding capability" --
+            # library-identity detection, exactly the kind of signal #323 said this
+            # engine is good at, not the behavioral one it isn't.
+            if ai_orchestrator and (db_complexity >= 2 or arch_io) and safety_density < 0.5:
                 appsec_report["over_permissioned_agent"] = True
                 appsec_report["critical_warnings"].append(
                     "CRITICAL [Over-Permissioned Agent]: AI is bound to tools with raw Database/IO write access and < 50% safety density. High risk of autonomous data corruption."

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -11,6 +11,5 @@
   "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
   "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",
   "disqualifiers": "language_lens.py's toxic-contributor penalty is fully dead; zero of the 57 language definitions set this key (vs. 'discriminators', set 57 times)",
-  "ai_tools": "already documented dead per #323 (removed from SIGNAL_SCHEMA); ai_appsec_sensor.py still reads it",
   "mechanical_families": "prism.py; not chased down to a confirmed verdict -- open lead"
 }

--- a/tests/security_auditing/test_ai_appsec_sensor.py
+++ b/tests/security_auditing/test_ai_appsec_sensor.py
@@ -37,8 +37,12 @@ def test_autonomous_execution_vector_detection():
 # ==============================================================================
 def test_over_permissioned_agent_detection():
     """
-    Proves that an AI agent given autonomous tools, write-access to complex
-    databases, and low defensive programming density triggers the Over-Permissioned Agent alert.
+    Proves that an agent orchestration framework (langchain/llama_index --
+    #365/#323: the closest lexically-detectable proxy for agentic tool-binding
+    this engine has, since "ai_tools" was removed from SIGNAL_SCHEMA in #323
+    as fundamentally undetectable via regex), combined with write-access to
+    complex databases and low defensive programming density, triggers the
+    Over-Permissioned Agent alert.
     """
     sensor = AIAppSecSensor()
 
@@ -48,7 +52,7 @@ def test_over_permissioned_agent_detection():
             "coding_loc": 100,
             "telemetry": {},
             "equations": {
-                "ai_tools": 1,  # Agentic tool calling enabled
+                "llm_orchestrator": 1,  # langchain/llama_index present -> agentic tool-binding
                 "safety": 0,  # Dangerously low defensive programming -> density 0.0
             },
         }
@@ -62,6 +66,38 @@ def test_over_permissioned_agent_detection():
     )
     assert any(
         "Over-Permissioned Agent" in warning for warning in appsec_report["critical_warnings"]
+    )
+
+
+# ==============================================================================
+# TEST 2.1: THE DEAD KEY REGRESSION GUARD (#365)
+# ==============================================================================
+def test_over_permissioned_agent_no_longer_reads_dead_ai_tools_key():
+    """
+    Regression guard for #365: a mocked "ai_tools" equation -- the removed
+    SIGNAL_SCHEMA key this rule used to (uselessly) gate on -- must NOT
+    trigger the Over-Permissioned Agent alert on its own. Only a real,
+    still-live signal (llm_orchestrator) should be able to.
+    """
+    sensor = AIAppSecSensor()
+
+    mock_files = [
+        {
+            "max_db_complexity": 3,
+            "coding_loc": 100,
+            "telemetry": {},
+            "equations": {
+                "ai_tools": 1,  # dead key -- must be inert
+                "safety": 0,
+            },
+        }
+    ]
+
+    result = sensor.hunt_threats(mock_files)
+    appsec_report = result[0]["telemetry"]["ai_appsec"]
+
+    assert appsec_report["over_permissioned_agent"] is False, (
+        "The dead 'ai_tools' key must not be able to trigger this rule!"
     )
 
 


### PR DESCRIPTION
## Summary
Closes #365. The "Over-Permissioned Agent Binding" rule gated on `equations.get("ai_tools", 0) > 0` -- but `"ai_tools"` was deliberately removed from `SIGNAL_SCHEMA` in #323, which explicitly called out this exact consequence: *"Feeding inputs into security-critical rules (e.g. AIAppSecSensor's 'over-permissioned agent' detector -- see companion issue) that can never be honestly computed even once the plumbing is fixed."* That companion issue was never filed until #325's dead key audit found it independently as #365.

#323's own reasoning rules out simply reintroducing an `"ai_tools"` signal: agent tool-**calling** is behavior (an autonomous execution pattern), not library identity, and a regex-based structural signature engine can't reliably detect behavior -- that's precisely why the category was removed rather than left broken. So the fix isn't a rename like #364's; it's picking a signal this engine CAN honestly compute.

**`ai_orchestrator`** (`equations["llm_orchestrator"]`, detecting `langchain`/`llama_index` imports) is that signal: those are specifically the frameworks whose entire purpose is binding an LLM to tools/actions, so "this file imports an agent orchestration framework" is a defensible, lexically-detectable proxy for "this file has agentic tool-binding capability" -- library-identity detection, exactly the kind of signal #323 said this engine is good at. It's also already computed one line above in this same function for rule #1, so this is a one-line change to rule #2's condition, not a new detector.

## Test plan
- [x] The existing Over-Permissioned Agent test updated to mock `"llm_orchestrator"` instead of the dead `"ai_tools"` key (matching what the real engine can now produce).
- [x] New regression guard (`test_over_permissioned_agent_no_longer_reads_dead_ai_tools_key`) proving a mocked `"ai_tools"` value alone can no longer trigger the rule -- locking in that the dead key has zero remaining effect, not just that a live key works.
- [x] `tests/dead_key_audit_baseline.json`: `"ai_tools"` removed now that it's fixed (`python tests/dead_key_audit.py --ci` confirmed clean at 13 baselined keys, zero regressions).
- [x] `python -m pytest tests/ -q` -- full suite, 856 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)