### PR TITLE
Skip heavy CI on docs-only PRs and auto-merge the LLM brief bot PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,7 @@ name: "CodeQL Security Scan"
 on:
   pull_request:
     branches: [main]
+    paths-ignore: ["docs/**"]
   schedule:
     - cron: '0 12 * * 1'
 

--- a/.github/workflows/dead-key-audit.yml
+++ b/.github/workflows/dead-key-audit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore: ["docs/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/gitgalaxy.yml
+++ b/.github/workflows/gitgalaxy.yml
@@ -3,6 +3,7 @@ name: GitGalaxy Zero-Trust Pipeline
 on:
   pull_request:
     branches: [main]
+    paths-ignore: ["docs/**"]
   push:
     branches: [main]
 
@@ -113,6 +114,7 @@ jobs:
           mv *_galaxy_llm.md docs/gitgalaxy_architecture_brief.md
 
       - name: Open PR with Updated LLM Brief
+        id: llm-brief-pr
         uses: squid-protocol/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # forked from peter-evans/create-pull-request v8.0.0
         with:
           token: ${{ secrets.AUTOMATION_PAT }}
@@ -122,3 +124,14 @@ jobs:
           branch: auto/llm-architecture-brief
           delete-branch: true
           add-paths: docs/gitgalaxy_architecture_brief.md
+
+      # Nothing gates this PR (branch protection requires 0 reviews/checks),
+      # so without this it just sits mergeable-but-unmerged until a human
+      # notices. Auto-merge lets GitHub merge it itself once whatever checks
+      # do run finish, instead of requiring a manual click every time.
+      - name: Enable auto-merge for the LLM Brief PR
+        if: steps.llm-brief-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+        run: |
+          gh pr merge --squash --auto "${{ steps.llm-brief-pr.outputs.pull-request-number }}" --repo ${{ github.repository }}

--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - v6-dev
+    paths-ignore: ["docs/**"]
 
 jobs:
   crucible-audit:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,6 +3,7 @@ name: GitGalaxy Smoke Tests
 on:
   pull_request:
     branches: [main]
+    paths-ignore: ["docs/**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Diagnosed per your report: two separate, unrelated problems, neither of which was a PR queue issue.

**Why so much ran:** none of `codeql.yml`, `dead-key-audit.yml`, `golden-crucible.yml`, `smoke-test.yml`, or `gitgalaxy.yml`'s `pull_request` trigger had a `paths` filter. A bot PR touching exactly one markdown file still ran the full 12-way smoke-test matrix, both `crucible-audit` legs, CodeQL, and the whole pre-gate pipeline. Added `paths-ignore: ["docs/**"]` to all five. Left Muninn unfiltered on purpose (secret-scanning should run on any file) and left `golden-master-guard.yml` alone (already cheap).

**Why it needed manual merging:** checked branch protection directly -- `required_approving_review_count: 0`, `required_status_checks.contexts: []`, no rulesets. Nothing was blocking merge; PR #305 had simply been sitting fully mergeable for 2 days because `allow_auto_merge` was off at the repo level and the workflow never requested it. I've already flipped `allow_auto_merge` on via the API, and this PR adds a step right after PR creation to call `gh pr merge --squash --auto`.

## Test plan
- [x] All 5 modified workflow YAMLs parse cleanly
- [x] `allow_auto_merge` confirmed `true` on the repo via API
- [ ] Next LLM-brief bot run merges itself without manual intervention -- can't be verified until that job runs again (next push to `main`)