### PR TITLE
Fix "House of Cards" report section and per-file repo_z_score (#370, #371)

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -916,6 +916,15 @@ class Orchestrator:
             t_phase = time.time()
             summary = self.processor.summarize_galaxy_metrics(repository_graph, total_unparsable)
             summary["network_macro"] = network_macro
+
+            # #371: repo_z_score is repo-wide (only knowable once summary is
+            # computed), but record_keeper.py/llm_recorder.py read it per-file
+            # off telemetry -- thread it down now that it exists, or every file's
+            # column/report field stays permanently the 0.0 fallback.
+            repo_z_score = summary.get("repo_macro_species", {}).get("z_score", 0.0)
+            for file_data in (repository_graph or []):
+                file_data.setdefault("telemetry", {})["repo_z_score"] = repo_z_score
+
             report = self.processor.generate_forensic_report(repository_graph)
             logger.debug(f"⏱️ EXECUTION_TIME [Phase 8 - Metrics Synthesis]: {time.time() - t_phase:.2f}s")
 
@@ -2492,6 +2501,11 @@ class Orchestrator:
             # 7. Synthesis and Database Forging
             summary = self.processor.summarize_galaxy_metrics(repository_graph, unparsable_audits)
             summary["network_macro"] = network_macro
+
+            # #371: see the identical backfill in the main pipeline above.
+            repo_z_score = summary.get("repo_macro_species", {}).get("z_score", 0.0)
+            for file_data in (repository_graph or []):
+                file_data.setdefault("telemetry", {})["repo_z_score"] = repo_z_score
             session_meta = {
                 "engine": f"GitGalaxy Scope v{self.version} (Delta Mode)",
                 "target": self.root.name,

--- a/gitgalaxy/recorders/llm_recorder.py
+++ b/gitgalaxy/recorders/llm_recorder.py
@@ -1176,7 +1176,10 @@ class LLMRecorder:
                         )
                 lines.append("")
 
-            hoc = sys_bots.get("house_of_cards", [])
+            # #370: the real bottleneck-detector key is "fragile_dependency_chain"
+            # (signal_processor.py) -- "house_of_cards" was never a real key, just
+            # this section's own display name mistakenly used as the lookup too.
+            hoc = sys_bots.get("fragile_dependency_chain", [])
             if hoc and hoc[0]["score"] > 0:
                 lines.append("### 🃏 House of Cards (Closeness * Error Risk)")
                 lines.append(

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -1001,6 +1001,45 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         self.assertNotIn("ai_guardrails", sanitized_file["telemetry"], "Failed to purge SARIF ignored rule!")
 
     # ==============================================================================
+    # TEST 14.5: THE REPO Z-SCORE BACKFILL (#371)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._resolve_dependency_graph")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._calculate_risk_exposures")
+    @patch("gitgalaxy.galaxyscope.RecordKeeper")
+    @patch("gitgalaxy.galaxyscope.SarifRecorder")
+    def test_repo_z_score_backfilled_into_per_file_telemetry(self, mock_sarif, mock_db, mock_calc, mock_res, mock_ext, mock_cen):
+        """
+        Regression test for #371: repo_z_score is only knowable once the
+        repo-wide summary is computed, but record_keeper.py/llm_recorder.py
+        read it per-file off telemetry -- before this fix, nothing ever
+        threaded the repo-wide value back down, so it was always the 0.0
+        fallback. Proves the real summarize_galaxy_metrics() output survives
+        into every file's telemetry.
+        """
+        config = self.mock_config.copy()
+        config["SARIF_ONLY"] = True  # Bypass the destructive GPU Recorder
+
+        scope = Orchestrator(".", config)
+        scope.parsed_files = [{"path": "src/api.py", "telemetry": {}, "equations": {}}]
+
+        scope.network_sensor = MagicMock()
+        scope.network_sensor.build_dependency_graph.return_value = (scope.parsed_files, {})
+        scope.auditor = MagicMock()
+        scope.auditor.audit.return_value = (scope.parsed_files, [])
+        scope.model_auditor = MagicMock()
+        scope.model_auditor.audit_repository.return_value = scope.parsed_files
+        scope.processor = MagicMock()
+        scope.processor.summarize_galaxy_metrics.return_value = {
+            "repo_macro_species": {"z_score": 3.7},
+        }
+
+        scope.execute_pipeline("fake.json")
+
+        self.assertEqual(scope.parsed_files[0]["telemetry"]["repo_z_score"], 3.7)
+
+    # ==============================================================================
     # TEST 15: THE GIT-LESS VOID (Fallback OS Walk)
     # ==============================================================================
     @patch("gitgalaxy.galaxyscope.subprocess.check_output")

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,8 +1,6 @@
 {
   "aperture_reason": "signal_processor.py, audit_recorder.py; #325's own pre-documented instance #3 -- real key is 'reason'",
-  "repo_z_score": "record_keeper.py/llm_recorder.py read it flat off per-file telemetry; real value is nested at summary['repo_macro_species']['z_score'] and never threaded down",
   "max_big_o": "dev_agent_firewall.py reads it off file_data directly; only producer sets it as a networkx graph node attribute (network_risk_sensor.py), never copied back",
-  "house_of_cards": "llm_recorder.py's 'House of Cards' report section always empty; real bottleneck-detector key is 'fragile_dependency_chain' (signal_processor.py)",
   "has_tests": "dev_agent_firewall.py's Silent Mutation Risk dampener can never be satisfied by real test coverage; nothing writes telemetry['has_tests']",
   "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
   "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",

--- a/tests/tools_recorders/test_llm_recorder.py
+++ b/tests/tools_recorders/test_llm_recorder.py
@@ -186,6 +186,31 @@ def test_build_markdown_generates_context(recorder, mock_pipeline_state):
     assert "Prompt Injection Surface" in md_text
 
 
+def test_house_of_cards_section_reads_fragile_dependency_chain(recorder, mock_pipeline_state):
+    """
+    Regression test for #370: the "House of Cards" section used to read
+    sys_bots.get("house_of_cards", []) -- a key signal_processor.py's real
+    bottleneck detector never produces (its actual key is
+    "fragile_dependency_chain"). Proves a real fragile_dependency_chain
+    entry now renders in that section.
+    """
+    parsed, unparsable, summary, session = mock_pipeline_state
+
+    forensic_report = {
+        "systemic_bottlenecks": {
+            "fragile_dependency_chain": [
+                {"path": "src/core/config_loader.py", "score": 12.5, "close": 0.8, "err": 15.6}
+            ],
+        }
+    }
+
+    md_text = recorder._build_markdown(parsed, unparsable, summary, session, forensic_report)
+
+    assert "House of Cards" in md_text
+    assert "src/core/config_loader.py" in md_text
+    assert "Severity: 12.5" in md_text
+
+
 # ==============================================================================
 # TEST 3: SQLITE KNOWLEDGE GRAPH GENERATION
 # ==============================================================================


### PR DESCRIPTION
## Summary
Closes #370, #371. Two report-accuracy bugs in the same family: real data is computed somewhere in the pipeline, but never actually threaded through to the recorder that's supposed to display it.

**#370**: `llm_recorder.py`'s "House of Cards" markdown section read `sys_bots.get("house_of_cards", [])` -- but `signal_processor.py`'s real bottleneck-detector key is `"fragile_dependency_chain"`. The section's own field reads (`h['close']`, `h['err']`) already matched that key's real entry shape exactly, confirming this was purely a top-level key mismatch, not a deeper schema drift -- fixed by reading the right key.

**#371**: `record_keeper.py` and `llm_recorder.py` both read a per-file `telemetry["repo_z_score"]`, but the only real z-score `signal_processor.py` computes is repo-**wide**, at `summary["repo_macro_species"]["z_score"]` -- nothing ever copied it down into each file's own telemetry. Fixed by backfilling it in `galaxyscope.py` right after `summary` is computed, in both pipeline modes (the main `orchestrate()` path and the incremental "Delta Mode" path) -- `summary` can only exist after `repository_graph` is fully assembled, so this has to be a post-hoc backfill loop, not a per-file computation.

## Test plan
- [x] `test_llm_recorder.py`: new test driving `_build_markdown()` with a real `fragile_dependency_chain` bottleneck entry, proving the House of Cards section renders it.
- [x] `test_galaxyscope.py`: new end-to-end test running the real `execute_pipeline()` (mocking only the heavy engines, matching the existing SARIF sanitization test's harness) with a mocked `summarize_galaxy_metrics()` z-score, proving it survives into `scope.parsed_files[0]["telemetry"]["repo_z_score"]`.
- [x] `tests/dead_key_audit_baseline.json`: `"house_of_cards"`/`"repo_z_score"` removed now that they're fixed (`python tests/dead_key_audit.py --ci` confirmed clean at 7 baselined keys, zero regressions).
- [x] `python -m pytest tests/ -q` -- full suite, 858 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)