### PR TITLE
Require deliberate, reviewable golden master updates (#330)

### DIFF
--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -12,11 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - mode: full-precision
-            golden_master: tests/golden_master_audit.json
-          - mode: zero-dependency
-            golden_master: tests/golden_master_zero_dep_audit.json
+        mode: [full-precision, zero-dependency]
 
     steps:
       - name: Checkout GitGalaxy PR
@@ -42,32 +38,21 @@ jobs:
             echo "Deliberately skipping networkx/tiktoken/pandas/xgboost -- Zero-Dependency Mode leg."
           fi
           pip install -e .
+          pip install pytest
 
       - name: Fetch Golden Test Repo (Language Crucible)
         run: |
           echo "Cloning Language Crucible repository (pinned to v1.0)..."
           git clone --branch v1.0 --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
-      - name: Execute Resilience Engine
-        env:
-          GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
+      - name: Run Golden Crucible Test (${{ matrix.mode }})
         run: |
-          echo "Initiating GitGalaxy Golden Test Sequence (${{ matrix.mode }})..."
-          mkdir -p telemetry_out
-
-          # Scan only the structural corpus (language-crucible/data), not the
-          # repo's own tools/, raw_output/, or docs -- those are repo
-          # housekeeping, not part of the golden-master comparison surface.
-          timeout 180s galaxyscope ./language-crucible/data --output ./telemetry_out/ --file-speed --splicing-speed
-
-      - name: Compare Against Golden Master
-        run: |
-          python3 gitgalaxy/tests/golden_diff.py "gitgalaxy/${{ matrix.golden_master }}" ./telemetry_out/data_galaxy_audit.json
+          cd gitgalaxy
+          # tests/test_golden_crucible.py detects zero-dependency mode itself
+          # from whichever engines this leg installed above, and picks the
+          # matching golden master fixture automatically.
+          pytest -m golden_crucible tests/test_golden_crucible.py -v
 
       - name: Debug File System (Tree)
         if: always()  # This ensures the tree prints even if the previous step fails
-        run: |
-          echo "=== ROOT DIRECTORY TREE ==="
-          tree -L 2
-          echo "=== TELEMETRY OUT CONTENTS ==="
-          ls -lh telemetry_out/
+        run: tree -L 2

--- a/.github/workflows/golden-master-guard.yml
+++ b/.github/workflows/golden-master-guard.yml
@@ -1,0 +1,49 @@
+name: Golden Master Change Guard
+
+# Non-blocking (#330): flags any PR that modifies a golden-crucible fixture
+# so it's never invisible in a large diff, without stopping legitimate
+# intentional updates. Updates should come from
+# tests/tools/update_golden_master.py and be explained in the PR
+# description -- see CONTRIBUTING.md.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v6-dev
+
+permissions:
+  contents: read
+
+jobs:
+  flag-golden-master-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check for golden master fixture changes
+        run: |
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- \
+            tests/golden_master_audit.json tests/golden_master_zero_dep_audit.json)
+
+          if [ -z "$CHANGED" ]; then
+            echo "No golden master fixture changes in this PR."
+            exit 0
+          fi
+
+          {
+            echo "## ⚠️ This PR modifies a golden-crucible fixture"
+            echo ""
+            echo "Files changed:"
+            echo '```'
+            echo "$CHANGED"
+            echo '```'
+            echo ""
+            echo "These files should only ever change via \`tests/tools/update_golden_master.py\`,"
+            echo "and the PR description should explain *why* GitGalaxy's output was expected to"
+            echo "change. Reviewers: confirm the description covers this before approving."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,20 @@ To ensure your contribution integrates smoothly into the Zero-Trust ecosystem:
 
 ---
 
+## 🔒 Updating the Golden Crucible Baseline
+
+`tests/golden_master_audit.json` and `tests/golden_master_zero_dep_audit.json` are the accepted-good snapshots that every PR's output is diffed against (see the `crucible-audit` check). A failing diff means GitGalaxy's output changed -- that's either a bug you should fix, or an intentional improvement whose new baseline needs to be deliberately re-blessed.
+
+**Never** hand-copy fresh output over these files. Always use:
+
+```
+python tests/tools/update_golden_master.py
+```
+
+It shows you exactly what's about to change before writing anything, and requires explicit confirmation. If your PR touches either fixture, **explain why in the PR description** (e.g. "improved the Rust parser, now correctly detects async trait bounds") -- a CI check flags any PR that modifies these files so it's never invisible in a large diff.
+
+---
+
 ## 🐛 Reporting Discrepancies
 
 If the GalaxyScope CLI misidentifies a repository's structure or fails to parse a specific file phenotype, please use our **[Parsing Discrepancy Form](https://github.com/squid-protocol/gitgalaxy/issues/new/choose)**. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,7 @@ testpaths = [
 ]
 markers = [
     "smoke: quick core engine tests for CI/CD pipelines",
+    "golden_crucible: opt-in end-to-end regression test against the language-crucible corpus; needs a local checkout. Run explicitly via `pytest -m golden_crucible`.",
 ]
