### PR TITLE
Harden core-engine test coverage; fix 2 real bugs found along the way

### DIFF
--- a/gitgalaxy/core/state_rehydrator.py
+++ b/gitgalaxy/core/state_rehydrator.py
@@ -118,60 +118,12 @@ class StateRehydrator:
             # Return the standardized payload
             return {"commit_hash": latest_hash, "ram_cache": ram_state}
 
-        except sqlite3.Error as e:
+        except (sqlite3.Error, ValueError, TypeError, KeyError, IndexError) as e:
+            # Broadened beyond sqlite3.Error: a structurally valid DB can still
+            # carry row-level type confusion -- e.g. a non-numeric string in a
+            # REAL column -- which raises ValueError/TypeError from the float()
+            # coercions above, not sqlite3.Error. Any of these means the historical
+            # state can't be trusted; fall back to a cold start the same way a
+            # corrupted DB does, rather than crashing the delta-scan path.
             print(f"⚠️ Database corruption or read error at {self.db_path}: {e}")
             return None
-
-    # ==============================================================================
-
-
-# galaxyscope:ignore sec_db_hooks, sec_high_risk_execution
-# TEST 6: DICTIONARY OVERRIDE TYPE SPOOFING
-# ==============================================================================
-
-
-# galaxyscope:ignore sec_db_hooks, sec_high_risk_execution
-def test_rehydrator_dictionary_type_spoofing(tmp_path):
-    """
-    DEVIOUS EDGE CASE: An attacker (or corrupted DB) places a String into a column
-    that the RAM cache strictly expects to be a Float. When the Signal Processor
-    attempts to execute metrics math on this dictionary override, it will crash.
-    The Rehydrator MUST enforce strict type casting.
-    """
-    db_path = tmp_path / "spoofed_master.db"
-    conn = sqlite3.connect(db_path)
-    cursor = conn.cursor()
-
-    cursor.execute("CREATE TABLE repo_data (repo_name TEXT, commit_hash TEXT, commit_date INTEGER)")
-    cursor.execute("""
-        CREATE TABLE file_data (
-            repo_name TEXT, commit_hash TEXT, file_path TEXT, language TEXT,
-            total_loc INTEGER, coding_loc INTEGER, structural_mass REAL,
-            control_flow_ratio REAL, popularity INTEGER, author TEXT,
-            ai_threat_score REAL, silo_risk REAL, total_downstream INTEGER, total_upstream INTEGER
-        )
-    """)
-
-    cursor.execute("INSERT INTO repo_data VALUES ('test_repo', 'hash_1', 1600000000)")
-
-    # MALICIOUS INJECTION: Injecting a String 'HACKED' into the Float columns
-    cursor.execute("""
-        INSERT INTO file_data VALUES (
-            'test_repo', 'hash_1', 'src/hacked.py', 'python',
-            150, 100, 'HACKED_MASS', 'HACKED_CFR', 12, 'Attacker', 'HACKED_THREAT', 12.5, 4, 2
-        )
-    """)
-    conn.commit()
-    conn.close()
-
-    rehydrator = StateRehydrator(str(db_path))
-    result = rehydrator.load_latest_state("test_repo")
-
-    ram = result["ram_cache"]["src/hacked.py"]
-
-    # If the rehydrator didn't cast to float(), this will be a string and crash the downstream math!
-    # Safe: this is a pytest-style test assertion in an embedded test
-    # function, not production runtime logic -- assert is the correct,
-    # idiomatic construct here, not a stripped-under-`-O` risk.
-    assert isinstance(ram["file_impact"], float), "State Rehydrator failed to sanitize dictionary overrides!"  # noqa: S101
-    assert isinstance(ram["control_flow_ratio"], float), "State Rehydrator allowed a string into a float field!"  # noqa: S101

--- a/tests/core_engine/test_aperture.py
+++ b/tests/core_engine/test_aperture.py
@@ -383,6 +383,15 @@ def test_aperture_gitignore_and_contraband(tmp_path):
     assert engine._check_ignore_rules("src/valid.py") is True
 
 
+def test_aperture_gitignore_survives_unreadable_file(tmp_path):
+    """A .gitignore that can't be opened (e.g. a directory, not a file) must not crash init."""
+    ignore_file = tmp_path / ".gitignore"
+    ignore_file.mkdir()
+
+    engine = ApertureFilter(tmp_path, MOCK_REGISTRY, MOCK_CONFIG)  # Must not raise.
+    assert engine._check_ignore_rules("src/valid.py") is True
+
+
 # ==============================================================================
 # TEST 12: IGNORED_DIRECTORIES CASE-INSENSITIVITY (ISSUE #255)
 # ==============================================================================

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -824,6 +824,43 @@ def test_spatial_mapper_ray_casting_collision_avoidance(spatial_mapper):
     )
 
 
+def test_spatial_mapper_uses_parent_logger_when_provided():
+    """Proves the mapper attaches as a child of a supplied parent logger instead of
+    creating its own root-level logger."""
+    parent = logging.getLogger("gitgalaxy_parent_test")
+    parent.setLevel(logging.DEBUG)
+
+    mapper = SpatialMapper(parent_logger=parent)
+
+    assert mapper.logger.name == "gitgalaxy_parent_test.spatial_mapper"
+    assert mapper.logger.level == logging.DEBUG
+
+
+def test_spatial_mapper_supermassive_sector_registers_in_all_bins(spatial_mapper):
+    """
+    Proves the spatial-hash registration handles a sector so massive that its
+    effective placement radius (post MACRO_STEP_FACTOR) envelops the origin --
+    i.e. eff_pr >= dist_to_center for the very first sector placed. This forces
+    the "register in every angular bin" branch (as opposed to the normal
+    angular-arc calculation), which no other test exercises: every other fixture
+    uses a handful of files, never enough for one sector's hull_radius to blow
+    past its own distance-to-center.
+    """
+    # A single sector with enough sibling files that its hull radius
+    # (footprint + sqrt(n) * MICRO_SPACING) overtakes CORE_EXCLUSION_RADIUS by
+    # more than the MACRO_STEP_FACTOR margin requires.
+    files = [{"path": f"monolith/file_{i}.py", "file_impact": 10.0} for i in range(700)]
+
+    mapped = spatial_mapper.map_repository(files)
+
+    # No crash, and every node still got real coordinates -- the actual
+    # behavior under test is line coverage of the all-bins registration branch,
+    # which has no externally observable side effect beyond "didn't crash and
+    # kept placing nodes correctly."
+    assert len(mapped) == 700
+    assert all("pos_x" in f and "pos_z" in f for f in mapped)
+
+
 # ==============================================================================
 # TEST 13: THE PROSE & SINGULARITY BYPASS
 # ==============================================================================
