### PR TITLE
Fix: Abort git stream on ls-files failure to prevent timeout trap (#706)

### DIFF
--- a/gitgalaxy/metrics/chronometer.py
+++ b/gitgalaxy/metrics/chronometer.py
@@ -253,9 +253,9 @@ class Chronometer:
             )
             tracked_files = set(res.stdout.splitlines())
             total_files = len(tracked_files)
-        except Exception:
-            tracked_files = set()
-            total_files = 1000  # Fallback safety
+        except Exception as e:
+            self.logger.warning(f"Chronometer: git ls-files failed ({e}). Aborting stream to prevent timeout trap.")
+            return
 
         # ======================================================================
         # DEFENSIVE ARCHITECTURE: Compute & RAM Starvation Guard

--- a/tests/core_engine/test_chronometer.py
+++ b/tests/core_engine/test_chronometer.py
@@ -196,3 +196,18 @@ def test_chronometer_temporal_collapse_guard(mock_getmtime, mock_walk, mock_run,
     assert chrono.repo_min_time == expected_safe_min, (
         f"Temporal Collapse Guard Failed! Expected neutralized min_time {expected_safe_min}, got {chrono.repo_min_time}"
     )
+@patch("gitgalaxy.metrics.chronometer.subprocess.run")
+def test_scan_git_history_fallback_abort(mock_run, tmp_path):
+    """Proves the chronometer aborts _scan_git_history if ls-files fails, avoiding a timeout trap."""
+    mock_run.side_effect = Exception("ls-files failed")
+    
+    with patch("gitgalaxy.metrics.chronometer.Chronometer._initialize_history_scan"):
+        chrono = Chronometer(tmp_path)
+        chrono.is_git_enabled = True
+        
+        # This should return immediately and not call subprocess.Popen for git log
+        with patch("gitgalaxy.metrics.chronometer.subprocess.Popen") as mock_popen:
+            chrono._scan_git_history()
+            
+            # Verify Popen (git log stream) was never called
+            mock_popen.assert_not_called()


### PR DESCRIPTION
If `git ls-files` fails, the chronometer now safely short-circuits `_scan_git_history` instead of uselessly streaming git logs against an empty set and getting caught in a 15-second hard timeout loop.

Resolves #706.