### PR TITLE
chore: token-budget setup — CLAUDE.md + model-tiered subagents

### DIFF
--- a/.claude/agents/issue-triage.md
+++ b/.claude/agents/issue-triage.md
@@ -1,0 +1,44 @@
+---
+name: issue-triage
+description: Use for turning a findings source (test/audit output, lint baseline diffs, security scan results, a TODO sweep, an epic that needs sub-issues broken out) into well-formed GitHub issues on squid-protocol/gitgalaxy. Read-heavy, structured writing work -- good fit for a cheaper/faster model than the main conversation. Do NOT use this for deciding *whether* something is worth an issue in the first place if that call is ambiguous -- surface the ambiguous ones back to the main conversation instead of guessing.
+tools: Bash, Read, Grep, Glob, WebFetch
+model: haiku
+---
+
+You turn a findings source into properly-formed GitHub issues for this repo. You do not fix
+the underlying problem -- you file it clearly enough that whoever picks it up doesn't have to
+re-derive context.
+
+## Before filing anything
+
+1. Read the actual finding yourself (the failing test, the audit line, the lint diff) -- never
+   paraphrase a summary you were handed without checking it against the source.
+2. Search for duplicates first: `gh issue list --search "<key terms>" --state all`. If a close
+   match exists, report it instead of filing a new one.
+3. Check `gh label list --limit 200` for the current label taxonomy before applying labels --
+   don't invent new ones and don't reuse a label whose description doesn't actually fit (this
+   repo's labels are domain-specific, e.g. `appsec`/`supply-chain`/`vuln:*`/`threat:*` describe
+   what the *scanner* detects in a target codebase, not repo-hygiene meta-labels -- don't
+   conflate the two).
+
+## Issue shape
+
+- Title: short, specific, matches the existing style (`[TYPE] Component: specific problem`,
+  or for epic sub-issues, the pattern used by issues like #602-#618 -- check a few recent
+  closed issues in the same family with `gh issue view <n>` before writing the title).
+- Body: enough detail that the issue is actionable without the finding source open next to it
+  -- exact file/line, the failing input or command, expected vs. actual. Link back to the epic
+  or audit run it came from if there is one.
+- If filing multiple related issues (e.g. one per language, one per audit category), keep the
+  template consistent across all of them -- copy the structure from the first one you write.
+
+## When you're unsure
+
+If it's unclear whether a finding is worth its own issue, whether it's a duplicate, or what
+label fits, don't guess -- report it back with your reasoning and let the main conversation
+decide. Filing a bad issue is more expensive to clean up than asking.
+
+## Output
+
+End with a short list of what was filed (issue numbers + titles + links), what was skipped as
+a duplicate, and anything you flagged as ambiguous.

--- a/.claude/agents/pipeline-manager.md
+++ b/.claude/agents/pipeline-manager.md
@@ -1,0 +1,40 @@
+---
+name: pipeline-manager
+description: Use for CI/pipeline hygiene sweeps on squid-protocol/gitgalaxy -- checking `gh pr checks` status across open PRs, triaging Dependabot PRs (stale/needs-rebase, invalid dependabot.yml config, failed label application), investigating a failing workflow run, or a general "what needs attention" pass. Read-heavy triage that reports a punch list -- good fit for a cheaper/faster model than the main conversation. Do NOT merge, close, force-push, or push commits to shared branches on your own authority -- report what you found and what you'd recommend, and let the main conversation get user confirmation before taking any action with real blast radius.
+tools: Bash, Read, Grep, Glob
+model: haiku
+---
+
+You do CI/pipeline hygiene triage for this repo. You investigate and report; you do not take
+actions with real blast radius on your own.
+
+## What to check, depending on what was asked
+
+- Open PR status: `gh pr list --state open --json number,title,createdAt,isDraft` then
+  `gh pr checks <n>` on ones that look stale or relevant. Flag anything red, anything stuck
+  pending for an unusually long time, and anything that's been open a long time with no
+  activity.
+- Dependabot PRs specifically: check for the "labels could not be found" / invalid-config
+  comment pattern, check if the PR's base has since drifted (a fix already landed on `main`
+  that the PR predates -- compare the PR's diff/created-at against relevant recent merges).
+  A stale Dependabot PR is usually fixed by commenting `@dependabot rebase`, not by manual
+  intervention -- but confirm with the main conversation before posting that comment if it's
+  not obviously safe.
+- Failing workflow runs: `gh run list --status failure --limit 20`, then `gh run view <id> --log-failed`
+  on the ones worth a closer look. Trace the failure to its actual cause, not just "it failed."
+- General sweep: combine the above into a single punch list.
+
+## Hard limits
+
+- Never merge a PR, close an issue/PR, force-push, or push commits directly. Never post a
+  `@dependabot rebase`/`@dependabot merge` comment or similar action-triggering comment without
+  it being clearly and unambiguously safe (e.g. the exact pattern already established and
+  approved earlier in this session) -- otherwise flag it as a recommendation instead.
+- If something looks like it needs a real decision (taxonomy call, a fix beyond a one-line
+  config change, anything destructive), stop and report it rather than deciding unilaterally.
+
+## Output
+
+A punch list: what's broken, what's stale, what you'd recommend doing about each, and
+anything you already know is safe to just do next time you're given the go-ahead. Group by
+urgency, not by discovery order.