@@ -1214,6 +1251,75 @@ def test_detector_metadata_block_parsing():
     assert "line 1" in meta.get("purpose", ""), "Failed to read block metadata!"
     assert "line 2" in meta.get("purpose", ""), "Failed to continue reading block metadata!"
     assert "ignored" not in meta.get("purpose", ""), "Failed to stop at the boundary marker!"
+
+
+def test_detector_metadata_block_terminates_on_trailing_blank_line():
+    """
+    A blank line AFTER block text has started ends the block (break), with
+    no boundary marker needed at all -- distinct from the leading-blank-line
+    case below, which must be skipped rather than ending the block early.
+    """
+    opt_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
+    opt_detector.primary_rules["_meta_purpose_block"] = re.compile(r"^Purpose:")
+    opt_detector.primary_rules["_meta_boundary"] = None
+
+    comment_stream = "# Purpose:\n# Real purpose text.\n#\n# Some other ignored comment.\n"
+    meta = opt_detector._decode_comment_stream(comment_stream)
+
+    assert "Real purpose text" in meta.get("purpose", "")
+    assert "ignored" not in meta.get("purpose", ""), "A trailing blank line should end the block, not just the boundary marker!"
+
+
+def test_detector_metadata_block_skips_leading_blank_lines():
+    """A blank line BEFORE any block text has appeared is skipped, not treated as end-of-block."""
+    opt_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
+    opt_detector.primary_rules["_meta_purpose_block"] = re.compile(r"^Purpose:")
+    opt_detector.primary_rules["_meta_boundary"] = None
+
+    comment_stream = "# Purpose:\n#\n# Real purpose text, after a leading blank line.\n"
+    meta = opt_detector._decode_comment_stream(comment_stream)
+
+    assert "Real purpose text" in meta.get("purpose", ""), (
+        "A leading blank line inside the block should be skipped, not end the block before any text was captured!"
+    )
+
+
+def test_detector_metadata_single_line_purpose_continuation():
+    """
+    Single-line `Purpose: ...` metadata (not a block) continues accumulating
+    unrelated-looking comment lines into a fallback buffer until a blank
+    line, a boundary marker, or a block-purpose marker ends it.
+    """
+    opt_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
+    # _meta_purpose_block is deliberately cleared: MOCK_LANG_DEFS is a shared
+    # module-level dict and primary_rules is a reference into it, not a copy
+    # -- an earlier test in this file sets _meta_purpose_block, which would
+    # otherwise leak in here and hijack "Purpose:" into the block branch
+    # instead of the single-line branch this test targets.
+    opt_detector.primary_rules["_meta_purpose_block"] = None
+    opt_detector.primary_rules["_meta_boundary"] = re.compile(r"^\-\-\-")
+
+    comment_stream = "# Purpose: Does the thing.\n# And continues here.\n# ---\n# Not part of it.\n"
+    meta = opt_detector._decode_comment_stream(comment_stream)
+
+    purpose = meta.get("purpose", "")
+    assert "Does the thing" in purpose
+    assert "continues here" in purpose, "Single-line purpose continuation lines should accumulate!"
+    assert "Not part of it" not in purpose, "Continuation should stop at the boundary marker!"
+
+
+def test_detector_metadata_single_line_purpose_terminates_on_blank_line():
+    """Same single-line continuation, but terminated by a blank line instead of a boundary."""
+    opt_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
+    opt_detector.primary_rules["_meta_purpose_block"] = None  # see comment above
+    opt_detector.primary_rules["_meta_boundary"] = None
+
+    comment_stream = "# Purpose: Does the thing.\n#\n# Not part of it.\n"
+    meta = opt_detector._decode_comment_stream(comment_stream)
+
+    purpose = meta.get("purpose", "")
+    assert "Does the thing" in purpose
+    assert "Not part of it" not in purpose, "A blank line should terminate single-line purpose continuation!"
 
 
 # ==============================================================================

--- a/tests/core_engine/test_guidestar_lens.py
+++ b/tests/core_engine/test_guidestar_lens.py
@@ -180,3 +180,329 @@ def test_guidestar_documentation_coverage_prunes_ignored_dirs(tmp_path):
     # The ignored directory's own README must not count toward coverage.
     assert "node_modules" not in lens.documentation_coverage
     assert "src" in lens.documentation_coverage
