### PR TITLE
Fix #713: bound spec_exposure ReDoS across remaining 17 vulnerable languages

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -451,7 +451,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -749,7 +755,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -1385,7 +1397,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -2038,7 +2056,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             # Gofmt mandates tabs; finding spaces at start signals structural friction.
             "tabs_vs_spaces": None,
@@ -3341,7 +3365,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -4210,7 +4240,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -4445,7 +4481,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -4694,7 +4736,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -5250,7 +5298,15 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|RFC|W3C|CERN|TBL)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(
+                r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit|RFC|W3C|CERN|TBL)[^\]]{0,300}\]", re.I
+            ),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries (Server-Side Rendering)
@@ -6136,7 +6192,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|rfc)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit|rfc)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries
@@ -6863,7 +6925,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt: The Fracture. Admitted fragility or hacks.
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure: Map vs. Territory. Audit tags.
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies): Indentation Tracker. Tabs vs 4-Spaces density markers.
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries: View Horizon. Server-Side Rendering computation boundaries.
@@ -8291,8 +8359,14 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt: The Fracture. Admitted fragility or hacks.
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure: Map vs. Territory. Audit tags and architecture specs.
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
             "spec_exposure": re.compile(
-                r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|RFC|W3C|CERN|TBL|ENQUIRE)[^\]]*\]|\b(?:Tim\s+Berners-Lee|WorldWideWeb|HyperText\s+Proposal)\b",
+                r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit|RFC|W3C|CERN|TBL|ENQUIRE)[^\]]{0,300}\]|\b(?:Tim\s+Berners-Lee|WorldWideWeb|HyperText\s+Proposal)\b",
                 re.I,
             ),
             # 30. tabs_vs_spaces (Formatting Inconsistencies): Indentation Tracker. Tabs vs 2-space standardization.
@@ -8853,8 +8927,14 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure (Spec / Audit Traceability)
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
             "spec_exposure": re.compile(
-                r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d+|spec|audit|CVE-\d{4}-\d+)[^\]]*\]",
+                r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d{1,10}|spec|audit|CVE-\d{4}-\d+)[^\]]{0,300}\]",
                 re.I,
             ),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
@@ -9635,7 +9715,15 @@ LANGUAGE_DEFINITIONS = {
             # 28. private_info: Hardcoded credentials or private keys. Requires assignment.
             "hardcoded_secrets": re.compile(r"\b(private_key|secret|mnemonic|api_key)\b[ \t]*[:=]", re.I),
             # 29. spec_exposure: Map vs. Territory. ERC/EIP standards and audit tags.
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|audit)[^\]]*\]|\b(ERC-\d+|EIP-\d+)\b", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(
+                r"\[(?:\s*SPEC\s*-\s*\d{1,10}|audit)[^\]]{0,300}\]|\b(ERC-\d+|EIP-\d+)\b", re.I
+            ),
             # 30. tabs_vs_spaces (Formatting Inconsistencies): Indentation Tracker. Handled natively.
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries: View Horizon.
@@ -9884,8 +9972,14 @@ LANGUAGE_DEFINITIONS = {
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
             "planned_debt": GLOBAL_PLANNED_DEBT,
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
             "spec_exposure": re.compile(
-                r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|RFC|W3C|CERN|TBL|ENQUIRE)[^\]]*\]|\b(?:WorldWideWeb|HyperText\s+Proposal|NeXTSTEP\s+Docs)\b",
+                r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit|RFC|W3C|CERN|TBL|ENQUIRE)[^\]]{0,300}\]|\b(?:WorldWideWeb|HyperText\s+Proposal|NeXTSTEP\s+Docs)\b",
                 re.I,
             ),
             "tabs_vs_spaces": None,
