### PR TITLE
Fix #773: Strict parsing tests for c structural signatures

### DIFF
--- a/gitgalaxy/standards/how_to_add_a_language.md
+++ b/gitgalaxy/standards/how_to_add_a_language.md
@@ -54,6 +54,8 @@ This dictionary defines the **Structural Signatures** used by an AST-free parsin
     * ❌ `\b(Import-Module|-Parallel)\b` — `-Parallel` can never satisfy the leading `\b`; real code always precedes it with whitespace (a non-word character), so the alternative silently never matches.
     * ✅ `\bImport-Module\b|-Parallel\b`
     * This was, by a wide margin, the single most common defect found across every language audited so far — it produces zero errors or warnings, the signature just quietly never matches its most common real-world form.
+    * **Whitespace itself is non-word too — this trap isn't limited to punctuation.** An alternative ending in `\s+`/`\s*` (not a symbol) has exactly the same problem: `\bCALL\s+\b` inside a shared group can only fire if a word character *immediately* follows all the consumed whitespace, which fails the moment the real form is `CALL 'SUBPROGRAM'` (a quote right after the space). Found independently in COBOL (`CALL\s+`) and elsewhere — treat any alternative ending in a `\s`-quantifier the same as one ending in a literal symbol.
+    * **A "broken" alternative can still silently work if a sibling alternative shadows it — always verify with a real `.search()` call, not by reading the regex shape.** If a group also contains a *shorter, unqualified* alternative that's a prefix of the broken one (e.g. bare `yield` next to broken `yield\s*\*`), the shorter one may satisfy the match first on every realistic input, masking the defect entirely. Confirmed repeatedly (YAML's `TODO`/`@todo`, Tcl's `::`-suffixed namespaces, Rust's `yield`/`yield\s*\*`) — don't flag *or* clear a boundary finding based on the pattern's shape alone; check what `.search()` actually returns on the realistic text.
 10. **Zero-Argument / Symbol-First-Argument Call Forms:** When anchoring a function/method call by name with a trailing `\b` (e.g. `\bapp\(\b`-style reasoning), remember real calls are frequently written with zero arguments or a quoted/numeric first argument — never assume a word character follows the opening paren.
     * ❌ A trailing `\b` placed right after a literal `(` — matches `app(x)` but not `app()` or `app("foo")`, which are usually the *more* common call shapes.
     * ✅ Drop the trailing `\b` when an alternative already ends on `(` — the paren is self-delimiting, same principle as Rule 9.
@@ -63,6 +65,22 @@ This dictionary defines the **Structural Signatures** used by an AST-free parsin
 12. **Comment-Style Completeness for `dead_code`:** If a language's lexical family supports more than one comment style (e.g. a `standard_block` language with both `//` and `/* */`), the `dead_code` keyword check must be wired to ALL of them, not just one — do not assume the style you happen to write the regex against first is the dominant one.
     * ❌ `(?:/\*)\s*(?:function|class|...)\b` — only fires inside block comments, silently missing every `// function foo() {}` line-comment case even though `//` is usually the far more common style.
     * ✅ `(?://|/\*)\s*(?:function|class|...)\b`