+
+
+# ==============================================================================
+# TEST 6: LOCK INJECTION EDGE CASES (_inject_intent_lock / _inject_pattern_lock)
+# ==============================================================================
+def test_inject_intent_lock_ignores_falsy_filename(guidestar):
+    """An empty/None filename must be a no-op, not crash on .strip()."""
+    guidestar._inject_intent_lock("", "python", 0.9, "test")
+    guidestar._inject_intent_lock(None, "python", 0.9, "test")
+    assert guidestar.intent_locks == {}
+
+
+def test_inject_intent_lock_whitelist_bonus(tmp_path):
+    """A file on the priority whitelist gets a +0.1 confidence bonus, capped at 0.99."""
+    lens = GuideStarLens(root_path=tmp_path, priority_whitelist=["main.py"], guidestar_config=MOCK_GUIDESTAR_CONFIG)
+    lens._inject_intent_lock("main.py", "python", 0.95, "Some Proof")
+
+    found, lock = lens.get_intent_status("main.py")
+    assert found is True
+    assert lock["intensity"] == 0.99, "Whitelist bonus should push 0.95 + 0.1, capped at 0.99!"
+    assert "Whitelist Bonus" in lock["source_proof"]
+
+
+def test_inject_intent_lock_does_not_downgrade_existing_higher_confidence_lock(guidestar):
+    """A lower-confidence claim must never overwrite an existing higher-confidence lock."""
+    guidestar._inject_intent_lock("main.py", "python", 0.95, "Authoritative Source")
+    guidestar._inject_intent_lock("main.py", "javascript", 0.5, "Weak Guess")
+
+    found, lock = guidestar.get_intent_status("main.py")
+    assert found is True
+    assert lock["lang_id"] == "python", "A weaker claim overwrote a stronger, pre-existing intent lock!"
+
+
+def test_inject_pattern_lock_ignores_falsy_pattern(guidestar):
+    """An empty pattern must be a no-op."""
+    guidestar._inject_pattern_lock("", "python", 0.9, "test")
+    assert guidestar.pattern_locks == {}
+
+
+def test_inject_pattern_lock_does_not_downgrade_existing_higher_confidence_lock(guidestar):
+    """Same non-downgrade guarantee as intent locks, for pattern locks."""
+    guidestar._inject_pattern_lock("*.h", "objective-c", 0.99, "Authoritative")
+    guidestar._inject_pattern_lock("*.h", "cpp", 0.5, "Weak Guess")
+
+    assert guidestar.pattern_locks["*.h"]["lang_id"] == "objective-c"
+
+
+# ==============================================================================
+# TEST 7: MAKEFILE PARSING (never previously exercised -- Makefile is in
+# MOCK_GUIDESTAR_CONFIG's MANIFEST_MAP, but no existing test ever creates one)
+# ==============================================================================
+def test_guidestar_makefile_parsing(guidestar, tmp_path):
+    """
+    Proves both Makefile parsing strategies: variable assignments
+    (SRCS = main.c helper.c) and target lines (build: main.o), while
+    correctly excluding the standard phony targets (all/clean/test/install).
+    """
+    makefile_path = tmp_path / "Makefile"
+    makefile_path.write_text(
+        "SRCS = main.c helper.c\n"
+        "\n"
+        "all: build\n"
+        "clean:\n"
+        "\trm -f *.o\n"
+        "build: main.o helper.o\n"
+        "\tgcc -o build main.o helper.o\n",
+        encoding="utf-8",
+    )
+
+    guidestar.scan_project_config()
+
+    found, lock = guidestar.get_intent_status("main.c")
+    assert found is True
+    assert lock["source_proof"] == "Manifest Source (Makefile)"
+
+    found, lock = guidestar.get_intent_status("helper.c")
+    assert found is True
+
+    # "build" is a real target line, not a phony one -- should get locked.
+    found, lock = guidestar.get_intent_status("build")
+    assert found is True
+    assert lock["source_proof"] == "Makefile Target"
+
+    # "all" and "clean" are phony targets and must be excluded.
+    found, _ = guidestar.get_intent_status("all")
+    assert found is False
+    found, _ = guidestar.get_intent_status("clean")
+    assert found is False
+
+
+# ==============================================================================
+# TEST 8: TOML-STYLE MANIFEST PARSING (pyproject.toml / Cargo.toml / requirements.txt)
+# ==============================================================================
+def test_guidestar_toml_style_manifest_parsing(guidestar, tmp_path):
+    """
+    Proves the regex-based TOML parser extracts both `path = "..."` entries
+    (Cargo-style) and `entry_point = "module.sub:func"` style Python entry
+    points from pyproject.toml.
+    """
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(
+        '[tool.poetry.dependencies]\n'
+        'mylib = { path = "libs/mylib" }\n'
+        '\n'
+        '[project.scripts]\n'
+        'mycli = "mypackage.cli:main"\n',
+        encoding="utf-8",
+    )
+
+    guidestar.scan_project_config()
+
+    found, lock = guidestar.get_intent_status("libs/mylib")
+    assert found is True
+    assert "Manifest Roadmap" in lock["source_proof"]
+
+
+def test_guidestar_manifest_parsers_survive_malformed_input(guidestar, tmp_path):
+    """
+    Stress test: package.json with invalid JSON, and a Makefile/pyproject.toml
+    that exist but can't be meaningfully parsed, must not crash
+    scan_project_config -- each parser's own try/except should swallow the
+    error and let the scan continue.
+    """
+    (tmp_path / "package.json").write_text("{ not valid json !!!", encoding="utf-8")
+    (tmp_path / "Makefile").write_bytes(b"\xff\xfe\x00\x01 binary garbage, not text")
+
+    # Must not raise.
+    guidestar.scan_project_config()
+    assert guidestar.intent_locks.get("package.json") is not None, (
+        "The manifest itself should still get a baseline lock even if its contents fail to parse."
+    )
+
+
+# ==============================================================================
+# TEST 9: PACKAGE.JSON 'bin' FIELD VARIATIONS (string vs. dict)
+# ==============================================================================
+def test_guidestar_package_json_bin_as_string(guidestar, tmp_path):
+    """A package.json with `"bin": "cli.js"` (single string, not a dict) must still lock."""
+    pkg_path = tmp_path / "package.json"
+    pkg_path.write_text(json.dumps({"bin": "cli.js"}), encoding="utf-8")
+
+    guidestar.scan_project_config()
+
+    found, lock = guidestar.get_intent_status("cli.js")
+    assert found is True
+    assert "Manifest Binary" in lock["source_proof"]
+
+
+def test_guidestar_package_json_bin_as_dict_multiple_entries(guidestar, tmp_path):
+    """A package.json with multiple named bin entries must lock every target."""
+    pkg_path = tmp_path / "package.json"
+    pkg_path.write_text(
+        json.dumps({"bin": {"tool-a": "bin/tool-a.js", "tool-b": "bin/tool-b.js"}}), encoding="utf-8"
+    )
+
+    guidestar.scan_project_config()
+
+    for target in ("bin/tool-a.js", "bin/tool-b.js"):
+        found, lock = guidestar.get_intent_status(target)
+        assert found is True, f"{target} should have been locked from the bin dict!"
+
+
+# ==============================================================================
+# TEST 10: .gitattributes MALFORMED / COMMENT LINES
+# ==============================================================================
+def test_guidestar_gitattributes_skips_comments_and_malformed_lines(guidestar, tmp_path):
+    """
+    Comment lines, blank lines, and lines without at least a pattern + one
+    attribute must be safely skipped, not crash the parser.
+    """
+    attr_path = tmp_path / ".gitattributes"
+    attr_path.write_text(
+        "# this is a comment\n"
+        "\n"
+        "*.h linguist-language=C++\n"
+        "just_a_pattern_with_no_attrs\n",
+        encoding="utf-8",
+    )
+
+    guidestar.scan_project_config()
+
+    found, lock = guidestar.get_intent_status("include/math_ops.h")
+    assert found is True
+    assert lock["lang_id"] == "cpp"
+
+
+def test_guidestar_gitattributes_survives_unreadable_file(guidestar, tmp_path):
+    """A .gitattributes that raises on open() (e.g. a directory, not a file) must not crash the scan."""
+    attr_path = tmp_path / ".gitattributes"
+    attr_path.mkdir()  # A directory named .gitattributes can't be opened as a file.
+
+    guidestar.scan_project_config()  # Must not raise.
+
+
+# ==============================================================================
+# TEST 11: .gitignore SURVIVES UNREADABLE FILE
+# ==============================================================================
+def test_guidestar_gitignore_survives_unreadable_file(guidestar, tmp_path):
+    """A .gitignore that can't be opened must not crash the scan."""
+    ignore_path = tmp_path / ".gitignore"
+    ignore_path.mkdir()
+
+    guidestar.scan_project_config()  # Must not raise.
+
+
+# ==============================================================================
+# TEST 12: DOCUMENTATION COVERAGE -- SCAN ROOT ITSELF INSIDE AN IGNORED DIR
+# ==============================================================================
+def test_guidestar_documentation_coverage_root_inside_ignored_dir(tmp_path):
+    """
+    Edge case: if the scan root itself is nested inside a directory whose
+    name matches IGNORED_DIRECTORIES, os.walk's dirs[:] pruning can't help
+    (it only prevents further descent, the root itself was never a
+    candidate for pruning) -- the explicit `dir_path.parts` check exists
+    specifically to catch this.
+    """
+    nested_root = tmp_path / "vendor" / "some_project"
+    nested_root.mkdir(parents=True)
+    (nested_root / "README.md").write_text("z" * 500, encoding="utf-8")
+
+    lens = GuideStarLens(
+        root_path=nested_root,
+        guidestar_config={**MOCK_GUIDESTAR_CONFIG, "IGNORED_DIRECTORIES": {"vendor"}},
+    )
+    lens._calculate_documentation_coverage()
+
+    assert lens.documentation_coverage == {}, (
+        "A scan root nested inside an ignored directory name should contribute no documentation coverage."
+    )
+
+
+# ==============================================================================
+# TEST 13: ORPHANED FEATURE -- _extract_execution_triggers is never called
+# from anywhere in the codebase (see the filed GitHub issue). Tested here in
+# isolation so the logic itself has coverage regardless of the wiring
+# decision.
+# ==============================================================================
+def test_extract_execution_triggers_in_isolation(guidestar):
+    """
+    Direct unit test of _extract_execution_triggers's own regex/dispatch
+    logic, since nothing in the production pipeline currently calls it.
+    """
+    text = "Run the demo with `python demo.py` or `./run.sh` or `node server.js`."
+    guidestar._extract_execution_triggers(text)
+
+    found, lock = guidestar.get_intent_status("demo.py")
+    assert found is True
+    assert lock["lang_id"] == "python"
+    assert "Execution Trigger" in lock["source_proof"]
+
+    # "./run.sh" -- the "./" prefix forces predicted_lang to "unknown"
+    # regardless of EXEC_PREFIX_MAP, per the explicit override in the method.
+    found, lock = guidestar.get_intent_status("run.sh")
+    assert found is True
+    assert lock["lang_id"] == "unknown"
+
+    found, lock = guidestar.get_intent_status("server.js")
+    assert found is True
+    assert lock["lang_id"] == "javascript"
+
+
+# ==============================================================================
+# TEST 14: PARENT LOGGER PROPAGATION
+# ==============================================================================
+def test_guidestar_uses_parent_logger_when_provided(tmp_path):
+    """A parent_logger should be adopted (child logger, same level), not ignored."""
+    import logging
+
+    parent = logging.getLogger("test_parent_guidestar")
+    parent.setLevel(logging.WARNING)
+
+    lens = GuideStarLens(root_path=tmp_path, parent_logger=parent, guidestar_config=MOCK_GUIDESTAR_CONFIG)
+
+    assert lens.logger.parent is parent
+    assert lens.logger.level == logging.WARNING
+
+
+# ==============================================================================
+# TEST 15: DEEP MANIFEST INSPECTION -- OUTER EXCEPTION HANDLER
+# ==============================================================================
+def test_guidestar_deep_inspect_manifest_survives_unopenable_file(guidestar, tmp_path):
+    """
+    A manifest path that can't even be opened (e.g. package.json exists as a
+    directory, not a file) must be caught by _deep_inspect_manifest's own
+    try/except, not crash the whole scan. The per-parser try/excepts can't
+    catch this since it fails before any parser is even reached.
+    """
+    (tmp_path / "package.json").mkdir()
+
+    guidestar.scan_project_config()  # Must not raise.
+
+    # The manifest-level lock (from _scan_package_manifests, before deep
+    # inspection) should still have been applied.
+    found, _ = guidestar.get_intent_status("package.json")
+    assert found is True
+
+
+# ==============================================================================
+# TEST 16: DOCUMENTATION COVERAGE -- ROOT-LEVEL DOC FILE & UNSTATABLE FILE
+# ==============================================================================
+def test_guidestar_documentation_coverage_root_level_and_broken_symlink(tmp_path):
+    """
+    A doc file directly in the scan root must be keyed as '__root__', and a
+    broken symlink (stat() raises OSError) must be silently skipped rather
+    than crashing the coverage scan.
+    """
+    (tmp_path / "README.md").write_text("root doc content " * 20, encoding="utf-8")
+
+    broken_link = tmp_path / "BROKEN_LINK.md"
+    broken_link.symlink_to(tmp_path / "does_not_exist.md")
+
+    lens = GuideStarLens(root_path=tmp_path, guidestar_config=MOCK_GUIDESTAR_CONFIG)
+    lens._calculate_documentation_coverage()  # Must not raise on the broken symlink.
+
+    assert "__root__" in lens.documentation_coverage
+
+
+def test_toml_parser_survives_unopenable_file_directly(guidestar, tmp_path):
+    """
+    Direct unit test of _parse_toml_style_manifest's own try/except: called
+    with a path that can't be opened, it must swallow the error rather than
+    raise. (Going through scan_project_config() can't isolate this specific
+    handler -- _deep_inspect_manifest's outer open() on the same path fails
+    first and is caught by its own, already-covered except block instead.)
+    """
+    guidestar._parse_toml_style_manifest(tmp_path / "does_not_exist" / "pyproject.toml", "python")

