### PR TITLE
Fix "aperture_reason" -> "reason" key mismatch (#374)

### DIFF
--- a/gitgalaxy/metrics/signal_processor.py
+++ b/gitgalaxy/metrics/signal_processor.py
@@ -302,7 +302,10 @@ class SignalProcessor:
             aperture_cfg = getattr(config, "APERTURE_CONFIG", {})
             secrets_exts = aperture_cfg.get("SECRETS_EXTENSIONS", set())
             secrets_exact = aperture_cfg.get("SECRETS_EXACT", set())
-            aperture_reason = ghost_meta.get("aperture_reason", "")
+            # #374: aperture.py always writes the key "reason" (e.g. "CRITICAL
+            # LEAK (Exposed Secret: '...')" for the exact case this override
+            # exists for), never "aperture_reason" -- confirmed via aperture.py:151.
+            aperture_reason = ghost_meta.get("reason", "") or ""
 
             is_critical_leak = "CRITICAL LEAK" in aperture_reason or ext in secrets_exts or filename in secrets_exact
 

--- a/gitgalaxy/recorders/audit_recorder.py
+++ b/gitgalaxy/recorders/audit_recorder.py
@@ -458,7 +458,10 @@ class AuditRecorder:
                 quarantined_files.append(
                     {
                         "Path": path,
-                        "Diagnostic": f"CRITICAL LEAK (Exposed Secret/Key): {domain_ctx.get('aperture_reason', 'Manual Bypass')}",
+                        # #374: signal_processor.py builds this domain_context via
+                        # {"alert": "CRITICAL LEAK BYPASS", **ghost_meta} -- ghost_meta
+                        # never had an "aperture_reason" key, only "reason" (aperture.py).
+                        "Diagnostic": f"CRITICAL LEAK (Exposed Secret/Key): {domain_ctx.get('reason', 'Manual Bypass')}",
                     }
                 )
 

--- a/tests/core_engine/test_signal_processor.py
+++ b/tests/core_engine/test_signal_processor.py
@@ -345,7 +345,7 @@ def test_signal_processor_doc_and_secrets_bypass(processor):
 
     # 2. Test Critical Secrets Leak
     meta_sec, sig_sec = create_synthetic_star(processor, "keys", 10)
-    meta_sec["metadata"] = {"aperture_reason": "CRITICAL LEAK"}
+    meta_sec["metadata"] = {"reason": "CRITICAL LEAK"}  # #374: real key is "reason", not "aperture_reason"
 
     res_sec = processor.calculate_risk_vector(meta_sec, sig_sec)
     assert 100.0 in res_sec["risk_vector"], (
@@ -374,7 +374,7 @@ def test_signal_processor_doc_and_secrets_churn_survives_normalization(processor
     meta_doc["temporal_telemetry"] = hot_temporal
 
     meta_sec, sig_sec = create_synthetic_star(processor, "keys", 10)
-    meta_sec["metadata"] = {"aperture_reason": "CRITICAL LEAK"}
+    meta_sec["metadata"] = {"reason": "CRITICAL LEAK"}  # #374: real key is "reason", not "aperture_reason"
     meta_sec["temporal_telemetry"] = hot_temporal
 
     for meta, sig in ((meta_doc, sig_doc), (meta_sec, sig_sec)):
@@ -1400,7 +1400,7 @@ def test_signal_processor_critical_leak_bypass(processor):
     """Proves that critical leaks bypass standard physics and max out secrets risk."""
     m_leak, sig_leak = create_synthetic_star(processor, "aws_key", 10, {})
     m_leak["path"] = "config/production.pem"
-    m_leak["metadata"] = {"aperture_reason": "CRITICAL LEAK DETECTED"}
+    m_leak["metadata"] = {"reason": "CRITICAL LEAK DETECTED"}  # #374: real key is "reason", not "aperture_reason"
 
     r_leak = processor.calculate_risk_vector(m_leak, sig_leak)
 
@@ -1414,6 +1414,27 @@ def test_signal_processor_critical_leak_bypass(processor):
     )
     assert r_leak["telemetry"]["domain_context"]["alert"] == "CRITICAL LEAK BYPASS", (
         "Bypass alert missing from telemetry!"
+    )
+
+
+def test_signal_processor_critical_leak_via_reason_text_alone(processor):
+    """
+    Regression test for #374 (#325's own pre-documented instance #3): isolates
+    the THIRD is_critical_leak path -- "CRITICAL LEAK" in the reason text --
+    from the other two (extension/exact-filename match), which the test above
+    already covers via a .pem path. This file has neither a secrets extension
+    nor an exact secrets filename, so it can ONLY trigger via
+    ghost_meta.get("reason", ""), proving that mechanism works in isolation
+    now that it reads the key aperture.py actually writes.
+    """
+    m_leak, sig_leak = create_synthetic_star(processor, "config_loader", 10, {})
+    m_leak["metadata"] = {"reason": "CRITICAL LEAK (Exposed Secret: 'config_loader.py')"}
+
+    r_leak = processor.calculate_risk_vector(m_leak, sig_leak)
+
+    idx_sec = processor.RISK_SCHEMA.index("secrets_risk")
+    assert r_leak["risk_vector"][idx_sec] == 100.0, (
+        "The reason-text-only critical leak path failed to fire!"
     )
 
 

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,5 +1,4 @@
 {
-  "aperture_reason": "signal_processor.py, audit_recorder.py; #325's own pre-documented instance #3 -- real key is 'reason'",
   "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
   "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",
   "disqualifiers": "language_lens.py's toxic-contributor penalty is fully dead; zero of the 57 language definitions set this key (vs. 'discriminators', set 57 times)",

--- a/tests/tools_recorders/test_audit_recorder.py
+++ b/tests/tools_recorders/test_audit_recorder.py
@@ -111,7 +111,12 @@ def test_audit_recorder_rule_based_threat_routing(recorder, tmp_path):
         {
             "path": "src/hardcoded.py",
             "telemetry": {
-                "domain_context": {"alert": "CRITICAL LEAK BYPASS"}
+                "domain_context": {
+                    "alert": "CRITICAL LEAK BYPASS",
+                    # #374: the real key signal_processor.py's ghost_meta spread
+                    # produces is "reason" (aperture.py), not "aperture_reason".
+                    "reason": "CRITICAL LEAK (Exposed Secret: 'hardcoded.py')",
+                }
             },
             "is_ml_threat": False, # ML missed it or deemed it safe
             "risk_vector": [100.0, 50.0, 0.0], # 100% Secrets Risk
@@ -125,7 +130,11 @@ def test_audit_recorder_rule_based_threat_routing(recorder, tmp_path):
 
     security = payload["3. Forensic Security & Vulnerability Audit"]
     assert security["Audit Status"] == "CRITICAL_THREATS_DETECTED (Rule-Based)"
-    assert len(security["Exposed Secrets & Credentials (Quarantined Files)"]) == 1
+    quarantined = security["Exposed Secrets & Credentials (Quarantined Files)"]
+    assert len(quarantined) == 1
+    assert "CRITICAL LEAK (Exposed Secret: 'hardcoded.py')" in quarantined[0]["Diagnostic"], (
+        "Diagnostic must surface the real Aperture reason text, not the 'Manual Bypass' fallback!"
+    )
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
Closes #374, #325's own pre-documented instance #3. `signal_processor.py`'s Critical Secrets Exposure Override read `ghost_meta.get("aperture_reason", "")`, but `aperture.py` never writes that key -- only `"reason"` (confirmed: `aperture.py:151`'s exact `"CRITICAL LEAK (Exposed Secret: '...')"` text, the literal case this override exists for, lands under `"reason"`). Same mismatch duplicated in `audit_recorder.py`'s quarantine diagnostic, which reads the same ghost_meta-derived `domain_context`.

**Traced the full data flow before treating this as fully fixed**, since a name-only fix can still be a no-op if the underlying value never reaches that dict at all: confirmed the ONLY current producer of "CRITICAL LEAK" reason text (`aperture.py`'s `SECRETS_EXACT`/`SECRETS_EXTENSIONS` shunt) is already redundantly caught by `is_critical_leak`'s other two conditions (`ext in secrets_exts or filename in secrets_exact`), which check the exact same config. So there's no live detection gap today either way -- but that redundancy also means the deeper wiring gap (`filter_res["reason"]` still never gets copied into `ghost_meta`/metadata for shunted files, even after this fix) has zero practical impact right now, so it's flagged here rather than addressed as a separate, larger worker-threading change.

Also added `or ""` to the read: `ghost_meta`'s `"reason"` convention (per `aperture.py`'s own result skeletons) uses an explicit `None` default, not absence -- `.get("reason", "")` would return `None` (not the `""` default) if that `None` ever flows into metadata, and `"CRITICAL LEAK" in None` raises `TypeError`.

## Test plan
- [x] Fixed 3 existing test mocks that hand-injected `"aperture_reason"` directly (the same false-confidence pattern seen throughout #325's findings -- two of them, using a plain `.py` path, could ONLY have been exercising a dead branch).
- [x] New isolated test (`test_signal_processor_critical_leak_via_reason_text_alone`) using a file with neither a secrets extension nor an exact secrets filename, so it can only trigger via the reason-text path, proving that mechanism specifically now works.
- [x] Extended `test_audit_recorder_rule_based_threat_routing` with a `"reason"` value and an assertion on the actual `Diagnostic` text, which previously went unchecked entirely.
- [x] `tests/dead_key_audit_baseline.json`: `"aperture_reason"` removed now that it's fixed (`python tests/dead_key_audit.py --ci` confirmed clean at 4 baselined keys, zero regressions).
- [x] `python -m pytest tests/ -q` -- full suite, 861 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)