### PR TITLE
Bump mistune to 3.3.4, patching a batch of newly-disclosed CVEs

### DIFF
--- a/gitgalaxy/requirements.txt
+++ b/gitgalaxy/requirements.txt
@@ -55,7 +55,7 @@ matplotlib-inline==0.2.2
 mccabe==0.7.0
 mdurl==0.1.2
 mergedeep==1.3.4
-mistune>=3.2.2
+mistune==3.3.4
 mkdocs==1.6.1
 mkdocs-get-deps==0.2.2
 mkdocs-material==9.7.6


### PR DESCRIPTION
## Summary
- `mistune` was floating at `>=3.2.2` (the only non-exact pin in this file), resolving to the vulnerable 3.2.2.
- Muninn's osv-scanner flagged 10 advisories against it on an unrelated PR (#395), same pattern as the earlier `pymdown-extensions` CVE: it rescans the full `requirements.txt` on every run.
- Bumped to `3.3.4` (latest), which fixes all of them, and pinned it exactly to match the rest of the file.

## Test plan
- [x] `pip install mistune==3.3.4` resolves cleanly standalone
- [x] CI will validate the full install + smoke tests