### PR TITLE
Fix: Prevent stderr deadlock in Chronometer Git stream (#705)

### DIFF
--- a/gitgalaxy/metrics/chronometer.py
+++ b/gitgalaxy/metrics/chronometer.py
@@ -329,7 +329,7 @@ class Chronometer:
                 cmd,
                 cwd=self.root,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 bufsize=1,
             )

--- a/tests/core_engine/test_chronometer.py
+++ b/tests/core_engine/test_chronometer.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 from unittest.mock import patch, MagicMock
 
 from gitgalaxy.metrics.chronometer import Chronometer
@@ -124,6 +125,10 @@ def test_scan_git_history_and_stream(mock_popen, mock_run, tmp_path):
         assert "src/utils.py" not in chrono.churn_map, (
             "Failed to skip ignored commit hash!"
         )
+
+        # Verify stderr deadlock guard (#705)
+        _, kwargs = mock_popen.call_args
+        assert kwargs.get("stderr") == subprocess.DEVNULL, "Popen must route stderr to DEVNULL to prevent deadlock!"
 
 
 # ==============================================================================


### PR DESCRIPTION
Routes stderr to DEVNULL to prevent OS pipe buffers from filling and deadlocking the chronometer on massive repositories.