+addopts = "-m 'not golden_crucible'"
 norecursedirs = ["tests/fixtures"]

--- a/tests/test_golden_crucible.py
+++ b/tests/test_golden_crucible.py
@@ -1,0 +1,95 @@
+"""
+Golden Crucible regression test (#329).
+
+Pytest-native replacement for what used to be a bare CI shell invocation of
+golden_diff.py. Runs the real `galaxyscope` CLI entry point against the
+language-crucible corpus and diffs the result against the committed golden
+master fixture that matches whatever engines happen to be installed in the
+current environment (full-precision vs Zero-Dependency Mode).
+
+Opt-in via the `golden_crucible` marker (excluded from the default
+`pytest tests/` run, see pyproject.toml's addopts) because it needs the
+language-crucible corpus checked out locally and takes real wall-clock time
+-- CI invokes it explicitly with `pytest -m golden_crucible`.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.galaxyscope import HAS_NETWORKX, HAS_TIKTOKEN, HAS_PYYAML
+from gitgalaxy.security.security_auditor import ML_AVAILABLE
+
+sys.path.insert(0, str(Path(__file__).parent))
+import golden_diff  # noqa: E402
+
+pytestmark = pytest.mark.golden_crucible
+
+REPO_ROOT = Path(__file__).parent.parent
+CRUCIBLE_DATA_PATH = Path(
+    os.environ.get("LANGUAGE_CRUCIBLE_PATH", REPO_ROOT.parent / "language-crucible")
+) / "data"
+
+
+def _zero_dependency_mode() -> bool:
+    # Same condition galaxyscope.py itself uses to decide which mode it ran in.
+    return not (HAS_NETWORKX and HAS_TIKTOKEN and ML_AVAILABLE and HAS_PYYAML)
+
+
+@pytest.mark.skipif(
+    not CRUCIBLE_DATA_PATH.exists(),
+    reason=(
+        f"language-crucible corpus not found at {CRUCIBLE_DATA_PATH} -- clone "
+        "squid-protocol/language-crucible (pinned to v1.0) as a sibling directory, "
+        "or set LANGUAGE_CRUCIBLE_PATH, to run this test."
+    ),
+)
+def test_golden_crucible_matches_baseline(tmp_path):
+    zero_dep = _zero_dependency_mode()
+    golden_master_path = REPO_ROOT / (
+        "tests/golden_master_zero_dep_audit.json" if zero_dep else "tests/golden_master_audit.json"
+    )
+
+    output_dir = tmp_path / "telemetry_out"
+    output_dir.mkdir()
+
+    subprocess.run(
+        [
+            "galaxyscope",
+            str(CRUCIBLE_DATA_PATH),
+            "--output",
+            str(output_dir) + os.sep,
+            "--file-speed",
+            "--splicing-speed",
+        ],
+        check=True,
+        timeout=180,
+        env={**os.environ, "GITGALAXY_LICENSE_KEY": "COMMUNITY_FREE_TIER"},
+    )
+
+    actual_path = output_dir / "data_galaxy_audit.json"
+    assert actual_path.exists(), f"galaxyscope did not produce the expected artifact at {actual_path}"
+
+    golden_data = golden_diff.load_and_sanitize(str(golden_master_path))
+    actual_data = golden_diff.load_and_sanitize(str(actual_path))
+
+    if golden_diff.generate_deterministic_hash(golden_data) == golden_diff.generate_deterministic_hash(actual_data):
+        return
+
+    diffs = golden_diff.deep_compare(golden_data, actual_data)
+    if not diffs:
+        # Hash mismatched but every leaf compared equal under tolerance --
+        # e.g. sub-epsilon float noise the hash-time rounding didn't fully absorb.
+        return
+
+    message = (
+        f"Structural drift detected against {golden_master_path.name} "
+        f"({len(diffs)} difference{'s' if len(diffs) != 1 else ''}):\n"
+    )
+    message += "\n".join(diffs[:50])
+    if len(diffs) > 50:
+        message += f"\n... and {len(diffs) - 50} more."
+    message += "\n\nIf this change is intentional (e.g. you improved a parser), regenerate the golden master."
+    pytest.fail(message, pytrace=False)

--- a/tests/tools/update_golden_master.py
+++ b/tests/tools/update_golden_master.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+The ONLY sanctioned way to update tests/golden_master_audit.json or
+tests/golden_master_zero_dep_audit.json (#330).
+
+golden_diff.py failing means GitGalaxy's output actually changed. That's
+either a bug (fix the engine, don't touch this file) or an intentional
+improvement (regenerate the fixture -- but deliberately, not by reflexively
+copying new output over the old baseline). This script exists so that
+second case always goes through one clearly-named, auditable path instead
+of `cp new_output.json golden_master.json`, and so the person running it
+sees exactly what they're about to bless before it happens.
+
+Usage:
+    python tests/tools/update_golden_master.py [--yes]
+
+Requires the language-crucible corpus checked out locally (same resolution
+as tests/test_golden_crucible.py): set LANGUAGE_CRUCIBLE_PATH, or have it
+as a sibling directory of this repo checkout.
+
+Updates whichever fixture matches the CURRENT environment (full-precision
+if networkx/tiktoken/pandas/xgboost are installed, zero-dependency-mode
+otherwise) -- run it once per mode if both fixtures need updating.
+"""
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import golden_diff  # noqa: E402
+
+from gitgalaxy.galaxyscope import HAS_NETWORKX, HAS_TIKTOKEN, HAS_PYYAML  # noqa: E402
+from gitgalaxy.security.security_auditor import ML_AVAILABLE  # noqa: E402
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+CRUCIBLE_DATA_PATH = Path(
+    os.environ.get("LANGUAGE_CRUCIBLE_PATH", REPO_ROOT.parent / "language-crucible")
+) / "data"
+
+
+def zero_dependency_mode() -> bool:
+    return not (HAS_NETWORKX and HAS_TIKTOKEN and ML_AVAILABLE and HAS_PYYAML)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive confirmation prompt (the diff summary is still printed either way).",
+    )
+    args = parser.parse_args()
+
+    if not CRUCIBLE_DATA_PATH.exists():
+        print(f"❌ language-crucible corpus not found at {CRUCIBLE_DATA_PATH}.")
+        print("   Clone squid-protocol/language-crucible (pinned to v1.0) as a sibling directory,")
+        print("   or set LANGUAGE_CRUCIBLE_PATH, then re-run.")
+        sys.exit(1)
+
+    zero_dep = zero_dependency_mode()
+    mode_name = "zero-dependency" if zero_dep else "full-precision"
+    golden_master_path = REPO_ROOT / (
+        "tests/golden_master_zero_dep_audit.json" if zero_dep else "tests/golden_master_audit.json"
+    )
+
+    print(f"=== Regenerating {golden_master_path.name} ({mode_name} mode) ===\n")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        output_dir = Path(tmp) / "telemetry_out"
+        output_dir.mkdir()
+
+        print(f"Running galaxyscope against {CRUCIBLE_DATA_PATH}...")
+        subprocess.run(
+            [
+                "galaxyscope",
+                str(CRUCIBLE_DATA_PATH),
+                "--output",
+                str(output_dir) + os.sep,
+                "--file-speed",
+                "--splicing-speed",
+            ],
+            check=True,
+            timeout=180,
+            env={**os.environ, "GITGALAXY_LICENSE_KEY": "COMMUNITY_FREE_TIER"},
+        )
+
+        new_output_path = output_dir / "data_galaxy_audit.json"
+        if not new_output_path.exists():
+            print(f"❌ galaxyscope did not produce the expected artifact at {new_output_path}")
+            sys.exit(1)
+
+        old_data = golden_diff.load_and_sanitize(str(golden_master_path)) if golden_master_path.exists() else {}
+        new_data = golden_diff.load_and_sanitize(str(new_output_path))
+
+        if golden_master_path.exists() and golden_diff.generate_deterministic_hash(
+            old_data
+        ) == golden_diff.generate_deterministic_hash(new_data):
+            print(f"\n✅ No drift detected -- {golden_master_path.name} already matches current output. Nothing to do.")
+            return
+
+        diffs = golden_diff.deep_compare(old_data, new_data)
+        print(f"\n--- {len(diffs)} difference(s) about to be baked into {golden_master_path.name} ---\n")
+        for diff in diffs[:50]:
+            print(diff)
+        if len(diffs) > 50:
+            print(f"... and {len(diffs) - 50} more.")
+
+        if not args.yes:
+            answer = input(
+                f"\nBless this as the new {mode_name} golden master? This will overwrite "
+                f"{golden_master_path.relative_to(REPO_ROOT)}. [y/N] "
+            )
+            if answer.strip().lower() != "y":
+                print("Aborted -- golden master left unchanged.")
+                sys.exit(1)
+
+        golden_master_path.write_bytes(new_output_path.read_bytes())
+
+    print(f"\n✅ Updated {golden_master_path.relative_to(REPO_ROOT)}.")
+    print("   Commit it as part of this PR, and explain in the PR description WHY the output")
+    print("   changed (e.g. \"improved X parser, now correctly detects Y\") -- see CONTRIBUTING.md.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Part 4 (final) of the golden-crucible cleanup (#328/#329 done via #395/#397/#398).

Nothing previously stopped a contributor from making a failing `crucible-audit` diff "pass" by copying fresh output over `tests/golden_master_audit.json` / `_zero_dep_audit.json`. A green check meant either "matches the accepted snapshot" or "was just silently re-blessed" -- indistinguishable from the CI result alone.

- **`tests/tools/update_golden_master.py`**: the one sanctioned update path. Regenerates output for whichever mode matches the current environment, prints the full diff against the existing fixture *before* touching anything, and requires interactive y/N confirmation (`--yes` available for scripted use, but the diff is always shown regardless).
- **`.github/workflows/golden-master-guard.yml`**: non-blocking -- writes a `GITHUB_STEP_SUMMARY` callout on any PR touching either fixture file, so it's never invisible in a large diff. Flags for reviewer attention rather than gating merge.
- **`CONTRIBUTING.md`**: documents the update path and the requirement to explain *why* in the PR description.

## Test plan
- [x] Injected an artificial drift into `golden_master_audit.json`, ran the script: diff summary printed correctly, `n` left the file untouched, `y` wrote the corrected output
- [x] Restored the real fixture, confirmed `golden_diff.py` still reports parity (deterministic hash match)
- [x] No-drift case: script correctly reports "Nothing to do" without prompting
- [x] `flake8`, `dead_key_audit.py --ci`, full `pytest tests/` (866 passed, 1 deselected, 1 pre-existing xfail) all clean
- [x] New workflow YAML parses cleanly