@@ -10700,7 +10794,13 @@ LANGUAGE_DEFINITIONS = {
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
             "planned_debt": GLOBAL_PLANNED_DEBT,
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
-            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             "tabs_vs_spaces": None,
             "ssr_boundaries": None,
             "events": None,
@@ -10852,7 +10952,13 @@ LANGUAGE_DEFINITIONS = {
             # 27. fragile_debt (Acknowledged Hacks / FIXMEs)
             "fragile_debt": GLOBAL_FRAGILE_DEBT,
             # 29. spec_exposure
-            "spec_exposure": re.compile(r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d+|spec|audit)[^\]]*\]", re.I),
+            # BUG FIX (Rule 14, #713): adjacent unbounded quantifiers with
+            # overlapping character sets (`\d+` next to `[^\]]*`) -- the
+            # same ReDoS shape already found and fixed independently in
+            # embedded_python, css, tcl, matlab, scheme, typescript, rust, c,
+            # cpp, csharp, groovy, shell, and sqlite earlier in this epic.
+            # Bounded both quantifiers.
+            "spec_exposure": re.compile(r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
             # 30. tabs_vs_spaces (Formatting Inconsistencies)
             "tabs_vs_spaces": None,
             # 31. ssr_boundaries

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -14410,3 +14410,95 @@ def test_csharp_redos_immunity_sweep():
     assert CSHARP_RULES["func_start"].search("public int Foo() {")
     assert CSHARP_RULES["class_start"].search("class Foo {")
     assert CSHARP_RULES["args"].search("x => x + 1")
+
+
+# ==============================================================================
+# CROSS-LANGUAGE SWEEP: spec_exposure ADJACENT-QUANTIFIER ReDoS (Issue #713)
+# ==============================================================================
+# Found while closing #584 (groovy strict-parsing tests): the `spec_exposure`
+# signature's `\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]` shape (or close
+# per-language variants) was copy-pasted across the majority of
+# LANGUAGE_DEFINITIONS entries, and most copies still carried the unbounded
+# `[^\]]*` immediately after the equally-unbounded `\d+` -- the classic
+# adjacent-overlapping-quantifier shape (digits satisfy both character
+# classes, so an unclosed "[SPEC-11111..." tag with no closing "]" forces
+# the engine to re-scan an ever-shrinking digit suffix at every possible
+# split point between the two quantifiers, O(n^2)).
+#
+# This exact bug class had already been found and fixed independently,
+# one language at a time, throughout this epic (embedded_python, css, tcl,
+# matlab, scheme, typescript, rust, c, cpp, csharp, groovy, shell, sqlite)
+# -- #713 is the systemic sweep catching every language that slipped
+# through those one-off passes. Rather than scatter 17 near-identical
+# regression tests across each language's own (already large) strict-
+# parsing section, this is the single dedicated cross-language test the
+# issue itself explicitly authorizes as the "cleaner" alternative.
+#
+# Fix: bound `\d+` to `\d{1,10}` and `[^\]]*` to `[^\]]{0,300}` -- the
+# exact same clamp already proven correct for shell/sqlite/groovy/etc
+# earlier in this epic. Generous enough for any realistic spec/audit tag,
+# only removing the pathological-input hang.
+_SPEC_EXPOSURE_REDOS_SWEEP_TARGETS = [
+    # (language, old vulnerable pattern text before this fix, extra correctness spot-check)
+    ("python", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("javascript", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("java", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("go", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("php", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("ruby", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("swift", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("kotlin", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("html", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|RFC|W3C|CERN|TBL)[^\]]*\]", "[RFC 2616]"),
+    ("assembly", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|rfc)[^\]]*\]", "[rfc]"),
+    ("perl", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    (
+        "dart",
+        r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|RFC|W3C|CERN|TBL|ENQUIRE)[^\]]*\]|\b(?:Tim\s+Berners-Lee|WorldWideWeb|HyperText\s+Proposal)\b",
+        "[ENQUIRE]",
+    ),
+    (
+        "dockerfile",
+        r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d+|spec|audit|CVE-\d{4}-\d+)[^\]]*\]",
+        "[CVE-2024-12345]",
+    ),
+    ("solidity", r"\[(?:\s*SPEC\s*-\s*\d+|audit)[^\]]*\]|\b(ERC-\d+|EIP-\d+)\b", "ERC-721"),
+    (
+        "objective-c",
+        r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit|RFC|W3C|CERN|TBL|ENQUIRE)[^\]]*\]|\b(?:WorldWideWeb|HyperText\s+Proposal|NeXTSTEP\s+Docs)\b",
+        "WorldWideWeb",
+    ),
+    ("yacc", r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", None),
+    ("m4", r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d+|spec|audit)[^\]]*\]", None),
+]
+
+
+@pytest.mark.parametrize(
+    "language,old_pattern_text,extra_positive",
+    _SPEC_EXPOSURE_REDOS_SWEEP_TARGETS,
+    ids=[t[0] for t in _SPEC_EXPOSURE_REDOS_SWEEP_TARGETS],
+)
+def test_spec_exposure_adjacent_quantifier_redos_sweep(language, old_pattern_text, extra_positive):
+    old_pattern = re.compile(old_pattern_text, re.I)
+
+    # Scale-relative sanity check (not an absolute wall-clock threshold,
+    # which is flaky across CI hardware of varying speed -- the exact
+    # failure mode of an earlier version of this same style of test in
+    # this file): a payload-size doubling should cost ~4x on the
+    # quadratic OLD pattern, vs ~2x for linear.
+    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
+    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
+    ratio = large_duration / small_duration if small_duration > 0 else 0
+    assert ratio > 2.5, (
+        f"{language}: sanity check failed -- old pattern was expected to show quadratic (~4x) "
+        f"scaling on a payload doubling, but only scaled {ratio:.2f}x "
+        f"({small_duration:.4f}s -> {large_duration:.4f}s)"
+    )
+
+    spec_exposure = LANGUAGE_DEFINITIONS[language]["rules"]["spec_exposure"]
+    assert_redos_immune(spec_exposure, "[SPEC-" + "1" * 100000, timeout_sec=3.0)
+    assert spec_exposure.search("[SPEC-123]"), f"{language}: lost the basic SPEC-NNN positive case"
+    assert spec_exposure.search("[audit]"), f"{language}: lost the basic [audit] positive case"
+    if extra_positive is not None:
+        assert spec_exposure.search(extra_positive), (
+            f"{language}: lost its own extra alternative ({extra_positive!r}) while bounding the fix"
+        )


