### PR TITLE
Fix .env secrets-leak: enforce_licensing_guard() reads from cwd (#466)

### DIFF
--- a/gitgalaxy/licensing.py
+++ b/gitgalaxy/licensing.py
@@ -87,7 +87,18 @@ def enforce_licensing_guard(tool_name: str = "GitGalaxy Engine v2"):
     # --- ZERO-DEPENDENCY .ENV LOADER ---
     # Python doesn't read .env files natively. This parses it manually
     # so we don't force users to pip install python-dotenv.
-    env_path = os.path.join(os.getcwd(), ".env")
+    #
+    # #466: This MUST be scoped to GitGalaxy's own user config location, never
+    # to os.getcwd(). The documented CI usage pattern is `cd <scan-target> &&
+    # galaxyscope .`, which makes cwd the (often third-party, untrusted)
+    # repository being scanned -- reading its .env would merge whatever keys
+    # that repo's own .env defines into this process's environment via
+    # setdefault(), a trust-boundary crossing this project flags in other
+    # codebases. The documented ways to supply GITGALAXY_LICENSE_KEY (README,
+    # action.yml) already set it as a real environment variable, not via a
+    # cwd-relative .env, so this loader is purely a local-dev convenience and
+    # never needs to see the scan target's files at all.
+    env_path = os.path.join(os.path.expanduser("~"), ".config", "gitgalaxy", ".env")
     if os.path.exists(env_path):
         try:
             with open(env_path, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

`enforce_licensing_guard()` built its `.env` path from `os.getcwd()`. The documented CI usage pattern is `cd <scan-target> && galaxyscope .`, which makes `cwd` the (often third-party, untrusted) repository being scanned. Every scan parsed whatever `.env` existed in the target repo and merged its contents into `os.environ` via `setdefault()` -- for a supply-chain security scanner, ingesting config from the thing being audited is exactly the trust-boundary crossing this project flags in other codebases.

- Scoped `env_path` to `~/.config/gitgalaxy/.env` (the user's own config location), matching the issue's suggested fix, instead of deriving it from the scan target's directory.
- Confirmed the documented ways to supply `GITGALAXY_LICENSE_KEY` (README's `export GITGALAXY_LICENSE_KEY=...`, `action.yml`'s env block) already set it as a real environment variable, not via a cwd-relative `.env` -- so this loader was always just a local-dev convenience and never needed to see the scan target's files.

## Test plan
- [x] Existing tests (`test_licensing_env_loader`, `test_licensing_env_loader_exception`) already patch `os.path.exists`/`open` generically without asserting the literal path, so they exercise the new location unmodified -- both pass.
- [x] `ruff check`/`ruff format --check` on the changed file: clean (pre-existing unrelated DTZ005/DTZ007 findings only).
- [x] Full suite: `pytest tests/` -- 866 passed, 1 pre-existing xfail.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)