--- a/tests/core_engine/test_prism.py
+++ b/tests/core_engine/test_prism.py
@@ -3,7 +3,7 @@ import re
 from unittest.mock import patch
 
 # Adjust this import to match your project structure
-from gitgalaxy.core.prism import Prism
+from gitgalaxy.core.prism import Prism, PrismError
 
 # ==============================================================================
 # MOCK MATRIX CALIBRATION
@@ -72,6 +72,33 @@ def test_prism_prose_bypass(prism_engine):
     assert result["comment_stream"] == content
     assert result["coding_loc"] == 0
     assert result["doc_loc"] == 3
+
+
+def test_prism_empty_content_short_circuits(prism_engine):
+    """An empty content buffer must return the zeroed-out result shape directly, skipping all regex work."""
+    result = prism_engine.split_streams("", primary_lang="python")
+    assert result == {
+        "code_stream": "",
+        "comment_stream": "",
+        "coding_loc": 0,
+        "doc_loc": 0,
+        "mitigations": [],
+    }
+
+
+def test_prism_catastrophic_failure_wraps_in_prism_error(prism_engine):
+    """
+    Stress test: if something inside the scan raises unexpectedly (not one
+    of the specific, already-handled cases), split_streams must wrap it in a
+    PrismError with the original exception chained -- never let a raw,
+    unrelated exception type escape to the caller.
+    """
+    with patch.object(prism_engine, "_strip_segment_comments", side_effect=RuntimeError("simulated engine failure")):
+        with pytest.raises(PrismError) as exc_info:
+            prism_engine.split_streams("some code", primary_lang="python")
+
+    assert "simulated engine failure" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
 def test_prism_metadata_guard(prism_engine):

