### PR TITLE
Bump pymdown-extensions to patch GHSA-9xwg-3r6f-jcx2 (CVE-2026-61632)

### DIFF
--- a/gitgalaxy/requirements.txt
+++ b/gitgalaxy/requirements.txt
@@ -93,7 +93,7 @@ pycparser==3.0
 pydeps==3.0.2
 pyflakes==3.4.0
 Pygments==2.20.0
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
 pynndescent==0.6.0
 pypandoc==1.17
 pyparsing==3.3.2


### PR DESCRIPTION
## Summary
A path-traversal advisory in the `b64` extension (inlines `<img src="...">` paths as base64 data URIs without checking the resolved path stays inside `base_path`) was newly published against the pinned `10.21.3`, and started failing the muninn security scan on unrelated PRs (osv-scanner rescans the whole `requirements.txt` on every PR, not just the diff) -- see the finding on #385/#387.

Docs-build-only dependency (mkdocs-material), not part of the `gitgalaxy` package's own runtime dependencies (`pyproject.toml` only requires PyYAML). Bumped to `11.0.1`, the latest available release, which includes the fix.

## Test plan
- [x] Single-line version pin bump, no code changes.
- [x] Will confirm the muninn check goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)