### PR TITLE
Convert golden_diff.py's CLI invocation into a real pytest test (#329)

### DIFF
--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -12,11 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - mode: full-precision
-            golden_master: tests/golden_master_audit.json
-          - mode: zero-dependency
-            golden_master: tests/golden_master_zero_dep_audit.json
+        mode: [full-precision, zero-dependency]
 
     steps:
       - name: Checkout GitGalaxy PR
@@ -42,32 +38,21 @@ jobs:
             echo "Deliberately skipping networkx/tiktoken/pandas/xgboost -- Zero-Dependency Mode leg."
           fi
           pip install -e .
+          pip install pytest
 
       - name: Fetch Golden Test Repo (Language Crucible)
         run: |
           echo "Cloning Language Crucible repository (pinned to v1.0)..."
           git clone --branch v1.0 --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
-      - name: Execute Resilience Engine
-        env:
-          GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
+      - name: Run Golden Crucible Test (${{ matrix.mode }})
         run: |
-          echo "Initiating GitGalaxy Golden Test Sequence (${{ matrix.mode }})..."
-          mkdir -p telemetry_out
-
-          # Scan only the structural corpus (language-crucible/data), not the
-          # repo's own tools/, raw_output/, or docs -- those are repo
-          # housekeeping, not part of the golden-master comparison surface.
-          timeout 180s galaxyscope ./language-crucible/data --output ./telemetry_out/ --file-speed --splicing-speed
-
-      - name: Compare Against Golden Master
-        run: |
-          python3 gitgalaxy/tests/golden_diff.py "gitgalaxy/${{ matrix.golden_master }}" ./telemetry_out/data_galaxy_audit.json
+          cd gitgalaxy
+          # tests/test_golden_crucible.py detects zero-dependency mode itself
+          # from whichever engines this leg installed above, and picks the
+          # matching golden master fixture automatically.
+          pytest -m golden_crucible tests/test_golden_crucible.py -v
 
       - name: Debug File System (Tree)
         if: always()  # This ensures the tree prints even if the previous step fails
-        run: |
-          echo "=== ROOT DIRECTORY TREE ==="
-          tree -L 2
-          echo "=== TELEMETRY OUT CONTENTS ==="
-          ls -lh telemetry_out/
+        run: tree -L 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,7 @@ testpaths = [
 ]
 markers = [
     "smoke: quick core engine tests for CI/CD pipelines",
+    "golden_crucible: opt-in end-to-end regression test against the language-crucible corpus; needs a local checkout. Run explicitly via `pytest -m golden_crucible`.",
 ]
+addopts = "-m 'not golden_crucible'"
 norecursedirs = ["tests/fixtures"]