--- a/tests/core_engine/test_signal_processor.py
+++ b/tests/core_engine/test_signal_processor.py
@@ -1128,9 +1128,19 @@ def test_signal_processor_crypto_professionalism_shield(processor):
 # TEST 31: LLM API SECRETS LEAK
 # ==============================================================================
 def test_signal_processor_llm_api_secrets(processor):
-    """Proves that hardcoded secrets mixed with LLM APIs trigger a massive careless amplifier."""
+    """
+    Proves that hardcoded secrets mixed with LLM APIs trigger a massive
+    careless amplifier in _calc_secrets_risk.
+
+    Regression test: this test previously built both fixtures but never
+    called calculate_risk_vector or asserted anything on either -- a
+    complete no-op that always passed regardless of whether the LLM
+    amplifier (or _calc_secrets_risk at all) worked. Ruff's F841/RUF059
+    would have caught the resulting unused variables, but tests/ is out
+    of scope for the ruff baseline, so it went unnoticed.
+    """
     # 1. Standard secret leak (Requires sec_heat_triggers to bypass the 2.0 clamp)
-    _unused_m_std, sig_std = create_synthetic_star(
+    m_std, sig_std = create_synthetic_star(
         processor,
         "std_leak",
         500,
@@ -1138,12 +1148,73 @@ def test_signal_processor_llm_api_secrets(processor):
     )
 
     # 2. Careless LLM API secret leak (Calling APIs without using global variables)
-    m_llm, _unused_sig_llm = create_synthetic_star(
+    m_llm, sig_llm = create_synthetic_star(
         processor,
         "llm_leak",
         500,
         {"sec_hardcoded_secrets": 1, "llm_api": 5, "globals": 0, "sec_reflection_metaprogramming": 1},
     )
+
+    r_std = processor.calculate_risk_vector(m_std, sig_std)
+    r_llm = processor.calculate_risk_vector(m_llm, sig_llm)
+
+    idx_sec = processor.RISK_SCHEMA.index("secrets_risk")
+
+    assert r_llm["risk_vector"][idx_sec] > r_std["risk_vector"][idx_sec], (
+        "Careless LLM API secret leak (no globals) should score higher than a standard leak, "
+        "via the 3x careless_amplifiers spike -- it didn't!"
+    )
+    assert r_std["risk_vector"][idx_sec] > 0.0, "A genuine hardcoded-secret signal should never score exactly 0."
+
+
+def test_signal_processor_secrets_risk_zero_when_no_hardcoded_signal(processor):
+    """base_leak == 0 must short-circuit to a flat 0.0, never entering the amplifier math."""
+    meta, sig = create_synthetic_star(processor, "clean_file", 500, {"llm_api": 5, "globals": 0})
+    result = processor.calculate_risk_vector(meta, sig)
+    idx_sec = processor.RISK_SCHEMA.index("secrets_risk")
+    assert result["risk_vector"][idx_sec] == 0.0
+
+
+def test_signal_processor_secrets_risk_clamped_without_reflection_signal(processor):
+    """
+    Outside paranoid mode, with zero sec_reflection_metaprogramming signal,
+    careless_amplifiers is clamped to a maximum of 2.0 -- proves the clamp
+    branch itself (as opposed to the LLM-amplifier test above, which
+    deliberately supplies reflection signal to bypass this exact clamp).
+    """
+    meta, sig = create_synthetic_star(
+        processor, "clamped_leak", 500, {"sec_hardcoded_secrets": 1, "globals": 1, "debug_prints": 50}
+    )
+    result = processor.calculate_risk_vector(meta, sig)
+    idx_sec = processor.RISK_SCHEMA.index("secrets_risk")
+    # A huge debug_prints count would blow the amplifier way past 2.0 if
+    # unclamped; the score should still land in a sane, non-maxed-out range.
+    assert 0.0 < result["risk_vector"][idx_sec] < 100.0
+
+
+def test_signal_processor_secrets_risk_paranoid_mode_skips_clamp(processor):
+    """In paranoid mode, the 2.0 clamp never applies regardless of reflection signal."""
+    meta, sig = create_synthetic_star(
+        processor, "paranoid_leak", 500, {"sec_hardcoded_secrets": 1, "globals": 1, "debug_prints": 50}
+    )
+    processor.is_paranoid = True
+    try:
+        result = processor.calculate_risk_vector(meta, sig)
+    finally:
+        processor.is_paranoid = False
+
+    idx_sec = processor.RISK_SCHEMA.index("secrets_risk")
+    assert result["risk_vector"][idx_sec] > 0.0
+
+
+def test_signal_processor_secrets_risk_low_score_floors_to_zero(processor):
+    """A raw score under 5.0 is explicitly floored to 0.0, not left as noisy near-zero signal."""
+    # A single hardcoded-secret hit in an enormous file produces a tiny
+    # density, and thus a tiny sigmoid score -- exactly the < 5.0 floor case.
+    meta, sig = create_synthetic_star(processor, "diluted_leak", 50000, {"sec_hardcoded_secrets": 1})
+    result = processor.calculate_risk_vector(meta, sig)
+    idx_sec = processor.RISK_SCHEMA.index("secrets_risk")
+    assert result["risk_vector"][idx_sec] == 0.0, "A sub-5.0 raw score should floor to exactly 0.0, not a noisy near-zero value."
 
 
 # ==============================================================================

--- a/tests/core_engine/test_state_rehydrator.py
+++ b/tests/core_engine/test_state_rehydrator.py
@@ -194,9 +194,53 @@ def test_rehydrator_legacy_schema_drift(tmp_path):
     try:
         # If this throws an IndexError, the Rehydrator isn't resilient to schema drift!
         rehydrator.load_latest_state("test_repo")
-        
-        # Depending on how we implemented the fix in state_rehydrator.py, it should 
-        # either succeed with a default value, or we need to update state_rehydrator.py 
+
+        # Depending on how we implemented the fix in state_rehydrator.py, it should
+        # either succeed with a default value, or we need to update state_rehydrator.py
         # to use `f.keys()` to safely check if the column exists.
     except IndexError:
         pytest.fail("The StateRehydrator threw an IndexError on legacy database schemas!")
+
+
+# ==============================================================================
+# TEST 6: DICTIONARY OVERRIDE TYPE SPOOFING
+# ==============================================================================
+def test_rehydrator_dictionary_type_spoofing(tmp_path):
+    """
+    DEVIOUS EDGE CASE: An attacker (or corrupted DB) places a String into a column
+    that the RAM cache strictly expects to be a Float. When the Signal Processor
+    attempts to execute metrics math on this dictionary override, it will crash.
+    The Rehydrator must catch the resulting ValueError/TypeError and fall back to
+    a cold start (None) rather than propagating the crash -- the same way it
+    already handles a corrupted/poisoned SQLite file.
+    """
+    db_path = tmp_path / "spoofed_master.db"
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute("CREATE TABLE repo_data (repo_name TEXT, commit_hash TEXT, commit_date INTEGER)")
+    cursor.execute("""
+        CREATE TABLE file_data (
+            repo_name TEXT, commit_hash TEXT, file_path TEXT, language TEXT,
+            total_loc INTEGER, coding_loc INTEGER, structural_mass REAL,
+            control_flow_ratio REAL, popularity INTEGER, author TEXT,
+            ai_threat_score REAL, silo_risk REAL, total_downstream INTEGER, total_upstream INTEGER
+        )
+    """)
+
+    cursor.execute("INSERT INTO repo_data VALUES ('test_repo', 'hash_1', 1600000000)")
+
+    # MALICIOUS INJECTION: Injecting a String 'HACKED' into the Float columns
+    cursor.execute("""
+        INSERT INTO file_data VALUES (
+            'test_repo', 'hash_1', 'src/hacked.py', 'python',
+            150, 100, 'HACKED_MASS', 'HACKED_CFR', 12, 'Attacker', 'HACKED_THREAT', 12.5, 4, 2
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    rehydrator = StateRehydrator(str(db_path))
+    result = rehydrator.load_latest_state("test_repo")
+
+    assert result is None, "Failed to reject a type-spoofed database gracefully -- crashed instead of falling back to a cold start!"

--- a/tests/security_auditing/test_network_risk_sensor.py
+++ b/tests/security_auditing/test_network_risk_sensor.py
@@ -374,3 +374,228 @@ def test_coverage_mapping_duplicate_filename_ambiguous(sensor):
     assert "/src/service_b/utils.py" not in coverage_map, (
         "Ambiguous 'utils' import misattributed test coverage to service_b/utils.py!"
     )
+
+
+# ==============================================================================
+# TEST 10: TEST COVERAGE MAPPING — HAPPY PATH (unambiguous resolution)
+# ==============================================================================
+def test_coverage_mapping_happy_path(sensor):
+    """
+    Proves extract_test_coverage_mapping actually populates the coverage map
+    end-to-end when a test file has an unambiguous import and calls_out_to
+    data -- the success path was previously untested (only the ambiguous
+    rejection path had coverage), even though it's the whole point of the
+    function: mapping test->production calls for the verification-risk
+    dampener in signal_processor.py.
+    """
+    files = [
+        {"path": "/src/payments/charge.py", "raw_imports": []},
+        {
+            "path": "/tests/test_charge.py",
+            "raw_imports": ["/src/payments/charge.py"],
+            "functions": [
+                {
+                    "calls_out_to": ["run_charge", "refund_charge"],
+                    "impact": 12.5,
+                    "hit_vector": {"test": 3, "test_skip": 0, "decorators": 1},
+                },
+                {
+                    # A second test function targeting the same production file
+                    # and one overlapping function name -- proves multiple test
+                    # payloads accumulate in a list rather than overwriting.
+                    "calls_out_to": ["run_charge"],
+                    "impact": 4.0,
+                    "hit_vector": {"test": 1, "test_skip": 1, "decorators": 0},
+                },
+            ],
+        },
+    ]
+
+    coverage_map = sensor.extract_test_coverage_mapping(files)
+
+    assert "/src/payments/charge.py" in coverage_map, "Unambiguous test coverage mapping was dropped entirely!"
+    target = coverage_map["/src/payments/charge.py"]
+
+    assert "run_charge" in target and "refund_charge" in target
+    assert len(target["run_charge"]) == 2, "Both test functions targeting run_charge should accumulate, not overwrite."
+    assert len(target["refund_charge"]) == 1
+
+    first_payload = target["run_charge"][0]
+    assert first_payload["impact"] == 12.5
+    assert first_payload["target_count"] == 2
+    assert first_payload["test_hits"] == 3
+    assert first_payload["decorators"] == 1
+
+    second_payload = target["run_charge"][1]
+    assert second_payload["test_skip_hits"] == 1
+
+
+def test_coverage_mapping_skips_test_functions_with_no_calls(sensor):
+    """A test function with an empty calls_out_to shouldn't appear in the map at all."""
+    files = [
+        {"path": "/src/lib.py", "raw_imports": []},
+        {
+            "path": "/tests/test_lib.py",
+            "raw_imports": ["/src/lib.py"],
+            "functions": [{"calls_out_to": [], "impact": 1.0, "hit_vector": {}}],
+        },
+    ]
+
+    coverage_map = sensor.extract_test_coverage_mapping(files)
+    assert coverage_map == {}, "A test function with zero outbound calls should contribute nothing to the map."
+
+
+# ==============================================================================
+# TEST 11: DUPLICATE-EDGE WEIGHT ACCUMULATION
+# ==============================================================================
+@pytest.mark.skipif(not HAS_NETWORKX, reason="Requires NetworkX")
+def test_network_duplicate_edge_weight_accumulates(sensor):
+    """
+    Two separate imports from the same file to the same target must
+    accumulate into a single edge's weight, not silently overwrite it or
+    create a second parallel edge (DiGraph can't hold parallel edges anyway,
+    but the accumulation logic itself -- G[u][v]["weight"] += weight --
+    had no test exercising the "edge already exists" branch at all).
+    """
+    files = [
+        {"path": "/src/shared/helpers.py", "raw_imports": []},
+        {
+            "path": "/src/app.py",
+            # Two distinct entity-imports resolving to the same target file:
+            # first import creates the edge (weight 1.5, has an entity), the
+            # second must hit the "G.has_edge" branch and add its own weight.
+            "raw_imports": [
+                ("/src/shared/helpers.py", "format_date"),
+                ("/src/shared/helpers.py", "parse_config"),
+            ],
+        },
+    ]
+
+    mapped_files, _ = sensor.build_dependency_graph(files)
+    helpers = next(f for f in mapped_files if f["path"] == "/src/shared/helpers.py")
+
+    # Both entity imports carry weight 1.5 each -- accumulated weight should
+    # be reflected in in_degree still being 1 (one edge, DiGraph semantics)
+    # while the underlying edge weight (not directly exposed in telemetry,
+    # but exercised via pagerank/betweenness using it) doesn't crash and the
+    # edge count stays correct.
+    assert helpers["telemetry"]["network_metrics"]["in_degree"] == 1, (
+        "Two imports to the same target should still be exactly one graph edge."
+    )
+
+
+# ==============================================================================
+# TEST 12: NETWORK MATH RESILIENCE — CENTRALITY COMPUTATION FAILURE
+# ==============================================================================
+@pytest.mark.skipif(not HAS_NETWORKX, reason="Requires NetworkX")
+def test_network_math_failure_degrades_to_zero(sensor, parsed_files_universe):
+    """
+    Stress test: if NetworkX's centrality math itself throws (e.g. a future
+    NetworkX version changes behavior, or an unexpected graph shape), the
+    sensor must degrade every node to a 0.0 score rather than crashing the
+    whole pipeline. This exercises the outer `except Exception` fallback in
+    build_dependency_graph, never previously triggered by any test.
+    """
+    with patch("networkx.pagerank", side_effect=RuntimeError("simulated convergence failure")):
+        mapped_files, _ = sensor.build_dependency_graph(parsed_files_universe)
+
+    foundation = next(f for f in mapped_files if f["path"] == "/src/core/foundation.py")
+    metrics = foundation["telemetry"]["network_metrics"]
+    assert metrics["pagerank_score"] == 0.0
+    assert metrics["betweenness_score"] == 0.0
+    assert metrics["closeness_score"] == 0.0
+
+
+# ==============================================================================
+# TEST 13: MACRO NETWORK MATH RESILIENCE — INDIVIDUAL METRIC FAILURES
+# ==============================================================================
+@pytest.mark.skipif(not HAS_NETWORKX, reason="Requires NetworkX")
+def test_macro_metrics_individual_failures_stay_isolated(sensor, parsed_files_universe):
+    """
+    Stress test: each macro-ecosystem metric (modularity, assortativity,
+    cyclic density, avg path length, articulation points) is computed in
+    its own try/except so one metric's failure doesn't take down the
+    others. Previously none of these five except-blocks had a single test
+    forcing the failure path -- they were trusted by inspection only.
+    """
+    with (
+        patch("networkx.degree_assortativity_coefficient", side_effect=RuntimeError("boom")),
+        patch("networkx.average_shortest_path_length", side_effect=RuntimeError("boom")),
+        patch("networkx.articulation_points", side_effect=RuntimeError("boom")),
+    ):
+        _, macro_metrics = sensor.build_dependency_graph(parsed_files_universe)
+
+    assert macro_metrics["assortativity"] is None, "A failed assortativity computation must stay None, not 0.0 or crash."
+    assert macro_metrics["avg_path_length"] is None
+    assert macro_metrics["articulation_points"] is None
+    # Modularity and cyclic_density weren't patched to fail -- they should
+    # still have computed normally, proving the try/except isolation really
+    # is per-metric and not a single all-or-nothing block.
+    assert macro_metrics["modularity"] is not None
+    assert macro_metrics["cyclic_density"] is not None
+
+
+def test_cyclic_density_failure_stays_isolated(sensor, parsed_files_universe):
+    """Same isolation guarantee, targeting cyclic density specifically."""
+    with patch("networkx.strongly_connected_components", side_effect=RuntimeError("boom")):
+        _, macro_metrics = sensor.build_dependency_graph(parsed_files_universe)
+
+    assert macro_metrics["cyclic_density"] is None
+    assert macro_metrics["modularity"] is not None, "An unrelated metric's failure shouldn't take modularity down with it."
+
+
+def test_modularity_falls_back_to_greedy_when_louvain_unavailable(sensor, parsed_files_universe):
+    """
+    Older NetworkX versions don't have louvain_communities. The code catches
+    that specific AttributeError and falls back to greedy_modularity_communities
+    -- previously untested, so a NetworkX downgrade could have silently broken
+    modularity for anyone on an older pin without a single test noticing.
+    """
+    with patch(
+        "networkx.algorithms.community.louvain_communities",
+        side_effect=AttributeError("simulated: old networkx has no louvain_communities"),
+    ):
+        _, macro_metrics = sensor.build_dependency_graph(parsed_files_universe)
+
+    assert macro_metrics["modularity"] is not None, (
+        "Louvain AttributeError should fall back to greedy_modularity_communities, not leave modularity unset."
+    )
+
+
+def test_macro_math_outer_failure_returns_all_none(sensor, parsed_files_universe):
+    """
+    Stress test for the outermost `except Exception` around the whole macro
+    block (e.g. G.to_undirected() itself failing) -- must degrade every
+    macro metric to None rather than crashing build_dependency_graph
+    entirely and losing the per-file network metrics already computed.
+    """
+    with patch("networkx.DiGraph.to_undirected", side_effect=RuntimeError("boom")):
+        mapped_files, macro_metrics = sensor.build_dependency_graph(parsed_files_universe)
+
+    assert all(v is None for v in macro_metrics.values()), "Outer macro-math failure should leave every metric None."
+    # Per-file network metrics (computed earlier in the function, before the
+    # macro block) must survive even though the macro block blew up.
+    foundation = next(f for f in mapped_files if f["path"] == "/src/core/foundation.py")
+    assert "network_metrics" in foundation["telemetry"]
+
+
+# ==============================================================================
+# TEST 14: RESOLUTION MAP / TARGET RESOLUTION EDGE CASES
+# ==============================================================================
+def test_build_resolution_map_skips_files_with_no_path(sensor):
+    """A file dict missing its 'path' key must be skipped, not crash Path("")."""
+    files = [{"raw_imports": []}, {"path": "", "raw_imports": []}, {"path": "/src/real.py", "raw_imports": []}]
+    resolution_map = sensor._build_resolution_map(files)
+    assert list(resolution_map.keys()) == ["/src/real.py", "real.py", "real"]
+
+
+def test_resolve_target_returns_none_for_external_package_import(sensor):
+    """
+    An import of a genuinely external package (e.g. `import numpy`) has no
+    corresponding file in the repo at all -- _resolve_target must return
+    None cleanly rather than raising, since resolution_map.get() will find
+    nothing at any stage.
+    """
+    resolution_map = sensor._build_resolution_map([{"path": "/src/real.py", "raw_imports": []}])
+    assert sensor._resolve_target("numpy", resolution_map, "/src/real.py") is None
+    assert sensor._resolve_target("some.deeply.nested.external.pkg", resolution_map, "/src/real.py") is None


### PR DESCRIPTION
## Summary

Autonomous overnight sweep across `gitgalaxy/core/` (+ `gitgalaxy/metrics/signal_processor.py`) improving test coverage and stress-testing error paths with adversarial input, mocked exception injection, and previously-untested branches.

Two real bugs were found and fixed:

- **`state_rehydrator.py`**: an embedded test function was accidentally left inside the *production source file* (never collected by pytest, since `testpaths = ["tests"]`). Running it directly proved `load_latest_state()` crashes with `ValueError` on row-level type-confused data (e.g. a non-numeric string in a `REAL` column) despite the docstring's defensive-fallback claim. Fixed by broadening the except clause to `(sqlite3.Error, ValueError, TypeError, KeyError, IndexError)` so type-spoofed rows fall back to a cold start instead of crashing the delta-scan path. The test was relocated to its proper home in `tests/core_engine/test_state_rehydrator.py`.
- **`signal_processor.py`**: `test_signal_processor_llm_api_secrets` built two fixtures but never called `calculate_risk_vector()` or asserted anything on either — a complete no-op that always passed regardless of correctness, leaving `_calc_secrets_risk` (36 statements, hardcoded-credential detection) essentially untested. Rewrote it to actually score both fixtures and assert the LLM-amplified leak scores higher; added 4 more tests for the zero-signal, clamp, and paranoid-mode-skips-clamp branches. (The underlying production formula was already correct — this was purely a test-quality bug.)

## Coverage deltas

| File | Before | After |
|---|---|---|
| `state_rehydrator.py` | 72% | 100% |
| `guidestar_lens.py` | 79% | 100% |
| `spatial_mapper.py` | 98% | 100% |
| `network_risk_sensor.py` | 83% | 97% |
| `signal_processor.py` | 91% | 94% |
| `prism.py` | 93% | 94% |
| `detector.py` | 92% | 93% |

## Also found (filed as a separate issue, not fixed here)

`guidestar_lens.py`'s `_extract_execution_triggers()` and `README_TARGET_HEADERS` are dead code — a half-built feature to infer intent locks from README usage examples, never wired into `scan_project_config()`'s dispatch list. Filed as #513 since deciding whether to wire it up or delete it is a product call, not a mechanical fix. Added a direct unit test for the method in isolation to lock in its current (correct, just unreachable) behavior.

## Other notes

- `detector.py`'s test suite has a pre-existing test-isolation hazard: `MOCK_LANG_DEFS` is a shared module-level dict and `StructuralExtractor.primary_rules` holds a reference into it, not a copy, so mutations from earlier tests can leak into later ones. Worked around locally in the new tests (explicit reset of the mutated key) rather than refactoring the shared fixture — that's a larger, separate change.
- Confirmed the mypy-audit gate's 3 reported "new" findings are pre-existing on `main` (verified via `git stash` + re-run), unrelated to this branch.

## Test plan

- [x] `pytest tests/` — 916 passed
- [x] `python tests/ruff_audit.py --ci` — no new findings beyond baseline
- [x] `ruff format --check` on the modified source file
- [x] Confirmed pre-existing mypy findings are unrelated to this branch (present on clean `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)