### PR TITLE
Archive each official release's crucible output for release-over-release comparison

### DIFF
--- a/.github/workflows/release-crucible-archive.yml
+++ b/.github/workflows/release-crucible-archive.yml
@@ -1,0 +1,111 @@
+name: Archive Release Output to Language Crucible
+
+# Runs once per official GitGalaxy release (never on a bare tag push --
+# the `release` webhook only fires for actual GitHub Releases): scans the
+# same pinned language-crucible/data corpus the crucible-audit CI gate
+# uses, so results stay comparable release-over-release.
+#
+# Storage split deliberately, to avoid unbounded git-history growth:
+#   - data_galaxy_audit.json (small, git-diffable) is committed into
+#     language-crucible/raw_output/<tag>/ via a PR, so it's browsable
+#     and diffable directly in that repo.
+#   - Everything heavier (SQLite DB, graph, SARIF, SBOM, GPU payload,
+#     LLM brief) attaches to the GitGalaxy release itself as assets --
+#     permanent, but never re-cloned as part of any repo's history.
+#
+# workflow_dispatch lets this be dry-run against a past release tag
+# without needing to cut a new one.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to archive (e.g. v2.4.5) -- for manual testing"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  archive-crucible-output:
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+    steps:
+      - name: Checkout GitGalaxy at the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          path: gitgalaxy
+          persist-credentials: false
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install GitGalaxy (full-precision)
+        run: |
+          cd gitgalaxy
+          python -m pip install --upgrade pip setuptools wheel
+          pip install PyYAML networkx tiktoken pandas xgboost
+          pip install -e .
+
+      - name: Fetch Language Crucible corpus (pinned to v1.0, same as CI)
+        run: |
+          git clone --branch v1.0 --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+
+      - name: Run GalaxyScope against the crucible corpus
+        env:
+          GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
+        run: |
+          mkdir -p telemetry_out
+          timeout 180s galaxyscope ./language-crucible/data --output ./telemetry_out/
+
+      - name: Upload heavy artifacts as release assets
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd telemetry_out
+          for f in data_galaxy_master.db data_galaxy_graph.sqlite data_galaxy_sarif.json data_galaxy_sbom.json data_galaxy_gpu.json data_galaxy_llm.md; do
+            if [ -f "$f" ]; then
+              gh release upload "$RELEASE_TAG" "$f" --repo squid-protocol/gitgalaxy --clobber
+            fi
+          done
+
+      - name: Checkout Language Crucible
+        uses: actions/checkout@v4
+        with:
+          repository: squid-protocol/language-crucible
+          path: language-crucible-write
+          token: ${{ secrets.AUTOMATION_PAT }}
+          persist-credentials: true
+
+      - name: Stage the archived baseline
+        run: |
+          mkdir -p "language-crucible-write/raw_output/${RELEASE_TAG}"
+          cp telemetry_out/data_galaxy_audit.json "language-crucible-write/raw_output/${RELEASE_TAG}/data_galaxy_audit.json"
+
+      - name: Open PR with the archived baseline
+        uses: squid-protocol/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # forked from peter-evans/create-pull-request v8.0.0
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}
+          path: language-crucible-write
+          repository: squid-protocol/language-crucible
+          commit-message: "chore: archive ${{ env.RELEASE_TAG }} crucible baseline"
+          title: "chore: archive ${{ env.RELEASE_TAG }} crucible baseline"
+          body: |
+            Automated archive of GitGalaxy `${{ env.RELEASE_TAG }}`'s output against the pinned
+            `data/` corpus (v1.0 tag), for release-over-release comparison.
+
+            The remaining artifacts (SQLite DB, graph, SARIF, SBOM, GPU payload, LLM brief) are
+            attached to the release itself rather than committed here:
+            ${{ github.event.release.html_url || format('https://github.com/squid-protocol/gitgalaxy/releases/tag/{0}', env.RELEASE_TAG) }}
+          branch: auto/crucible-archive-${{ env.RELEASE_TAG }}
+          delete-branch: true
+          add-paths: raw_output/${{ env.RELEASE_TAG }}/data_galaxy_audit.json


### PR DESCRIPTION
## Summary
Explored per your request: keep a permanent record of what each official GitGalaxy release produces against the language-crucible corpus, without letting that record become an unbounded storage cost.

- Triggers only on `release: published` (never a bare tag push) and skips prereleases/drafts.
- Scans `language-crucible/data` pinned to the same `v1.0` tag the `crucible-audit` CI gate already uses, so output stays comparable release-over-release (not confounded by the corpus itself changing).
- **Storage split:**
  - `data_galaxy_audit.json` (small, git-diffable) is committed into `language-crucible/raw_output/<tag>/` via a PR, reusing the existing `AUTOMATION_PAT` + forked `create-pull-request` pattern already used for the LLM-brief-bot in `gitgalaxy.yml`.
  - The heavier artifacts (SQLite DB, graph, SARIF, SBOM, GPU payload, LLM brief) attach to the GitGalaxy release itself as assets instead of being committed anywhere -- at the current ~weekly release cadence, committing everything every release would add multiple GB/year to `language-crucible`'s permanent git history.
- `workflow_dispatch` (with a `tag` input) lets this be dry-run against a past release without cutting a new one.

## ⚠️ Known gap I can't close from here
This needs `AUTOMATION_PAT` to have write + PR-creation access to `squid-protocol/language-crucible` specifically, not just `squid-protocol/gitgalaxy`. I can't verify that scope from this environment. **Do not merge/rely on this until it's been dry-run once via `workflow_dispatch`** (I'd suggest against `v2.4.5`) to confirm the cross-repo PR actually opens successfully.

## Test plan
- [x] Workflow YAML parses cleanly
- [x] Artifact filenames (`data_galaxy_master.db`, `_graph.sqlite`, `_sarif.json`, `_sbom.json`, `_gpu.json`, `_llm.md`, `_audit.json`) match what `galaxyscope` actually produces (verified against local runs from the golden-crucible work)
- [ ] End-to-end cross-repo PR creation -- **not yet verified, needs a manual dry-run**