### PR TITLE
Remove invalid "security" label from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     cooldown:
       default-days: 7
     labels:
-      - "security"
       - "github-actions"
 
   - package-ecosystem: "pip"
@@ -17,5 +16,4 @@ updates:
     cooldown:
       default-days: 7
     labels:
-      - "security"
       - "python"


### PR DESCRIPTION
## Summary
- Dependabot was reporting a config error: `Labels: The following labels could not be found: security. Please create it before Dependabot can add it to a pull request.`
- The generic `security` label collides with this repo's own `vuln:*`/`threat:*`/`appsec`/`supply-chain` taxonomy (this project is itself a security scanner), so it shouldn't be reused for repo-hygiene dependency PRs.
- Removed `security` from both the `github-actions` and `pip` update stanzas. The per-ecosystem labels (`python`/`github-actions`) already provide granularity, and GitHub auto-applies the `dependencies` label to Dependabot PRs regardless of this config (confirmed empirically — 14 past PRs already carry it without being listed here).

Also relevant: the Muninn scan flagged `mistune` 3.2.2 (PYSEC-2026-2210 / CVE-2026-59922, a ReDoS in the formatting plugin) on open PR #351 — that's already fixed on `main` via #396 (bumped to `mistune==3.3.4`, which is ≥3.3.0 and patched). PR #351 just predates that merge; rebasing it will clear both stale findings.

## Test plan
- [ ] Confirm Dependabot's next scheduled run (or a manual rebase of an open Dependabot PR) no longer reports the labels error.