### PR TITLE
Strict tests for groovy, fix 11 real bugs (2 ReDoS)

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -10782,8 +10782,30 @@ LANGUAGE_DEFINITIONS = {
             # (`[a-zA-Z_$][\w_$]*` with no \b anchor) got retried at every
             # position in a long `->`-less line -- O(n^2) (same bug found and
             # fixed in javascript's args). Bounded to {0,100}.
+            # BUG FIX: the return-type stepper required an uppercase first
+            # char, so lowercase primitive/void return types (`void foo()`,
+            # `int add()`) never matched at all. It also excluded `,`, so
+            # multi-param generic return types (`Map<String, Integer> foo()`)
+            # broke after the first type param. Added a primitive-keyword
+            # alternative and `,` to the class (same technique already used
+            # by C#'s func_start for this exact bug class).
+            # NESTED-DELIMITER FIX: the flat `[^)]*` param-list matcher broke
+            # on one-level-nested calls in default values (`int y =
+            # Math.max(3, 4)`), truncating at the inner `)`. Swapped for a
+            # bounded one-level-nesting form.
+            # BUG FIX (ambiguity sweep): despite the "CRITICAL FIX" comment's
+            # claim, this had no exclusion for control-flow keywords at all,
+            # so `if (x) {`, `while (x) {`, `switch (x) {`, `for (i in ...) {`,
+            # `catch (Exception e) {`, and `synchronized(lock) {` were all
+            # hallucinated as method parameter blocks (the condition
+            # misread as an argument list). Added the same style of negative
+            # lookahead func_start already uses.
             "args": re.compile(
-                r"^[ \t]*(?:(?:public|private|protected|static|final|def|abstract)[ \t]+){0,5}(?:[A-Z][a-zA-Z0-9_<>\[\]?]*[ \t]+){0,2}[A-Za-z_$][\w_$]*\s*\([^)]*\)|(?:\([^)]*\)|[a-zA-Z_$][\w_$]{0,100})\s*->",
+                r"^[ \t]*(?:(?:public|private|protected|static|final|def|abstract)[ \t]+){0,5}"
+                r"(?:(?:(?:void|int|long|short|byte|char|float|double|boolean)(?:\[\])?|[A-Z][a-zA-Z0-9_<>\[\]?,]*)[ \t]+){0,3}"
+                r"(?!(?:if|for|while|switch|catch|synchronized)\b)"
+                r"[A-Za-z_$][\w_$]*\s*\((?:[^()]|\([^()]*\))*\)"
+                r"|(?:\((?:[^()]|\([^()]*\))*\)|[a-zA-Z_$][\w_$]{0,100})\s*->",
                 re.M,
             ),
             # 3. linear (Sequential Boundaries)
@@ -10793,8 +10815,21 @@ LANGUAGE_DEFINITIONS = {
             # 4. func_start (Executable Logic Anchors)
             # HIGHLY TUNED: Uses Negative Lookahead to explicitly ignore Gradle DSL keywords (implementation, api, task)
             # Uses Positive Lookahead (?=[ \t]*\() to stop exactly at the function name without consuming punctuation.
+            # BUG FIX: same return-type stepper bug as `args` above -- lowercase
+            # primitive/void return types and multi-param generic return types
+            # (`Map<String, Integer> foo()`) never matched. See `args` comment.
+            # BUG FIX (ambiguity sweep): `synchronized` was missing from the
+            # exclusion list, so a synchronized block (`synchronized(lock) {
+            # ... }`) had the identical `identifier(...) {` shape as a real
+            # method and was misclassified as a method declaration named
+            # "synchronized". Confirmed pre-existing (not introduced by the
+            # return-type fix above); added to the exclusion list alongside
+            # the other control-flow-shaped keywords.
             "func_start": re.compile(
-                r"^[ \t]*(?:(?:public|private|protected|static|final|def)[ \t]+){0,5}(?:[A-Z][a-zA-Z0-9_<>\[\]?]*[ \t]+){0,2}(?!(?:if|for|while|switch|catch|new|return|class|interface|enum|trait|implementation|testImplementation|api|compileOnly|runtimeOnly|classpath|dependency|from|file|mavenCentral|plugins|dependencies|repositories|task|project|allprojects|subprojects|ext)\b)([A-Za-z_$][\w_$]*)(?=[ \t]*\()",
+                r"^[ \t]*(?:(?:public|private|protected|static|final|def)[ \t]+){0,5}"
+                r"(?:(?:(?:void|int|long|short|byte|char|float|double|boolean)(?:\[\])?|[A-Z][a-zA-Z0-9_<>\[\]?,]*)[ \t]+){0,3}"
+                r"(?!(?:if|for|while|switch|catch|synchronized|new|return|class|interface|enum|trait|implementation|testImplementation|api|compileOnly|runtimeOnly|classpath|dependency|from|file|mavenCentral|plugins|dependencies|repositories|task|project|allprojects|subprojects|ext)\b)"
+                r"([A-Za-z_$][\w_$]*)(?=[ \t]*\()",
                 re.M,
             ),
             # 5. class_start (Object / Entity Declarations)
@@ -10823,18 +10858,28 @@ LANGUAGE_DEFINITIONS = {
                 r"\b(public)\b|@(RestController|Controller|Service|Component|Bean|RequestMapping|GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\b"
             ),
             # 11. flux (State Mutation)
-            "state_mutation": re.compile(r"^[ \t]*\w+(?:\.\w+)*[ \t]*=|@(?:Setter|Data)\b", re.M),
+            # BUG FIX: the trailing bare `=` matched the first `=` of `==`,
+            # miscounting every equality comparison (`result == expected`) as
+            # an assignment. Added a negative lookahead to exclude `==`.
+            "state_mutation": re.compile(r"^[ \t]*\w+(?:\.\w+)*[ \t]*=(?!=)|@(?:Setter|Data)\b", re.M),
             # 12. dead_code (Commented Logic / Deprecated Trails)
             # Tuned to catch dead Gradle definitions and Groovy logic.
+            # BUG FIX (Rule 12): groovy is `standard_block` (both `//` and
+            # `/* */`), but this only ever fired on `//` -- every block-
+            # commented-out construct (`/* class Foo {} */`) silently never
+            # matched.
             "dead_code": re.compile(
-                r"//[ \t]*(?:def|class|void|if|for|while|import|implementation|compile|api|testImplementation)\b"
+                r"(?://|/\*)[ \t]*(?:def|class|void|if|for|while|import|implementation|compile|api|testImplementation)\b"
             ),
             # 13. doc (Structured Documentation)
             "doc": re.compile(r"/\*\*|@param|@return|@throws|@deprecated|@see"),
             # 14. test (Testing & Assertions)
             # Integrates Spock Framework keywords (given:, when:, then:, expect:) alongside JUnit.
+            # BUG FIX (Rule 5): `^\s*` matches newlines in re.M mode, so the
+            # Spock-label anchor could stretch across blank lines. Bounded to
+            # `[ \t]*` (same-line whitespace only).
             "test": re.compile(
-                r"@(?:Test|Before|After|BeforeEach|AfterEach|Mock)|assert\w*\s*\(|^\s*(?:given|when|then|expect|setup|cleanup|where):",
+                r"@(?:Test|Before|After|BeforeEach|AfterEach|Mock)|assert\w*\s*\(|^[ \t]*(?:given|when|then|expect|setup|cleanup|where):",
                 re.M,
             ),
             # --- PHASE 3: ARCHITECTURE & DOMAIN SENSORS ---
@@ -10845,16 +10890,38 @@ LANGUAGE_DEFINITIONS = {
             # 16. ui_framework (UI / View Components)
             "ui_framework": re.compile(r"\b(SwingBuilder|JFrame|JPanel|ModelAndView|ModelMap|Model|UIComponent)\b"),
             # 17. closures (Closures / Anonymous Functions)
-            "closures": re.compile(r"->|\{\s*(?:it|[\w\s,]+)\s*->"),
+            # REDOS FIX: `[\w\s,]+` followed by a separate trailing `\s*`
+            # let both consume the same whitespace run -- an unclosed `{`
+            # followed by thousands of spaces caused catastrophic
+            # backtracking (confirmed hang at n=2000). Collapsed into one
+            # bounded, non-overlapping class before the required `->`
+            # (same technique as kotlin's closures fix).
+            # BUG FIX: idiomatic paren-less trailing closures (`list.each {
+            # it }`, `.collect { it * 2 }`) have no `->` at all and never
+            # matched either alternative, missing Groovy's single most
+            # common closure shape. Added a dot-method-call-into-brace form.
+            "closures": re.compile(r"\.\w+[ \t]*\{|\{[ \t\n]*[a-zA-Z_][a-zA-Z0-9_ \t\n,]{0,150}?->|->"),
             # 18. globals (Global / Shared State)
             "globals": re.compile(r"\b(System\.getProperty|System\.getenv|project\.ext)\b|@Value"),
             # 19. decorators (Decorators / Annotations)
-            "decorators": re.compile(r"^[ \t]*@[\w.]+(?:\([^)]*\))?", re.M),
+            # NESTED-DELIMITER FIX (Rule 11): the flat `[^)]*` broke on one-
+            # level-nested annotation args (`@Grab(..., version=resolve())`),
+            # truncating at the inner `)`. Swapped for a bounded
+            # one-level-nesting form.
+            "decorators": re.compile(r"^[ \t]*@[\w.]+(?:\((?:[^()]|\([^()]*\))*\))?", re.M),
             # 20. generics (Generics / Type Parameters)
-            "generics": re.compile(r"<\s*[A-Z?][^>]*>"),
+            # NESTED-DELIMITER FIX (Rule 11): the flat `[^>]*` broke on one-
+            # level-nested generics (`Map<String, List<Id>>`), truncating at
+            # the first `>` and leaving the real closing `>` unconsumed.
+            # Swapped for a bounded one-level-nesting form.
+            "generics": re.compile(r"<\s*[A-Z?][^<>]{0,100}(?:<[^<>]{0,100}>[^<>]{0,100})*>"),
             # 21. comprehensions (Iterators / Comprehensions)
+            # BUG FIX: required a literal `(` right after the method name,
+            # but Groovy's idiomatic call form for these is a paren-less
+            # trailing closure (`list.each { it }`, `.collect { it * 2 }`)
+            # -- the far more common shape never matched at all.
             "comprehensions": re.compile(
-                r"\.(?:collect|find|findAll|grep|inject|each|eachWithIndex|map|filter|reduce)\("
+                r"\.(?:collect|find|findAll|grep|inject|each|eachWithIndex|map|filter|reduce)[ \t]*[({]"
             ),
             # 22. scientific (Numerical / Compute Libraries)
             "scientific": re.compile(r"\b(Math\.|BigDecimal|BigInteger|Random|SecureRandom)\b"),
@@ -10865,6 +10932,13 @@ LANGUAGE_DEFINITIONS = {
             ),
             # 24. import (Dependency Inclusions)
             "import": re.compile(r"^[ \t]*import\s+(?:static[ \t]+)?[\w.]+;?", re.M),
+            # BUG FIX: this key was entirely absent (not `None`), so Groovy
+            # imports never fed the dependency graph at all -- unlike every
+            # other JVM-family language here (e.g. java), which pairs
+            # `import` with a `_dependency_capture` group. Groovy imports
+            # follow the identical syntax, so this was a coverage gap, not
+            # an intentional Strict-Feature-Parity `None`.
+            "_dependency_capture": re.compile(r"^[ \t]*import[ \t]+(?:static[ \t]+)?([\w.]+)[ \t]*;?", re.M),
             # 25. ownership (Authorship Metadata)
             "ownership": re.compile(r"@author\s+(.*)", re.I),
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
@@ -10873,7 +10947,14 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # QUADRATIC BLOWUP FIX: `\d+` and the trailing `[^\]]*` both
+            # greedily match digits with no closing `]` ever present, so an
+            # unclosed `[SPEC-11111...` tag backtracks by re-scanning an
+            # ever-shrinking suffix -- O(n^2) (confirmed ~4x slowdown per
+            # input-size doubling; same bug class already fixed for shell
+            # and sqlite's spec_exposure elsewhere in this file). Bounded to
+            # {0,300}; real spec/audit tags don't get remotely that long.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -10892,8 +10973,13 @@ LANGUAGE_DEFINITIONS = {
             # Heavily captures Gradle plugin and dependency architecture.
             # BUG FIX: 7 of the 10 alternatives are `@`-prefixed Spring
             # annotations -- same bug, at scale.
+            # BUG FIX (Rule 9): `plugins\s*\{` and `dependencies\s*\{` both
+            # end on `{`, a non-word char, so the shared trailing `\b` could
+            # never fire (no word/non-word transition between `{` and
+            # whatever follows it) -- `plugins {` / `dependencies {` never
+            # matched at all, the two most common Gradle DSL entry points.
             "dependency_injection": re.compile(
-                r"\b(?:apply\s+plugin|plugins\s*\{|dependencies\s*\{)\b"
+                r"\bapply\s+plugin\b|\bplugins\s*\{|\bdependencies\s*\{"
                 r"|@Autowired|@Inject|@Component|@Service|@Repository|@Bean|@Configuration"
             ),
             # 34. macros

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -6193,3 +6193,551 @@ def test_livecode_pointers_redos_immune():
 def test_livecode_globals_redos_immune():
     pattern = LIVECODE_RULES["globals"]
     assert_redos_immune(pattern, "the " * 20000, timeout_sec=3.0)
+
+# ==============================================================================
+# GROOVY: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #584)
+# ==============================================================================
+GROOVY_RULES = LANGUAGE_DEFINITIONS["groovy"]["rules"]
+
+_GROOVY_SIMPLE_CASES = [
+    # (signature, positive snippet, text expected to NOT match / None to skip)
+    # --- PHASE 1 ---
+    ("branch", "if (x > 0) { return x } else { return -x }", "def x = 1"),
+    ("args", "def calculate(int x, int y = Math.max(3, 4)) {", "def x = 1"),
+    ("structural_boundaries", "class Foo {}", "if (x > 0) { println x }"),
+    ("func_start", "void plainMethod(String x) {", "if (x) {"),
+    ("class_start", "class Foo extends Bar {", "def foo() {}"),
+    # --- PHASE 2 ---
+    ("safety", "try { risky() } catch (Exception e) { }", "def x = 1"),
+    ("safety_bypasses", "def x = null", "def x = 5"),
+    ("high_risk_execution", "System.exit(1)", "println 'hi'"),
+    ("io", "def f = new File('data.txt')", "def x = 1"),
+    ("api", "@RestController\nclass FooController {}", "class Foo {}"),
+    ("state_mutation", "count = count + 1", "count == expected"),
+    ("dead_code", "// def oldMethod() {}", "// just a comment"),
+    ("doc", "/**\n * @param x the value\n */", "// just a comment"),
+    ("test", "@Test\nvoid testFoo() { assert x == 1 }", "def x = 1"),
+    # --- PHASE 3 ---
+    ("concurrency", "def t = new Thread({ doWork() })", "def x = 1"),
+    ("ui_framework", "def frame = new JFrame('Title')", "def x = 1"),
+    ("closures", "list.each { it * 2 }", "def x = 1"),
+    ("globals", "def home = System.getProperty('user.home')", "def x = 1"),
+    ("decorators", "@CompileStatic\nclass Foo {}", "class Foo {}"),
+    ("generics", "Map<String, List<Id>> data", "String data"),
+    ("comprehensions", "list.collect { it.toUpperCase() }", "def x = 1"),
+    ("scientific", "def r = Math.sqrt(4)", "def x = 1"),
+    ("reflection_metaprogramming", "foo.metaClass.bar = { -> 42 }", "def x = 1"),
+    ("import", "import com.example.Foo", "def x = 1"),
+    ("ownership", "// @author Jane Doe", "// regular comment"),
+    # --- PHASE 4 ---
+    ("planned_debt", "// TODO: refactor this", "// regular comment"),
+    ("fragile_debt", "// HACK: workaround for build tool bug", "// regular comment"),
+    ("spec_exposure", "// [SPEC-123] audit trail", "// regular comment"),
+    ("ssr_boundaries", "@ResponseBody\ndef foo() {}", "def foo() {}"),
+    ("events", "@EventListener\ndef onFoo() {}", "def foo() {}"),
+    ("dependency_injection", "dependencies {\n    implementation 'foo'\n}", "def x = 1"),
+    # --- PHASE 5 ---
+    ("telemetry", "logger.info('starting')", "println 'starting'"),
+    ("debug_prints", "println 'debug value: ' + x", "logger.info('x')"),
+    ("explicit_casts", "def x = (int) y", "def x = y"),
+    ("panics_and_aborts", "throw new RuntimeException('bad')", "return x"),
+    ("thread_sleeps", "Thread.sleep(1000)", "def x = 1"),
+    ("bitwise_ops", "def flags = mask ^ other", "def flags = mask && other"),
+    ("sync_locks", "synchronized(lock) { doWork() }", "def x = 1"),
+    ("immutability_locks", "final String name = 'x'", "String name = 'x'"),
+    ("cleanup", "connection.close()", "def x = 1"),
+    ("encapsulation", "private String name", "String name"),
+    ("listeners", "button.addListener(handler)", "def x = 1"),
+    ("test_skip", "@Ignore\nvoid testFoo() {}", "void testFoo() {}"),
+]
+
+
+@pytest.mark.parametrize("signature,positive,negative", _GROOVY_SIMPLE_CASES)
+def test_groovy_signature_positive_and_negative(signature, positive, negative):
+    pattern = GROOVY_RULES[signature]
+    assert pattern is not None, f"groovy's {signature!r} rule is unexpectedly None"
+    assert pattern.search(positive), f"groovy {signature!r} failed to match its own documented positive case"
+    if negative is not None:
+        assert not pattern.search(negative), (
+            f"groovy {signature!r} incorrectly matched an excluded/negative case: {negative!r}"
+        )
+
+
+def test_groovy_dependency_capture_extracts_import_path():
+    """
+    `import`'s paired capture-group rule (`_dependency_capture`) was
+    entirely absent from groovy's dict (not `None`) -- unlike every other
+    JVM-family language here (e.g. java), which pairs `import` with a
+    `_dependency_capture` group feeding the dependency graph. Groovy
+    imports follow the identical syntax, so the omission was a coverage
+    gap, not an intentional Strict-Feature-Parity `None`. Added the key;
+    this proves it captures group 1 as the exact dependency path.
+    """
+    pattern = GROOVY_RULES["_dependency_capture"]
+    assert pattern is not None, "_dependency_capture should not be None for groovy"
+
+    m = pattern.search("import com.example.foo.Bar")
+    assert m and m.group(1) == "com.example.foo.Bar"
+
+    m2 = pattern.search("import static com.example.Utils.helper")
+    assert m2 and m2.group(1) == "com.example.Utils.helper"
+
+    m3 = pattern.search("import com.example.gradle.Plugin;")
+    assert m3 and m3.group(1) == "com.example.gradle.Plugin"
+
+
+def test_groovy_dead_code_comment_style_completeness_regression():
+    """
+    Regression test (Rule 12): groovy is `standard_block` (both `//` and
+    `/* */` are valid comment delimiters), but `dead_code`'s keyword check
+    only ever fired on `//` -- every block-commented-out construct
+    (`/* class Foo {} */`) silently never matched even though the
+    identical line commented with `//` did.
+    """
+    pattern = GROOVY_RULES["dead_code"]
+    for keyword in ("def", "class", "void", "if", "for", "while", "import"):
+        line_style = f"// {keyword} foo() {{ }}"
+        block_style = f"/* {keyword} foo() {{ }} */"
+        assert pattern.search(line_style), f"'//' style with {keyword!r} didn't match"
+        assert pattern.search(block_style), f"'/* */' style with {keyword!r} didn't match"
+
+
+def test_groovy_state_mutation_equality_operator_false_positive_regression():
+    """
+    Regression test, confirmed real bug: the trailing bare `=` in
+    `^[ \\t]*\\w+(?:\\.\\w+)*[ \\t]*=` matched the first `=` of `==`,
+    miscounting every equality comparison (`result == expected`) as a
+    variable assignment. Fixed by adding a negative lookahead excluding a
+    second `=`.
+    """
+    pattern = GROOVY_RULES["state_mutation"]
+    assert not pattern.search("result == expected"), "== equality check regressed to a state_mutation match"
+    assert not pattern.search("count == 0"), "== equality check regressed to a state_mutation match"
+    assert pattern.search("x = 5"), "real assignment regressed"
+    assert pattern.search("result = compute()"), "real assignment regressed"
+
+
+def test_groovy_func_start_and_args_primitive_and_void_return_type_regression():
+    """
+    Regression test, confirmed real bug: the return-type stepper
+    (`(?:[A-Z][a-zA-Z0-9_<>\\[\\]?]*[ \\t]+){0,2}`) required an uppercase
+    first character, so any method with a lowercase primitive or `void`
+    return type -- `void foo()`, `int add()`, `boolean isValid()` --
+    never matched `func_start` or `args` at all. These are among the most
+    common method signatures in Groovy/Java-interop code. Fixed by adding
+    an explicit primitive-keyword alternative (with an optional `[]` for
+    array-of-primitive returns).
+    """
+    func_start = GROOVY_RULES["func_start"]
+    args = GROOVY_RULES["args"]
+
+    for snippet in (
+        "void plainMethod(String x) {",
+        "int add(int a, int b) {",
+        "boolean isValid() {",
+        "long computeHash() {",
+    ):
+        assert func_start.search(snippet), f"func_start regressed on primitive/void return type: {snippet!r}"
+        assert args.search(snippet), f"args regressed on primitive/void return type: {snippet!r}"
+
+    assert func_start.search("int[] getArray() {"), "array-of-primitive return type still didn't match"
+
+
+def test_groovy_func_start_and_args_multi_param_generic_return_type_regression():
+    """
+    Regression test, confirmed real bug: the return-type stepper's
+    character class excluded `,`, so a multi-parameter generic return
+    type (`Map<String, Integer> calculateTotals(...)`) broke after the
+    first type parameter -- the internal space-after-comma inside the
+    generic couldn't be consumed as the required inter-token whitespace,
+    so the whole method signature never matched. Fixed by adding `,` to
+    the class, which -- combined with the existing space-separated
+    repetition -- naturally splits `Map<String,`/`Integer>` into two
+    tokens (same technique already used by C#'s func_start for this
+    exact bug class).
+    """
+    func_start = GROOVY_RULES["func_start"]
+    args = GROOVY_RULES["args"]
+
+    signature = "Map<String, Integer> calculateTotals(List<Item> items) {"
+    m = func_start.search(signature)
+    assert m and m.group(1) == "calculateTotals", "multi-param generic return type still didn't match func_start"
+    assert args.search(signature), "multi-param generic return type still didn't match args"
+
+
+def test_groovy_func_start_and_args_synchronized_block_false_positive_regression():
+    """
+    Ambiguity-sweep finding, confirmed a real bug in both `func_start` and
+    `args`: a synchronized block (`synchronized(lock) { ... }`) has the
+    identical `identifier(...) {` textual shape as a real method
+    declaration/call. `func_start` already excluded other control-flow
+    keywords (if/for/while/switch/catch) but was missing `synchronized`;
+    `args` had no exclusion list at all and hallucinated a "parameter
+    block" out of every control-flow statement's condition
+    (`if (x) {`, `while (x) {`, `switch (x) {`, `for (i in ...) {`,
+    `catch (Exception e) {`, `synchronized(lock) {`). Confirmed
+    pre-existing (present before this issue's return-type fixes, verified
+    via `git stash`). Fixed by adding the missing keyword to func_start's
+    exclusion list and adding the same style of exclusion to args.
+    """
+    func_start = GROOVY_RULES["func_start"]
+    args = GROOVY_RULES["args"]
+
+    control_flow_blocks = [
+        "if (x > 0) {",
+        "while (x) {",
+        "switch (x) {",
+        "for (i in 1..10) {",
+        "catch (Exception e) {",
+        "synchronized(lock) {",
+    ]
+    for snippet in control_flow_blocks:
+        assert not func_start.search(snippet), f"func_start incorrectly matched a control-flow block: {snippet!r}"
+        assert not args.search(snippet), f"args incorrectly matched a control-flow block: {snippet!r}"
+
+    # Real method signatures and constructor/lambda arg forms must still match.
+    assert func_start.search("void plainMethod(String x) {")
+    assert args.search("void plainMethod(String x) {")
+    assert args.search("(x, y) -> x + y")
+
+
+def test_groovy_args_nested_paren_default_value_regression():
+    """
+    Nested-delimiter audit (Rule 11): `args`' parameter-list matcher used
+    a flat `[^)]*` class, which broke on a one-level-nested call inside a
+    default parameter value (`int y = Math.max(3, 4)`) -- it truncated at
+    the *inner* call's closing `)`, leaving the method's own closing `)`
+    uncaptured. Fixed with a bounded one-level-nesting form.
+    """
+    pattern = GROOVY_RULES["args"]
+    m = pattern.search("def calculate(int x, int y = Math.max(3, 4)) {")
+    assert m is not None
+    assert m.group(0) == "def calculate(int x, int y = Math.max(3, 4))", (
+        f"nested default-value call broke the paren match: {m.group(0)!r}"
+    )
+
+
+def test_groovy_decorators_nested_paren_regression():
+    """
+    Nested-delimiter audit (Rule 11): `decorators`' optional argument
+    matcher used a flat `[^)]*` class, which broke on a one-level-nested
+    call inside an annotation argument -- exactly the realistic
+    `@Grab(..., version=resolveVersion())` shape this issue calls out.
+    Fixed with a bounded one-level-nesting form so the full annotation
+    (including its real closing `)`) is captured.
+    """
+    pattern = GROOVY_RULES["decorators"]
+    snippet = "@Grab(group='org.example', module='lib', version=resolveVersion())"
+    m = pattern.search(snippet)
+    assert m is not None
+    assert m.group(0) == snippet, f"nested @Grab call broke the paren match: {m.group(0)!r}"
+
+    assert pattern.search("@CompileStatic"), "zero-arg decorator regressed"
+    assert pattern.search("@Grab(group='org.example', module='lib', version='1.0')"), "simple @Grab regressed"
+
+
+def test_groovy_generics_nested_regression():
+    """
+    Nested-delimiter audit (Rule 11): `generics` used a flat `[^>]*`
+    class, which broke on the exact one-level-nested construct this
+    issue calls out (`Map<String, List<Id>>`) -- it truncated at the
+    first `>` (after `List<Id`), leaving the real closing `>>` only
+    half-consumed. Fixed with a bounded one-level-nesting form.
+    """
+    pattern = GROOVY_RULES["generics"]
+    m = pattern.search("Map<String, List<Id>> data")
+    assert m is not None
+    assert m.group(0) == "<String, List<Id>>", f"nested generic broke the bracket match: {m.group(0)!r}"
+
+    assert pattern.search("List<String> names"), "simple generic regressed"
+
+
+def test_groovy_dependency_injection_brace_trailing_boundary_regression():
+    """
+    Regression test (Rule 9, trailing-side variant): `plugins\\s*\\{` and
+    `dependencies\\s*\\{` both end on `{`, a non-word character. Wrapped
+    in a shared trailing `\\b(...)\\b`, that boundary could never fire --
+    there is no word/non-word transition between `{` and whatever follows
+    it (whitespace or newline, both non-word). `plugins { ... }` and
+    `dependencies { ... }` -- the two most common Gradle DSL entry points
+    for dependency injection -- never matched at all. Fixed by dropping
+    the trailing `\\b` on the two brace-ending alternatives (the `{` is
+    already self-delimiting).
+    """
+    pattern = GROOVY_RULES["dependency_injection"]
+    assert pattern.search("plugins {\n    id 'groovy'\n}"), "plugins { still didn't match"
+    assert pattern.search("dependencies {\n    implementation 'foo'\n}"), "dependencies { still didn't match"
+    assert pattern.search("apply plugin: 'java'"), "apply plugin regressed"
+    assert pattern.search("@Autowired"), "Spring annotation alternative regressed"
+
+
+def test_groovy_closures_paren_less_trailing_closure_regression():
+    """
+    Regression test, confirmed real bug: both alternatives in the
+    original `closures` pattern (`->` and `\\{...->}`) required a literal
+    `->`. Groovy's single most common closure shape -- the paren-less
+    trailing closure with the implicit `it` parameter (`list.each { it *
+    2 }`, `.collect { println it }`) -- has no arrow at all and never
+    matched either alternative. Fixed by adding a dot-method-call-into-
+    brace alternative.
+    """
+    pattern = GROOVY_RULES["closures"]
+    assert pattern.search("list.each { it * 2 }"), "implicit-it .each closure didn't match"
+    assert pattern.search("list.collect { println it }"), "implicit-it .collect closure didn't match"
+    assert pattern.search("numbers.findAll { it > 5 }"), "implicit-it .findAll closure didn't match"
+    assert pattern.search("list.each { x -> println x }"), "explicit-arg closure regressed"
+    assert pattern.search("def c = { a, b -> a + b }"), "multi-arg closure literal regressed"
+
+
+def test_groovy_comprehensions_paren_less_trailing_closure_regression():
+    """
+    Regression test, confirmed real bug: `comprehensions` required a
+    literal `(` immediately after the iterator method name
+    (`\\.each\\(`), but Groovy's idiomatic call form for these methods is
+    a paren-less trailing closure (`list.each { it }`,
+    `.collect { it * 2 }`) -- the far more common shape never matched at
+    all. Fixed by allowing either `(` or `{` after the method name.
+    """
+    pattern = GROOVY_RULES["comprehensions"]
+    assert pattern.search("list.each { it * 2 }"), "paren-less .each didn't match"
+    assert pattern.search("list.collect { it.toUpperCase() }"), "paren-less .collect didn't match"
+    assert pattern.search("def result = list.findAll { it > 5 }"), "paren-less .findAll didn't match"
+    assert pattern.search("list.each(x)"), "parenthesized call form regressed"
+
+
+def test_groovy_closures_redos_immunity():
+    """
+    ReDoS scaling verification (Rule 5), confirmed real O(n^2)
+    catastrophic backtracking on the *original* pattern: the closure-
+    params alternative was `\\{\\s*(?:it|[\\w\\s,]+)\\s*->`, where
+    `[\\w\\s,]+` and the immediately following `\\s*` both accept
+    whitespace -- an unclosed `{` followed by thousands of spaces forced
+    the engine to retry every possible split of the whitespace run
+    between the two quantifiers. Verified genuine hang: the unfixed
+    pattern already timed out (>5s) at n=2000. Fixed by collapsing into a
+    single bounded, non-overlapping class before the required `->` (same
+    technique as kotlin's closures fix).
+    """
+    pattern = GROOVY_RULES["closures"]
+
+    timings = []
+    for n in (2000, 4000, 8000, 16000, 32000):
+        payload = "{" + " " * n
+        start = time.perf_counter()
+        pattern.search(payload)
+        timings.append(time.perf_counter() - start)
+
+    assert_redos_immune(pattern, "{" + " " * 100000, timeout_sec=3.0)
+
+    for earlier, later in zip(timings, timings[1:]):
+        assert later < max(earlier * 2.5, 0.01), f"closures scaling regressed toward O(n^2): {timings}"
+
+    # Realistic closures must still match after the fix.
+    assert pattern.search("list.each { it }")
+    assert pattern.search("{ x -> x + 1 }")
+
+
+def test_groovy_spec_exposure_quadratic_blowup_redos_regression():
+    """
+    ReDoS scaling verification (Rule 5), confirmed real O(n^2)
+    catastrophic backtracking: the original pattern's `\\d+` and the
+    trailing `[^\\]]*` both greedily match digit characters with no
+    closing `]` ever present -- an unclosed `[SPEC-11111...` tag
+    backtracks by re-scanning an ever-shrinking digit suffix.
+    This is the same bug class already fixed for shell and sqlite's
+    spec_exposure elsewhere in this file, but groovy (and ~24 other
+    languages sharing the identical unbounded pattern -- see this issue's
+    PR description for the full cross-language finding) still carried the
+    vulnerable form. A digit-heavy adversarial payload is required to
+    trigger it -- a letter-only payload (as used to verify some other
+    languages' spec_exposure in this same epic, e.g. yacc) does not, since
+    `\\d+` stops immediately at the first non-digit and there is no
+    overlap to backtrack through. Fixed by bounding the trailing class to
+    `{0,300}` (the same clamp already used by shell/sqlite's spec_exposure
+    for this exact bug).
+    """
+    pattern = GROOVY_RULES["spec_exposure"]
+
+    timings = []
+    for n in (2000, 4000, 8000, 16000, 32000):
+        payload = "[SPEC-" + "1" * n
+        start = time.perf_counter()
+        pattern.search(payload)
+        timings.append(time.perf_counter() - start)
+
+    assert_redos_immune(pattern, "[SPEC-" + "1" * 100000, timeout_sec=3.0)
+
+    # Generous ceiling (real O(n^2) is ~4x/doubling): absorbs scheduler
+    # noise under a full-suite parallel run while still catching a
+    # regression back to catastrophic backtracking.
+    for earlier, later in zip(timings, timings[1:]):
+        assert later < max(earlier * 3.0, 0.02), f"spec_exposure scaling regressed toward O(n^2): {timings}"
+
+    assert pattern.search("[SPEC-123] audit trail"), "realistic spec tag regressed"
+    assert pattern.search("[audit] traceability tag"), "realistic audit tag regressed"
+
+
+def test_groovy_redos_immunity():
+    """
+    ReDoS scaling verification (Rule 5) for the remaining rules with
+    unbounded-looking quantifiers, each fired against a never-closing
+    adversarial payload at a large multiplier. None showed a real
+    catastrophic-backtracking growth curve, so no bounding was needed for
+    these -- included here as regression coverage against a future edit
+    reintroducing an unbounded ambiguity.
+    """
+    assert_redos_immune(GROOVY_RULES["args"], "def foo(" + "a," * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["func_start"], "public Foo " * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["generics"], "<A" * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["decorators"], "@Foo(" * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["state_mutation"], "a." * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["dependency_injection"], "plugins {" * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["class_start"], "public " * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["import"], "import " + "a." * 50000, timeout_sec=2.0)
+    assert_redos_immune(GROOVY_RULES["ownership"], "@author " + "x" * 100000, timeout_sec=2.0)
+
+    # Realistic-but-large inputs must still match after any bounding.
+    assert GROOVY_RULES["args"].search("def foo(String x, int y) {")
+    assert GROOVY_RULES["func_start"].search("void plainMethod(String x) {")
+    assert GROOVY_RULES["generics"].search("List<String> names")
+    assert GROOVY_RULES["decorators"].search("@CompileStatic")
+    assert GROOVY_RULES["state_mutation"].search("x = 5")
+    assert GROOVY_RULES["dependency_injection"].search("plugins {")
+    assert GROOVY_RULES["class_start"].search("class Foo {")
+    assert GROOVY_RULES["import"].search("import com.example.Foo")
+    assert GROOVY_RULES["ownership"].search("@author Jane Doe")
+
+
+def test_groovy_lexical_family_dead_code_fires_under_both_comment_styles():
+    """
+    Comment-style audit (Rule 12), confirming lexical_family parity beyond
+    the single-keyword regression above: groovy is `standard_block`, so
+    both native comment delimiters must independently trigger dead_code
+    for the same underlying commented-out logic.
+    """
+    pattern = GROOVY_RULES["dead_code"]
+    for keyword in ("def", "class", "if", "for", "while", "import"):
+        line_style = f"// {keyword} (x) {{ }}"
+        block_style = f"/* {keyword} (x) {{ }} */"
+        assert pattern.search(line_style), f"'//' style with {keyword!r} didn't match"
+        assert pattern.search(block_style), f"'/* */' style with {keyword!r} didn't match"
+
+
+def test_groovy_bitwise_ops_and_closures_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template (bitwise_ops vs
+    closures, previously found in Rust's `|a| a + 1` and C++'s
+    `std::cout <<`): checked and confirmed a structurally-forced
+    non-collision, not a bug. `bitwise_ops` deliberately excludes `<<`
+    and `>>` (Groovy heavily overloads `<<` for list/stream appending) and
+    only fires on `^`/`~`, neither of which closures' `->`/`{...->}`/
+    `.method {` shapes ever produce. Confirmed no shared literal token
+    between the two rules on realistic code.
+    """
+    bitwise_ops = GROOVY_RULES["bitwise_ops"]
+    closures = GROOVY_RULES["closures"]
+
+    closure_snippet = "list.each { it -> it * 2 }"
+    assert closures.search(closure_snippet)
+    assert not bitwise_ops.search(closure_snippet)
+
+    append_snippet = "list << newItem"
+    assert not bitwise_ops.search(append_snippet), "Groovy's << append operator incorrectly flagged as bitwise_ops"
+
+    bitwise_snippet = "def flags = mask ^ other"
+    assert bitwise_ops.search(bitwise_snippet)
+    assert not closures.search(bitwise_snippet)
+
+
+def test_groovy_func_start_and_generics_intentional_overlap():
+    """
+    Known ambiguity pattern from the issue template (func_start vs
+    generics, previously found in C# via deeply nested generic return
+    types): confirmed a genuine, intentional double-classification for
+    groovy, not a bug. A method with a generic return type
+    (`Map<String, Integer> calculateTotals(...)`) is legitimately BOTH a
+    function declaration AND a use of generics -- the same text span
+    correctly satisfies both signatures simultaneously.
+    """
+    func_start = GROOVY_RULES["func_start"]
+    generics = GROOVY_RULES["generics"]
+
+    signature = "Map<String, Integer> calculateTotals(List<Item> items) {"
+    assert func_start.search(signature)
+    assert generics.search(signature)
+
+    # A generic-free method must still satisfy func_start alone.
+    plain = "void plainMethod(String x) {"
+    assert func_start.search(plain)
+    assert not generics.search(plain)
+
+
+def test_groovy_high_risk_execution_and_panics_and_aborts_system_exit_intentional_overlap():
+    """
+    Ambiguity-sweep finding: both `high_risk_execution` and
+    `panics_and_aborts` list `System.exit` as an alternative. Confirmed
+    intentional, not a bug: `System.exit()` genuinely fits both
+    categories simultaneously -- it is a process-killing, catastrophic
+    runtime call (high_risk_execution) AND it forcefully destroys the
+    current execution context (panics_and_aborts). This mirrors accepted
+    double-classification precedent elsewhere in this file (e.g. pointer
+    address-of vs bitwise AND for `&`).
+    """
+    high_risk_execution = GROOVY_RULES["high_risk_execution"]
+    panics_and_aborts = GROOVY_RULES["panics_and_aborts"]
+
+    snippet = "System.exit(1)"
+    assert high_risk_execution.search(snippet)
+    assert panics_and_aborts.search(snippet)
+
+    throw_only = "throw new RuntimeException('bad')"
+    assert panics_and_aborts.search(throw_only)
+    assert not high_risk_execution.search(throw_only)
+
+
+def test_groovy_closures_and_comprehensions_trailing_closure_intentional_overlap():
+    """
+    Ambiguity-sweep finding introduced by this issue's own fixes: adding
+    paren-less trailing-closure support to both `closures` and
+    `comprehensions` means a call like `list.each { it }` now correctly
+    matches both. Confirmed intentional, not a bug: the construct
+    genuinely is both a collection iterator (comprehensions) AND an
+    anonymous inline callback (closures) simultaneously -- the same
+    double-classification this codebase already accepts elsewhere (e.g.
+    JS's `arr.map(x => x*2)` matching both comprehensions and closures
+    via its arrow function).
+    """
+    closures = GROOVY_RULES["closures"]
+    comprehensions = GROOVY_RULES["comprehensions"]
+
+    snippet = "list.each { it * 2 }"
+    assert closures.search(snippet)
+    assert comprehensions.search(snippet)
+
+    # A closure with no iterator-method prefix satisfies closures alone.
+    bare_closure = "def c = { a, b -> a + b }"
+    assert closures.search(bare_closure)
+    assert not comprehensions.search(bare_closure)
+
+
+def test_groovy_dead_code_and_doc_no_false_collision():
+    """
+    Ambiguity check: `dead_code`'s new `/\\*` alternative (added to fix
+    the Rule 12 comment-style gap) and `doc`'s `/\\*\\*` JavaDoc-opener
+    alternative could plausibly collide now that dead_code also scans
+    block comments. Confirmed no false collision on realistic input: a
+    real JavaDoc block (`/**` followed by a newline before any content)
+    never satisfies dead_code's `[ \\t]*keyword` requirement, since `[
+    \\t]*` cannot cross the newline to reach the keyword on the next
+    line. dead_code only fires on the single-star `/* keyword` form.
+    """
+    dead_code = GROOVY_RULES["dead_code"]
+    doc = GROOVY_RULES["doc"]
+
+    javadoc = "/**\n * @param x the value\n */"
+    assert doc.search(javadoc)
+    assert not dead_code.search(javadoc), "real JavaDoc opener incorrectly triggered dead_code"
+
+    block_dead_code = "/* class Foo {} */"
+    assert dead_code.search(block_dead_code)
+    assert not doc.search(block_dead_code), "single-star block comment incorrectly triggered doc"


### PR DESCRIPTION
Closes #584. Part of epic #518.

## Summary
Found and fixed 11 real bugs: `dead_code` missing `/* */`, `state_mutation` miscounting `==` as `=`, `func_start`/`args` never matching lowercase/void return types or multi-param generics, nested-delimiter truncation in `args`/`decorators`/`generics`, `dependency_injection`'s Gradle DSL entry points never matching (trailing `\b` after `{`), `closures`/`comprehensions` missing Groovy's dominant paren-less trailing-closure idiom, `synchronized` blocks hallucinated as methods, a missing `_dependency_capture`, and 2 confirmed ReDoS findings (closures, spec_exposure).

**Cross-language finding, not fixed here:** the `spec_exposure` ReDoS pattern is copy-pasted across **28 languages**, including already-closed `yacc`. Confirmed via direct timing (~4x/doubling, consistent across samples). Filing a dedicated sweep issue separately.

## Test plan
- [x] 67 new tests — full strict suite 1274 passed
- [x] Full suite — 2197 passed
- [x] `ruff_audit.py` / `mypy_audit.py` / `dead_key_audit.py --ci` — no new findings
- [x] Golden crucible: zero diff, confirmed legitimate (`find`-verified zero real groovy files anywhere in the corpus)

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>