### PR TITLE
Fix TYPOSQUAT_WHITELIST, typosquat_hits, and disqualifiers (#375, #376, #377)

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -976,6 +976,12 @@ class Orchestrator:
 
             # Attach it to the summary payload
             summary["ecosystem_audits"] = ecosystem_audits
+
+            # #376: computed back in Phase 2 (_resolve_dependency_graph), where
+            # summary doesn't exist yet -- stashed on self and folded in here.
+            # record_keeper.py's real read is summary["typosquat_hits"] directly
+            # (top level, not nested under ecosystem_audits).
+            summary["typosquat_hits"] = getattr(self, "typosquat_hits", 0)
             
             # ==========================================================
             # PHASE 10.5: CI/CD POLICY ENFORCEMENT GATE
@@ -1861,6 +1867,13 @@ class Orchestrator:
         if typosquat_hits > 0:
             logger.warning(f"Intercepted {typosquat_hits} typosquatting attempts via repository baseline analysis.")
 
+        # #376: this count was previously only ever logged, never attached to
+        # summary/ecosystem_audits -- record_keeper.py's typosquat_hits column
+        # was always the fallback 0. summary doesn't exist yet at this point in
+        # the pipeline (this runs in Phase 2, summary isn't built until Phase 8),
+        # so stash it on self and fold it in once summary is assembled.
+        self.typosquat_hits = typosquat_hits
+
         # Evict memory before Pass 2
         for rel_path, meta in self.ram_cache.items():
             if "popularity_hits" in meta:
@@ -2506,6 +2519,10 @@ class Orchestrator:
             repo_z_score = summary.get("repo_macro_species", {}).get("z_score", 0.0)
             for file_data in (repository_graph or []):
                 file_data.setdefault("telemetry", {})["repo_z_score"] = repo_z_score
+
+            # #376: see the identical backfill in the main pipeline above.
+            summary["typosquat_hits"] = getattr(self, "typosquat_hits", 0)
+
             session_meta = {
                 "engine": f"GitGalaxy Scope v{self.version} (Delta Mode)",
                 "target": self.root.name,

--- a/gitgalaxy/standards/gitgalaxy_config.py
+++ b/gitgalaxy/standards/gitgalaxy_config.py
@@ -152,6 +152,12 @@ APERTURE_CONFIG = {
         "auth.json",
         "shadow",
     },
+    # --- 0.5. TYPOSQUAT WHITELIST (#375) ---
+    # Import/module tokens galaxyscope.py's typosquat radar (PASS_1.5) must
+    # never flag, even if they're a Levenshtein neighbor of a heavily-used
+    # anchor import. Empty by default -- populate with known-legitimate,
+    # structurally-similar-looking package names specific to your ecosystem.
+    "TYPOSQUAT_WHITELIST": set(),
     # --- 1. The Global Blocklist ---
     "IGNORED_DIRECTORIES": {
         # 1. Version Control Ghosts

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -7841,6 +7841,11 @@ LANGUAGE_DEFINITIONS = {
         "exact_matches": [],
         # ECOSYSTEM ANCHORS & DISAMBIGUATION: Critical for resolving the massive .m collision with Objective-C. Binary workspace and figure files act as absolute anchors.
         "discriminators": [".m", ".mat", ".fig", ".mlx", "project.prj"],
+        # #377: this is exactly the "massive .m collision with Objective-C" the
+        # comment above already calls out -- heavy presence of Objective-C's OWN
+        # ecosystem anchors (its own "discriminators", below) elsewhere in the
+        # repo is direct evidence AGAINST an ambiguous .m file being MATLAB.
+        "disqualifiers": [".mm", "project.pbxproj", ".storyboard", ".xib", ".xcworkspace", "Podfile", "Cartfile"],
         # Instantly claims any .m file that uses MATLAB's unique comment character (%)
         # or the MATLAB function declaration syntax. Defeats Objective-C gravity theft.
         # Instantly claims any .m file via a definitive MATLAB section break (%%)
@@ -8433,6 +8438,10 @@ LANGUAGE_DEFINITIONS = {
             "Podfile",
             "Cartfile",
         ],
+        # #377: the symmetric counterpart to matlab's disqualifiers above -- heavy
+        # presence of MATLAB's own ecosystem anchors elsewhere in the repo is
+        # direct evidence AGAINST an ambiguous .m file being Objective-C.
+        "disqualifiers": [".mat", ".fig", ".mlx", "project.prj"],
         # EXECUTION SIGNATURES: Compiled natively via LLVM/Clang; no shebangs exist.
         "shebangs": [],
         "internal_discriminator": re.compile(

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -436,6 +436,44 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         self.assertIn("TYPOSQUATTING", hacked_node["metadata"]["alert"])
 
     # ==============================================================================
+    # TEST 8.5: THE TYPOSQUAT WHITELIST (#375)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.logger")
+    def test_typosquatting_radar_respects_whitelist(self, mock_logger):
+        """
+        Regression test for #375: APERTURE_CONFIG had no "TYPOSQUAT_WHITELIST"
+        key at all, so galaxyscope.py's own whitelist shield
+        (`if orphan_imp in whitelist: continue`) could never suppress anything.
+        Same setup as the doppelganger test above, but "requasts" is now an
+        explicitly whitelisted, known-legitimate import name -- it must NOT
+        be flagged.
+        """
+        from gitgalaxy.standards import gitgalaxy_config
+
+        scope = Orchestrator(".", self.mock_config)
+
+        scope.ram_cache = {
+            "src/app.py": {"raw_imports": {"requests"}},
+            "src/api.py": {"raw_imports": {"requests"}},
+            "src/db.py": {"raw_imports": {"requests"}},
+            "src/legit.py": {"raw_imports": {"requasts"}},
+        }
+        scope.stem_map = {k: k for k in scope.ram_cache.keys()}
+
+        original_whitelist = gitgalaxy_config.APERTURE_CONFIG.get("TYPOSQUAT_WHITELIST")
+        gitgalaxy_config.APERTURE_CONFIG["TYPOSQUAT_WHITELIST"] = {"requasts"}
+        try:
+            scope._resolve_dependency_graph()
+        finally:
+            gitgalaxy_config.APERTURE_CONFIG["TYPOSQUAT_WHITELIST"] = original_whitelist
+
+        legit_node = scope.ram_cache["src/legit.py"]
+        self.assertNotIn(
+            "sec_homoglyphs", legit_node.get("equations", {}),
+            "A whitelisted import must not be flagged as typosquatting!",
+        )
+
+    # ==============================================================================
     # TEST 9: INCREMENTAL DELTA SHIFT (State Rehydration)
     # ==============================================================================
     @patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
@@ -1038,6 +1076,53 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         scope.execute_pipeline("fake.json")
 
         self.assertEqual(scope.parsed_files[0]["telemetry"]["repo_z_score"], 3.7)
+
+    # ==============================================================================
+    # TEST 14.6: THE TYPOSQUAT HITS BACKFILL (#376)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.Orchestrator._build_file_census")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._resolve_dependency_graph")
+    @patch("gitgalaxy.galaxyscope.Orchestrator._calculate_risk_exposures")
+    @patch("gitgalaxy.galaxyscope.RecordKeeper")
+    @patch("gitgalaxy.galaxyscope.SarifRecorder")
+    def test_typosquat_hits_folded_into_summary(self, mock_sarif, mock_db, mock_calc, mock_res, mock_ext, mock_cen):
+        """
+        Regression test for #376: _resolve_dependency_graph() (Phase 2) computes
+        and logs a real typosquat_hits count, but summary doesn't exist yet at
+        that point in the pipeline -- nothing ever attached the count to it, so
+        record_keeper.py's typosquat_hits column was always the fallback 0.
+        _resolve_dependency_graph() is mocked here (as in the sibling #371 test
+        above), so this test sets scope.typosquat_hits directly to simulate what
+        a real typosquatting hit would have stashed on the instance, and proves
+        it survives into summary once Phase 10 assembles it.
+        """
+        config = self.mock_config.copy()
+        config["DB_ONLY"] = True  # Only the SQLite recorder needs to run for this test
+
+        scope = Orchestrator(".", config)
+        scope.parsed_files = [{"path": "src/api.py", "telemetry": {}, "equations": {}}]
+        scope.typosquat_hits = 3  # Simulates a real hit from _resolve_dependency_graph()
+
+        scope.network_sensor = MagicMock()
+        scope.network_sensor.build_dependency_graph.return_value = (scope.parsed_files, {})
+        scope.auditor = MagicMock()
+        scope.auditor.audit.return_value = (scope.parsed_files, [])
+        scope.model_auditor = MagicMock()
+        scope.model_auditor.audit_repository.return_value = scope.parsed_files
+        scope.processor = MagicMock()
+        scope.processor.summarize_galaxy_metrics.return_value = {}
+
+        captured_summary = {}
+
+        def _capture_record_mission(*args, **kwargs):
+            captured_summary.update(kwargs.get("summary", {}))
+
+        mock_db.return_value.record_mission.side_effect = _capture_record_mission
+
+        scope.execute_pipeline("fake.json")
+
+        self.assertEqual(captured_summary.get("typosquat_hits"), 3)
 
     # ==============================================================================
     # TEST 15: THE GIT-LESS VOID (Fallback OS Walk)

--- a/tests/core_engine/test_language_lens.py
+++ b/tests/core_engine/test_language_lens.py
@@ -309,6 +309,42 @@ def test_local_ecosystem_consensus_and_toxic_pruning(mock_iterdir, isolated_dete
 
 
 # ==============================================================================
+# TEST 11.5: MATLAB vs OBJECTIVE-C .m COLLISION (#377)
+# ==============================================================================
+def test_matlab_objective_c_m_collision_resolved_by_real_disqualifiers():
+    """
+    Regression test for #377: the real LANGUAGE_DEFINITIONS's own comments
+    ("Critical for resolving the massive .m collision with Objective-C" /
+    "The ultimate defense against MATLAB") describe exactly this scenario, but
+    zero of the 57 language definitions ever populated a "disqualifiers" list
+    -- the toxic-collapse mechanism test_local_ecosystem_consensus_and_toxic_pruning
+    proves above was fully wired, but had no real data anywhere to act on.
+    Uses the REAL LanguageDetector against the REAL LANGUAGE_DEFINITIONS (not
+    the isolated mock fixture) so this only passes if the live data is correct.
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    detector = LanguageDetector(LANGUAGE_DEFINITIONS, {})
+
+    # A repo with heavy Xcode/Objective-C ecosystem presence (Podfile, .storyboard)
+    # alongside the ambiguous .m files -- MATLAB's own disqualifiers should
+    # collapse its score to 0, leaving Objective-C to win.
+    global_tally = {
+        ".m": 5,
+        ".storyboard": 3,
+        "podfile": 1,
+    }
+
+    lang, _ = detector._evaluate_ecosystem_gravity(
+        "src/nonexistent_dir_for_this_test/AppDelegate.m", ".m", global_tally
+    )
+
+    assert lang == "objective-c", (
+        "Strong Objective-C ecosystem anchors must disqualify the MATLAB candidate for a contested .m file!"
+    )
+
+
+# ==============================================================================
 # TEST 12: Legacy Focus Gateway
 # ==============================================================================
 def test_legacy_focus_gateway(isolated_detector):

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,6 +1,3 @@
 {
-  "TYPOSQUAT_WHITELIST": "read from APERTURE_CONFIG, which has no such key; the typosquat whitelist is always empty",
-  "typosquat_hits": "galaxyscope.py computes and logs this count but never attaches it to summary/ecosystem_audits; record_keeper.py's column is always the fallback 0",
-  "disqualifiers": "language_lens.py's toxic-contributor penalty is fully dead; zero of the 57 language definitions set this key (vs. 'discriminators', set 57 times)",
-  "mechanical_families": "prism.py; not chased down to a confirmed verdict -- open lead"
+  "mechanical_families": "prism.py's comment-family dispatch never matches the real taxonomy at all -- escalated from an 'open lead' to #386 (critical: comment/code separation is broken for all 58 languages), fix pending in a separate branch"
 }


### PR DESCRIPTION
## Summary
Closes #375, #376, #377. Three low-priority findings from #325's dead key audit, each a genuine gap rather than a rename:

**#375**: `galaxyscope.py`'s typosquat radar already assumed `APERTURE_CONFIG["TYPOSQUAT_WHITELIST"]` existed, but the key was never defined -- the whitelist was always empty. This one fails in the safe/loud direction (more false positives, not missed detections), unlike most of #325's other findings. Added the key (empty by default, preserving today's behavior) as a real, documented, extensible config surface.

**#376**: `_resolve_dependency_graph()` (Phase 2) computes and logs a real `typosquat_hits` count, but `summary` doesn't exist yet at that point in the pipeline -- nothing ever attached it, so `record_keeper.py`'s column was always the fallback 0. Stashed the count on `self` during Phase 2, folded into `summary` once Phase 10 assembles it, in both the main pipeline and the Delta Mode incremental-scan pipeline.

**#377**: `language_lens.py`'s toxic-contributor `"disqualifiers"` penalty was fully dead -- zero of 57 language definitions ever populated it, vs. `"discriminators"` (its positive-signal sibling), populated 57 times. Rather than speculatively inventing disqualifier data for all 57 languages without domain-expert verification (risky -- a wrong entry could actively misclassify files), populated just the ONE pair the existing comments already single out as the intended use case: MATLAB vs. Objective-C's `.m` collision (*"Critical for resolving the massive .m collision with Objective-C"* / *"The ultimate defense against MATLAB"*). Each language's disqualifiers are the OTHER language's own already-validated discriminators (minus the shared `.m` extension) -- a symmetric, low-risk relationship that reuses existing, working data rather than guessing new data.

## Test plan
- [x] `test_galaxyscope.py`: new tests proving a whitelisted import is never flagged as typosquatting, and that a real `typosquat_hits` count survives from Phase 2 into the summary passed to `record_mission()`.
- [x] `test_language_lens.py`: new test using the REAL `LanguageDetector` against the REAL `LANGUAGE_DEFINITIONS` (not the isolated mock fixture every other test in this file uses) proving a repo with strong Objective-C ecosystem anchors (`Podfile`, `.storyboard`) now correctly disqualifies MATLAB for a contested `.m` file.
- [x] `tests/dead_key_audit_baseline.json`: all three removed now that they're fixed. `"mechanical_families"` stays baselined but its note is updated -- investigating it surfaced a much larger, separate finding (**#386**: comment/code separation is broken for all 58 languages), filed and scoped separately rather than folded into this pass.
- [x] `python -m pytest tests/ -q` -- full suite, 863 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)