### PR DESCRIPTION
## Summary
Fixes #713. The `spec_exposure` signature's `\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]` shape (or close per-language variants) was copy-pasted across the majority of `LANGUAGE_DEFINITIONS`, and most copies still carried the unbounded `[^\]]*` immediately after the equally-unbounded `\d+` — digits satisfy both character classes, so an unclosed `[SPEC-11111...` tag with no closing `]` forces the engine to re-scan an ever-shrinking digit suffix at every possible split point, genuine O(n²) catastrophic backtracking.

The original issue found 28 languages carrying this bug. Re-audited the current state before touching anything — this exact class had already been fixed independently, one language at a time, across this epic (embedded_python, css, tcl, matlab, scheme, typescript, rust, c, cpp, csharp, groovy, shell, sqlite). Confirmed only **17** remain vulnerable: `python, javascript, java, go, php, ruby, swift, kotlin, html, assembly, perl, dart, dockerfile, solidity, objective-c, yacc, m4`.

Applied the same clamp already proven correct for the earlier fixes: bounded `\d+` to `\d{1,10}` and `[^\]]*` to `[^\]]{0,300}`. Deliberately left each language's own extra alternatives (html's `RFC|W3C|CERN|TBL`, dockerfile's `CVE-\d{4}-\d+`, solidity's `ERC-\d+|EIP-\d+`, etc.) untouched beyond the specific adjacent-quantifier shape — not part of the vulnerability, not this issue's scope.

## Test plan
- [x] New test: `test_spec_exposure_adjacent_quantifier_redos_sweep` — a single dedicated cross-language regression test parametrized over all 17 languages, rather than scattering 17 near-identical tests (the issue itself explicitly authorizes this as the cleaner alternative). Uses the scale-relative ratio methodology, not an absolute wall-clock threshold.
- [x] Full strict-parsing suite — 2508 passed
- [x] Full test suite — 3414 passed; 14 pre-existing, unrelated failures in `test_security_auditor.py` (missing `xgboost` in this environment, confirmed identical without this change)
- [x] `ruff format --check` / `ruff_audit.py --ci` — clean
- [x] Differential Scan (`crucible_check.py`, both venvs) — zero diff, confirmed legitimate rather than masking a problem: the corpus's only 18 real Specification Traceability Tag hits are all in `cobol`/`agc_assembly`, neither of which is among the 17 languages touched here (both were already correctly excluded as "not affected" by the original issue)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>