### PR TITLE
Wire golden_diff.py into golden-crucible.yml (closes #328)

### DIFF
--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -9,7 +9,15 @@ on:
 jobs:
   crucible-audit:
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: full-precision
+            golden_master: tests/golden_master_audit.json
+          - mode: zero-dependency
+            golden_master: tests/golden_master_zero_dep_audit.json
+
     steps:
       - name: Checkout GitGalaxy PR
         uses: actions/checkout@v4
@@ -27,26 +35,35 @@ jobs:
         run: |
           cd gitgalaxy
           python -m pip install --upgrade pip setuptools wheel
-          # Explicitly install heavy engines so GitGalaxy doesn't run in Zero-Dependency Mode
-          pip install PyYAML networkx tiktoken pandas xgboost
+          if [ "${{ matrix.mode }}" = "full-precision" ]; then
+            echo "Installing heavy engines for Full-Precision Mode..."
+            pip install PyYAML networkx tiktoken pandas xgboost
+          else
+            echo "Deliberately skipping networkx/tiktoken/pandas/xgboost -- Zero-Dependency Mode leg."
+          fi
           pip install -e .
 
       - name: Fetch Golden Test Repo (Language Crucible)
         run: |
           echo "Cloning Language Crucible repository (pinned to v1.0)..."
           git clone --branch v1.0 --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+
       - name: Execute Resilience Engine
         env:
           GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
         run: |
-          echo "Initiating GitGalaxy Golden Test Sequence..."
+          echo "Initiating GitGalaxy Golden Test Sequence (${{ matrix.mode }})..."
           mkdir -p telemetry_out
 
           # Scan only the structural corpus (language-crucible/data), not the
           # repo's own tools/, raw_output/, or docs -- those are repo
           # housekeeping, not part of the golden-master comparison surface.
           timeout 180s galaxyscope ./language-crucible/data --output ./telemetry_out/ --file-speed --splicing-speed
-      
+
+      - name: Compare Against Golden Master
+        run: |
+          python3 gitgalaxy/tests/golden_diff.py "gitgalaxy/${{ matrix.golden_master }}" ./telemetry_out/data_galaxy_audit.json
+
       - name: Debug File System (Tree)
         if: always()  # This ensures the tree prints even if the previous step fails
         run: |
@@ -54,5 +71,3 @@ jobs:
           tree -L 2
           echo "=== TELEMETRY OUT CONTENTS ==="
           ls -lh telemetry_out/
-      
-  

--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -1616,6 +1616,23 @@ class Orchestrator:
         # scheduling.
         self.ram_cache = dict(sorted(self.ram_cache.items()))
 
+        # unparsable_files is appended to from the same as_completed() loop
+        # (the "parser_bypass" branch above) as well as from the earlier
+        # sequential filesystem walk, so it's a mix of stable and
+        # nondeterministic ordering. Sorting it here, once both sources have
+        # finished contributing, makes the "Unparsable Artifacts" report
+        # order deterministic the same way ram_cache now is. This was missed
+        # in the original ordering fix -- two back-to-back runs on the same
+        # machine happened to interleave identically and masked it, but a
+        # genuinely different machine (e.g. a CI runner) did not.
+        self.unparsable_files.sort(key=lambda entry: entry["path"])
+
+        # Same nondeterminism, same fix: _record_anomaly() is called both from
+        # the sequential Phase 0 walk and from this parallel loop, and
+        # _summarize_anomalies() later turns iteration order directly into
+        # the "unparsable_artifacts" list order.
+        self.anomalies.sort(key=lambda entry: (entry["star"], entry["diagnostic"]))
+
     def _resolve_dependency_graph(self):
         """
         Pass 1.5: Optimized relational token aggregation & Fuzzy Suffix Matching.

--- a/tests/golden_diff.py
+++ b/tests/golden_diff.py
@@ -22,11 +22,20 @@ def load_and_sanitize(filepath: str) -> Dict[str, Any]:
         context = data["1. Forensic Trail (Traceability)"].get("Analysis Context", {})
         context.pop("Analysis ISO Timestamp", None)
         context.pop("Total Scan Duration", None)
-        
+        # Absolute path is machine/runner-specific (e.g. /home/joe/... locally
+        # vs /home/runner/work/... in CI) -- never structurally meaningful.
+        context.pop("Absolute Project Path", None)
+
         git_footprint = data["1. Forensic Trail (Traceability)"].get("Source Control Footprint (Immutable Anchor)", {})
         git_footprint.pop("Commit Hash (SHA-1)", None)
         git_footprint.pop("Last Code Integration Date", None)
-        
+        # Remote URL formatting depends on the clone method (HTTPS clones
+        # append .git, some don't), and a `--branch <tag> --depth 1` clone
+        # lands in detached HEAD ("HEAD") instead of the tag's branch name.
+        # Neither reflects anything about the analyzed repository's structure.
+        git_footprint.pop("Remote Origin URL", None)
+        git_footprint.pop("Active Branch", None)
+
     return data
 
 def _normalize_floats(data: Any) -> Any:

--- a/tests/golden_master_audit.json
+++ b/tests/golden_master_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-25T01:33:53.789011+00:00",
-            "Total Scan Duration": "26.21 seconds"
+            "Analysis ISO Timestamp": "2026-07-25T02:25:32.232289+00:00",
+            "Total Scan Duration": "27.32 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -151,6 +151,9 @@
                 ".mat": {
                     "Blocked (Unsupported Extension: '.mat')": 1
                 },
+                ".m": {
+                    "Blocked (Machine-Generated Source Code Signature: 73 LOC)": 1
+                },
                 ".cf": {
                     "Blocked (Unsupported Extension: '.cf')": 1
                 },
@@ -169,20 +172,17 @@
                 ".i": {
                     "Blocked (Unsupported Extension: '.i')": 1
                 },
-                ".podspec": {
-                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
-                },
-                ".csv": {
-                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
-                },
-                ".m": {
-                    "Blocked (Machine-Generated Source Code Signature: 73 LOC)": 1
-                },
                 ".ss": {
                     "Blocked (Lexical Monotony: High structural repetition detected in 10586 LOC)": 1
                 },
                 ".bash": {
                     "Blocked (Machine-Generated Source Code Signature: 3531 LOC)": 1
+                },
+                ".podspec": {
+                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
+                },
+                ".csv": {
+                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
                 },
                 ".tsv": {
                     "Blocked (Saturation: Line 1 exceeds 500 chars)": 1
@@ -6253,10 +6253,26 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "c/cpython/configure",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 36288 LOC exceeds safe regex boundaries)",
+            "Size": "971338 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "c/micropython/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "3389 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "c/sqlite/parse.y",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2161 LOC)",
+            "Size": "76434 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -6501,10 +6517,26 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/json",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "1414 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/layer.tar",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Explicitly Denied Extension: '.tar')",
             "Size": "9216 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158/json",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "557 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -6545,6 +6577,14 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Explicitly Denied Extension: '.tar')",
             "Size": "10240 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/xattr/json",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "1443 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -6805,6 +6845,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "objective-c/worldwideweb/WorldWideWeb_main.m",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 73 LOC)",
+            "Size": "2192 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "perl/bugzilla/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -6973,6 +7021,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "python/fastapi/tests/test_sub_callbacks.py",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 96 exceeds 500 chars)",
+            "Size": "14598 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "python/fastapi/uv.lock",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Unsupported Extension: '.lock')",
@@ -6993,6 +7049,14 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Unsupported Extension: '.rst')",
             "Size": "9874 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "python/numpy/generate_umath.py",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1695 LOC)",
+            "Size": "55081 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7045,10 +7109,42 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "rust/tokio/tokio_udp.rs",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 2342 LOC)",
+            "Size": "88127 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "rust/wasmtime/wasmtime_ir_instructions.rs",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1541 LOC)",
+            "Size": "54752 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "scala/kafka/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "11358 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "scheme/racket/syntax.ss",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10586 LOC)",
+            "Size": "486498 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "shell/brew/brew_completion.bash",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 3531 LOC)",
+            "Size": "58169 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7101,6 +7197,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "tabular/tsv_genomics/gwas_sample.tsv",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "8022 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "tcl/sqlite/all.test",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -7149,6 +7253,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "tcl/sqlite/fuzzcheck.c",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2744 LOC)",
+            "Size": "87981 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "tcl/sqlite/rtreefuzz001.test",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -7161,6 +7273,14 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "8702 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "tcl/sqlite/testrunner.tcl",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Unsupported Format (.undeterminable)",
+            "Size": "56482 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7181,6 +7301,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "typescript/assemblyscript/builtins.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 11395 LOC)",
+            "Size": "420717 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "typescript/fp-ts/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -7193,6 +7321,46 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "11601 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/LICENSE.txt",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 56 LOC)",
+            "Size": "9197 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/checker.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 54435 LOC exceeds safe regex boundaries)",
+            "Size": "3151774 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/emitter.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 6379 LOC)",
+            "Size": "273338 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/parser.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10824 LOC)",
+            "Size": "539685 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/types.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10671 LOC)",
+            "Size": "487846 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7277,190 +7445,6 @@
             "Discovery Proof": "Radar Scan"
         },
         {
-            "Path": "zig/zls/config_gen.zig",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
-            "Size": "43593 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "zig/zls/mach/LICENSE",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
-            "Size": "751 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "c/cpython/configure",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 36288 LOC exceeds safe regex boundaries)",
-            "Size": "971338 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "c/sqlite/parse.y",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2161 LOC)",
-            "Size": "76434 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/json",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "1414 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158/json",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "557 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/xattr/json",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "1443 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "objective-c/worldwideweb/WorldWideWeb_main.m",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 73 LOC)",
-            "Size": "2192 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "python/fastapi/tests/test_sub_callbacks.py",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 96 exceeds 500 chars)",
-            "Size": "14598 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "python/numpy/generate_umath.py",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1695 LOC)",
-            "Size": "55081 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "rust/tokio/tokio_udp.rs",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 2342 LOC)",
-            "Size": "88127 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "rust/wasmtime/wasmtime_ir_instructions.rs",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1541 LOC)",
-            "Size": "54752 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "scheme/racket/syntax.ss",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10586 LOC)",
-            "Size": "486498 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "shell/brew/brew_completion.bash",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 3531 LOC)",
-            "Size": "58169 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "tabular/tsv_genomics/gwas_sample.tsv",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "8022 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "tcl/sqlite/fuzzcheck.c",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2744 LOC)",
-            "Size": "87981 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "tcl/sqlite/testrunner.tcl",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Unsupported Format (.undeterminable)",
-            "Size": "56482 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/assemblyscript/builtins.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 11395 LOC)",
-            "Size": "420717 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/LICENSE.txt",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 56 LOC)",
-            "Size": "9197 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/checker.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 54435 LOC exceeds safe regex boundaries)",
-            "Size": "3151774 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/emitter.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 6379 LOC)",
-            "Size": "273338 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/parser.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10824 LOC)",
-            "Size": "539685 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/types.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10671 LOC)",
-            "Size": "487846 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
             "Path": "zig/tigerbeetle/download.ps1",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Unsupported Format (.undeterminable)",
@@ -7485,10 +7469,26 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "zig/zls/config_gen.zig",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
+            "Size": "43593 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "zig/zls/langref.html.in",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Saturation: Line 9 exceeds 500 chars)",
             "Size": "351215 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "zig/zls/mach/LICENSE",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
+            "Size": "751 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },

--- a/tests/golden_master_zero_dep_audit.json
+++ b/tests/golden_master_zero_dep_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-25T01:35:06.768712+00:00",
-            "Total Scan Duration": "24.2 seconds"
+            "Analysis ISO Timestamp": "2026-07-25T02:26:33.047793+00:00",
+            "Total Scan Duration": "24.95 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -151,6 +151,9 @@
                 ".mat": {
                     "Blocked (Unsupported Extension: '.mat')": 1
                 },
+                ".m": {
+                    "Blocked (Machine-Generated Source Code Signature: 73 LOC)": 1
+                },
                 ".cf": {
                     "Blocked (Unsupported Extension: '.cf')": 1
                 },
@@ -169,20 +172,17 @@
                 ".i": {
                     "Blocked (Unsupported Extension: '.i')": 1
                 },
-                ".podspec": {
-                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
-                },
-                ".csv": {
-                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
-                },
-                ".m": {
-                    "Blocked (Machine-Generated Source Code Signature: 73 LOC)": 1
-                },
                 ".ss": {
                     "Blocked (Lexical Monotony: High structural repetition detected in 10586 LOC)": 1
                 },
                 ".bash": {
                     "Blocked (Machine-Generated Source Code Signature: 3531 LOC)": 1
+                },
+                ".podspec": {
+                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
+                },
+                ".csv": {
+                    "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)": 1
                 },
                 ".tsv": {
                     "Blocked (Saturation: Line 1 exceeds 500 chars)": 1
@@ -6253,10 +6253,26 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "c/cpython/configure",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 36288 LOC exceeds safe regex boundaries)",
+            "Size": "971338 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "c/micropython/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "3389 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "c/sqlite/parse.y",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2161 LOC)",
+            "Size": "76434 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -6501,10 +6517,26 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/json",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "1414 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/layer.tar",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Explicitly Denied Extension: '.tar')",
             "Size": "9216 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158/json",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "557 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -6545,6 +6577,14 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Explicitly Denied Extension: '.tar')",
             "Size": "10240 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/xattr/json",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "1443 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -6805,6 +6845,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "objective-c/worldwideweb/WorldWideWeb_main.m",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 73 LOC)",
+            "Size": "2192 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "perl/bugzilla/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -6973,6 +7021,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "python/fastapi/tests/test_sub_callbacks.py",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 96 exceeds 500 chars)",
+            "Size": "14598 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "python/fastapi/uv.lock",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Unsupported Extension: '.lock')",
@@ -6993,6 +7049,14 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Unsupported Extension: '.rst')",
             "Size": "9874 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "python/numpy/generate_umath.py",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1695 LOC)",
+            "Size": "55081 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7045,10 +7109,42 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "rust/tokio/tokio_udp.rs",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 2342 LOC)",
+            "Size": "88127 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "rust/wasmtime/wasmtime_ir_instructions.rs",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1541 LOC)",
+            "Size": "54752 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "scala/kafka/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "11358 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "scheme/racket/syntax.ss",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10586 LOC)",
+            "Size": "486498 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "shell/brew/brew_completion.bash",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 3531 LOC)",
+            "Size": "58169 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7101,6 +7197,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "tabular/tsv_genomics/gwas_sample.tsv",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
+            "Size": "8022 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "tcl/sqlite/all.test",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -7149,6 +7253,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "tcl/sqlite/fuzzcheck.c",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2744 LOC)",
+            "Size": "87981 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "tcl/sqlite/rtreefuzz001.test",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -7161,6 +7273,14 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "8702 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "tcl/sqlite/testrunner.tcl",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Unsupported Format (.undeterminable)",
+            "Size": "56482 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7181,6 +7301,14 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "typescript/assemblyscript/builtins.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 11395 LOC)",
+            "Size": "420717 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "typescript/fp-ts/LICENSE",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
@@ -7193,6 +7321,46 @@
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
             "Size": "11601 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/LICENSE.txt",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 56 LOC)",
+            "Size": "9197 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/checker.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 54435 LOC exceeds safe regex boundaries)",
+            "Size": "3151774 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/emitter.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 6379 LOC)",
+            "Size": "273338 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/parser.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10824 LOC)",
+            "Size": "539685 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "typescript/typescript_compiler/types.ts",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10671 LOC)",
+            "Size": "487846 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },
@@ -7277,190 +7445,6 @@
             "Discovery Proof": "Radar Scan"
         },
         {
-            "Path": "zig/zls/config_gen.zig",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
-            "Size": "43593 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "zig/zls/mach/LICENSE",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
-            "Size": "751 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "c/cpython/configure",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 36288 LOC exceeds safe regex boundaries)",
-            "Size": "971338 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "c/sqlite/parse.y",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2161 LOC)",
-            "Size": "76434 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/json",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "1414 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158/json",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "557 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "dockerfile/moby/builder/remotecontext/internal/tarsum/testdata/xattr/json",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "1443 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "objective-c/worldwideweb/WorldWideWeb_main.m",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 73 LOC)",
-            "Size": "2192 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "python/fastapi/tests/test_sub_callbacks.py",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 96 exceeds 500 chars)",
-            "Size": "14598 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "python/numpy/generate_umath.py",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1695 LOC)",
-            "Size": "55081 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "rust/tokio/tokio_udp.rs",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 2342 LOC)",
-            "Size": "88127 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "rust/wasmtime/wasmtime_ir_instructions.rs",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 1541 LOC)",
-            "Size": "54752 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "scheme/racket/syntax.ss",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10586 LOC)",
-            "Size": "486498 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "shell/brew/brew_completion.bash",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 3531 LOC)",
-            "Size": "58169 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "tabular/tsv_genomics/gwas_sample.tsv",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Saturation: Line 1 exceeds 500 chars)",
-            "Size": "8022 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "tcl/sqlite/fuzzcheck.c",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 2744 LOC)",
-            "Size": "87981 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "tcl/sqlite/testrunner.tcl",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Unsupported Format (.undeterminable)",
-            "Size": "56482 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/assemblyscript/builtins.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 11395 LOC)",
-            "Size": "420717 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/LICENSE.txt",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Machine-Generated Source Code Signature: 56 LOC)",
-            "Size": "9197 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/checker.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Monolithic Amalgamation: 54435 LOC exceeds safe regex boundaries)",
-            "Size": "3151774 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/emitter.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 6379 LOC)",
-            "Size": "273338 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/parser.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10824 LOC)",
-            "Size": "539685 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
-            "Path": "typescript/typescript_compiler/types.ts",
-            "Forensic Category": "Excluded Artifact",
-            "Diagnostic Reason": "Blocked (Lexical Monotony: High structural repetition detected in 10671 LOC)",
-            "Size": "487846 bytes",
-            "Identity Confidence": "0.0%",
-            "Discovery Proof": "Radar Scan"
-        },
-        {
             "Path": "zig/tigerbeetle/download.ps1",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Unsupported Format (.undeterminable)",
@@ -7485,10 +7469,26 @@
             "Discovery Proof": "Radar Scan"
         },
         {
+            "Path": "zig/zls/config_gen.zig",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
+            "Size": "43593 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
             "Path": "zig/zls/langref.html.in",
             "Forensic Category": "Excluded Artifact",
             "Diagnostic Reason": "Blocked (Saturation: Line 9 exceeds 500 chars)",
             "Size": "351215 bytes",
+            "Identity Confidence": "0.0%",
+            "Discovery Proof": "Radar Scan"
+        },
+        {
+            "Path": "zig/zls/mach/LICENSE",
+            "Forensic Category": "Excluded Artifact",
+            "Diagnostic Reason": "Blocked (System Exclusion, Hidden Directory, or Dynamic Ignored Dir)",
+            "Size": "751 bytes",
             "Identity Confidence": "0.0%",
             "Discovery Proof": "Radar Scan"
         },


### PR DESCRIPTION
## Summary
Part 2 of the golden-crucible cleanup (#328/#329/#330), on top of #395 (which fixed the engine nondeterminism and regenerated clean baselines) and #396 (unrelated CVE bump that was blocking CI on unrelated PRs).

- `golden-crucible.yml` previously ran the scan and just printed a debug `tree` -- `golden_diff.py` was never invoked, so CI passed no matter what the engine produced. This is the literal bug in #328.
- Split into a `fail-fast: false` matrix (`full-precision`, `zero-dependency`), matching the two golden master fixtures that already exist (`tests/golden_master_audit.json`, `tests/golden_master_zero_dep_audit.json`) -- these are genuinely different code paths and deserve independent pass/fail rather than one leg silently covering for the other.
- Each leg ends with a `Compare Against Golden Master` step invoking `golden_diff.py`, which now fails the job on real structural drift.

Closes #328.

## Test plan
- [x] Ran both legs locally (full-precision venv with networkx/tiktoken/pandas/xgboost, zero-dep venv without) against `language-crucible/data`, diffed against the golden masters merged in #395 -- both report a Stage 1 hash match
- [x] CI will run the actual matrix end-to-end