--- a/tests/test_golden_crucible.py
+++ b/tests/test_golden_crucible.py
@@ -1,0 +1,95 @@
+"""
+Golden Crucible regression test (#329).
+
+Pytest-native replacement for what used to be a bare CI shell invocation of
+golden_diff.py. Runs the real `galaxyscope` CLI entry point against the
+language-crucible corpus and diffs the result against the committed golden
+master fixture that matches whatever engines happen to be installed in the
+current environment (full-precision vs Zero-Dependency Mode).
+
+Opt-in via the `golden_crucible` marker (excluded from the default
+`pytest tests/` run, see pyproject.toml's addopts) because it needs the
+language-crucible corpus checked out locally and takes real wall-clock time
+-- CI invokes it explicitly with `pytest -m golden_crucible`.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.galaxyscope import HAS_NETWORKX, HAS_TIKTOKEN, HAS_PYYAML
+from gitgalaxy.security.security_auditor import ML_AVAILABLE
+
+sys.path.insert(0, str(Path(__file__).parent))
+import golden_diff  # noqa: E402
+
+pytestmark = pytest.mark.golden_crucible
+
+REPO_ROOT = Path(__file__).parent.parent
+CRUCIBLE_DATA_PATH = Path(
+    os.environ.get("LANGUAGE_CRUCIBLE_PATH", REPO_ROOT.parent / "language-crucible")
+) / "data"
+
+
+def _zero_dependency_mode() -> bool:
+    # Same condition galaxyscope.py itself uses to decide which mode it ran in.
+    return not (HAS_NETWORKX and HAS_TIKTOKEN and ML_AVAILABLE and HAS_PYYAML)
+
+
+@pytest.mark.skipif(
+    not CRUCIBLE_DATA_PATH.exists(),
+    reason=(
+        f"language-crucible corpus not found at {CRUCIBLE_DATA_PATH} -- clone "
+        "squid-protocol/language-crucible (pinned to v1.0) as a sibling directory, "
+        "or set LANGUAGE_CRUCIBLE_PATH, to run this test."
+    ),
+)
+def test_golden_crucible_matches_baseline(tmp_path):
+    zero_dep = _zero_dependency_mode()
+    golden_master_path = REPO_ROOT / (
+        "tests/golden_master_zero_dep_audit.json" if zero_dep else "tests/golden_master_audit.json"
+    )
+
+    output_dir = tmp_path / "telemetry_out"
+    output_dir.mkdir()
+
+    subprocess.run(
+        [
+            "galaxyscope",
+            str(CRUCIBLE_DATA_PATH),
+            "--output",
+            str(output_dir) + os.sep,
+            "--file-speed",
+            "--splicing-speed",
+        ],
+        check=True,
+        timeout=180,
+        env={**os.environ, "GITGALAXY_LICENSE_KEY": "COMMUNITY_FREE_TIER"},
+    )
+
+    actual_path = output_dir / "data_galaxy_audit.json"
+    assert actual_path.exists(), f"galaxyscope did not produce the expected artifact at {actual_path}"
+
+    golden_data = golden_diff.load_and_sanitize(str(golden_master_path))
+    actual_data = golden_diff.load_and_sanitize(str(actual_path))
+
+    if golden_diff.generate_deterministic_hash(golden_data) == golden_diff.generate_deterministic_hash(actual_data):
+        return
+
+    diffs = golden_diff.deep_compare(golden_data, actual_data)
+    if not diffs:
+        # Hash mismatched but every leaf compared equal under tolerance --
+        # e.g. sub-epsilon float noise the hash-time rounding didn't fully absorb.
+        return
+
+    message = (
+        f"Structural drift detected against {golden_master_path.name} "
+        f"({len(diffs)} difference{'s' if len(diffs) != 1 else ''}):\n"
+    )
+    message += "\n".join(diffs[:50])
+    if len(diffs) > 50:
+        message += f"\n... and {len(diffs) - 50} more."
+    message += "\n\nIf this change is intentional (e.g. you improved a parser), regenerate the golden master."
+    pytest.fail(message, pytrace=False)


### PR DESCRIPTION
## Summary
Part 3 of the golden-crucible cleanup (#328 done via #395/#397, #329/#330 remaining).

- Adds `tests/test_golden_crucible.py`: runs the real `galaxyscope` CLI against the language-crucible corpus and diffs against whichever golden master fixture matches the current environment (same `zero_dependency_mode` detection `galaxyscope.py` itself uses), using `golden_diff.py`'s comparison functions as a library instead of a subprocess shell-out.
- New `golden_crucible` pytest marker, excluded from the default `pytest tests/` run via `pyproject.toml`'s `addopts` -- it needs the corpus checked out locally (`LANGUAGE_CRUCIBLE_PATH` env var, or a sibling `../language-crucible` dir by default) and takes real wall-clock time. Skips cleanly with a clear message if the corpus is missing rather than failing.
- `golden-crucible.yml` now runs `pytest -m golden_crucible` instead of duplicating the "run galaxyscope, diff against golden master" logic directly in the workflow -- one implementation instead of two that could drift apart.

## Test plan
- [x] `LANGUAGE_CRUCIBLE_PATH=... pytest -m golden_crucible tests/test_golden_crucible.py -v` passes in both a full-precision venv and a zero-dependency venv
- [x] Default `pytest tests/` run deselects this test (866 passed, 1 deselected, 1 pre-existing xfail)
- [x] Workflow YAML parses cleanly (`yaml.safe_load`)
- [x] `flake8 . --select=E9,F63,F7,F82` and `python tests/dead_key_audit.py --ci` clean