### PR TITLE
fix: crucible_check.py zero-dep venv missing PyYAML

### DIFF
--- a/tests/tools/crucible_check.py
+++ b/tests/tools/crucible_check.py
@@ -62,6 +62,11 @@ def ensure_venv(mode_key: str) -> Path:
         print(f"[{mode_key}] Creating venv at {mode_dir} (first run only) ...")
         venv_module.create(mode_dir, with_pip=True)
         subprocess.run([str(py), "-m", "pip", "install", "-q", "--upgrade", "pip"], check=True)
+        # Full (non --no-deps) install once, so pyproject.toml's core dependencies (e.g.
+        # PyYAML, a hard requirement, not a "full-precision" extra) are actually present --
+        # "zero-dependency" only means the optional networkx/tiktoken/pandas/xgboost stack
+        # is absent, not that core deps are stripped too.
+        subprocess.run([str(py), "-m", "pip", "install", "-q", "-e", str(REPO_ROOT)], check=True)
         if extra_deps:
             subprocess.run([str(py), "-m", "pip", "install", "-q", *extra_deps], check=True)
         subprocess.run([str(py), "-m", "pip", "install", "-q", "pytest"], check=True)


### PR DESCRIPTION
## Summary

`crucible_check.py`'s zero-dep venv path never ran a plain `pip install -e .`, only the
`--no-deps` refresh, so it never picked up `pyproject.toml`'s core dependencies (PyYAML is a
hard requirement, not a full-precision extra). Caught immediately dogfooding the script
against a clean `main` while verifying #617 -- produced a spurious single-field diff
(`Missing Dependencies/pyyaml`) with no real code behind it.

## Test plan

- [x] Deleted and rebuilt `.crucible_venvs/zero_dependency` -- `crucible_check.py --mode both`
      now reports clean PASS on both legs against unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)