### PR TITLE
Fix a missed "recursive_c_style" reference in _strip_nested_comments (#386 follow-up)

### DIFF
--- a/gitgalaxy/core/prism.py
+++ b/gitgalaxy/core/prism.py
@@ -535,7 +535,11 @@ class Prism:
         Iterative Peel loop for recursively nested block comments (e.g. Rust/Swift/Scala).
         Hardened with active string-masking to prevent logic erosion.
         """
-        delims = self.lexical_families.get("recursive_c_style", {}).get("delimiters", ["//", "/*", "*/"])
+        # #386 follow-up: was "recursive_c_style" -- missed in the original
+        # rename pass. Currently harmless by coincidence (the fallback default
+        # below matches "recursive_block"'s real delimiters exactly today),
+        # but was silently ignoring the real config, not reading it.
+        delims = self.lexical_families.get("recursive_block", {}).get("delimiters", ["//", "/*", "*/"])
         if len(delims) < 3:
             return text, []
 

--- a/tests/core_engine/test_prism.py
+++ b/tests/core_engine/test_prism.py
@@ -130,6 +130,25 @@ def test_prism_nested_block_peeling(prism_engine):
     assert "Inner comment" in docs
 
 
+def test_prism_nested_block_peeling_reads_the_real_lexical_families_key(prism_engine):
+    """
+    Regression test for a #386 follow-up: _strip_nested_comments() looked up
+    self.lexical_families.get("recursive_c_style", ...) -- the OLD dead name,
+    missed in the original rename pass -- and only "worked" because its
+    hardcoded fallback default (["//", "/*", "*/"]) happened to coincidentally
+    match "recursive_block"'s real delimiters. Using non-default delimiters
+    here proves the lookup key itself is correct, not just the fallback.
+    """
+    prism_engine.lexical_families["recursive_block"] = {"delimiters": ["##", "<<", ">>"]}
+
+    content = "fn main() {\n    << Outer << Inner >> Back to outer >>\n    do_work();\n}"
+    result = prism_engine.split_streams(content, primary_lang="rust")
+
+    assert "do_work();" in result["code_stream"]
+    assert "Outer" not in result["code_stream"]
+    assert "Inner" in result["comment_stream"]
+
+
 # ==============================================================================
 # TEST 4: POSITIONAL ANCHORS
 # ==============================================================================


### PR DESCRIPTION
## Summary
Follow-up to #386. The original rename pass fixed `split_streams()`'s three family-name special cases and `_compile_regex_matrix()`'s `fam_key` checks, but missed one more reference: `_strip_nested_comments()` independently looked up `self.lexical_families.get("recursive_c_style", {})` to fetch its own delimiters, rather than receiving them from the already-scoped call site.

**Currently harmless by coincidence, not by correctness**: the lookup always returns `{}` (the key doesn't exist post-rename), falling back to the hardcoded default `["//", "/*", "*/"]` -- which happens to exactly match `"recursive_block"`'s real delimiters today. If that real config value ever changed, this method would silently keep using the stale hardcoded default instead of the real one.

Fixed the key name. Added a regression test that overrides `"recursive_block"` with non-default delimiters (`##`, `<<`, `>>`) specifically so the fallback-coincidence can't mask a wrong lookup key -- the previous test only used the default C-style delimiters, which is exactly why this one slipped through the original PR's own review.

## Test plan
- [x] New test `test_prism_nested_block_peeling_reads_the_real_lexical_families_key`, which would have failed against the old code (non-default delimiters don't match the hardcoded fallback).
- [x] `python -m pytest tests/ -q` -- full suite, 866 passed, 1 pre-existing xfail.
- [x] `flake8 . --count --select=E9,F63,F7,F82` -- 0.
- [x] `python tests/dead_key_audit.py --ci` -- clean, 0-key baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)