### PR TITLE
Fix #703: dedupe secrets shunt config

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -11251,16 +11251,6 @@ LANGUAGE_DEFINITIONS = {
             ".7",
             ".8",
             ".9",
-            # --- THE SECRETS SHUNT (ASCII ONLY) ---
-            ".pem",
-            ".key",
-            ".pub",
-            ".crt",
-            ".cer",
-            ".asc",
-            ".gpg",
-            ".sig",
-            ".ovpn",
         ],
         # ABSOLUTE IDENTITY: The universally recognized, extensionless plaintext anchors.
         # FIX: Added ubiquitous community files. Removed binary keystore exact matches.
@@ -11275,21 +11265,6 @@ LANGUAGE_DEFINITIONS = {
             "CODE_OF_CONDUCT",
             "SECURITY",
             "MAINTAINERS",
-            # --- THE SECRETS SHUNT (ASCII ONLY) ---
-            "id_rsa",
-            "id_dsa",
-            "id_ed25519",
-            "id_ecdsa",
-            ".env",
-            ".env.local",
-            ".env.production",
-            ".npmrc",
-            ".htpasswd",
-            ".pypirc",
-            "credentials.json",
-            "client_secret.json",
-            "auth.json",
-            "shadow",
         ],
         # ECOSYSTEM ANCHORS: Universal fallback discriminators.
         "discriminators": [".txt", ".md", "README", "LICENSE"],

--- a/tests/core_engine/test_aperture.py
+++ b/tests/core_engine/test_aperture.py
@@ -431,3 +431,82 @@ def test_aperture_ignored_directories_case_insensitive(tmp_path):
 
     # Non-matching source files still pass
     assert engine._check_ignore_rules("src/valid.py") is True
+
+
+# ==============================================================================
+# TEST: SECRETS SHUNT CONFIGURATION DRIFT (#703)
+# ==============================================================================
+def test_plaintext_language_definition_does_not_duplicate_secrets_shunt_config():
+    """
+    Regression test for #703: the secrets-extension/exact-match lists used
+    to be hardcoded twice -- once as the real source of truth in
+    gitgalaxy_config.py's APERTURE_CONFIG (what aperture.py's Gate 1.1
+    Credential Exposure Radar actually reads), and again, redundantly,
+    inside language_standards.py's "plaintext" language entry under a
+    "THE SECRETS SHUNT (ASCII ONLY)" comment block.
+
+    That second copy was provably dead: Gate 1.1 runs unconditionally at
+    the top of ApertureFilter.evaluate_path_integrity() and returns early
+    (rejecting the file) before Gate 1.5 (Language Registry Validation) --
+    the only gate that ever reads a language's "extensions"/"exact_matches"
+    -- is reached. A file matching SECRETS_EXTENSIONS/SECRETS_EXACT can
+    never fall through to have its extension checked against "plaintext"'s
+    list, so the duplicate served no runtime purpose and was pure
+    configuration-drift risk (add a new secret extension to one file,
+    forget the other).
+
+    Asserts the two configs stay decoupled going forward: no entry from
+    gitgalaxy_config.py's real SECRETS_EXTENSIONS/SECRETS_EXACT should ever
+    reappear in language_standards.py's "plaintext" extensions/exact_matches.
+    """
+    from gitgalaxy.standards.gitgalaxy_config import APERTURE_CONFIG
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    plaintext_extensions = set(LANGUAGE_DEFINITIONS["plaintext"]["extensions"])
+    plaintext_exact_matches = set(LANGUAGE_DEFINITIONS["plaintext"]["exact_matches"])
+
+    overlapping_extensions = plaintext_extensions & APERTURE_CONFIG["SECRETS_EXTENSIONS"]
+    overlapping_exact = plaintext_exact_matches & APERTURE_CONFIG["SECRETS_EXACT"]
+
+    assert not overlapping_extensions, (
+        f"plaintext's extensions re-duplicated SECRETS_EXTENSIONS entries: {overlapping_extensions}"
+    )
+    assert not overlapping_exact, f"plaintext's exact_matches re-duplicated SECRETS_EXACT entries: {overlapping_exact}"
+
+
+def test_aperture_secrets_shunt_unaffected_by_removing_plaintext_duplication(tmp_path):
+    """
+    End-to-end regression test for #703: proves removing the duplicated
+    entries from language_standards.py's "plaintext" definition did not
+    regress the actual secrets-shunt behavior. Uses the REAL
+    APERTURE_CONFIG and LANGUAGE_DEFINITIONS (not the minimal mocks used
+    elsewhere in this file) to confirm Gate 1.1 still rejects secret
+    extensions/filenames purely from gitgalaxy_config.py, with no
+    dependency on "plaintext"'s own (now-deduplicated) lists.
+    """
+    from gitgalaxy.standards.gitgalaxy_config import APERTURE_CONFIG
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    real_engine = ApertureFilter(
+        root_dir=tmp_path,
+        language_definitions=LANGUAGE_DEFINITIONS,
+        aperture_config=APERTURE_CONFIG,
+    )
+
+    pem_file = tmp_path / "private_key.pem"
+    pem_file.write_text("-----BEGIN RSA PRIVATE KEY-----", encoding="utf-8")
+    is_valid, _, reason = real_engine.evaluate_path_integrity(pem_file)
+    assert is_valid is False
+    assert "CRITICAL LEAK" in reason
+
+    ssh_key_file = tmp_path / "id_rsa"
+    ssh_key_file.write_text("-----BEGIN OPENSSH PRIVATE KEY-----", encoding="utf-8")
+    is_valid, _, reason = real_engine.evaluate_path_integrity(ssh_key_file)
+    assert is_valid is False
+    assert "CRITICAL LEAK" in reason
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_KEY=secret", encoding="utf-8")
+    is_valid, _, reason = real_engine.evaluate_path_integrity(env_file)
+    assert is_valid is False
+    assert "CRITICAL LEAK" in reason