--- a/.claude/hooks/pytest_quiet.py
+++ b/.claude/hooks/pytest_quiet.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook (Bash matcher): auto-adds `-q` to a bare pytest invocation so a
+green run reports a summary line instead of dumping per-test scaffolding into
+context. Declines to touch anything already carrying a verbosity flag (-v/-q)
+or anything compound (piped/chained/redirected) -- appending a flag to the end
+of e.g. `pytest tests/ | tee log.txt` would attach it to `tee`, not pytest.
+"""
+
+import json
+import re
+import sys
+
+data = json.load(sys.stdin)
+command = data.get("tool_input", {}).get("command", "")
+stripped = command.strip()
+
+# Only the final statement needs to be a bare pytest invocation -- commands
+# commonly chain `cd`/`source` first via newlines or `&&` before the actual
+# pytest call.
+last_line = stripped.splitlines()[-1].strip() if stripped else ""
+last_statement = re.split(r"&&", last_line)[-1].strip()
+
+is_pytest = bool(re.match(r"^(python3?\s+-m\s+)?pytest\b", last_statement))
+is_compound = bool(re.search(r"[|;>]", last_statement))
+has_verbosity_flag = bool(re.search(r"(^|\s)(-v+|--verbose|-q|--quiet)(\s|$)", last_statement))
+
+if is_pytest and not is_compound and not has_verbosity_flag:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": (
+                        "Auto-added -q to keep a green pytest run from dumping "
+                        "per-test scaffolding into context."
+                    ),
+                    "updatedInput": {"command": command + " -q"},
+                }
+            }
+        )
+    )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,42 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m pytest tests/security_auditing/test_ai_appsec_sensor.py -q)",
+      "Bash(python -m pytest tests/security_auditing/ -q)",
+      "Bash(git commit -m ' *)",
+      "Bash(python -m pytest tests/core_engine/test_detector.py::test_detector_orphan_and_duplicate_logic -q)",
+      "Bash(python -m pytest tests/security_auditing/test_security_auditor.py tests/tools_recorders/test_llm_recorder.py tests/tools_recorders/test_record_keeper.py tests/core_engine/test_galaxyscope.py tests/core_engine/test_zero_dependency.py -q)",
+      "Bash(gh pr create -R squid-protocol/gitgalaxy --title 'Aggregate duplicate_logic count into equations, mirroring orphaned_logic' --body ' *)",
+      "Bash(python -c ' *)",
+      "Bash(python -m pytest tests/core_engine/test_language_lens.py::test_collision_resolved_confidence_is_clamped -q)",
+      "Bash(python -)",
+      "Bash(python -m pytest tests/core_engine/ -q)",
+      "Bash(gh issue *)",
+      "Bash(xargs -I{} cat {})",
+      "Bash(python -m pytest tests/core_engine/test_config_resolver.py -q)",
+      "Bash(python -m pytest tests/core_engine/test_galaxyscope.py tests/core_engine/test_aperture.py -q)",
+      "Bash(git branch *)",
+      "Bash(git cherry-pick *)",
+      "Bash(git reset *)",
+      "Bash(awk 'NR==560,NR==860{if \\($0 ~ /^class |^    def /\\) print NR\": \"$0}' gitgalaxy/galaxyscope.py)",
+      "Bash(python -c \"import gitgalaxy.galaxyscope\")",
+      "Bash(python -m pytest tests/core_engine/test_galaxyscope.py -q)"
+    ],
+    "additionalDirectories": [
+      "/tmp/gh-issues"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pytest_quiet.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/issue-generation/SKILL.md
+++ b/.claude/skills/issue-generation/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: issue-generation
+description: Turn a findings source (failing tests, an audit run, a lint baseline diff, a security scan, an epic that needs sub-issues) into filed GitHub issues on squid-protocol/gitgalaxy. Use when the user asks to "file issues for X", "break this epic into sub-issues", "open issues for these findings", or similar.
+---
+
+Delegate this to the `issue-triage` subagent (`.claude/agents/issue-triage.md`) via the Agent
+tool -- it runs on a cheaper/faster model and its own isolated context, so it doesn't inherit
+this conversation's full history for what is fundamentally a read-and-write-issues task.
+
+Before delegating:
+1. Identify the actual findings source (a file, command output, or something already in this
+   conversation) and make sure it's concrete enough to hand off -- don't delegate on a vague
+   pointer like "the failures from earlier," paste or point to the actual content.
+2. Write a self-contained prompt for the agent: what the findings source is, any relevant repo
+   conventions already established in this conversation (label choices, title format, an epic
+   number to link against), and whether to run in the foreground or background.
+   - Foreground (`run_in_background: false`) if the user is waiting on the issue numbers to do
+     something next.
+   - Background otherwise.
+3. If the finding set is large and spans genuinely independent sub-topics, it's fine to split
+   across multiple agent calls -- but don't split so finely that duplicate-checking (the agent
+   searches existing issues before filing) gets bypassed by parallel runs racing each other.
+
+After the agent reports back, relay its punch list (filed / skipped-as-duplicate / flagged-as-
+ambiguous) to the user. Resolve anything the agent flagged as ambiguous yourself or by asking
+the user -- don't silently drop it.

--- a/.claude/skills/pipeline-check/SKILL.md
+++ b/.claude/skills/pipeline-check/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: pipeline-check
+description: Sweep CI/pipeline health on squid-protocol/gitgalaxy -- open PR status, stale or misconfigured Dependabot PRs, failing workflow runs. Use when the user asks to "check the pipeline", "see what's failing", "check on the PRs", "babysit PRs", or similar status/triage requests. Not for actually merging, closing, or fixing things -- that's a follow-up step after reviewing the report.
+---
+
+Delegate this to the `pipeline-manager` subagent (`.claude/agents/pipeline-manager.md`) via the
+Agent tool -- it runs on a cheaper/faster model and its own isolated context, appropriate for
+what is fundamentally a read-only `gh`/`git` status sweep.
+
+Tell it what to focus on if the user was specific (e.g. "just Dependabot PRs", "just check if
+CI is green on PR #N"); otherwise ask it for a general sweep.
+
+Run it in the background (`run_in_background: true`) unless the user is actively waiting on
+the result before doing something else.
+
+The agent will not merge, close, force-push, or post action-triggering comments (like
+`@dependabot rebase`) on its own -- it reports a punch list with recommendations. When it
+reports back:
+1. Relay the punch list to the user.
+2. For anything the agent recommends as an action, confirm with the user before taking it
+   yourself (per this project's standing risk-of-action guidance) -- the agent's
+   recommendation is not itself authorization to act.

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ museum_2/
 # ...except committed regression-check baselines, e.g. dead_key_audit_baseline.json
 # and mypy_audit_baseline.json -- these are source, not generated output.
 !tests/*_baseline.json
+# ...and the shared Claude Code project config (team-wide permissions/hooks/model
+# settings). settings.local.json stays ignored -- that one's per-machine/personal.
+!.claude/settings.json
 *_llm.md
 venvs/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+GitGalaxy (the "blAST engine") is an AST-free, LLM-free static analysis engine. It ingests a
+repository, extracts **Structural Signatures** via bounded, ReDoS-proof regexes (no compiler
+toolchain, no ASTs), and builds a mathematical knowledge graph used for risk scoring, SBOM
+generation, dependency mapping, and 3D visualization. CLI entry points: `galaxyscope` / `blast`.
+
+## Commands
+
+```bash
+pip install -e .                              # editable install
+galaxyscope <path-to-repo>                     # run a scan
+python -m pytest tests/                        # full suite (golden_crucible tests excluded by default, see pyproject.toml addopts)
+python -m pytest tests/core_engine/test_foo.py::test_bar -q   # single test
+python -m pytest -m golden_crucible            # opt-in: needs a local language-crucible checkout (LANGUAGE_CRUCIBLE_PATH)
+python tests/ruff_audit.py --ci                # baseline-gated lint (see "Baseline-gated audits" below)
+python tests/mypy_audit.py --ci                # baseline-gated type check
+python tests/dead_key_audit.py --ci            # baseline-gated dead-config-key audit
+ruff format .                                  # zero-tolerance formatting (not baseline-gated)
+```
+
+## Architecture
+
+Data flows through `gitgalaxy/core/` in a fixed pipeline, each stage handing off to the next
+(see `gitgalaxy/core/README.md` for the full writeup):
+
+1. **`aperture.py`** — zero-trust ingestion filter (rejects binaries/huge files before any I/O).
+2. **`guidestar_lens.py`** — parses manifests (`package.json`, `Cargo.toml`, etc.) for an
+   "Intent Lock" baseline, avoiding expensive heuristic guessing downstream.
+3. **`prism.py`** — splits raw source into the executable payload vs. the comment/doc surface,
+   shielding string literals so the splitter can't be fooled by delimiter-like text inside them.
+4. **`detector.py`** — the structural extractor: applies the per-language regex rules from
+   `gitgalaxy/standards/language_standards.py` to count signatures (branch, io, safety_bypasses,
+   etc.), including mid-file language switching for polyglot/embedded code.
+5. **`network_risk_sensor.py`** — builds the import-statement dependency DAG, runs PageRank for
+   blast-radius scoring.
+6. **`spatial_mapper.py`** — projects the DAG into 3D coordinates for the WebGPU visualizer.
+7. **`state_rehydrator.py`** — incremental-scan cache (skips re-parsing unchanged files via the
+   SQLite-backed previous-run state).
+
+Downstream of core: `gitgalaxy/metrics/` (risk scoring math, false-positive suppression),
+`gitgalaxy/security/` (network-weighted threat scoring, taint tracking, AI/agentic threat
+detection), `gitgalaxy/recorders/` (output formatting: SARIF, SBOM, LLM-optimized summaries,
+SQLite), `gitgalaxy/standards/` (the per-language rule registry + `gitgalaxy_config.py` global
+config), `gitgalaxy/tools/` (standalone DevSecOps/legacy-migration CLIs built on top of core).
+Each of those directories has its own `README.md` — read the relevant one before working deep
+inside it rather than re-deriving the architecture from source.
+
+## Adding or hardening a language's structural signatures
+
+Full protocol (LLM generation prompt, the 12 numbered engine rules for ReDoS/boundary
+correctness, strict-testing prompt) lives in
+`gitgalaxy/standards/how_to_add_a_language.md` — read that file directly rather than expecting
+a summary here; it's long because the rules matter and drift if paraphrased. Tests for this
+live in `tests/core_engine/test_language_standards_strict.py`, one section per language.
+
+## Baseline-gated audits (ruff / mypy / dead-key)
+
+These are regression gates, not zero-tolerance floors: each has a committed baseline file
+(`tests/ruff_audit_baseline.json` etc.) and `--ci` mode fails only on *new* findings beyond it.
+This lets CI enforce "no new problems" without demanding the pre-existing backlog be fixed
+first. If you fix backlog findings, regenerate the baseline by running the script without
+`--ci`. `ruff format --check` is the one zero-tolerance exception (whole repo was reformatted
+once at adoption, so there's no backlog to carry).
+
+## The Differential Scan (PR protocol for engine/regex changes)
+
+Any PR touching parsing logic (`detector.py`, `language_standards.py`, `prism.py`, etc.) is
+expected to be verified against `tests/golden_master_audit.json` /
+`tests/golden_master_zero_dep_audit.json` — snapshots diffed by the `crucible-audit` CI check
+against a ~80-repo corpus plus the PR's target repo. A failing diff means output changed: either
+a bug, or an intentional improvement that needs the baseline re-blessed. **Never hand-edit these
+fixtures.** Regenerate with `python tests/tools/update_golden_master.py` (shows the diff, asks
+for confirmation) and explain *why* in the PR description — CI flags any PR touching these files.
+
+## Issue generation and pipeline/CI triage
+
+Two subagents with pinned models are set up for this so routine triage doesn't burn main-context
+tokens or a premium model: `.claude/agents/issue-triage.md` (filing well-formed GitHub issues
+from findings) and `.claude/agents/pipeline-manager.md` (CI status / Dependabot triage — reports
+recommendations, never merges/closes/pushes on its own authority). Invoke via the
+`issue-generation` and `pipeline-check` skills, or the Agent tool directly.
+
+## Model tiering (token budget)
+
+This repo pins models per-role instead of running everything on one tier, so the expensive
+model is only spent where the extra judgment actually pays for itself.
+
+**Main session (manual `/model` switch)**
+- **Sonnet (default)**: everyday coding, debugging, code review, regex/rule work.
+- **Opus**: switch in manually for architecture-level planning, high-ambiguity design
+  decisions, or multi-system tradeoffs (e.g. redesigning the core pipeline stage boundaries,
+  not writing one more detector rule) — the extra compute is worth it there.
+
+**Subagents (pinned in each agent's frontmatter)**
+- **Haiku**: mechanical, read-heavy, well-defined output shape, no judgment calls beyond
+  "escalate if ambiguous" — `issue-triage`, `pipeline-manager`. Both are written to hand
+  anything ambiguous (duplicate calls, label taxonomy, destructive actions) back to the main
+  conversation rather than guess, which is what makes Haiku safe here.
+- **Sonnet**: anything requiring nuanced judgment, synthesis across multiple sources, or
+  writing/reviewing code on the subagent's own authority.
+
+When adding a new subagent, default it to Haiku unless the task demonstrably needs more
+judgment than "read input, produce well-formed output, escalate ambiguity" — don't pin Sonnet
+out of caution alone.
+
+## Licensing
+
+PolyForm Noncommercial 1.0.0 — free for research/education/hobby use; commercial use requires a
+separate license. Contributions are licensed under the same terms (see `CONTRIBUTING.md`).


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` documenting the engine architecture plus a model-tiering policy for token budget: Sonnet by default for the main session (manual `/model` switch to Opus for architecture-level/high-ambiguity work), Haiku for mechanical/read-heavy subagents that escalate ambiguity rather than guess.
- Add the `issue-triage` and `pipeline-manager` subagents (pinned to `haiku`) plus their `issue-generation`/`pipeline-check` skill wrappers, so routine GitHub issue filing and CI/Dependabot triage run in isolated context on a cheap model instead of burning main-conversation tokens.
- Fix a real bug in `.claude/hooks/pytest_quiet.py`: the `is_pytest`/`is_compound` regexes anchored on the whole command string, so a multi-line command like `cd repo` / `source venv` / `python -m pytest ...` never matched `^pytest` and the hook silently no-opped. Now checks the last statement (after the final newline or `&&`).
- Un-ignore `.claude/settings.json` as shared team config (permissions + hooks); `.claude/settings.local.json` stays personal/ignored.

## Test plan
- [x] Verified `pytest_quiet.py` fix against the exact failing multi-line command, a piped/compound command, an already-quiet command, and a bare pytest command — all four behave correctly (checked via direct stdin invocation and confirmed live through an actual multi-line `Bash` pytest run in this session).
- [ ] Reviewer sanity-check: confirm the Haiku pin for `issue-triage`/`pipeline-manager` holds up on a real triage run (both agents are written to escalate anything ambiguous back to the main conversation rather than guess).

🤖 Generated with [Claude Code](https://claude.com/claude-code)