### PR TITLE
Fix prism.py's comment-family taxonomy -- comment/code separation was broken for all 58 languages (#386)

### DIFF
--- a/gitgalaxy/core/prism.py
+++ b/gitgalaxy/core/prism.py
@@ -80,7 +80,16 @@ class Prism:
             self.logger = logging.getLogger("prism")
             self.logger.setLevel(logging.INFO)
 
-        self.lexical_families = comment_definitions.get("mechanical_families", {})
+        # #386: was "mechanical_families", a key nothing ever wrote (see #378's
+        # dead key audit finding) -- the real key in LEXICAL_FAMILY_HEURISTICS
+        # (gitgalaxy_config.py) is "lexical_families". This alone was only half
+        # the bug: the family NAMES used below and in _compile_regex_matrix()
+        # also didn't match the real per-language "lexical_family" values
+        # (standard_block/line_exclusive/recursive_block/positional_anchored),
+        # so comment stripping never actually ran for ANY language even before
+        # this fix -- see the family-name renames below and in
+        # _compile_regex_matrix().
+        self.lexical_families = comment_definitions.get("lexical_families", {})
         self.languages = language_definitions
 
         self.logger.debug("Initializing Prism and warming up regex matrix...")
@@ -177,7 +186,9 @@ class Prism:
                 )
 
             for lang_id, segment_text in segments:
-                family = self.languages.get(lang_id, {}).get("lexical_family", "c_style_comment")
+                # #386: default fallback renamed to match the real taxonomy
+                # ("standard_block" is what "c_style_comment" always meant here).
+                family = self.languages.get(lang_id, {}).get("lexical_family", "standard_block")
                 self.logger.debug(f"Scanning segment [{lang_id}] using syntax family '{family}'...")
 
                 # Strip comments from the segment
@@ -231,18 +242,24 @@ class Prism:
             lits.extend(php_lits)
 
         # 2. SPECIALIZED LEXICAL FAMILY ROUTING
-        if family == "recursive_c_style":
+        # #386: these three used to check "recursive_c_style"/"column_sensitive"/
+        # "single_line_only" -- names that never matched any real per-language
+        # "lexical_family" value (the real taxonomy is standard_block/
+        # line_exclusive/recursive_block/positional_anchored/block_exclusive/
+        # non_lexical), so none of these branches, nor the generic REGEX_MATRIX
+        # stripper below, ever actually ran for any language.
+        if family == "recursive_block":
             code, nested_lits = self._strip_nested_comments(text)
             lits.extend(nested_lits)
             return code, "\n".join(lits)
 
-        if family == "column_sensitive":
+        if family == "positional_anchored":
             code, pos_lits = self._strip_positional_comments(text)
             if pos_lits:
                 lits.extend(pos_lits.splitlines())
             return code, "\n".join(lits)
 
-        if family == "single_line_only":
+        if family == "line_exclusive":
             code, single_lits = self._strip_single_line_comments(text)
             if single_lits:
                 lits.extend(single_lits.splitlines())
@@ -280,8 +297,22 @@ class Prism:
         """Safely pre-compiles the standard regex matrix based on dynamic config lengths."""
         matrix = {}
 
+        # #386: fam_key now matches the real per-language "lexical_family"
+        # values. "recursive_block"/"positional_anchored" are excluded here
+        # because _strip_segment_comments() already special-cases and fully
+        # handles them above, before this matrix is ever consulted.
+        #
+        # KNOWN LIMITATION (tracked, not fixed here): "standard_block"'s real
+        # delimiter list has 9 entries (C-style //, /* */; SQL/Lua-style --,
+        # --[[, ]]; Haskell-style {-, -}; and a trailing #), but the pattern
+        # below only uses the first 3 (d[0..2], i.e. // and /* */). Languages
+        # in this family that don't use C-style delimiters at all (sqlite,
+        # lua, haskell, powershell, perl) still won't get comments stripped
+        # after this fix -- same as before, not a regression, just incomplete
+        # coverage for those five. The ~24 C-style languages in this family
+        # (c, cpp, java, javascript, go, etc.) are fully fixed.
         for fam_key, data in self.lexical_families.items():
-            if fam_key in ("recursive_c_style", "column_sensitive"):
+            if fam_key in ("recursive_block", "positional_anchored"):
                 continue
 
             delims = data.get("delimiters", [])