+    * The same completeness check applies to `doc`/`ownership` if they're anchored to a specific comment marker (e.g. m4's `dnl` vs. its equally-real `#` default comment) — don't assume the family's shared delimiter table and the rule's own hand-written anchor agree just because they're both "correct" in isolation.
+13. **Multiline Flag Completeness for `^`-Anchored Rules:** Any rule using `^` (start-of-line anchor) MUST include `re.M` in its compile flags. Without it, `^` anchors to the true start of the *string*, not the start of each line — the rule can then only ever fire if the anchored keyword happens to be the literal first characters of the entire file, almost never true for a real multi-line source file.
+    * ❌ `re.compile(r"^(?:EXPOSE|VOLUME|ENTRYPOINT)\b")` with no `re.M` — can only match if one of these keywords is the first thing in the file; a real Dockerfile always starts with `FROM`, so this silently never fires.
+    * ✅ `re.compile(r"^(?:EXPOSE|VOLUME|ENTRYPOINT)\b", re.M)`
+    * Exactly as invisible as Rule 9's defect: the pattern compiles fine and the anchor "looks" correct, it just structurally can't match real multi-line code. Always check the flags, not just the pattern text.
+14. **Adjacent Quantifiers With Overlapping Character Classes (a ReDoS shape distinct from Rule 11):** Two quantified pieces placed back-to-back, where the first's character class is a superset of or overlaps the second's, let the engine try exponentially many ways to split the matched text between them before failing on a payload with no valid closing token. This is NOT about bracket/delimiter nesting (see Rule 11) — it happens with any adjacent quantifiers, including a plain `\s+ ... \s+` sandwiching an unbounded middle piece.
+    * ❌ `\d+[^\]]*` — `[^\]]*` also matches digits, so on a long run of digits with no closing `]`, the engine repartitions the run between the two quantifiers exponentially. Confirmed independently broken this exact way in 7+ languages in this codebase's own audit history (embedded_python, css, tcl, matlab, scheme, typescript, rust) — bound both: `\d{1,10}[^\]]{0,300}`.
+    * ❌ `\s+.*\s+FROM` — `.` matches whitespace too, so a long space-only run with no `FROM` ever appearing lets the engine partition it between `\s+`, `.*`, and the second `\s+` in exponentially many ways. Confirmed **9+ real seconds at just n=2000** in one case — far faster to blow up than the typical nested-delimiter shape, which usually only shows real cost around n=16000-32000. Replace the unbounded middle piece with the actual expected token shape (e.g. a real identifier character class) — this is usually both more correct AND removes the ambiguity entirely.
+    * When testing for this shape, start the scaling sweep at a SMALL n (e.g. 2000) rather than assuming n=32000 is where a real hang would first appear.
+15. **A Documented Exclusion Must Actually Exclude:** If a rule's own comment claims to exclude a specific case (e.g. "only public methods, not private"), verify the regex uses a negative lookahead/lookbehind to actually enforce it — not an *optional* positive group that, when it fails to match the excluded text, simply backs off and matches the unqualified base case anyway.
+    * ❌ `methods\b(?:[ \t]*\(Access[ \t]*=[ \t]*public[ \t]*\))?` intended to flag only public methods blocks — the qualifying group is optional, so `methods (Access = private)` still matches via the bare `methods` alone; the "exclusion" never actually gates anything.
+    * ✅ `methods\b(?![ \t]*\([^)]*\bAccess[ \t]*=[ \t]*(?:private|protected)\b)` — a negative lookahead that genuinely blocks the match when the excluded condition is present.
+    * This defect is invisible to a casual read of the regex — it *looks* like it discriminates on the qualifier — and only surfaces when you specifically test the case the comment claims to exclude.
+16. **Identifier Capture Classes Must Match the Language's Real Grammar:** A capture class like `[a-zA-Z0-9_!?-]+` for a function/type name assumes a narrow, C-like identifier grammar. Many languages (Lisp-family especially, but any language with idiomatic naming conventions using extra punctuation) allow far more characters in identifiers than that. Because the capture typically feeds a required trailing lookahead, a truncated capture doesn't just capture less — it can break the lookahead entirely, turning a partial-match bug into a complete non-match for the whole rule.
+    * ❌ `[a-zA-Z0-9_!?-]+` for Scheme identifiers — excludes `> < = * + / . ~ $ % ^ &`, so idiomatic names like `list->vector`, `1+`, and SRFI-9's `<TypeName>` record-naming convention never matched AT ALL, because the truncated capture broke the trailing lookahead requiring whitespace/`)` right after.
+    * ✅ Check the language's actual identifier grammar (e.g. R7RS's special-initial/special-subsequent character sets) before picking the capture class, and verify against real idiomatic names from that language's own standard library — not just simple ASCII test names.
 
 ### THE LEXICAL PARSING FAMILIES
 You must assign the language to one of these 5 lexical parsing families based on how it handles comments and non-executable text:
@@ -249,15 +267,28 @@ fine":
    key, parametrized into a single test. Every positive snippet must be realistic code you'd
    actually find in a real file of this language — not a synthetic string engineered to match.
 2. **Symbolic-boundary audit (Rule 9/10).** For every `\b(...)\b` group in the dict, check whether