### PR DESCRIPTION
## Summary
Fixes #703. `gitgalaxy_config.py`'s `APERTURE_CONFIG` (`SECRETS_EXTENSIONS`/`SECRETS_EXACT`) and `language_standards.py`'s `plaintext` language entry both hardcoded the same secrets-related extensions/filenames.

Traced the actual runtime dependency before removing anything: `aperture.py`'s `ApertureFilter.evaluate_path_integrity()` checks Gate 1.1 (Credential Exposure Radar, reading `APERTURE_CONFIG` directly) *before* Gate 1.5 (Language Registry Validation — the only gate that reads a language's `extensions`/`exact_matches`). Gate 1.1 unconditionally returns early (rejecting the file) for any `SECRETS_EXTENSIONS`/`SECRETS_EXACT` match, so a file matching those can never reach Gate 1.5 — `plaintext`'s duplicated copy was provably dead code, not just redundant-looking. Confirmed no other module references the `plaintext` key for any other purpose.

Removed the duplicated `THE SECRETS SHUNT (ASCII ONLY)` extension and exact_match entries from `plaintext`'s definition. `gitgalaxy_config.py`'s `APERTURE_CONFIG` is now the sole source of truth.

## Test plan
- [x] New test: `test_plaintext_language_definition_does_not_duplicate_secrets_shunt_config` — asserts the two configs stay decoupled going forward.
- [x] New test: `test_aperture_secrets_shunt_unaffected_by_removing_plaintext_duplication` — end-to-end, using the real `APERTURE_CONFIG` + `LANGUAGE_DEFINITIONS`, confirming `.pem`/`id_rsa`/`.env` files are still correctly rejected after the dedup.
- [x] `pytest tests/core_engine/test_aperture.py` — 15 passed, 1 pre-existing xfail
- [x] `ruff format --check` / `ruff_audit.py --ci` — clean
- [x] `crucible_check.py` (both venvs) — zero diff, as expected (Gate 1.1 always intercepts these files first, so no scan output could possibly change)
- [x] Full suite — 14 pre-existing, unrelated failures in `test_security_auditor.py` confirmed identical with this change stashed out (missing `xgboost` in this environment)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>