### PR TITLE
Dampen Silent Mutation Risk with real test coverage (#373)

### DIFF
--- a/gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py
+++ b/gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py
@@ -102,7 +102,13 @@ class DevAgentFirewall:
 
             # 4. Cascading State Flux (Silent Mutation Risk)
             in_degree = network_metrics.get("in_degree", 0)
-            has_tests = file_data.get("telemetry", {}).get("has_tests", False)
+            # #373: telemetry["has_tests"] never had a producer, so this dampener
+            # could never be satisfied by real coverage. test_coverage_map
+            # (galaxyscope.py, network_risk_sensor.py's outbound-call mapping
+            # from test files to production functions) is a real, already-
+            # computed signal for exactly this -- a non-empty map means at
+            # least one function in this file is actually exercised by a test.
+            has_tests = bool(file_data.get("test_coverage_map", {}))
 
             if state_flux > 50 and in_degree > 5 and not has_tests:
                 guardrails["silent_mutation_risk"] = True

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,6 +1,5 @@
 {
   "aperture_reason": "signal_processor.py, audit_recorder.py; #325's own pre-documented instance #3 -- real key is 'reason'",
-  "has_tests": "dev_agent_firewall.py's Silent Mutation Risk dampener can never be satisfied by real test coverage; nothing writes telemetry['has_tests']",
   "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
   "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",
   "disqualifiers": "language_lens.py's toxic-contributor penalty is fully dead; zero of the 57 language definitions set this key (vs. 'discriminators', set 57 times)",

--- a/tests/security_auditing/test_dev_agent_firewall.py
+++ b/tests/security_auditing/test_dev_agent_firewall.py
@@ -189,8 +189,8 @@ def test_silent_mutation_risk_detection(firewall):
     mock_files = [
         {
             "risk_vector": [10.0, 55.0, 20.0],  # ☢️ Index 1 is state_flux (> 50)
+            "test_coverage_map": {},  # ☢️ Zero test coverage (#373: real signal, not telemetry["has_tests"])
             "telemetry": {
-                "has_tests": False,                   # ☢️ Zero test coverage
                 "network_metrics": {"in_degree": 6},  # ☢️ > 5 dependencies rely on this
             }
         }
@@ -201,6 +201,33 @@ def test_silent_mutation_risk_detection(firewall):
 
     assert guardrails.get("silent_mutation_risk") is True, "Failed to detect Silent Mutation Risk!"
     assert any("Cascading State Flux" in warning for warning in guardrails["warnings"])
+
+
+def test_silent_mutation_risk_dampened_by_real_test_coverage(firewall):
+    """
+    Regression test for #373: the Silent Mutation Risk dampener used to read
+    telemetry["has_tests"], a key nothing ever produced -- meaning real test
+    coverage could never suppress this guardrail. Proves a non-empty
+    test_coverage_map (at least one function genuinely exercised by a test)
+    now correctly dampens it, even with the same high-flux/high-in-degree
+    conditions as the test above.
+    """
+    mock_files = [
+        {
+            "risk_vector": [10.0, 55.0, 20.0],
+            "test_coverage_map": {"process_payment": [{"impact": 5.0}]},  # Real coverage
+            "telemetry": {
+                "network_metrics": {"in_degree": 6},
+            }
+        }
+    ]
+
+    result = firewall.evaluate_ecosystem(mock_files)
+    guardrails = result[0]["telemetry"]["ai_guardrails"]
+
+    assert guardrails.get("silent_mutation_risk") is False, (
+        "Real test coverage must dampen the Silent Mutation Risk guardrail!"
+    )
 
 
 # ==============================================================================
@@ -217,9 +244,9 @@ def test_safe_agentic_baseline(firewall):
             "max_big_o": 1,
             "risk_vector": [10, 5, 0],  # ✅ Low risk debt
             "hit_vector": [0, 0],       # ✅ No dynamic execution
+            "test_coverage_map": {"handler": [{"impact": 1.0}]},  # ✅ Real test coverage
             "telemetry": {
                 "doc_density": 0.85,
-                "has_tests": True,
                 "network_metrics": {
                     "normalized_blast_radius": 0.5,
                     "in_degree": 1,
@@ -276,9 +303,8 @@ def test_survives_short_vectors(firewall):
             # Schema says state_flux is at index 1, but we only pass index 0
             "risk_vector": [99.0], 
             # Schema says metaprogramming is at index 1, but we only pass index 0
-            "hit_vector": [5],     
+            "hit_vector": [5],
             "telemetry": {
-                "has_tests": False,
                 "network_metrics": {"in_degree": 10},
                 "doc_density": 0.1
             }


### PR DESCRIPTION
## Summary
Closes #373. `dev_agent_firewall.py`'s "Cascading State Flux (Silent Mutation Risk)" rule read `telemetry["has_tests"]`, a key no producer anywhere ever wrote -- so `not has_tests` was always `True`, and a high-flux, high-in-degree file could never have this guardrail dampened by genuine test coverage, no matter how thoroughly tested it actually was. Unlike most of #325's other findings, this was a **false-positive** risk, not a false-negative one.

`file_data["test_coverage_map"]` (`galaxyscope.py`, backed by `network_risk_sensor.py`'s outbound-call mapping from test files to the production functions they actually invoke) is a real, already-computed signal for exactly this: a non-empty map means at least one function in this file is genuinely exercised by a test. Swapped the dead telemetry read for `bool(file_data.get("test_coverage_map", {}))`.

## Test plan
- [x] The existing Silent Mutation Risk test updated to use `test_coverage_map` (empty, matching the "still triggers" case it was already proving).
- [x] New test (`test_silent_mutation_risk_dampened_by_real_test_coverage`) proving the mirror case -- identical high-flux/high-in-degree conditions, but with real coverage now correctly suppressing the guardrail.
- [x] Clean Baseline test updated to grant real coverage via `test_coverage_map` instead of the dead telemetry flag; dropped the now-inert `has_tests` field from the short-vectors edge case test.
- [x] `tests/dead_key_audit_baseline.json`: `"has_tests"` removed now that it's fixed (`python tests/dead_key_audit.py --ci` confirmed clean at 5 baselined keys, zero regressions).
- [x] `python -m pytest tests/ -q` -- full suite, 860 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)