### PR TITLE
Shorten action.yml description to unblock GitHub Marketplace publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'GitGalaxy Scanner'
-description: 'Repo intelligence for humans and AI, without compilation: architecture mapping, risk scoring, and SBOM/SARIF generation for zero-trust CI/CD — SARIF output is ready for upload to security dashboard.'
+description: 'Repo intelligence for AI and humans: architecture mapping, risk scoring, and SBOM/SARIF generation for CI/CD security gates.'
 branding:
   icon: 'shield'
   color: 'purple'


### PR DESCRIPTION
## Summary
- The Action's `description` field in `action.yml` was 198 characters; GitHub Marketplace requires it under 125.
- This surfaced while drafting the v2.4.5 release: the "Publish this Action to the GitHub Marketplace" panel showed a blocking error.
- Trimmed to 124 characters while keeping the core value prop (architecture mapping, risk scoring, SBOM/SARIF for CI/CD).

## Test plan
- [x] Confirmed new description is 124 chars (`< 125` requirement)
- [x] Confirmed no other lines in `action.yml` changed