-   any alternative starts or ends on a non-word character. For each one found, write a regression
-   test proving the *realistic* real-world form (preceded/followed by whitespace, not a
-   conveniently-placed word character) actually matches.
+   any alternative starts or ends on a non-word character — including a bare `\s+`/`\s*`, which is
+   just as non-word as a literal symbol. For each one found, write a regression test proving the
+   *realistic* real-world form (preceded/followed by whitespace or punctuation, not a
+   conveniently-placed word character) actually matches. Before flagging (or clearing) a finding,
+   run the actual `.search()` call on the realistic text — a structurally-broken alternative can be
+   silently masked by a shorter, unqualified sibling alternative in the same group that matches
+   first on every realistic input (confirmed repeatedly: YAML's `TODO`/`@todo`, Tcl's
+   `::`-suffixed namespaces, Rust's `yield`/`yield\s*\*`). The pattern's shape alone is not proof
+   either way.
 3. **Nested-delimiter audit (Rule 11).** For every rule using a flat negated class as a delimiter
    matcher (`[^\]]+`, `[^)]+`, `[^}]+`), construct a realistic one-level-nested input for this
    language (a generic type, a nested call, a nested nested structure) and verify it still matches.
+   Separately, check for **adjacent quantifiers with overlapping character classes** (Rule 14) —
+   not a nesting/bracket issue, but two quantified pieces back-to-back where the first's character
+   class overlaps the second's (`\d+` next to `[^\]]+`, or `\s+` next to `.*`). This shape has shown
+   up independently in 7+ languages for the exact same copy-pasted `spec_exposure` pattern, and can
+   be *far* more explosive than a typical nested-delimiter ReDoS (one real case hung for 9+ seconds
+   at just n=2000) — start the scaling sweep at a small n, not just n=32000.
 4. **Comment-style audit (Rule 12).** If the language's `lexical_family` supports more than one
-   comment style, verify `dead_code` fires under each of them, not just the one it was seemingly
-   written against.
+   comment style, verify `dead_code` (and `doc`/`ownership`, if they're anchored to a specific
+   comment marker rather than the family's full delimiter set) fires under each of them, not just
+   the one it was seemingly written against.
 5. **ReDoS adversarial payloads, verified by scaling — not a single timing.** For every rule with
    an unbounded-looking quantifier, construct the "never closes" adversarial payload (e.g. `"{" *
    n` for a rule expecting a closing `}`, `"(" * n` for one expecting `)`) and measure actual
@@ -265,7 +296,9 @@ fine":
    32000). A roughly 2x time increase per doubling is linear and fine. A roughly 4x increase per
    doubling is the signature of real O(n²) catastrophic backtracking and must be fixed (bound the
    quantifier, e.g. `{0,300}` / `{0,500}`, generous enough to still match realistic code) — do not
-   report a ReDoS finding, and do not clear one, off a single timing.
+   report a ReDoS finding, and do not clear one, off a single timing. See Rule 14 above for a shape
+   that can blow up dramatically faster than the usual nested-delimiter case — don't assume n=32000
+   is always where trouble would first appear.
 6. **Ambiguity sweep.** For every *pair* of signatures in the dict (not just an assumed subset),
    check for shared literal tokens, then empirically verify each flagged pair on real-shaped input:
    is it a genuine false collision (two signatures matching the exact same text when they
@@ -276,6 +309,29 @@ fine":
    `bitwise_ops` vs `closures`. Not every finding is a bug — e.g. a test-assertion DSL whose
    "matches" keyword genuinely invokes a regex engine under the hood (Pester's `Should -Match`) is
    a correct, intentional double-classification, not a false positive. State which it is and why.
+7. **`re.M` completeness audit (Rule 13).** For every rule whose pattern uses a literal `^` outside
+   a character class, confirm `re.M` is actually set in its compile flags. A missing flag produces
+   no error and no warning — the rule simply can never match past the first line of a file, which
+   is easy to miss entirely if you only read the pattern text and not the flags argument.
+8. **Lexical-family sanity check.** Before writing any signature-level tests, compare the
+   language's own inline `# Rationale:` comment (next to its `lexical_family` field) against the
+   *actual* value assigned. If they describe different families, don't just fix the mismatch —
+   empirically confirm via `Prism.split_streams()` against a realistic multi-line comment sample
+   whether comments are actually being stripped as the rationale comment assumes. This has
+   surfaced real, separate pipeline bugs twice (HTML mistagged `line_exclusive` instead of
+   `block_exclusive`; Scheme mistagged `line_exclusive` despite describing a nested-block family
+   that was never implemented) — file pipeline-level findings like this as their own issue rather
+   than folding a `prism.py` fix into a per-language strict-parsing PR (see Step 5's on-target
+   discipline below), and write this language's signature tests against the *actual* observed
+   stripping behavior, not the aspirational one.
+9. **Schema completeness audit (Rule 4, revisited).** Diff the full baseline key list (everything
+   in the Output Schema below) against this language's actual `rules.keys()` — not just against
+   the subset that's currently non-`None`. A key can be missing from the dict *entirely*, which
+   looks identical to "hasn't been assigned yet" unless you explicitly check for its presence.
+   Found this way in COBOL: `import` was absent outright (not `None`) even though
+   `_dependency_capture` right next to it was already correctly parsing COPY/INCLUDE targets — a
+   real, working regex for the key was clearly intended and just never added. If a key is
+   genuinely inapplicable, it should be explicit `None` per Rule 4, not silently absent.
 
 ### Step 5: Verify Against the Language Crucible
 The project maintains `tests/test_golden_crucible.py`, which runs the real `galaxyscope` CLI

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -2808,7 +2808,15 @@ LANGUAGE_DEFINITIONS = {
                 # FIX: We now use strict O(1) alternation `(?:\s*[*&]+\s*|\s+)` which
                 # forces the engine to choose exactly one path and never backtrack.
                 # =====================================================================
-                r'\b(extern|__declspec\(dllexport\)|__attribute__\(\(visibility\("default"\)\)\))\b|'
+                # BUG FIX (Rule 9): `__declspec(dllexport)` and
+                # `__attribute__((visibility("default")))` both end in `)`
+                # (non-word) but shared a trailing `\b` with word-ending
+                # `extern` -- `\b` right after can only fire if the next char
+                # is a word character, never true for the realistic form
+                # (whitespace/newline before the return type follows). Pulled
+                # both out of the shared boundary group.
+                r"\bextern\b|__declspec\(dllexport\)|"
+                r'__attribute__\(\(visibility\("default"\)\)\)|'
                 r"^[ \t]*(?!static\b)[a-zA-Z_]\w*(?:\s*[*&]+\s*|\s+)[a-zA-Z_]\w*(?:\[[^\]]*\])?\s*=?|"
                 r"^[ \t]*[a-zA-Z_]\w*(?:\s*[*&]+\s*|\s+)[a-zA-Z_]\w*\s*\([^)]*\)\s*;",
                 re.M,
@@ -2852,8 +2860,15 @@ LANGUAGE_DEFINITIONS = {
             # 21. comprehensions
             "comprehensions": None,
             # 22. scientific (Numerical / Compute Libraries)
+            # BUG FIX (Rule 9): `cblas_` ends in `_` (a word char) and was
+            # clearly intended as a prefix match for any BLAS routine
+            # (`cblas_dgemm`, `cblas_sgemm`, ...), but shared a trailing `\b`
+            # with word-ending siblings -- real usage always continues with
+            # more word characters right after (`cblas_dgemm`), so the
+            # boundary could never fire (both sides word chars). Pulled out
+            # of the shared group with only a leading `\b`.
             "scientific": re.compile(
-                r"\b(math\.h|tgmath\.h|complex\.h|cblas_|dgemm|sin|cos|tan|exp|log|sqrt|complex|I|_Float\d+|__m\d+)\b"
+                r"\b(?:math\.h|tgmath\.h|complex\.h|dgemm|sin|cos|tan|exp|log|sqrt|complex|I|_Float\d+|__m\d+)\b|\bcblas_"
             ),
             # 23. heat_triggers (Metaprogramming & Reflection)
             # Macros with args and unstructured jumps.
@@ -2869,7 +2884,12 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, and
+            # rust earlier in this epic. Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -2928,7 +2948,11 @@ LANGUAGE_DEFINITIONS = {
             # 48. listeners (Event Listeners / Observers)
             "listeners": re.compile(r"\b(on_event|handler|callback|signal\(|sigaction\()"),
             # 49. test_skip (Bypassed Tests / Ignored Specs)
-            "test_skip": re.compile(r"\b(IGNORE_TEST|test\.skip|mock\(|fake\()\b"),
+            # BUG FIX (Rule 10): `mock\(`/`fake\(` end in a literal `(` but
+            # shared a trailing `\b` with word-ending siblings -- broke on
+            # the truly-empty-argument call form (`mock()`), where the next
+            # char after `(` is `)`, not a word char.
+            "test_skip": re.compile(r"\b(?:IGNORE_TEST|test\.skip)\b|mock\(|fake\("),
             # --- PHASE 3: HYBRID DOMAIN SENSORS (C Specifics) ---
             "serialization_parsing": re.compile(r"\b(cJSON_Parse|json_loads|xmlReadMemory|xmlParseFile|jansson)\b"),
             "regex_execution": re.compile(r"\b(regcomp|regexec|regfree)\b"),

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -13099,3 +13099,350 @@ def test_cobol_redos_immunity_sweep():
     assert COBOL_RULES["func_start"].search("       100-PROCESS-RECORDS SECTION.")
     assert COBOL_RULES["class_start"].search("       PROGRAM-ID. MYPROG.")
     assert COBOL_RULES["time_date_logic"].search("ACCEPT WS-DATE FROM DATE.")
+
+
+# ==============================================================================
+# C: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #773, part of epic #518)
+# ==============================================================================
+# NOTE: filed as one of 6 new sub-issues (#773-778) after auditing and
+# rejecting the epic's founding premise that C/C++/C#/COBOL/Rust/TypeScript
+# already had adequate coverage -- see #518's updated "Why" section. This
+# language previously had only two isolated regression tests
+# (test_c_knr_ambiguity_trap covering func_start's K&R ReDoS trap, and
+# test_c_pointer_ambiguity_overlap covering api/explicit_casts pointer-depth
+# ReDoS), not the full per-signature template. Both are folded into this
+# suite below rather than duplicated.
+C_RULES = LANGUAGE_DEFINITIONS["c"]["rules"]
+
+_C_SIMPLE_CASES = [
+    # (signature, positive snippet, text expected to NOT match / None to skip)
+    ("branch", "if (x > 0) {", "int x = 1;"),
+    ("args", "int foo(int a, int b) {", "foo(a, b);"),
+    ("structural_boundaries", "return x;", "x = 1;"),
+    ("func_start", "int foo(int a) {", "if (x) {"),
+    ("class_start", "struct Point {", "int x;"),
+    ("safety", "assert(x > 0);", "x = 1;"),
+    ("safety_bypasses", "strcpy(dst, src);", "memcpy(dst, src, n);"),
+    ("high_risk_execution", 'system("ls");', 'printf("hi");'),
+    ("io", 'fopen("file", "r");', "malloc(10);"),
+    ("api", "extern int foo(void);", "static int foo(void);"),
+    ("state_mutation", "x = 5;", "if (x == 5)"),
+    ("dead_code", "// if (x) foo();", "// just a note"),
+    ("doc", "/** @brief does X */", "// just a note"),
+    ("test", "TEST(Foo, Bar) {", "x = 1;"),
+    ("concurrency", "pthread_create(&t, NULL, f, NULL);", "x = 1;"),
+    ("ui_framework", "GtkWidget *w;", "x = 1;"),
+    ("globals", "int global_var = 5;", "if (x == 1)"),
+    ("decorators", "[[nodiscard]] int foo();", "int foo();"),
+    ("generics", "_Generic(x, int: 1, float: 2);", "int x;"),
+    ("scientific", "sqrt(x);", "foo(x);"),
+    ("reflection_metaprogramming", "#define MAX(a,b) ((a)>(b)?(a):(b))", "#define MAX 100"),
+    ("import", "#include <stdio.h>", "#define FOO 1"),
+    ("ownership", "// Author: Jane Doe", "// just a note"),
+    ("planned_debt", "// TODO: fix this", "// done"),
+    ("fragile_debt", "// HACK: workaround", "// clean"),
+    ("spec_exposure", "[SPEC-123]", "// just a note"),
+    ("ssr_boundaries", "FCGI_Accept();", "x = 1;"),
+    ("events", "epoll_wait(fd, events, 10, -1);", "x = 1;"),
+    ("dependency_injection", "struct foo_ops ops;", "x = 1;"),
+    ("macros", "#define FOO 1", "int x = 1;"),
+    ("pointers", "int *p = &x;", "int x = 1;"),
+    ("memory_alloc", "malloc(10);", "x = 1;"),
+    ("inline_asm", 'asm("nop");', "x = 1;"),
+    ("telemetry", 'syslog(LOG_INFO, "msg");', "x = 1;"),
+    ("debug_prints", 'printf("hi");', 'syslog(LOG_INFO, "x");'),
+    ("explicit_casts", "y = (int)x;", "int x;"),
+    ("panics_and_aborts", "abort();", "return 0;"),
+    ("thread_sleeps", "sleep(5);", "x = 1;"),
+    ("bitwise_ops", "x = a << 2;", "x = a + 2;"),
+    ("sync_locks", "pthread_mutex_lock(&m);", "x = 1;"),
+    ("immutability_locks", "const int x = 1;", "int x = 1;"),
+    ("cleanup", "fclose(f);", 'fopen(f, "r");'),
+    ("encapsulation", "static int helper(void) {", "int helper(void) {"),
+    ("listeners", "signal(SIGINT, handler);", "x = 1;"),
+    ("test_skip", "mock();", "test_run();"),
+    ("serialization_parsing", "cJSON_Parse(str);", "x = 1;"),
+    ("regex_execution", "regcomp(&re, pattern, 0);", "x = 1;"),
+    ("time_date_logic", "time_t t = time(NULL);", "x = 1;"),
+    ("ipc_rpc_bridges", "pipe(fds);", "x = 1;"),
+]
+
+
+@pytest.mark.parametrize("signature,positive,negative", _C_SIMPLE_CASES)
+def test_c_signature_positive_and_negative(signature, positive, negative):
+    pattern = C_RULES[signature]
+    assert pattern is not None, f"c's {signature!r} rule is unexpectedly None"
+    assert pattern.search(positive), f"c {signature!r} failed to match its own documented positive case"
+    if negative is not None:
+        assert not pattern.search(negative), f"c {signature!r} incorrectly matched an excluded case: {negative!r}"
+
+
+def test_c_dependency_capture_extracts_include_targets():
+    dep = C_RULES["_dependency_capture"]
+    m = dep.search('#include "myheader.h"')
+    assert m and m.group(1) == "myheader.h"
+
+    m2 = dep.search("#include <stdio.h>")
+    assert m2 and m2.group(1) == "stdio.h"
+
+    m3 = dep.search("#embed <data.bin>")
+    assert m3 and m3.group(1) == "data.bin"
+
+
+def test_c_api_declspec_and_attribute_boundary_regression():
+    """
+    Real bug found and fixed (Rule 9): `__declspec(dllexport)` and
+    `__attribute__((visibility("default")))` both end in `)` (non-word) but
+    shared a trailing `\\b` with word-ending `extern` -- `\\b` right after
+    can only fire if the next char is a word character, never true for the
+    realistic form (whitespace/newline before the return type follows).
+    """
+    old_pattern = re.compile(
+        r'\b(extern|__declspec\(dllexport\)|__attribute__\(\(visibility\("default"\)\)\))\b|'
+        r"^[ \t]*(?!static\b)[a-zA-Z_]\w*(?:\s*[*&]+\s*|\s+)[a-zA-Z_]\w*(?:\[[^\]]*\])?\s*=?|"
+        r"^[ \t]*[a-zA-Z_]\w*(?:\s*[*&]+\s*|\s+)[a-zA-Z_]\w*\s*\([^)]*\)\s*;",
+        re.M,
+    )
+    realistic = "__declspec(dllexport) void foo();"
+    assert not old_pattern.search(realistic), "sanity check: bug must reproduce against the old pattern"
+
+    api = C_RULES["api"]
+    assert api.search(realistic)
+    assert api.search("extern int x;"), "the already-working extern form must still work"
+    assert api.search('__attribute__((visibility("default"))) void foo();')
+
+
+def test_c_scientific_cblas_prefix_boundary_regression():
+    """
+    Real bug found and fixed (Rule 9): `cblas_` ends in `_` (a word char)
+    and was clearly intended as a prefix match for any BLAS routine
+    (cblas_dgemm, cblas_sgemm, ...), but shared a trailing `\\b` with
+    word-ending siblings -- real usage always continues with more word
+    characters right after, so the boundary could never fire (both sides
+    word chars).
+    """
+    old_pattern = re.compile(
+        r"\b(math\.h|tgmath\.h|complex\.h|cblas_|dgemm|sin|cos|tan|exp|log|sqrt|complex|I|_Float\d+|__m\d+)\b"
+    )
+    realistic = "cblas_dgemm(args);"
+    assert not old_pattern.search(realistic), "sanity check: bug must reproduce against the old pattern"
+
+    scientific = C_RULES["scientific"]
+    assert scientific.search(realistic)
+    assert scientific.search("dgemm(args);"), "the already-working bare dgemm form must still work"
+
+
+def test_c_test_skip_empty_call_boundary_regression():
+    """
+    Real bug found and fixed (Rule 10): `mock\\(`/`fake\\(` end in a literal
+    `(` but shared a trailing `\\b` with word-ending siblings -- broke on
+    the truly-empty-argument call form (`mock()`), where the next char
+    after `(` is `)`, not a word char.
+    """
+    old_pattern = re.compile(r"\b(IGNORE_TEST|test\.skip|mock\(|fake\()\b")
+    realistic = "mock();"
+    assert not old_pattern.search(realistic), "sanity check: bug must reproduce against the old pattern"
+
+    test_skip = C_RULES["test_skip"]
+    assert test_skip.search(realistic)
+    assert test_skip.search("fake();")
+    assert test_skip.search("IGNORE_TEST(foo)"), "the already-working IGNORE_TEST form must still work"
+
+
+def test_c_spec_exposure_redos_regression():
+    """
+    Real bug found and fixed (Rule 14): adjacent unbounded quantifiers with
+    overlapping character sets (`\\d+` next to `[^\\]]*`) -- the same ReDoS
+    shape already found and fixed independently in embedded_python, css,
+    tcl, matlab, scheme, typescript, and rust earlier in this epic (the 8th
+    language with this exact shape). Bounded both quantifiers.
+    """
+    old_pattern = re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I)
+    # Prove the quadratic blowup directly via timing: unclosed bracket with
+    # digits then padding forces the engine to re-partition the trailing
+    # run between `\d+` and `[^\]]*` on every failed attempt to find `]`.
+    import time
+
+    start = time.perf_counter()
+    old_pattern.search("[SPEC-" + "1" * 16000 + " " * 16000)
+    duration = time.perf_counter() - start
+    assert duration > 0.3, "sanity check: old pattern should show measurable quadratic cost at this scale"
+
+    spec_exposure = C_RULES["spec_exposure"]
+    assert_redos_immune(spec_exposure, "[SPEC-" + " " * 100000, timeout_sec=3.0)
+    assert spec_exposure.search("[SPEC-123]")
+    assert spec_exposure.search("[audit]")
+
+
+def test_c_explicit_casts_vs_pointers_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template: C-style cast syntax
+    (e.g. `(int*)`) can overlap with pointer-asterisk repetition. Verified
+    no false collision -- a bare cast without a pointer declaration doesn't
+    also fire `pointers`, and a line with both a real pointer declaration
+    and a cast legitimately fires both (intentional dual classification,
+    not a bug).
+    """
+    explicit_casts = C_RULES["explicit_casts"]
+    pointers = C_RULES["pointers"]
+
+    bare_cast = "double val = (double)x;"
+    assert explicit_casts.search(bare_cast)
+    assert not pointers.search(bare_cast)
+
+    cast_and_ptr = "int *y = (int*)malloc(10);"
+    assert explicit_casts.search(cast_and_ptr)
+    assert pointers.search(cast_and_ptr), "a real pointer declaration alongside a cast should still fire pointers"
+
+
+def test_c_func_start_vs_macros_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template (already found in C++:
+    a multi-line #define spiral hallucinating a function match). Unlike
+    C++'s func_start (which allows a bare constructor-style identifier
+    with no preceding return type, and so can hallucinate a match by
+    skipping the macro run to reach a later bare `myFunc() {`), C's
+    func_start always requires an explicit return-type token immediately
+    before the identifier -- so a dangling return type followed by a long
+    run of #define lines can never bridge across them to a hallucinated
+    match; it correctly finds nothing at all.
+    """
+    func_start = C_RULES["func_start"]
+    macros = C_RULES["macros"]
+
+    poison = "int\n" + "#define FOO 1\n" * 1000 + "myFunc() {"
+    assert_redos_immune(func_start, poison, timeout_sec=3.0)
+    matches = list(func_start.finditer(poison))
+    assert len(matches) == 0, "C's func_start requires a return type -- a bare 'myFunc() {' must never match"
+    assert macros.search("#define FOO 1")
+
+    # A real return type immediately preceding the identifier still matches.
+    valid = "int myFunc() {"
+    matches2 = list(func_start.finditer(valid))
+    assert len(matches2) == 1
+    assert matches2[0].group(1) == "myFunc"
+
+
+def test_c_intentional_double_classification_sweep():
+    """
+    Ambiguity sweep finding: several C constructs legitimately fire two
+    signatures representing different perspectives on the same underlying
+    action -- intentional, not false collisions:
+    - `free(p)` -> cleanup (resource release) + memory_alloc (deallocation)
+    - `mmap(...)` -> memory_alloc + ipc_rpc_bridges (mmap is both a raw
+      allocation and a common shared-memory/IPC primitive)
+    - `socket(...)` -> io + ipc_rpc_bridges
+    - `fork()` -> high_risk_execution (process-killing context switch) +
+      ipc_rpc_bridges (process creation for IPC)
+    - `close(fd)` -> io + cleanup
+    - `alloca(10)` -> safety_bypasses (unchecked stack allocation) +
+      memory_alloc
+    - `pthread_mutex_lock(&m)` -> concurrency + sync_locks (both explicitly
+      define this as their own primitive)
+    - `restrict`/`alignas(...)` -> structural_boundaries (own keyword list)
+      + immutability_locks (own keyword list) -- both rules intentionally
+      claim these qualifiers
+    - `goto end;` -> branch (control-flow jump) + reflection_metaprogramming
+      (unstructured jump signal)
+    - `struct foo_ops ops;` -> class_start (any struct declaration) +
+      dependency_injection (the `_ops` vtable-style suffix)
+    """
+    free_call = "free(p);"
+    assert C_RULES["cleanup"].search(free_call)
+    assert C_RULES["memory_alloc"].search(free_call)
+
+    mmap_call = "mmap(NULL, len, PROT_READ, 0, fd, 0);"
+    assert C_RULES["memory_alloc"].search(mmap_call)
+    assert C_RULES["ipc_rpc_bridges"].search(mmap_call)
+
+    socket_call = "socket(AF_INET, SOCK_STREAM, 0);"
+    assert C_RULES["io"].search(socket_call)
+    assert C_RULES["ipc_rpc_bridges"].search(socket_call)
+
+    fork_call = "fork();"
+    assert C_RULES["high_risk_execution"].search(fork_call)
+    assert C_RULES["ipc_rpc_bridges"].search(fork_call)
+
+    close_call = "close(fd);"
+    assert C_RULES["io"].search(close_call)
+    assert C_RULES["cleanup"].search(close_call)
+
+    alloca_call = "alloca(10);"
+    assert C_RULES["safety_bypasses"].search(alloca_call)
+    assert C_RULES["memory_alloc"].search(alloca_call)
+
+    mutex_call = "pthread_mutex_lock(&m);"
+    assert C_RULES["concurrency"].search(mutex_call)
+    assert C_RULES["sync_locks"].search(mutex_call)
+
+    assert C_RULES["structural_boundaries"].search("restrict")
+    assert C_RULES["immutability_locks"].search("restrict")
+    assert C_RULES["structural_boundaries"].search("alignas(16)")
+    assert C_RULES["immutability_locks"].search("alignas(16)")
+
+    goto_stmt = "goto end;"
+    assert C_RULES["branch"].search(goto_stmt)
+    assert C_RULES["reflection_metaprogramming"].search(goto_stmt)
+
+    ops_struct = "struct foo_ops ops;"
+    assert C_RULES["class_start"].search(ops_struct)
+    assert C_RULES["dependency_injection"].search(ops_struct)
+
+
+def test_c_knr_ambiguity_trap():
+    """
+    Proves the C function spawner does not spiral into a permutation death
+    loop when encountering the MS-DOS BEGIN macro or massive parameter
+    gaps. Pre-existing regression test, folded into this suite unchanged.
+    """
+    c_func = C_RULES["func_start"]
+
+    poison_knr = "int legacy_func(a, b, c) \n" + "    int a; int b; int c;\n" * 50 + "    INVALID_MACRO"
+    assert_redos_immune(c_func, poison_knr, timeout_sec=3.0)
+
+    valid_knr = "int legacy_func(a) \n    int a; \n BEGIN \n"
+    matches = list(c_func.finditer(valid_knr))
+    assert len(matches) == 1
+    assert matches[0].group(1) == "legacy_func"
+
+
+def test_c_pointer_ambiguity_overlap():
+    r"""
+    Proves that O(1) alternation `(?:\s*[*&]+\s*|\s+)` successfully prevents
+    exponential evaluation on massive strings of pointer asterisks.
+    Pre-existing regression test, folded into this suite unchanged.
+    """
+    c_api = C_RULES["api"]
+    c_cast = C_RULES["explicit_casts"]
+
+    poison_cast = "( int " + "* " * 200 + ") "
+    poison_api = "extern int " + "* " * 200 + " var"
+
+    assert_redos_immune(c_cast, poison_cast)
+    assert_redos_immune(c_api, poison_api)
+
+
+def test_c_redos_immunity_sweep():
+    """
+    ReDoS immunity sweep across c's remaining rules with unbounded-looking
+    quantifiers, verified via a systematic scaling sweep (n=2000/4000/8000/
+    16000/32000) before writing this test.
+    """
+    assert_redos_immune(C_RULES["args"], "int foo(" + "int a," * 6000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["args"], "int foo(int (*cb)(" + "a," * 16000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["func_start"], "int foo" + " " * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["func_start"], "__attribute__((" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["class_start"], "struct " + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["decorators"], "[[" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["generics"], "_Generic(" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["explicit_casts"], "(int" + " " * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["_dependency_capture"], "#include <" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["import"], "#include <" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["inline_asm"], "asm" + " " * 100000, timeout_sec=3.0)
+    assert_redos_immune(C_RULES["globals"], "a" * 100000 + " = 1;", timeout_sec=3.0)
+    assert_redos_immune(C_RULES["pointers"], "&" + "a" * 100000, timeout_sec=3.0)
+
+    # sanity: all still match their real positive cases after the sweep
+    assert C_RULES["func_start"].search("int foo(int a) {")
+    assert C_RULES["class_start"].search("struct Point {")
+    assert C_RULES["explicit_casts"].search("y = (int)x;")


### PR DESCRIPTION
## Summary
- Full per-signature strict-parsing test coverage for `c`'s 49 non-`None` structural signatures in `tests/core_engine/test_language_standards_strict.py`, following the epic #518 template (positive/negative case, cross-rule ambiguity checks, ReDoS scaling sweep for every signature). Folds in the two pre-existing isolated regression tests (`test_c_knr_ambiguity_trap`, `test_c_pointer_ambiguity_overlap`) rather than duplicating them.
- Four real bugs found and fixed in `gitgalaxy/standards/language_standards.py`'s `c` rules:
  - **`api`**: `__declspec(dllexport)` and `__attribute__((visibility("default")))` both end in `)` (non-word) but shared a trailing `\b` with word-ending `extern` — the boundary could never fire since real usage is always followed by whitespace/newline, not a word character. Pulled both out of the shared group (Rule 9).
  - **`scientific`**: `cblas_` ends in `_` (a word char) and was clearly meant as a prefix match for BLAS routines (`cblas_dgemm`, ...), but shared a trailing `\b` with word-ending siblings — broke on every realistic call since both sides of the boundary are word chars (Rule 9).
  - **`test_skip`**: `mock\(`/`fake\(` shared a trailing `\b` with word-ending siblings, breaking on the truly-empty-argument call form `mock()` (Rule 10).
  - **`spec_exposure`**: adjacent unbounded quantifiers with overlapping character sets (`\d+` next to `[^\]]*`) — the same ReDoS shape already found in 7 other languages this epic (embedded_python, css, tcl, matlab, scheme, typescript, rust). Bounded both quantifiers (Rule 14).
- Updated `gitgalaxy/standards/how_to_add_a_language.md` with lessons learned across the whole epic so far: two new Rule 9 bullets (whitespace-ending alternatives share the same boundary trap as symbols; a broken alternative can silently self-heal via a shadowing sibling — always verify with `.search()`, not pattern shape), a Rule 12 comment-style completeness bullet, four new engine rules (13: `re.M` completeness, 14: adjacent overlapping quantifiers, 15: a documented exclusion must actually exclude, 16: identifier classes must match the language's real grammar), and three new Strict Testing Prompt checklist items.

## Test plan
- [x] `pytest tests/core_engine/test_language_standards_strict.py -k test_c_` — 60 new tests pass
- [x] `pytest tests/core_engine/test_language_standards_strict.py` — full suite, 2356 passed
- [x] Adjacent extraction/prism/aperture/language_lens/statistical_auditor/dead_key_audit test files (referencing `c`) — pass, except one pre-existing unrelated failure (`test_detector_tiktoken_mass_success`, confirmed identical on `main` via `git stash`)
- [x] `ruff format --check` — clean
- [x] `python tests/ruff_audit.py --ci` — no new findings beyond baseline
- [x] `python tests/mypy_audit.py --ci` — 2 new findings, both in `guidestar_lens.py` (untouched by this PR, confirmed via `git status` scope)
- [x] Differential Scan (`python tests/tools/crucible_check.py`) — both `full_precision` and `zero_dependency` venvs PASS with zero diff against the golden master corpus

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>