@@ -293,9 +324,9 @@ class Prism:
             p = ""
 
             # Dynamically build regex based on family type and safe bounds checks
-            if fam_key == "c_style_comment" and len(d) >= 3:
+            if fam_key == "standard_block" and len(d) >= 3:
                 p = rf"({d[0]}[^\n]*|{d[1]}.*?{d[2]})"
-            elif fam_key == "single_line_only" and len(d) >= 1:
+            elif fam_key == "line_exclusive" and len(d) >= 1:
                 p = rf"({d[0]}[^\n]*)"
             elif fam_key == "embedded_syntax" and len(d) >= 3:
                 # If len is 4, include d[3], otherwise just [0,1,2]
@@ -307,7 +338,7 @@ class Prism:
                 p = rf"({d[1]}.*?{d[2]}|{d[3]}.*?{d[4]}|{d[0]}[^\n]*)"
             elif fam_key == "multi_style_dash" and len(d) >= 3:  # Fallback
                 p = rf"({d[1]}.*?{d[2]}|{d[0]}[^\n]*)"
-            elif fam_key == "single_line_only":
+            elif fam_key == "line_exclusive":
                 # =====================================================================
                 # THE FIX: Neutralized the Zero-Width ReDoS Bomb.
                 #
@@ -345,7 +376,7 @@ class Prism:
                     full_pattern = f"{self.LITERAL_MASK_PATTERN}|{p}"
 
                     flags = re.S | re.M
-                    if fam_key == "single_line_only":
+                    if fam_key == "line_exclusive":
                         flags |= re.IGNORECASE
 
                     matrix[fam_key] = re.compile(full_pattern, flags)

--- a/tests/core_engine/test_prism.py
+++ b/tests/core_engine/test_prism.py
@@ -11,23 +11,33 @@ from gitgalaxy.core.prism import Prism
 # We mock the language and comment definitions so the tests run deterministically
 # regardless of what is inside your actual language_standards.py file.
 
+# #386: these used to be a fictional taxonomy ("mechanical_families",
+# "c_style_comment", "single_line_only", "recursive_c_style",
+# "column_sensitive") that never matched the real config
+# (gitgalaxy_config.py's LEXICAL_FAMILY_HEURISTICS uses "lexical_families",
+# and real per-language "lexical_family" values are standard_block/
+# line_exclusive/recursive_block/positional_anchored/block_exclusive/
+# non_lexical) -- every test in this file passed anyway, because they never
+# exercised the real config, which is exactly how prism.py's total failure
+# to strip comments for any language went undetected. Renamed to match
+# reality so this class of drift can't silently recur.
 MOCK_COMMENT_DEFS = {
-    "mechanical_families": {
-        "c_style_comment": {"delimiters": ["//", "/*", "*/"]},
-        "single_line_only": {"delimiters": ["#"]},
-        "recursive_c_style": {"delimiters": ["//", "/*", "*/"]},
-        "column_sensitive": {"delimiters": []},
+    "lexical_families": {
+        "standard_block": {"delimiters": ["//", "/*", "*/"]},
+        "line_exclusive": {"delimiters": ["#"]},
+        "recursive_block": {"delimiters": ["//", "/*", "*/"]},
+        "positional_anchored": {"delimiters": []},
     }
 }
 
 MOCK_LANG_DEFS = {
-    "c": {"lexical_family": "c_style_comment"},
-    "python": {"lexical_family": "single_line_only"},
-    "rust": {"lexical_family": "recursive_c_style"},
-    "cobol": {"lexical_family": "column_sensitive"},
+    "c": {"lexical_family": "standard_block"},
+    "python": {"lexical_family": "line_exclusive"},
+    "rust": {"lexical_family": "recursive_block"},
+    "cobol": {"lexical_family": "positional_anchored"},
     "markdown": {"lexical_family": "prose"},
     "html": {"lexical_family": "xml"},
-    "php": {"lexical_family": "c_style_comment"},
+    "php": {"lexical_family": "standard_block"},
 }
 
 
@@ -193,7 +203,7 @@ def test_prism_format_and_xml_bypass(prism_engine):
 # ==============================================================================
 def test_prism_php_string_extraction(prism_engine):
     """Proves PHP Heredoc and large strings are stripped to the documentation stream."""
-    prism_engine.languages["php"] = {"lexical_family": "c_style_comment"}
+    prism_engine.languages["php"] = {"lexical_family": "standard_block"}
     prism_engine.PHP_HEREDOC_PATTERN = re.compile(r"<<<EOT[\s\S]*?EOT;", re.M)
     prism_engine.PHP_MULTILINE_STRING = re.compile(r"'(?:\\'|[^'])*'", re.M)
 
@@ -249,18 +259,18 @@ def test_prism_regex_matrix_calibration_edge_cases():
 
     # 1. Primary Branches (Full Delimiter Sets)
     primary_families = {
-        "single_line_only": {"delimiters": ["#", "<#", "#>"]},
+        "line_exclusive": {"delimiters": ["#", "<#", "#>"]},
         "multi_style_dash": {"delimiters": ["--", html_open, html_close, "{-", "-}"]},
         "embedded_syntax": {"delimiters": ["//", "/*", "*/", "#"]},
         "empty_delim": {"delimiters": []},
     }
 
     engine_primary = Prism(
-        comment_definitions={"mechanical_families": primary_families},
+        comment_definitions={"lexical_families": primary_families},
         language_definitions={},
     )
 
-    assert "single_line_only" in engine_primary.REGEX_MATRIX
+    assert "line_exclusive" in engine_primary.REGEX_MATRIX
     assert "multi_style_dash" in engine_primary.REGEX_MATRIX
     assert re.escape("{-") in engine_primary.REGEX_MATRIX["multi_style_dash"].pattern
     assert "embedded_syntax" in engine_primary.REGEX_MATRIX
@@ -275,7 +285,7 @@ def test_prism_regex_matrix_calibration_edge_cases():
     }
 
     engine_fallback = Prism(
-        comment_definitions={"mechanical_families": fallback_families},
+        comment_definitions={"lexical_families": fallback_families},
         language_definitions={},
     )
 
