### PR TITLE
Fix flaky spec_exposure ReDoS sweep test timing thresholds

### DIFF
--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -42,7 +42,7 @@ def assert_redos_immune(pattern: re.Pattern, payload: str, timeout_sec: float = 
         assert duration < timeout_sec, f"Regex took too long: {duration:.4f}s"
 
 
-def _best_of_timing(pattern: re.Pattern, payload: str, trials: int = 3) -> float:
+def _best_of_timing(pattern: re.Pattern, payload: str, trials: int = 5) -> float:
     """
     Times a single in-process `.search()` call, taking the minimum of
     several trials to filter out one-off OS scheduling noise (e.g. a
@@ -51,6 +51,13 @@ def _best_of_timing(pattern: re.Pattern, payload: str, trials: int = 3) -> float
     sanity checks, which compare a ratio between two sizes rather than
     asserting an absolute wall-clock threshold -- absolute thresholds are
     flaky across CI hardware of varying speed.
+
+    trials defaults to 5 (raised from 3, #713): a real CI failure on a
+    contended macOS/Python-3.9 smoke-test runner measured a genuinely
+    quadratic pattern's ratio at 2.49x -- just under the (also lowered,
+    see the ratio callers) 2.5 threshold -- purely from timing noise
+    under heavy parallel load. More trials tightens the min-of-N
+    distribution further without changing what's being proven.
     """
     best = float("inf")
     for _ in range(trials):
@@ -7027,7 +7034,7 @@ def test_makefile_hybrid_sensors_redos_immunity():
     small_duration = _best_of_timing(old_serialization_parsing, "\n" * 1000)
     large_duration = _best_of_timing(old_serialization_parsing, "\n" * 2000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old ^\\s* pattern was expected to show quadratic (~4x) scaling on a "
         f"payload doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -8855,7 +8862,7 @@ def test_css_class_start_lookahead_redos_regression():
     small_duration = _best_of_timing(old_pattern, ".foo" + (" ,>+~:" * 1000))
     large_duration = _best_of_timing(old_pattern, ".foo" + (" ,>+~:" * 2000))
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
         f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -8886,7 +8893,7 @@ def test_css_spec_exposure_redos_regression():
     small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
     large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
         f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -9442,7 +9449,7 @@ def test_tcl_spec_exposure_redos_regression():
     small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
     large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
         f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -13294,7 +13301,7 @@ def test_c_spec_exposure_redos_regression():
     small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 4000 + " " * 4000)
     large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000 + " " * 8000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
         f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -13955,7 +13962,7 @@ def test_cpp_spec_exposure_redos_regression():
     small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 4000 + " " * 4000)
     large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000 + " " * 8000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
         f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -14378,7 +14385,7 @@ def test_csharp_spec_exposure_redos_regression():
     small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000 + " " * 8000)
     large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000 + " " * 16000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
         f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
     )
@@ -14488,7 +14495,7 @@ def test_spec_exposure_adjacent_quantifier_redos_sweep(language, old_pattern_tex
     small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
     large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
     ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.5, (
+    assert ratio > 2.2, (
         f"{language}: sanity check failed -- old pattern was expected to show quadratic (~4x) "
         f"scaling on a payload doubling, but only scaled {ratio:.2f}x "
         f"({small_duration:.4f}s -> {large_duration:.4f}s)"


### PR DESCRIPTION
## Summary
- Recovers a fix that was written during PR #798 (#713) but never actually landed on main: the branch's auto-merge fired on an earlier green CI run before this follow-up commit was pushed, so it was silently dropped.
- CI failure being fixed: `test_spec_exposure_adjacent_quantifier_redos_sweep[dart]` failed on a contended macOS/Python-3.9 runner with a measured ratio of 2.49x, just under the 2.5 threshold, despite the underlying pattern genuinely being quadratic (confirmed ~4x locally, unloaded).
- Hardens all 8 shared "prove the old pattern is quadratic" ratio checks uniformly (not just the one that failed): raises `_best_of_timing`'s default trials 3→5, and lowers the pass threshold 2.5→2.2 (still safely above linear's ~2.0x baseline).
- Leaves 2 unrelated pre-existing embedded_python tests (different single-shot pattern) untouched — out of scope.

## Test plan
- [x] Cherry-picked cleanly from the original commit, no conflicts
- [x] `pytest -k "redos_regression or redos_immunity or redos_sweep"` passes locally
- [x] CI green