### PR TITLE
Close #592: strict tests for kotlin, fix 3 real regex bugs

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -4249,8 +4249,13 @@ LANGUAGE_DEFINITIONS = {
                 r"\b(ApplicationCall|call\.respond|call\.respondText|call\.respondHtml|ServerResponse|ModelAndView)\b"
             ),
             # 32. events (Event Emitters / Pub-Sub)
+            # BUG FIX: required a literal `(`, but Kotlin's idiomatic
+            # SAM-conversion trailing-lambda form (`flow.collect { value ->
+            # ... }`, omitting the parens entirely) is the dominant
+            # real-world style for Flow collectors -- more common than the
+            # parenthesized form. Widened to accept either `(` or `{`.
             "events": re.compile(
-                r"\.(?:collect|collectLatest|observe|subscribe|onNext)\(|\b(LiveData|Observer|Observable|FlowCollector)\b"
+                r"\.(?:collect|collectLatest|observe|subscribe|onNext)\s*[\(\{]|\b(LiveData|Observer|Observable|FlowCollector)\b"
             ),
             # 33. dependency_injection (Dependency Injection / IoC)
             "dependency_injection": re.compile(
@@ -4291,7 +4296,12 @@ LANGUAGE_DEFINITIONS = {
             # 47. encapsulation (Access Modifiers / Encapsulation)
             "encapsulation": re.compile(r"\b(private|protected|internal)\b"),
             # 48. listeners (Event Listeners / Observers)
-            "listeners": re.compile(r"\.(?:collect|observe|subscribe|on[A-Z]\w*|set[A-Z]\w*Listener)\("),
+            # BUG FIX: required a literal `(`, but the idiomatic Kotlin
+            # SAM-conversion trailing-lambda form (`button.setOnClickListener
+            # { ... }`, omitting the parens entirely) is the dominant
+            # real-world style for Android/Compose listeners. Widened to
+            # accept either `(` or `{`.
+            "listeners": re.compile(r"\.(?:collect|observe|subscribe|on[A-Z]\w*|set[A-Z]\w*Listener)\s*[\(\{]"),
             # 49. test_skip (Bypassed Tests / Ignored Specs)
             "test_skip": re.compile(r"@(?:Ignore|Disabled)|test\.skip\(|mockk|spyK|fake\("),
             # --- PHASE 3: HYBRID DOMAIN SENSORS (Kotlin Specifics) ---
@@ -4312,7 +4322,14 @@ LANGUAGE_DEFINITIONS = {
             "time_date_logic": re.compile(
                 r"\b(Clock\.System\.now|Instant\.now|System\.currentTimeMillis|Duration\.minutes|LocalDate)\b"
             ),
-            "ipc_rpc_bridges": re.compile(r"\b(Intent\(|BroadcastReceiver|HttpClient\(|ProcessBuilder|bindService)\b"),
+            # BUG FIX: `Intent\(`/`HttpClient\(` both end on `(` (non-word),
+            # so the shared trailing \b only fired when a word char
+            # immediately followed the paren -- true for the common
+            # `Intent(this, Foo::class.java)` form, but never for the
+            # zero-argument form (`HttpClient()`), where `)` follows.
+            "ipc_rpc_bridges": re.compile(
+                r"\b(?:BroadcastReceiver|ProcessBuilder|bindService)\b|\bIntent\(|\bHttpClient\("
+            ),
         },
     },
     "sqlite": {

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -3033,3 +3033,178 @@ def test_swift_explicit_casts_and_pointers_no_false_collision():
     assert not casts.search("UnsafeMutablePointer<Int>"), "explicit_casts incorrectly matched an unsafe pointer type"
     assert pointers.search("UnsafeMutablePointer<Int>")
     assert not pointers.search("let x = value as? String"), "pointers incorrectly matched an explicit cast"
+
+
+# ==============================================================================
+# KOTLIN: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #592)
+# ==============================================================================
+KOTLIN_RULES = LANGUAGE_DEFINITIONS["kotlin"]["rules"]
+
+_KOTLIN_SIMPLE_CASES = [
+    # (signature, positive snippet, text expected to NOT match / None to skip)
+    ("branch", "if (x) { return }", None),
+    ("args", "fun foo(x: Int) {", None),
+    ("func_start", "fun foo() {", None),
+    ("class_start", "class Foo {", None),
+    ("safety", "val x = require(x > 0)", None),
+    ("safety_bypasses", "val x = value!!", None),
+    ("high_risk_execution", "exitProcess(1)", None),
+    ("io", "val f = File(path)", None),
+    ("api", "public fun foo() {}", None),
+    ("state_mutation", "var count = 0", None),
+    ("dead_code", "// fun foo() {}", None),
+    ("doc", "/** A doc comment */", None),
+    ("test", "assertEquals(a, b)", None),
+    ("concurrency", "launch { compute() }", None),
+    ("ui_framework", "@Composable\nfun Foo() {}", None),
+    ("closures", "{ x -> x * 2 }", None),
+    ("globals", "companion object", None),
+    ("decorators", "@JvmStatic", None),
+    ("generics", "fun <T> foo(x: T) {}", None),
+    ("comprehensions", "list.map { it * 2 }", None),
+    ("scientific", "kotlin.math.sqrt(4.0)", None),
+    ("reflection_metaprogramming", "Foo::class", None),
+    ("import", "import kotlin.collections.List", None),
+    ("ownership", "@author Jane Doe", None),
+    ("planned_debt", "// TODO: refactor", None),
+    ("fragile_debt", "// HACK: workaround", None),
+    ("spec_exposure", "// [SPEC-123] implements the contract", None),
+    ("ssr_boundaries", "call.respond(HttpStatusCode.OK)", None),
+    ("events", "flow.collect { value -> use(value) }", None),
+    ("dependency_injection", "@Inject\nlateinit var foo: Foo", None),
+    ("macros", '@Suppress("unused")', None),
+    ("pointers", "val p: CPointer<IntVar>", None),
+    ("memory_alloc", "memScoped { }", None),
+    ("telemetry", 'Log.i("tag", "message")', None),
+    ("debug_prints", 'println("debug")', None),
+    ("explicit_casts", "x as String", None),
+    ("panics_and_aborts", 'throw RuntimeException("err")', None),
+    ("thread_sleeps", "delay(1000)", None),
+    ("bitwise_ops", "a xor b", None),
+    ("sync_locks", "val mutex = Mutex()", None),
+    ("immutability_locks", "val x = 5", None),
+    ("cleanup", "conn.close()", None),
+    ("encapsulation", "private val x = 5", None),
+    ("listeners", "button.setOnClickListener { doThing() }", None),
+    ("test_skip", "@Ignore", None),
+    ("serialization_parsing", "Json.decodeFromString(str)", None),
+    ("regex_execution", "Regex(pattern)", None),
+    ("time_date_logic", "Instant.now()", None),
+    ("ipc_rpc_bridges", "val intent = Intent(this, Foo::class.java)", None),
+]
+
+
+@pytest.mark.parametrize("signature,positive,negative", _KOTLIN_SIMPLE_CASES)
+def test_kotlin_signature_positive_and_negative(signature, positive, negative):
+    pattern = KOTLIN_RULES[signature]
+    assert pattern is not None, f"kotlin's {signature!r} rule is unexpectedly None"
+    assert pattern.search(positive), f"kotlin {signature!r} failed to match its own documented positive case"
+    if negative is not None:
+        assert not pattern.search(negative), (
+            f"kotlin {signature!r} incorrectly matched an excluded/negative case: {negative!r}"
+        )
+
+
+def test_kotlin_ipc_rpc_bridges_empty_args_boundary_regression():
+    """
+    Regression test: `Intent\\(`/`HttpClient\\(` both end on `(`
+    (non-word), so the shared trailing \\b only fired when a word char
+    immediately followed the paren -- true for the common
+    `Intent(this, Foo::class.java)` form, but never for the zero-argument
+    form (`HttpClient()`).
+    """
+    pattern = KOTLIN_RULES["ipc_rpc_bridges"]
+    assert pattern.search("val client = HttpClient()"), "the zero-argument HttpClient() form still didn't match"
+    assert pattern.search("val intent = Intent(this, Foo::class.java)")
+    assert pattern.search("BroadcastReceiver receiver;")
+
+
+def test_kotlin_events_and_listeners_trailing_lambda_regression():
+    """
+    Regression test: `events` and `listeners` both required a literal
+    `(`, but Kotlin's idiomatic SAM-conversion trailing-lambda form
+    (`flow.collect { value -> ... }`, `button.setOnClickListener { ... }`,
+    omitting the parens entirely) is the dominant real-world style --
+    more common than the parenthesized form. Widened both to accept
+    either `(` or `{`.
+    """
+    events = KOTLIN_RULES["events"]
+    listeners = KOTLIN_RULES["listeners"]
+    assert events.search("flow.collect { value -> use(value) }"), (
+        "the trailing-lambda .collect { } form still didn't match"
+    )
+    assert events.search("flow.collect(collector)")
+    assert listeners.search("button.setOnClickListener { doThing() }"), (
+        "the trailing-lambda setOnClickListener { } form still didn't match"
+    )
+    assert listeners.search("button.setOnClickListener(listener)")
+    assert not listeners.search("val collection = List(5) { it }"), (
+        "listeners incorrectly matched an unrelated List(...) { ... } constructor call"
+    )
+
+
+def test_kotlin_ambiguity_sweep_shared_literals_are_not_bugs():
+    """
+    Documents 2 pairs the automated ambiguity sweep flagged: args<->
+    dead_code (sharing "fun"), class_start<->func_start (sharing
+    visibility/inheritance modifiers like "public"/"open"/"abstract").
+    Both confirmed non-bugs: class_start/func_start correctly co-firing
+    as mutually exclusive on the same declaration (one anchors a class,
+    the other a function) is intentional; dead_code's `//` comment-prefix
+    requirement disambiguates it from func_start/class_start, but (as
+    with several other languages closed earlier in this sweep) `args`
+    itself isn't comment-aware and still matches a bareword "fun" inside
+    a commented-out line -- an accepted, pre-existing design limit (args
+    isn't line-anchored), not a new bug, consistent with the same
+    finding already documented for perl/solidity/dart/go/ruby/scala/
+    swift's own ambiguity sweeps.
+    """
+    args = KOTLIN_RULES["args"]
+    dead_code = KOTLIN_RULES["dead_code"]
+    class_start = KOTLIN_RULES["class_start"]
+    func_start = KOTLIN_RULES["func_start"]
+
+    live_fun = "fun foo() {"
+    assert args.search(live_fun)
+    assert not dead_code.search(live_fun)
+
+    commented_fun = "// fun foo() {"
+    assert dead_code.search(commented_fun)
+    assert not func_start.search(commented_fun), "func_start incorrectly matched a commented-out fun"
+
+    public_class = "public class Foo {"
+    assert class_start.search(public_class) and not func_start.search(public_class)
+    public_fun = "public fun foo() {"
+    assert func_start.search(public_fun) and not class_start.search(public_fun)
+
+
+def test_kotlin_test_vs_regex_execution_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template (TypeScript's
+    `myRegex.test('x')` colliding with its test-framework `.test(`):
+    kotlin's `test` signature only matches `@Test`-style annotations,
+    `assert*(`/`mockk`/`spyk`/`test(` barewords, or `shouldBe`/`every`/
+    `verify` calls -- never a bare `.test(`-style regex method, so it
+    doesn't collide with `regex_execution`'s `Regex(`/`.matches(`/
+    `.find(` forms.
+    """
+    test_pattern = KOTLIN_RULES["test"]
+    regex_pattern = KOTLIN_RULES["regex_execution"]
+    snippet = "myRegex.matches(input)"
+    assert regex_pattern.search(snippet)
+    assert not test_pattern.search(snippet), "test incorrectly matched a regex method call"
+
+
+def test_kotlin_explicit_casts_and_pointers_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template (C's cast syntax
+    overlapping pointer-asterisk repetition): kotlin's explicit_casts
+    (`as Type`/`.toInt()`/etc.) and pointers (`CPointer<T>`/
+    `COpaquePointer`) don't share tokens and fire independently.
+    """
+    casts = KOTLIN_RULES["explicit_casts"]
+    pointers = KOTLIN_RULES["pointers"]
+    assert casts.search("x as String")
+    assert not casts.search("val p: CPointer<IntVar>"), "explicit_casts incorrectly matched a Kotlin/Native pointer"
+    assert pointers.search("val p: CPointer<IntVar>")
+    assert not pointers.search("x as String"), "pointers incorrectly matched an explicit cast"


### PR DESCRIPTION
## Summary

Comprehensive strict-parsing test closure for `kotlin` (50 signatures, issue #592), continuing the epic #518 initiative. Found and fixed **3 real, currently-shipping bugs**. (Kotlin already received two empty-`()`-boundary fixes in the earlier go cross-language sweep, #647 -- `serialization_parsing`'s `Gson()` and `regex_execution`'s `Regex()`/`.toRegex()`. This PR covers the rest of the checklist plus the remaining bugs found along the way.)

### Bugs found and fixed

- **`ipc_rpc_bridges`**: `Intent\(`/`HttpClient\(` both end on `(` (non-word), so the shared trailing `\b` only fired when a word char immediately followed the paren -- true for the common `Intent(this, Foo::class.java)` form, but never for the zero-argument form (`HttpClient()`).
- **`events` & `listeners`** (a distinct, more significant bug -- not the boundary shape): both required a literal `(`, but Kotlin's idiomatic SAM-conversion trailing-lambda form (`flow.collect { value -> ... }`, `button.setOnClickListener { ... }`, omitting the parens entirely) is the **dominant real-world style** for Flow collectors and Android/Compose listeners -- more common than the parenthesized form these patterns were restricted to. Widened both to accept either `(` or `{`.

Each fix verified with before/after empirical checks against realistic snippets, including a negative check that the broadened `listeners` pattern doesn't false-positive on unrelated `List(5) { it }`-style constructor calls.

### Ambiguity sweep

2 pairs checked: `args<->dead_code` (sharing "fun"), `class_start<->func_start` (sharing visibility/inheritance modifiers). Both confirmed non-bugs: `class_start`/`func_start` correctly co-firing as mutually exclusive on the same declaration is intentional, and `dead_code`'s `//` prefix disambiguates it from `func_start`/`class_start` -- though `args` itself remains non-comment-aware and still matches a bareword "fun" inside a commented-out line, an accepted pre-existing design limit already documented identically for perl/solidity/dart/go/ruby/scala/swift's own ambiguity sweeps in this initiative.

Also verified the issue's flagged `explicit_casts`-vs-`pointers` and `test`-vs-`regex_execution` concerns: no overlap in either case.

### ReDoS

Ran the generic 6-payload-shape sweep at n=10000 plus targeted adversarial payloads against `args`/`func_start`/`class_start`'s annotation stacking and `generics`'s bracket nesting -- no findings.

### Golden master

No fixture changes needed: the crucible corpus only has 5 kotlin files, and none happen to use the specific idioms fixed here (confirmed via `grep` against the corpus directory) -- zero drift, same as haskell's (#635) and scala's (#651) zero-crucible-impact fixes. Both golden-crucible tests (full-precision and zero-dependency) pass unchanged.

## Test plan
- [x] `pytest tests/core_engine/test_language_standards_strict.py` -- 748 passed (full file)
- [x] Full suite (`pytest tests/ -m "not golden_crucible"`) -- passes (3 pre-existing, unrelated `test_detector.py`/`test_prism.py` isolation-ordering failures confirmed present identically on `main`, not caused by this diff)
- [x] `ruff_audit.py --ci` + `ruff format` -- clean
- [x] `mypy_audit.py --ci` -- no new errors
- [x] `pytest -m golden_crucible` in both full-precision and zero-dependency venvs -- both green, zero fixture changes

Closes #592