### PR TITLE
Ignore log.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ htmlcov/
 
 # LOGS & DATABASES
 *.log
+log.txt
 gitgalaxy_dropped_orders.log
 *.sqlite3
 *.sqlite3-journal


### PR DESCRIPTION
Small real gitignore gap fix, also doubles as the verification push for #424's infinite-loop fix -- watching to confirm full-report runs once and the bot's own resulting commit correctly gets skipped.