### PR TITLE
Fix confirmed live infinite loop: skip full-report on the bot's own commits

### DIFF
--- a/.github/workflows/gitgalaxy.yml
+++ b/.github/workflows/gitgalaxy.yml
@@ -63,9 +63,19 @@ jobs:
   # 3 of them and let the rest live only in the ephemeral runner.
   # --fail-on-malware stays on here too, as a safety net in case
   # branch protection is ever bypassed.
+  #
+  # The LLM brief embeds a Timestamp/Scan Duration/Git Commit in its own
+  # content (llm_recorder.py), so it always differs from the last commit
+  # even with zero real code changes -- and merging the bot's own PR is
+  # itself a push to main. Without the second half of this condition, that
+  # is a genuine infinite loop: this confirmed live on 2026-07-25, landing
+  # 13 junk commits in ~13 minutes before being caught and disabled. Skip
+  # regenerating when the triggering push IS the bot's own previous merge.
   # ============================================================
   full-report:
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' &&
+      !startsWith(github.event.head_commit.message, 'docs: auto-update LLM architectural brief')
     name: Full Report (SARIF, SBOM, LLM Brief)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
This is the real root cause behind the LLM-brief bot's merge issues, and it went live right after #410 merged.

`llm_recorder.py` embeds Timestamp, Scan Duration, and Git Commit directly in the generated brief -- so the brief content is guaranteed to differ from whatever's committed on *every single run*, even with zero real code changes. Since `full-report` runs on every push to `main`, and merging the bot's own PR is itself a push to `main`, this is a genuine self-triggering infinite loop.

**It actually ran:** 13 junk commits landed on `main` in ~13 minutes (#411 through #423) before I caught it and disabled `gitgalaxy.yml` to stop it. What had been masking this bug the whole time was purely accidental -- requiring a human to click merge acted as an unintentional rate-limiter. #410's auto-merge fix (which was itself correct) removed that safety net and the dormant loop immediately went live.

**Fix:** skip `full-report` entirely when the triggering push's commit message matches the bot's own squash-merge title (`docs: auto-update LLM architectural brief (#N)`). Breaks the cycle at the source -- the job doesn't run a second consecutive time -- so auto-merge stays correctly in place for every real code-change push.

## ⚠️ Note on checks
`gitgalaxy.yml` is currently disabled repo-wide (emergency stop), so this PR's own pre-gate checks won't run. Reviewed the diff manually; will re-enable the workflow immediately after merging this.

## Test plan
- [x] Workflow YAML parses cleanly
- [x] Confirmed the loop's actual behavior via `gh run list` (13 iterations, ~60-70s apart) and `git log` (13 matching junk commits)
- [ ] Next real push to `main` regenerates the brief and merges once, without a second self-triggered run -- verify after merging + re-enabling