### PR TITLE
Fix CodeQL init/analyze version mismatch (supersedes #355, #358)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,12 +31,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
#358 (bump \`codeql-action/analyze\` to 4.37.1 alone) was failing:
\`\`\`
##[error]Loaded a configuration file for version '4.36.2', but running version '4.37.1'
\`\`\`

\`github/codeql-action\`'s \`init\` and \`analyze\` steps must be pinned to the same version -- \`analyze\` refuses to run against a config written by a different version's \`init\`. Dependabot tracks \`init\` and \`analyze\` as separate dependencies (two \`uses:\` lines pointing at the same monorepo) and opened two independent PRs (#355 for \`init\`, #358 for \`analyze\`) that are individually broken and only valid merged together. Confirmed this happened identically at the 4.37.0 bump too (#236/#237, both closed unmerged for the same reason).

Bumped both to 4.37.1 (\`7188fc3\`) together in one atomic change.

Also created the missing \`security\` label -- \`dependabot.yml\` references it but it didn't exist, so every dependency PR (including #358) got a "labels could not be found" warning and silently skipped applying it.

Closing #355 and #358 as superseded by this.

## Test plan
- [x] Workflow YAML parses cleanly
- [ ] CodeQL \`Analyze (python)\` check passes on *this* PR -- direct live verification of the fix