### PR TITLE
Pin remaining CI action references to full commit SHA

### DIFF
--- a/.github/workflows/gitgalaxy.yml
+++ b/.github/workflows/gitgalaxy.yml
@@ -112,7 +112,7 @@ jobs:
           sarif_file: gitgalaxy-results_sarif.json
 
       - name: Upload SBOM as Build Artifact   # unchanged
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gitgalaxy-sbom
           path: gitgalaxy-results_sbom.json

--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout GitGalaxy PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: gitgalaxy
           persist-credentials: false
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/golden-master-guard.yml
+++ b/.github/workflows/golden-master-guard.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-crucible-archive.yml
+++ b/.github/workflows/release-crucible-archive.yml
@@ -36,14 +36,14 @@ jobs:
       RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
     steps:
       - name: Checkout GitGalaxy at the release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_TAG }}
           path: gitgalaxy
           persist-credentials: false
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -79,7 +79,7 @@ jobs:
           done
 
       - name: Checkout Language Crucible
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: squid-protocol/language-crucible
           path: language-crucible-write


### PR DESCRIPTION
## Summary

Most workflows already pin `actions/checkout`/`actions/setup-python` to a full commit SHA (e.g. `actions/checkout@9c091bb2... # v7.0.0`), but four workflows still referenced mutable version tags:

- `golden-crucible.yml`: `actions/checkout@v4`, `actions/setup-python@v6`
- `golden-master-guard.yml`: `actions/checkout@v4`
- `publish.yml`: `actions/checkout@v4` (x4), `actions/setup-python@v6`
- `release-crucible-archive.yml`: `actions/checkout@v4` (x2), `actions/setup-python@v6`
- `gitgalaxy.yml`: `actions/upload-artifact@v7`

Mutable tags can be repointed at a different commit after the fact -- exactly the class of supply-chain risk this project's own tooling (Supply Chain Firewall, Vault Sentinel) flags in other people's repos.

Resolved each tag to the commit it currently points to via the GitHub API (no version bumps -- `v4` stays `v4.4.0`, `v6` stays `v6.3.0`, `v7` stays `v7.0.1`, matching what's already pinned to those exact versions elsewhere in the repo) and pinned to that SHA with a version comment, matching the existing style.

`pypa/gh-action-pypi-publish@release/v1` in `publish.yml` is deliberately left as a floating branch reference -- that's PyPA's own documented, recommended way to consume this action as part of the Trusted Publishing/OIDC flow, not an oversight I missed.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on every changed file -- valid YAML.
- [x] Each SHA verified against the GitHub API to match exactly what the corresponding version tag currently resolves to (no behavior change, purely pinning).
- [x] Grepped all workflow files afterward for any remaining `@vN`-style tag references on `actions/`/`pypa/` -- none besides the intentional `release/v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)