@@ -301,6 +311,52 @@ def test_prism_embedded_syntax_fourth_delimiter_not_dropped(prism_engine):
     assert "value = 1" in result["code_stream"]
     assert "this is a hash comment" in result["comment_stream"]
     assert "this is a hash comment" not in result["code_stream"]
+
+# ==============================================================================
+# TEST 9.5: THE REAL CONFIG, NOT THE MOCK (#386)
+# ==============================================================================
+def test_prism_strips_comments_against_the_real_config():
+    """
+    Regression test for #386: every other test in this file drives Prism
+    through MOCK_COMMENT_DEFS/MOCK_LANG_DEFS, which used to be a fictional,
+    internally-consistent taxonomy that never matched the real
+    gitgalaxy_config.py/language_standards.py config -- meaning NONE of them
+    would have caught prism.py's total failure to strip comments for any of
+    the 58 real languages. This test wires up the REAL config instead, and
+    proves comment stripping actually works for one language per real family
+    (standard_block, line_exclusive, recursive_block, positional_anchored).
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+    from gitgalaxy.standards.gitgalaxy_config import LEXICAL_FAMILY_HEURISTICS
+
+    real_prism = Prism(LEXICAL_FAMILY_HEURISTICS, LANGUAGE_DEFINITIONS)
+
+    # standard_block (C)
+    result = real_prism.split_streams(
+        "// a comment\nint main() {\n    /* block */\n    return 0;\n}\n", "c"
+    )
+    assert "a comment" not in result["code_stream"]
+    assert "a comment" in result["comment_stream"]
+
+    # line_exclusive (Python)
+    result = real_prism.split_streams("x = 1  # a comment\ny = 2\n", "python")
+    assert "a comment" not in result["code_stream"]
+    assert "a comment" in result["comment_stream"]
+
+    # recursive_block (Rust)
+    result = real_prism.split_streams(
+        "fn main() {\n    // a comment\n}\n", "rust"
+    )
+    assert "a comment" not in result["code_stream"]
+    assert "a comment" in result["comment_stream"]
+
+    # positional_anchored (COBOL)
+    result = real_prism.split_streams(
+        "       IDENTIFICATION DIVISION.\n      * a comment\n", "cobol"
+    )
+    assert "a comment" not in result["code_stream"]
+    assert "a comment" in result["comment_stream"]
+
 
 # ==============================================================================
 # TEST 10: INLINE SUPPRESSION EXTRACTION (Devious Edge Cases)

--- a/tests/dead_key_audit_baseline.json
+++ b/tests/dead_key_audit_baseline.json
@@ -1,3 +1,1 @@
-{
-  "mechanical_families": "prism.py's comment-family dispatch never matches the real taxonomy at all -- escalated from an 'open lead' to #386 (critical: comment/code separation is broken for all 58 languages), fix pending in a separate branch"
-}
+{}


### PR DESCRIPTION
## Summary
Closes #386, closes #378. **Comment/code separation was completely broken for every one of the 58 supported languages**, verified empirically -- `Prism(REAL_CONFIG).split_streams("x = 1  # comment", "python")` returned the comment still embedded in `code_stream`, `comment_stream` empty, even for Python.

### Root cause
`split_streams()` special-cased exactly three family names (`"recursive_c_style"`, `"column_sensitive"`, `"single_line_only"`) for dedicated stripping logic, and fell back to a `REGEX_MATRIX` built from `comment_definitions.get("mechanical_families", {})` for everything else -- a key nothing ever wrote (#378's original dead-key finding). But fixing that key name alone wouldn't have been enough: **none** of the three special-cased names, nor the matrix-building `fam_key`s (`"c_style_comment"`, `"single_line_only"`, `"embedded_syntax"`, `"multi_style_dash"`), matched the **real** per-language `"lexical_family"` taxonomy actually used across `language_standards.py` (`standard_block`: 29 languages, `line_exclusive`: 21, `recursive_block`: 3, `positional_anchored`: 3, `block_exclusive`: 1, `non_lexical`: 1). So every single language fell through to the always-empty generic stripper.

This went undetected because `test_prism.py`'s entire suite ran against a hand-built mock config (`MOCK_COMMENT_DEFS`/`MOCK_LANG_DEFS`) using a fictional, internally-consistent taxonomy that matched `split_streams()`'s special cases but never matched the real config -- every test passed without ever exercising real data.

### Fix
Renamed `prism.py`'s three special-cased family checks and `_compile_regex_matrix()`'s `fam_key` checks to the real taxonomy (`recursive_c_style` -> `recursive_block`, `column_sensitive` -> `positional_anchored`, `single_line_only` -> `line_exclusive`, `c_style_comment` -> `standard_block`), plus the default `"lexical_family"` fallback. Verified empirically post-fix: C, Python, Rust, and COBOL (one language per previously-broken family) now correctly separate comments from code. **Contained entirely to `prism.py`** -- no changes to `gitgalaxy_config.py` or any of the 58 language definitions, per the scoped plan discussed in #386.

### Known limitations, tracked but not fixed here (approved scope)
- `"standard_block"`'s real delimiter list has 9 entries (C-style, SQL/Lua-style `--`/`--[[`/`]]`, Haskell-style `{-`/`-}`, and a trailing `#`), but the regex-building branch only uses the first 3 (`//` and `/* */`). The ~24 C-style languages in this family (c, cpp, java, javascript, go, etc.) are fully fixed; the 5 that don't use C-style delimiters at all (sqlite, lua, haskell, powershell, perl) are unchanged from before -- not a regression, since nothing was stripped for them either way.
- `"block_exclusive"` (xml, 1 language) has its own separately malformed delimiter data (`["", "--!>"]`) and isn't covered by this fix.
- `golden_master.json` is **not** regenerated here. This fix will very likely shift LOC/signal counts across most of the corpus now that comments actually stop leaking into code -- per #330's philosophy, that's a deliberate, reviewable update someone should make on purpose, not a side effect of this PR. The golden-crucible CI check isn't currently wired to `golden_diff.py` (#328), so this won't silently break a gate, but the fixture itself is now stale relative to correct behavior.

## Test plan
- [x] `test_prism.py`'s mock config renamed to match the real taxonomy (same fictional-but-now-consistent structure, so no coverage lost).
- [x] New `test_prism_strips_comments_against_the_real_config()` wires up the REAL `LANGUAGE_DEFINITIONS`/`LEXICAL_FAMILY_HEURISTICS` directly (not the mock) and proves comment stripping now works for one real language per family -- exactly the test category that would have caught this bug originally.
- [x] `tests/dead_key_audit_baseline.json`: `"mechanical_families"` removed now that it's fixed.
- [x] `python -m pytest tests/ -q` -- full suite, 862 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)