### PR TITLE
Close #608: strict tests for scala, fix 9 real regex bugs

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -7741,8 +7741,11 @@ LANGUAGE_DEFINITIONS = {
             # 13. doc: Structured Documentation. Scaladoc documentation (/**) and annotations.
             "doc": re.compile(r"/\*\*|@param|@return|@tparam|@throws|@see|@note"),
             # 14. test: Testing & Assertions. ScalaTest, MUnit, and standard expect/verify markers.
+            # BUG FIX: `test\s*\(` ends on `(` (non-word), so the shared
+            # trailing \b could never fire. Never matched.
             "test": re.compile(
-                r"\b(test\s*\(|it\s+should|assertEquals|assertThrows|AnyFunSuite|WordSpec|munit|weaver)\b|\b(?:must|expect|assert)\s*[\(\{]"
+                r"\b(?:it\s+should|assertEquals|assertThrows|AnyFunSuite|WordSpec|munit|weaver)\b"
+                r"|\btest\s*\(|\b(?:must|expect|assert)\s*[\(\{]"
             ),
             # --- PHASE 3: ARCHITECTURE & DOMAIN SENSORS ---
             # 15. concurrency: Temporal Static. Effect systems and Actor paradigms (ZIO, Cats Effect, Akka).
@@ -7799,8 +7802,14 @@ LANGUAGE_DEFINITIONS = {
                 re.M,
             ),
             # 25. ownership: Authorship indicators.
+            # BUG FIX: the Scaladoc `@author` tag was grouped with
+            # `Created by`/`Maintainer`/`Copyright`, all of which require a
+            # literal `:` -- but Scaladoc's actual convention (matching
+            # Javadoc, and how java's own ownership rule already handles
+            # it) is `@author Jane Doe`, with no colon at all. The colon
+            # requirement meant the real Scaladoc tag never matched.
             "ownership": re.compile(
-                r"(?:@author|Created by|Maintainer|Copyright|Tim Berners-Lee):\s+([^\n]+)",
+                r"@author\s+([^\n]+)|(?:Created by|Maintainer|Copyright|Tim Berners-Lee):\s+([^\n]+)",
                 re.I,
             ),
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
@@ -7816,8 +7825,11 @@ LANGUAGE_DEFINITIONS = {
             # 30. tabs_vs_spaces (Formatting Inconsistencies): Indentation Tracker. Tabs vs 2-space standardization.
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries: View Horizon. Play Framework and twirl template endpoints.
+            # BUG FIX: `Ok\(`/`BadRequest\(` both end on `(` (non-word), so
+            # the shared trailing \b could never fire. Neither of Play's
+            # two most common Result constructors ever matched.
             "ssr_boundaries": re.compile(
-                r"\b(Action|Controller|HttpRoutes|ServerEndpoint|twirl|html\.[a-zA-Z_]\w*|Ok\(|BadRequest\()\b"
+                r"\b(?:Action|Controller|HttpRoutes|ServerEndpoint|twirl|html\.[a-zA-Z_]\w*)\b|\bOk\(|\bBadRequest\("
             ),
             # 32. events: Pub/Sub Network. Stream processing and event bus signatures.
             "events": re.compile(r"\b(Source|Flow|Sink|fs2\.Stream|ZStream|EventBus|system\.eventStream|Observable)\b"),
@@ -7834,10 +7846,28 @@ LANGUAGE_DEFINITIONS = {
                 r"\b(inline\s+def|transparent\s+inline|macro|scala\.quoted|Expr|Type|Quotes)\b|\$\{.*?\}|\'\{"
             ),
             # 35. pointers: Memory Map. Scala Native C-Interop pointers.
-            "pointers": re.compile(r"\b(Ptr\[[^\]]+\]|scala\.scalanative\.unsafe|!ptr|ptr\.|CFuncPtr|CStruct\d+)\b"),
+            # BUG FIX: `Ptr\[[^\]]+\]` ends on the closing `]` (non-word),
+            # so the shared trailing \b could never fire -- unlike
+            # `decode\[` elsewhere (bounded only by the opening `[`, always
+            # followed by a word-char type name), this alternative matches
+            # through the CLOSING bracket, and whatever follows a type
+            # declaration (` = `, `;`, a newline) is never a word
+            # character. Never matched. Also bounded the previously
+            # unbounded `[^\]]+` to `{1,200}`. (`!ptr` is left as-is: it's
+            # harmlessly masked by `ptr\.` matching the same text via its
+            # own valid boundary, since `!` immediately preceding `ptr` is
+            # a valid non-word-to-word transition.)
+            "pointers": re.compile(
+                r"\bPtr\[[^\]]{1,200}\]|\b(?:scala\.scalanative\.unsafe|!ptr|ptr\.|CFuncPtr|CStruct\d+)\b"
+            ),
             # 36. memory_alloc: Manual Memory Management. Heap and Native allocations.
+            # BUG FIX: `zone[ \t]*\{` ends on `{` and `alloc\[[^\]]+\]` ends
+            # on the closing `]` -- both non-word, so the shared trailing
+            # \b could never fire for either. Neither ever matched. Also
+            # bounded the previously unbounded `[^\]]+` to `{1,200}`.
             "memory_alloc": re.compile(
-                r"\b(Zone|zone[ \t]*\{|alloc\[[^\]]+\]|malloc|calloc|free|scala\.scalanative\.libc\.stdlib)\b"
+                r"\b(?:Zone|malloc|calloc|free|scala\.scalanative\.libc\.stdlib)\b"
+                r"|zone[ \t]*\{|alloc\[[^\]]{1,200}\]"
             ),
             # 37. inline_asm: Bare Metal.
             "inline_asm": None,
@@ -7867,7 +7897,10 @@ LANGUAGE_DEFINITIONS = {
             # 47. encapsulation (Encapsulation / Access Modifiers)
             "encapsulation": re.compile(r"\b(private|protected)\b|private\[[^\]]+\]"),
             # 48. listeners (Event Listeners / Observers) Waiting for state broadcasts.
-            "listeners": re.compile(r"\b(on\(|addEventListener|subscribe|watch|useEffect|listen)\b"),
+            # BUG FIX: `on\(` ends on `(` (non-word), so the shared
+            # trailing \b could never fire -- never true for the common
+            # real call shape `on('event', ...)`, where a quote follows.
+            "listeners": re.compile(r"\bon\(|\b(?:addEventListener|subscribe|watch|useEffect|listen)\b"),
             # 49. test_skip (Bypassed Tests / Ignored Specs)
             "test_skip": re.compile(r"\b(ignore|pending|skip|xit|xdescribe)\b"),
             # --- PHASE 3: HYBRID DOMAIN SENSORS (Scala Specifics) ---
@@ -7875,10 +7908,16 @@ LANGUAGE_DEFINITIONS = {
                 r"\b(io\.circe|decode\[|asJson|Json\.parse|Json\.toJson|upickle\.default)\b"
             ),
             "regex_execution": re.compile(r'"[^"]+"\.r\b|\bRegex\s*\(|\.(findAllIn|findFirstIn|replaceAllIn)\b'),
+            # BUG FIX: `Duration\s*\(` ends on `(` (non-word), so the
+            # shared trailing \b only fired for the non-empty-argument form
+            # (`Duration(5, SECONDS)`, where a digit follows the paren),
+            # not the empty-argument form (`Duration()`).
             "time_date_logic": re.compile(
-                r"\b(Duration\s*\(|FiniteDuration|System\.currentTimeMillis|LocalDate\.now)\b"
+                r"\b(?:FiniteDuration|System\.currentTimeMillis|LocalDate\.now)\b|\bDuration\s*\("
             ),
-            "ipc_rpc_bridges": re.compile(r"\b(ActorSystem|ActorRef|sys\.process\._|Process\s*\(|Future\.apply)\b"),
+            # BUG FIX: `Process\s*\(` ends on `(` -- same bug. Never
+            # matched the common `Process("cmd")` form (a quote follows).
+            "ipc_rpc_bridges": re.compile(r"\b(?:ActorSystem|ActorRef|sys\.process\._|Future\.apply)\b|\bProcess\s*\("),
         },
     },
     "dockerfile": {

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -2258,6 +2258,219 @@ def test_dart_router_boundary_regression():
 
 
 # ==============================================================================
+# SCALA: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #608)
+# ==============================================================================
+SCALA_RULES = LANGUAGE_DEFINITIONS["scala"]["rules"]
+
+_SCALA_SIMPLE_CASES = [
+    # (signature, positive snippet, text expected to NOT match / None to skip)
+    ("branch", "if (x) then y else z", None),
+    ("args", "def foo(x: Int, y: Int) = x + y", None),
+    ("structural_boundaries", "import scala.util.Try", None),
+    ("func_start", "def foo() = {}", None),
+    ("class_start", "class Foo {", None),
+    ("safety", "val x: Option[Int] = None", None),
+    ("safety_bypasses", "x.asInstanceOf[String]", None),
+    ("high_risk_execution", "System.exit(1)", None),
+    ("io", "Source.fromFile(path)", None),
+    ("api", "export Foo._", None),
+    ("state_mutation", "var count = 0", None),
+    ("dead_code", "// def foo() = {}", "// just a note"),
+    ("doc", "/** A doc comment */", None),
+    ("test", "assertEquals(1, 1)", None),
+    ("concurrency", "Future { compute() }", None),
+    ("ui_framework", 'dom.document.getElementById("x")', None),
+    ("closures", "list.map(x => x * 2)", None),
+    ("globals", 'sys.env("HOME")', None),
+    ("decorators", "@deprecated", None),
+    ("generics", "List[Int]", None),
+    ("comprehensions", "for (x <- list) yield x * 2", None),
+    ("scientific", "scala.math.sqrt(4)", None),
+    ("reflection_metaprogramming", "implicit val x: Int = 5", None),
+    ("import", "import scala.util.Try", None),
+    ("ownership", "@author Jane Doe", None),
+    ("planned_debt", "// TODO: refactor", None),
+    ("fragile_debt", "// HACK: workaround", None),
+    ("spec_exposure", "// [SPEC-123] implements the contract", None),
+    ("ssr_boundaries", "class MyController extends Controller {", None),
+    ("events", "val source: Source[Int, _] = ???", None),
+    ("dependency_injection", "lazy val foo = wire[FooService]", None),
+    ("macros", "inline def foo() = 1", None),
+    ("pointers", "val p: Ptr[Int] = ???", None),
+    ("memory_alloc", "val z = Zone", None),
+    ("telemetry", 'logger.info("message")', None),
+    ("debug_prints", 'println("debug")', None),
+    ("explicit_casts", "x.toInt", None),
+    ("panics_and_aborts", 'throw new Exception("err")', None),
+    ("thread_sleeps", "Thread.sleep(1000)", None),
+    ("bitwise_ops", "a ^ b", None),
+    ("sync_locks", "synchronized { }", None),
+    ("immutability_locks", "val x = 5", None),
+    ("cleanup", "conn.close()", None),
+    ("encapsulation", "private val x = 5", None),
+    ("listeners", 'emitter.on("event", cb)', None),
+    ("test_skip", 'ignore("not ready") { }', None),
+    ("serialization_parsing", "decode[Foo](json)", None),
+    ("regex_execution", '"[0-9]+".r', None),
+    ("time_date_logic", "FiniteDuration(5, SECONDS)", None),
+    ("ipc_rpc_bridges", "val sys = ActorSystem()", None),
+]
+
+
+@pytest.mark.parametrize("signature,positive,negative", _SCALA_SIMPLE_CASES)
+def test_scala_signature_positive_and_negative(signature, positive, negative):
+    pattern = SCALA_RULES[signature]
+    assert pattern is not None, f"scala's {signature!r} rule is unexpectedly None"
+    assert pattern.search(positive), f"scala {signature!r} failed to match its own documented positive case"
+    if negative is not None:
+        assert not pattern.search(negative), (
+            f"scala {signature!r} incorrectly matched an excluded/negative case: {negative!r}"
+        )
+
+
+def test_scala_ownership_scaladoc_author_no_colon_regression():
+    """
+    Regression test: the Scaladoc `@author` tag was grouped with
+    `Created by`/`Maintainer`/`Copyright`, all of which require a literal
+    `:` -- but Scaladoc's actual convention (matching Javadoc, and java's
+    own ownership rule) is `@author Jane Doe`, with no colon. The colon
+    requirement meant the real tag never matched.
+    """
+    pattern = SCALA_RULES["ownership"]
+    assert pattern.search("@author Jane Doe"), "the real, colon-less @author form still didn't match"
+    assert pattern.search("Created by: Jane Doe")
+    assert pattern.search("Copyright: 2026 Acme")
+
+
+def test_scala_test_signature_boundary_regression():
+    """Regression test: `test\\s*\\(` ends on `(`, so the shared trailing \\b never fired."""
+    pattern = SCALA_RULES["test"]
+    assert pattern.search('test("should work") { }'), "test(...) still didn't match"
+    assert pattern.search("assertThrows[Exception] { }")
+
+
+def test_scala_ssr_boundaries_play_result_boundary_regression():
+    """
+    Regression test: `Ok\\(`/`BadRequest\\(` both end on `(`, so the
+    shared trailing \\b never fired for Play's two most common Result
+    constructors.
+    """
+    pattern = SCALA_RULES["ssr_boundaries"]
+    assert pattern.search('Ok("success")'), "Ok(...) still didn't match"
+    assert pattern.search('BadRequest("error")')
+    assert pattern.search("class MyController extends Controller {")
+
+
+def test_scala_pointers_ptr_bracket_boundary_regression():
+    """
+    Regression test: `Ptr\\[[^\\]]+\\]` ends on the closing `]`, so the
+    shared trailing \\b never fired (unlike `decode\\[` elsewhere, which
+    is bounded only by the opening `[` and always followed by a word-char
+    type name).
+    """
+    pattern = SCALA_RULES["pointers"]
+    assert pattern.search("val p: Ptr[Int] = ???"), "Ptr[Int] still didn't match"
+    assert pattern.search("ptr.isEmpty")
+
+
+def test_scala_memory_alloc_zone_and_alloc_boundary_regression():
+    """
+    Regression test: `zone[ \\t]*\\{` ends on `{` and `alloc\\[[^\\]]+\\]`
+    ends on the closing `]` -- both non-word, so the shared trailing \\b
+    never fired for either.
+    """
+    pattern = SCALA_RULES["memory_alloc"]
+    assert pattern.search("zone { implicit z => foo() }"), "zone { ... } still didn't match"
+    assert pattern.search("val buf = alloc[Byte](10)"), "alloc[...] still didn't match"
+    assert pattern.search("Zone.apply { }")
+
+
+def test_scala_listeners_on_call_boundary_regression():
+    pattern = SCALA_RULES["listeners"]
+    assert pattern.search("emitter.on('data', cb)"), "on(...) still didn't match its most common form"
+    assert pattern.search("stream.subscribe(observer)")
+
+
+def test_scala_time_date_and_ipc_empty_args_boundary_regression():
+    """
+    Regression test: `Duration\\s*\\(` and `Process\\s*\\(` both end on
+    `(`, so the shared trailing \\b only fired when a word char (e.g. a
+    digit argument) immediately followed -- never true for the
+    zero/quoted-argument forms (`Duration()`, `Process("cmd")`).
+    """
+    time_pattern = SCALA_RULES["time_date_logic"]
+    ipc_pattern = SCALA_RULES["ipc_rpc_bridges"]
+    assert time_pattern.search("val d = Duration()"), "Duration() still didn't match"
+    assert time_pattern.search("val d = Duration(5, SECONDS)")
+    assert ipc_pattern.search('val p = Process("ls")'), 'Process("cmd") still didn\'t match'
+    assert ipc_pattern.search("val sys = ActorSystem()")
+
+
+def test_scala_ambiguity_sweep_shared_literals_are_not_bugs():
+    """
+    Documents 3 pairs the automated ambiguity sweep flagged for sharing
+    literals: class_start<->dead_code ("class"/"object"/"trait"),
+    class_start<->func_start ("final"/"open"/"transparent" modifiers),
+    dead_code<->import ("import"). All confirmed false positives:
+    dead_code's `//` comment-prefix requirement disambiguates it from
+    both class_start and import, and class_start/func_start's shared
+    modifiers correctly co-firing as mutually exclusive on the SAME
+    declaration (one anchors a class, the other a def) is intentional,
+    not a collision.
+
+    Also documents a raw-regex-level collision the sweep didn't flag:
+    `import`'s pattern has no comment-prefix exclusion, so
+    `// import scala.util.Try` matches both `dead_code` AND `import` at
+    the raw-regex level. This is expected and harmless in practice --
+    comment text is stripped from the code stream by prism.py's
+    lexical-family-based comment stripper before `import` ever
+    evaluates it in the real pipeline (the same shape as ruby's
+    doc-vs-panics_and_aborts YARD-tag collision, documented there too).
+    """
+    class_start = SCALA_RULES["class_start"]
+    dead_code = SCALA_RULES["dead_code"]
+    func_start = SCALA_RULES["func_start"]
+    import_pattern = SCALA_RULES["import"]
+
+    live_class = "class Foo {"
+    assert class_start.search(live_class)
+    assert not dead_code.search(live_class)
+
+    commented_class = "// class Foo {"
+    assert dead_code.search(commented_class)
+    assert not class_start.search(commented_class)
+
+    final_class = "final class Foo {"
+    assert class_start.search(final_class) and not func_start.search(final_class)
+    final_def = "final def foo() = {}"
+    assert func_start.search(final_def) and not class_start.search(final_def)
+
+    live_import = "import scala.util.Try"
+    assert import_pattern.search(live_import)
+    assert not dead_code.search(live_import)
+
+    commented_import = "// import scala.util.Try"
+    assert dead_code.search(commented_import) and import_pattern.search(commented_import), (
+        "documented raw-regex collision changed shape -- update this test's rationale"
+    )
+
+
+def test_scala_explicit_casts_and_pointers_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template (C's cast syntax
+    overlapping pointer-asterisk repetition): scala's explicit_casts
+    (`asInstanceOf[...]`/`.toInt`/etc.) and pointers (`Ptr[...]`/
+    `scala.scalanative.unsafe`) don't share tokens and fire independently.
+    """
+    casts = SCALA_RULES["explicit_casts"]
+    pointers = SCALA_RULES["pointers"]
+    assert casts.search("x.toInt")
+    assert not casts.search("val p: Ptr[Int] = ???"), "explicit_casts incorrectly matched a Scala Native pointer type"
+    assert pointers.search("val p: Ptr[Int] = ???")
+    assert not pointers.search("x.toInt"), "pointers incorrectly matched an explicit cast"
+
+
+# ==============================================================================
 # RUBY: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #607)
 # ==============================================================================
 RUBY_RULES = LANGUAGE_DEFINITIONS["ruby"]["rules"]


### PR DESCRIPTION
## Summary

Comprehensive strict-parsing test closure for `scala` (51 signatures, issue #608), continuing the epic #518 initiative. Found and fixed **9 real, currently-shipping bugs** during the systematic per-signature review and ambiguity/ReDoS sweep. (Scala already received two `@`-boundary fixes in the earlier dart cross-language sweep, #645 -- `safety_bypasses`'s `@unchecked` and `dependency_injection`'s `@Inject`; this PR covers the rest of the language's checklist plus several more real bugs found along the way.)

### Bugs found and fixed

- **`test`**: `test\s*\(` ends on `(` -- the shared trailing `\b` never fired for the most common test-block call form.
- **`ssr_boundaries`**: `Ok\(`/`BadRequest\(` both end on `(` -- Play Framework's two most common Result constructors never matched.
- **`pointers`**: `Ptr\[[^\]]+\]` ends on the closing `]` (unlike `decode\[` elsewhere, bounded only by the opening bracket) -- Scala Native pointer type declarations never matched. Also bounded the previously unbounded `[^\]]+` to `{1,200}`.
- **`memory_alloc`**: `zone[ \t]*\{` ends on `{` and `alloc\[[^\]]+\]` ends on the closing `]` -- neither Scala Native allocation form ever matched. Also bounded `[^\]]+` to `{1,200}`.
- **`listeners`**: `on\(` ends on `(` -- the common `on('event', ...)` call shape never matched.
- **`time_date_logic`**: `Duration\s*\(` ends on `(` -- only matched when a word char (a digit argument) immediately followed, never the zero-argument form `Duration()`.
- **`ipc_rpc_bridges`**: `Process\s*\(` ends on `(` -- same bug; never matched the common `Process("cmd")` form (a quote follows).
- **`ownership`** (a distinct bug, not the boundary shape): the Scaladoc `@author` tag was grouped with `Created by`/`Maintainer`/`Copyright`, all of which require a literal `:` -- but Scaladoc's actual convention (matching Javadoc, and how java's own `ownership` rule already handles it) is `@author Jane Doe`, no colon at all. The colon requirement meant the real Scaladoc tag never matched.

Each fix verified with before/after empirical checks against realistic snippets.

### Ambiguity sweep

3 pairs checked: `class_start<->dead_code`, `class_start<->func_start` (sharing modifiers like "final"), `dead_code<->import` -- all confirmed non-bugs (`dead_code`'s `//` prefix disambiguates; `class_start`/`func_start` correctly co-firing as mutually exclusive on the same declaration is intentional).

Also documented (not fixed) a raw-regex-level collision: `import`'s pattern has no comment-prefix exclusion, so a commented-out import matches both `dead_code` and `import` at the raw-regex level. This is harmless in practice -- `prism.py`'s comment stripper removes comment text before `import` ever evaluates it in the real pipeline (the same shape as ruby's `doc`-vs-`panics_and_aborts` YARD-tag collision, documented in #607).

### ReDoS

Ran the generic 6-payload-shape sweep at n=10000 plus targeted adversarial payloads against `args`/`func_start`/`class_start`'s vertical-modifier handling and `generics`'s bracket nesting -- no findings.

### Golden master

No fixture changes needed: the crucible corpus only has 7 scala files, and none happen to use the specific idioms fixed here (confirmed via `grep` against the corpus directory) -- zero drift, same as haskell's zero-crucible-impact fixes in an earlier PR (#635). Both golden-crucible tests (full-precision and zero-dependency) pass unchanged.

## Test plan
- [x] `pytest tests/core_engine/test_language_standards_strict.py` -- 584 passed (full file)
- [x] Full suite (`pytest tests/ -m "not golden_crucible"`) -- passes (1 pre-existing, unrelated `test_prism.py` isolation-ordering failure confirmed present identically on `main`, not caused by this diff)
- [x] `ruff_audit.py --ci` + `ruff format` -- clean
- [x] `mypy_audit.py --ci` -- no new errors
- [x] `pytest -m golden_crucible` in both full-precision and zero-dependency venvs -- both green, zero fixture changes

Closes #608