### PR TITLE
Copy max_big_o back onto the file dict, not just the graph node (#372)

### DIFF
--- a/gitgalaxy/core/network_risk_sensor.py
+++ b/gitgalaxy/core/network_risk_sensor.py
@@ -293,6 +293,14 @@ class NetworkRiskSensor:
             if "telemetry" not in f:
                 f["telemetry"] = {}
 
+            # #372: max_big_o was already read from the graph node (above) to
+            # compute is_algorithmic_bottleneck, but never copied back onto the
+            # file dict itself -- dev_agent_firewall.py's Agentic Black Hole
+            # check reads file_data.get("max_big_o") directly (a different
+            # object than this function's own G.nodes[path]), so it was always
+            # falling back to 1 and could never trigger on real complexity.
+            f["max_big_o"] = max_big_o
+
             f["telemetry"]["network_metrics"] = {
                 "pagerank_score": round(pr_score, 6),
                 "normalized_blast_radius": round(pr_normalized, 3),
@@ -434,6 +442,13 @@ class NetworkRiskSensor:
                 "is_algorithmic_bottleneck": False,
             }
             f["telemetry"]["popularity"] = in_d
+
+            # #372: computing max_big_o doesn't actually need networkx (it's
+            # pure Python off "functions"), so Zero-Dependency Mode shouldn't
+            # leave dev_agent_firewall.py's Agentic Black Hole check any more
+            # broken here than in the main path.
+            funcs = f.get("functions", [])
+            f["max_big_o"] = max([func.get("big_o_depth", 1) for func in funcs]) if funcs else 1
 
         macro_metrics = {
             "modularity": 0.0,

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,6 +1,5 @@
 {
   "aperture_reason": "signal_processor.py, audit_recorder.py; #325's own pre-documented instance #3 -- real key is 'reason'",
-  "max_big_o": "dev_agent_firewall.py reads it off file_data directly; only producer sets it as a networkx graph node attribute (network_risk_sensor.py), never copied back",
   "has_tests": "dev_agent_firewall.py's Silent Mutation Risk dampener can never be satisfied by real test coverage; nothing writes telemetry['has_tests']",
   "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
   "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",

--- a/tests/security_auditing/test_dev_agent_firewall.py
+++ b/tests/security_auditing/test_dev_agent_firewall.py
@@ -42,6 +42,40 @@ def test_black_hole_detection(firewall):
 
 
 # ==============================================================================
+# TEST 1.5: THE BLACK HOLE, END TO END (#372 -- the real pipeline, not a mock)
+# ==============================================================================
+def test_black_hole_detection_from_real_network_risk_sensor_output(firewall):
+    """
+    Regression test for #372: dev_agent_firewall.py read file_data["max_big_o"]
+    directly, but the only real producer set it as a networkx graph node
+    attribute (network_risk_sensor.py) that was never copied back onto the
+    file dict -- so this check could never fire on real data, only on a
+    hand-mocked "max_big_o" like the test above. Drives a REAL
+    NetworkRiskSensor.build_dependency_graph() output into the REAL firewall.
+    """
+    from gitgalaxy.core.network_risk_sensor import NetworkRiskSensor
+
+    parsed_files = [
+        {
+            "path": "src/math/heavy_calc.py",
+            "raw_imports": [],
+            "risk_vector": [],
+            "token_mass": 8500,  # Exceeds 8k limit
+            "functions": [{"big_o_depth": 4, "is_recursive": True}],  # O(N^4)
+            "telemetry": {},
+        }
+    ]
+
+    mapped_files, _ = NetworkRiskSensor().build_dependency_graph(parsed_files)
+    result = firewall.evaluate_ecosystem(mapped_files)
+    guardrails = result[0]["telemetry"]["ai_guardrails"]
+
+    assert guardrails["is_agentic_black_hole"] is True, (
+        "max_big_o from the real network sensor output must reach the firewall!"
+    )
+
+
+# ==============================================================================
 # TEST 2: The HITL Mandate (Blast Radius + Risk Debt)
 # ==============================================================================
 def test_hitl_mandate_detection(firewall):

--- a/tests/security_auditing/test_network_risk_sensor.py
+++ b/tests/security_auditing/test_network_risk_sensor.py
@@ -166,6 +166,13 @@ def test_network_algorithmic_bottleneck(sensor, parsed_files_universe):
         heavy_calc["telemetry"]["network_metrics"]["is_algorithmic_bottleneck"] is True
     )
 
+    # 3. #372: max_big_o itself must be copied onto the file dict, not just used
+    # internally to compute is_algorithmic_bottleneck -- dev_agent_firewall.py
+    # reads file_data.get("max_big_o") directly, a different object than this
+    # function's own G.nodes[path].
+    assert foundation["max_big_o"] == 1
+    assert heavy_calc["max_big_o"] == 4
+
 
 # ==============================================================================
 # TEST 5: ZERO-DEPENDENCY FALLBACK
@@ -186,6 +193,14 @@ def test_network_fallback_mode(sensor, parsed_files_universe):
         assert (
             foundation["telemetry"]["network_metrics"]["pagerank_score"] == 0.0
         )  # Math is disabled
+
+        # #372: max_big_o computation is pure Python (off "functions"), so it
+        # must still work in Zero-Dependency Mode, not just the networkx path.
+        heavy_calc = next(
+            f for f in mapped_files if f["path"] == "/src/math/heavy_calc.py"
+        )
+        assert foundation["max_big_o"] == 1
+        assert heavy_calc["max_big_o"] == 4
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
Closes #372. `dev_agent_firewall.py`'s Agentic Black Hole check reads `file_data.get("max_big_o")` directly, but the only producer, `network_risk_sensor.py`, set it exclusively as a networkx graph node attribute (`G.nodes[path]`) -- a different object entirely. The function already reads `max_big_o` back OUT of the graph node to compute `is_algorithmic_bottleneck`, it just never wrote that same value onto the file dict itself. One-line fix at the exact point telemetry is already written back to the file node.

Also fixed the Zero-Dependency Mode fallback path (`_fallback_build_graph`), which didn't compute `max_big_o` at all -- it doesn't actually need networkx (it's pure Python off `"functions"`), so there's no reason Zero-Dependency Mode should be any more broken here than the main path.

## Test plan
- [x] `test_network_risk_sensor.py`: assertions on both the main networkx path and the Zero-Dependency Mode fallback proving `file_data["max_big_o"]` is now populated correctly for both a simple and a complex function.
- [x] `test_dev_agent_firewall.py`: new end-to-end test (`test_black_hole_detection_from_real_network_risk_sensor_output`) that runs the REAL `NetworkRiskSensor.build_dependency_graph()` and feeds its real output into the REAL `DevAgentFirewall.evaluate_ecosystem()`, proving the Agentic Black Hole guardrail now fires on genuine O(N^4) complexity -- not just a hand-mocked `"max_big_o": 3` like the existing unit test.
- [x] `tests/dead_key_audit_baseline.json`: `"max_big_o"` removed now that it's fixed (`python tests/dead_key_audit.py --ci` confirmed clean at 6 baselined keys, zero regressions).
- [x] `python -m pytest tests/ -q` -- full suite, 859 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)