### PR TITLE
Fix race between LLM-brief PR auto-merge and GitHub's clean-status rejection

### DIFF
--- a/.github/workflows/gitgalaxy.yml
+++ b/.github/workflows/gitgalaxy.yml
@@ -125,13 +125,22 @@ jobs:
           delete-branch: true
           add-paths: docs/gitgalaxy_architecture_brief.md
 
-      # Nothing gates this PR (branch protection requires 0 reviews/checks),
-      # so without this it just sits mergeable-but-unmerged until a human
-      # notices. Auto-merge lets GitHub merge it itself once whatever checks
-      # do run finish, instead of requiring a manual click every time.
-      - name: Enable auto-merge for the LLM Brief PR
+      # Nothing gates this PR today (branch protection requires 0
+      # reviews/checks), so without this it just sits mergeable-but-unmerged
+      # until a human notices. `gh pr merge --auto` alone is unreliable here:
+      # GitHub's enablePullRequestAutoMerge mutation *rejects* PRs that are
+      # already in "clean" (immediately mergeable) status with "Pull request
+      # is in clean status" -- and given 0 required checks, a fresh PR here
+      # reaches clean almost instantly, so whether --auto lands before or
+      # after that happens is a race (confirmed: PR #409 hit the rejection).
+      # Try a direct merge first (the expected path today); only fall back
+      # to --auto if that's rejected because something is still genuinely
+      # pending -- which is exactly the case --auto is for.
+      - name: Merge the LLM Brief PR
         if: steps.llm-brief-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.AUTOMATION_PAT }}
         run: |
-          gh pr merge --squash --auto "${{ steps.llm-brief-pr.outputs.pull-request-number }}" --repo ${{ github.repository }}
+          PR="${{ steps.llm-brief-pr.outputs.pull-request-number }}"
+          gh pr merge --squash "$PR" --repo ${{ github.repository }} || \
+            gh pr merge --squash --auto "$PR" --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
PR #409's post-gate merge step failed: `GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)`.

Confirmed by checking #409 directly -- `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`, still open. GitHub's `enablePullRequestAutoMerge` mutation specifically rejects PRs that are already immediately mergeable (there's nothing left to wait for). Since branch protection on `main` requires 0 status checks and 0 reviews, a fresh bot PR here reaches "clean" almost instantly -- so whether `gh pr merge --auto` runs before or after GitHub finishes computing that is a genuine race, not a reliable path. It happened to land on the working side for #305 and the losing side for #409.

Fix: try a direct `gh pr merge --squash` first (the expected/correct path today, given 0 required checks), and only fall back to `--auto` if that's rejected for a still-pending reason -- which is exactly the case `--auto` exists for.

Manually merged #409 to clear the immediate backlog.

## Test plan
- [x] Workflow YAML parses cleanly
- [x] #409 manually merged, unblocked
- [ ] Next LLM-brief bot run merges via the direct path without hitting the race -- can't be verified until that job runs again (next push to `main`)