### PR TITLE
Fix: Resolve Commit Header Parsing Collision (#704)

### DIFF
--- a/gitgalaxy/metrics/chronometer.py
+++ b/gitgalaxy/metrics/chronometer.py
@@ -279,7 +279,7 @@ class Chronometer:
             "log",
             "--since=1.year",
             "--name-only",
-            "--pretty=format:%H|%at|%an",
+            "--pretty=format:@@GIT_COMMIT@@|%H|%at|%an",
             "--no-merges",
         ]
 
@@ -351,19 +351,19 @@ class Chronometer:
                 if not clean_line:
                     continue
 
-                # Check if this is the commit header (Hash|Timestamp|Author)
-                if "|" in clean_line:
-                    parts = clean_line.split("|", 2)
-                    if len(parts) >= 2 and parts[1].isdigit():
-                        commit_hash = parts[0]
+                # Check if this is the commit header (@@GIT_COMMIT@@|Hash|Timestamp|Author)
+                if clean_line.startswith("@@GIT_COMMIT@@|"):
+                    parts = clean_line.split("|", 3)
+                    if len(parts) >= 3 and parts[2].isdigit():
+                        commit_hash = parts[1]
 
                         if commit_hash in ignored_hashes:
                             skip_current_commit = True
                             continue
 
                         skip_current_commit = False
-                        current_ts = float(parts[1])
-                        current_author = parts[2].strip() if len(parts) > 2 else "Unknown"
+                        current_ts = float(parts[2])
+                        current_author = parts[3].strip() if len(parts) > 3 else "Unknown"
                         continue
 
                 if skip_current_commit:

--- a/tests/core_engine/test_chronometer.py
+++ b/tests/core_engine/test_chronometer.py
@@ -97,10 +97,10 @@ def test_scan_git_history_and_stream(mock_popen, mock_run, tmp_path):
     mock_process = MagicMock()
     mock_stdout = MagicMock()
     mock_stdout.__iter__.return_value = [
-        "hash1|1000|Alice\n",
+        "@@GIT_COMMIT@@|hash1|1000|Alice\n",
         '"src/main.py"\n',  # Quoted path trap
         "\n",  # Empty line trap
-        "hash_ignored|2000|Bob\n",
+        "@@GIT_COMMIT@@|hash_ignored|2000|Bob\n",
         "src/utils.py\n",  # Should be skipped entirely because the hash is ignored!
     ]
     mock_process.stdout = mock_stdout

--- a/tests/core_engine/test_chronometer_timeout.py
+++ b/tests/core_engine/test_chronometer_timeout.py
@@ -23,8 +23,8 @@ class TestChronometerTimeout(unittest.TestCase):
         def infinite_git_log():
             while True:
                 # Yields a valid line so the internal logic has to do work
-                yield "mock_hash|1700000000|TestAuthor\n"
-                yield "src/safe_file.py\n"
+                yield "@@GIT_COMMIT@@|mock_hash|1700000000|TestAuthor\n"
+                yield "src/main.py\n"
 
         # We attach the generator to a MagicMock so we can assert .close() is called on it later
         mock_stdout = MagicMock()


### PR DESCRIPTION
This PR fixes issue #704 by introducing a deterministic anchor `@@GIT_COMMIT@@|` into the git log format. This prevents filenames with pipes and digits (e.g. `config|1234|settings.json`) from being incorrectly parsed as commit headers, ensuring the churn cache and stability metrics remain unpoisoned.

Resolves #704.