### PR TITLE
Fix #735: html attribute-value rules only recognized double-quoted values

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -5132,14 +5132,23 @@ LANGUAGE_DEFINITIONS = {
             # markup (`<div *ngIf="cond">`) -- a `\b` between two non-word
             # characters can never fire, so Angular's structural directive
             # never matched. Pulled out with no leading `\b` (self-delimiting).
+            # BUG FIX (#735): every `"[^"]*"`-shaped attribute-value pattern
+            # in this rules dict assumed double-quoted HTML attributes only
+            # -- `<div v-if='cond'>` (single-quoted, equally valid HTML)
+            # never matched. Swapped the literal `"` delimiters for a
+            # `["\']` quote-character class and widened the wildcard
+            # content class to `[^"\']` (excludes either quote char) --
+            # the same idiom this file's own `_dependency_capture` already
+            # uses. No ReDoS risk added: still exactly one unbounded
+            # quantifier per gap, just a wider character class.
             "branch": re.compile(
-                r'<(?:details|summary|noscript)\b|\b(?:v-if|ng-if|x-if|hx-swap)="[^"]*"|\*ngIf="[^"]*"|\{%\s*(?:if|elif|else|endif)\s*[^%]*%\}|\{\{#if\s+[^}]+\}\}',
+                r"<(?:details|summary|noscript)\b|\b(?:v-if|ng-if|x-if|hx-swap)=[\"'][^\"']*[\"']|\*ngIf=[\"'][^\"']*[\"']|\{%\s*(?:if|elif|else|endif)\s*[^%]*%\}|\{\{#if\s+[^}]+\}\}",
                 re.I,
             ),
             # 2. args (Parameters / Coupling)
             # Attribute signatures defining input coupling. Bounded to prevent ReDoS on massive data attrs.
             "args": re.compile(
-                r'\b(?:data-[a-zA-Z0-9_-]+|aria-[a-z]+|name|value|placeholder|for|alt|step|min|max)="[^"]*"',
+                r"\b(?:data-[a-zA-Z0-9_-]+|aria-[a-z]+|name|value|placeholder|for|alt|step|min|max)=[\"'][^\"']*[\"']",
                 re.I,
             ),
             # 3. linear (Sequential Boundaries)
@@ -5167,14 +5176,14 @@ LANGUAGE_DEFINITIONS = {
             # four never matched. Pulled out with no trailing `\b`
             # (self-delimiting on the closing quote).
             "safety": re.compile(
-                r'\b(?:required|readonly|disabled)\b|pattern="[^"]*"|sandbox="[^"]*"|rel="noopener(?: noreferrer)?"'
-                r'|integrity="[^"]*"|<meta\s+http-equiv="Content-Security-Policy"',
+                r"\b(?:required|readonly|disabled)\b|pattern=[\"'][^\"']*[\"']|sandbox=[\"'][^\"']*[\"']|rel=[\"']noopener(?: noreferrer)?[\"']"
+                r"|integrity=[\"'][^\"']*[\"']|<meta\s+http-equiv=[\"']Content-Security-Policy[\"']",
                 re.I,
             ),
             # 7. safety_neg (Safety Bypasses / Unchecked Types)
             # Actively bypasses standard browser safety (e.g. target="_blank" without noopener).
             "safety_bypasses": re.compile(
-                r'target="_blank"(?!\s+rel="noopener")|href="javascript:[^"]*"|on[a-z]+="[^"]*(?:eval\(|document\.write\()',
+                r"target=[\"']_blank[\"'](?!\s+rel=[\"']noopener[\"'])|href=[\"']javascript:[^\"']*[\"']|on[a-z]+=[\"'][^\"']*(?:eval\(|document\.write\()",
                 re.I,
             ),
             # 8. danger (High-Risk Execution / System Calls)
@@ -5183,13 +5192,13 @@ LANGUAGE_DEFINITIONS = {
             # 9. io (I/O & Network Boundaries)
             # Hyperlink navigation and resource fetching. (The core of the Web).
             "io": re.compile(
-                r'\b(?:src|href|action|poster|data)="[^"]*"|<(?:a|form|iframe|audio|video|object|embed|source|track|img)\b',
+                r"\b(?:src|href|action|poster|data)=[\"'][^\"']*[\"']|<(?:a|form|iframe|audio|video|object|embed|source|track|img)\b",
                 re.I,
             ),
             # 10. api (Public Surface Area)
             # Exposed identifiers and metadata consumption surface.
             "api": re.compile(
-                r'\b(?:id|name|role|exportparts|part|itemprop|itemscope|itemtype)="[^"]*"|<slot\b|<meta\s+(?:property="og:|name="twitter:)',
+                r"\b(?:id|name|role|exportparts|part|itemprop|itemscope|itemtype)=[\"'][^\"']*[\"']|<slot\b|<meta\s+(?:property=[\"']og:|name=[\"']twitter:)",
                 re.I,
             ),
             # 11. flux (State Mutation)
@@ -5204,7 +5213,7 @@ LANGUAGE_DEFINITIONS = {
             # 13. doc (Structured Documentation)
             # Structured intent for crawlers and accessibility.
             "doc": re.compile(
-                r'<title>[^<]*</title>|<meta\s+name="(?:description|keywords|author)"\s+content="[^"]*"|\baria-(?:description|label|labelledby|describedby|details)="[^"]*"',
+                r"<title>[^<]*</title>|<meta\s+name=[\"'](?:description|keywords|author)[\"']\s+content=[\"'][^\"']*[\"']|\baria-(?:description|label|labelledby|describedby|details)=[\"'][^\"']*[\"']",
                 re.I,
             ),
             # 14. test (Testing & Assertions)
@@ -5217,20 +5226,20 @@ LANGUAGE_DEFINITIONS = {
             # on `"`, and the shared trailing `\b` can't fire against the
             # non-word char that follows a closing attribute quote. Pulled out.
             "concurrency": re.compile(
-                r'\b(?:async|defer)\b|loading="lazy"|fetchpriority="(?:high|low)"|decoding="async"'
-                r'|<link\s+rel="(?:preload|prefetch|preconnect|modulepreload|prerender)"',
+                r"\b(?:async|defer)\b|loading=[\"']lazy[\"']|fetchpriority=[\"'](?:high|low)[\"']|decoding=[\"']async[\"']"
+                r"|<link\s+rel=[\"'](?:preload|prefetch|preconnect|modulepreload|prerender)[\"']",
                 re.I,
             ),
             # 16. ui_framework (UI / View Components)
             # Formatting tags and Tailwind/Bootstrap utility density.
             "ui_framework": re.compile(
-                r'<(?:b|i|u|strong|em|mark|small|del|ins|sub|sup)\b|\bclass="[^"]*(?:flex|grid|absolute|relative|block|inline-block|container|row|col-[0-9]+|justify-center|items-center|w-full|h-full)[^"]*"',
+                r"<(?:b|i|u|strong|em|mark|small|del|ins|sub|sup)\b|\bclass=[\"'][^\"']*(?:flex|grid|absolute|relative|block|inline-block|container|row|col-[0-9]+|justify-center|items-center|w-full|h-full)[^\"']*[\"']",
                 re.I,
             ),
             # 17. closures (Closures / Anonymous Functions)
             # DOM encapsulation via Shadow DOM.
             "closures": re.compile(
-                r'<template\s+shadowrootmode="[^"]*">|<template\s+shadowroot="[^"]*">',
+                r"<template\s+shadowrootmode=[\"'][^\"']*[\"']>|<template\s+shadowroot=[\"'][^\"']*[\"']>",
                 re.I,
             ),
             # 18. globals (Global / Shared State)
@@ -5249,7 +5258,7 @@ LANGUAGE_DEFINITIONS = {
             "decorators": re.compile(
                 r"\b(?:hidden|inert)\b(?:[ \t]*=)?"
                 r"|\b(?:class|style|tabindex|draggable|spellcheck|dir|lang|translate)[ \t]*="
-                r'|hx-[a-z-]+="[^"]*"|x-[a-z-]+="[^"]*"|v-[a-z-]+="[^"]*"',
+                r"|hx-[a-z-]+=[\"'][^\"']*[\"']|x-[a-z-]+=[\"'][^\"']*[\"']|v-[a-z-]+=[\"'][^\"']*[\"']",
                 re.I,
             ),
             # 20. generics (Generics / Type Parameters)
@@ -5261,7 +5270,7 @@ LANGUAGE_DEFINITIONS = {
             # the shared leading `\b` (boundary between two non-word chars)
             # never fired. Pulled out with no leading `\b`.
             "comprehensions": re.compile(
-                r'\b(?:v-for|ng-repeat|x-for)="[^"]*"|\*ngFor="[^"]*"|\{%\s*for\b[^%]*%\}|\{\{#each\b[^}]*\}\}',
+                r"\b(?:v-for|ng-repeat|x-for)=[\"'][^\"']*[\"']|\*ngFor=[\"'][^\"']*[\"']|\{%\s*for\b[^%]*%\}|\{\{#each\b[^}]*\}\}",
                 re.I,
             ),
             # 22. scientific (Numerical / Compute Libraries)
@@ -5280,16 +5289,16 @@ LANGUAGE_DEFINITIONS = {
             # (multi-declaration, no trailing `;`) never matched under the
             # old pattern. Dropped the semicolon requirement; presence of
             # any inline style attribute is the actual intent here.
-            "reflection_metaprogramming": re.compile(r'style="[^"]*"|\bon[a-z]+="[^"]*"', re.I),
+            "reflection_metaprogramming": re.compile(r"style=[\"'][^\"']*[\"']|\bon[a-z]+=[\"'][^\"']*[\"']", re.I),
             # 24. import (Dependency Inclusions)
             "import": re.compile(
-                r'<script\s+type="(?:importmap|module)"|<link\s+(?:rel="stylesheet"|rev="[^"]*")',
+                r"<script\s+type=[\"'](?:importmap|module)[\"']|<link\s+(?:rel=[\"']stylesheet[\"']|rev=[\"'][^\"']*[\"'])",
                 re.I,
             ),
             "_dependency_capture": re.compile(r'<(?:script[^>]+src|link[^>]+href)\s*=\s*["\']([^"\']+)["\']', re.I),
             # 25. ownership (Authorship Metadata)
             "ownership": re.compile(
-                r'<meta\s+name="(?:author|creator|publisher)"\s+content="([^"]+)"|<link\s+rev="made"\s+href="mailto:[^"]+"',
+                r"<meta\s+name=[\"'](?:author|creator|publisher)[\"']\s+content=[\"']([^\"']+)[\"']|<link\s+rev=[\"']made[\"']\s+href=[\"']mailto:[^\"']+[\"']",
                 re.I,
             ),
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
@@ -5312,13 +5321,13 @@ LANGUAGE_DEFINITIONS = {
             # 31. ssr_boundaries (Server-Side Rendering)
             # Back-end template engine hydration.
             "ssr_boundaries": re.compile(
-                r'<\?php|<%|<%=|\{\{\s*[^}]+\s*\}\}|\{%\s*[^%]+\s*%\}|\b(?:data-reactroot|data-server-rendered|ng-version|nuxt-ssr)="[^"]*"',
+                r"<\?php|<%|<%=|\{\{\s*[^}]+\s*\}\}|\{%\s*[^%]+\s*%\}|\b(?:data-reactroot|data-server-rendered|ng-version|nuxt-ssr)=[\"'][^\"']*[\"']",
                 re.I,
             ),
             # 32. events (Event Emitters / Pub-Sub)
             # Declarative event dispatchers.
             "events": re.compile(
-                r'\bhx-trigger="[^"]*"|@[a-z]+="[^"]*"|v-on:[a-z]+="[^"]*"|\([a-z]+\)="[^"]*"',
+                r"\bhx-trigger=[\"'][^\"']*[\"']|@[a-z]+=[\"'][^\"']*[\"']|v-on:[a-z]+=[\"'][^\"']*[\"']|\([a-z]+\)=[\"'][^\"']*[\"']",
                 re.I,
             ),
             # 33. dependency_injection (Dependency Injection / IoC)
@@ -5326,7 +5335,7 @@ LANGUAGE_DEFINITIONS = {
             # shared-boundary trap as safety/concurrency above (the char
             # after a closing attribute quote is never a word char), so
             # this never matched at all. Self-delimiting on the quote.
-            "dependency_injection": re.compile(r'<script\s+type="importmap"', re.I),
+            "dependency_injection": re.compile(r"<script\s+type=[\"']importmap[\"']", re.I),
             # 34. macros (Preprocessor Directives / Macros)
             # Server Side Includes (SSI).
             "macros": re.compile(r"<!--#\s*(?:include|exec|echo|config|if|else|endif)\b", re.I),
@@ -5341,7 +5350,7 @@ LANGUAGE_DEFINITIONS = {
             # 38. telemetry (Structured Logging / Telemetry)
             # Professional analytics trackers.
             "telemetry": re.compile(
-                r'<script[^>]*src="[^"]*(?:analytics|gtag|gtm|segment|plausible|mixpanel)[^"]*"|\bdata-layer\b|\bnavigator\.sendBeacon\b',
+                r"<script[^>]*src=[\"'][^\"']*(?:analytics|gtag|gtm|segment|plausible|mixpanel)[^\"']*[\"']|\bdata-layer\b|\bnavigator\.sendBeacon\b",
                 re.I,
             ),
             # 39. debug_prints (Debug Artifacts / Unstructured Outputs) (Standard Output / Debug Prints)
@@ -5368,7 +5377,7 @@ LANGUAGE_DEFINITIONS = {
             # `disabled` alternative (matching regardless of the actual
             # true/false value, which was never the intent) -- pulled out so
             # the match is for the right reason.
-            "immutability_locks": re.compile(r'\b(?:readonly|disabled|inert)\b|aria-disabled="true"', re.I),
+            "immutability_locks": re.compile(r"\b(?:readonly|disabled|inert)\b|aria-disabled=[\"']true[\"']", re.I),
             # 46. cleanup (Resource Cleanup / Teardown)
             "cleanup": re.compile(
                 r'\b(?:removeEventListener|clearInterval|clearTimeout|remove|innerHTML\s*=\s*[\'"][\'"])\s*\(',

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -8713,6 +8713,131 @@ def test_html_redos_immunity_sweep():
 
 
 # ==============================================================================
+# Issue #735: html attribute-value rules assumed double-quoted attributes only
+# ==============================================================================
+_HTML_SINGLE_QUOTE_TARGETS = [
+    # (rule_name, single-quoted snippet, double-quoted snippet)
+    ("branch", "<div v-if='cond'>", '<div v-if="cond">'),
+    ("args", "<input data-foo='bar'>", '<input data-foo="bar">'),
+    ("safety", "<input pattern='[0-9]+'>", '<input pattern="[0-9]+">'),
+    ("safety_bypasses", "<a target='_blank'>", '<a target="_blank">'),
+    ("io", "<img src='x.png'>", '<img src="x.png">'),
+    ("api", "<div id='main'>", '<div id="main">'),
+    ("doc", "<meta name='description' content='hi'>", '<meta name="description" content="hi">'),
+    ("concurrency", "<img loading='lazy'>", '<img loading="lazy">'),
+    ("ui_framework", "<div class='flex'>", '<div class="flex">'),
+    ("closures", "<template shadowrootmode='open'>", '<template shadowrootmode="open">'),
+    ("decorators", "<div hx-get='/x'>", '<div hx-get="/x">'),
+    ("reflection_metaprogramming", "<div style='color:red'>", '<div style="color:red">'),
+    ("import", "<script type='module'>", '<script type="module">'),
+    ("ownership", "<meta name='author' content='Jane Doe'>", '<meta name="author" content="Jane Doe">'),
+    ("ssr_boundaries", "<div data-reactroot='true'>", '<div data-reactroot="true">'),
+    ("events", "<div hx-trigger='click'>", '<div hx-trigger="click">'),
+    ("dependency_injection", "<script type='importmap'>", '<script type="importmap">'),
+    ("telemetry", "<script src='gtag.js'>", '<script src="gtag.js">'),
+    ("immutability_locks", "<input aria-disabled='true'>", '<input aria-disabled="true">'),
+    ("comprehensions", "<li v-for='x in y'>", '<li v-for="x in y">'),
+]
+
+
+@pytest.mark.parametrize("signature,single_quoted,double_quoted", _HTML_SINGLE_QUOTE_TARGETS)
+def test_html_single_quoted_attribute_values_regression(signature, single_quoted, double_quoted):
+    """
+    Regression test for issue #735: every one of these 20 rules originally
+    hard-coded a literal `"..."` delimiter around attribute values
+    (`"[^"]*"`). Real-world markup legally uses single quotes for attribute
+    values (`<div class='flex'>`) just as often, and none of these rules
+    recognized that form at all. Fixed by widening each to the
+    `["'][^"']*["']` idiom already used elsewhere in this file
+    (`_dependency_capture`) -- a quote-character-class for the delimiters
+    plus a content class excluding both quote characters, rather than an
+    alternation -- so there's no added unbounded quantifier and thus no new
+    ReDoS surface.
+    """
+    pattern = HTML_RULES[signature]
+    assert pattern is not None, f"html's {signature!r} rule is unexpectedly None"
+    assert pattern.search(single_quoted), f"html {signature!r} still didn't match the single-quoted form"
+    assert pattern.search(double_quoted), f"html {signature!r} regressed on the double-quoted form"
+
+
+def test_html_single_quote_bug_reproduces_on_old_double_quote_only_patterns():
+    """
+    Sanity check that the bug fixed above was real: reconstruct two of the
+    original double-quote-only patterns and confirm they genuinely failed
+    to match single-quoted markup before the fix.
+    """
+    old_branch = re.compile(
+        r'<(?:details|summary|noscript)\b|\b(?:v-if|ng-if|x-if|hx-swap)="[^"]*"'
+        r'|\*ngIf="[^"]*"|\{%\s*(?:if|elif|else|endif)\s*[^%]*%\}|\{\{#if\s+[^}]+\}\}',
+        re.I,
+    )
+    assert not old_branch.search("<div v-if='cond'>"), "sanity check: bug must reproduce on old branch pattern"
+
+    old_ui_framework = re.compile(
+        r"<(?:b|i|u|strong|em|mark|small|del|ins|sub|sup)\b"
+        r'|\bclass="[^"]*(?:flex|grid|absolute|relative|block|inline-block|container|row|col-[0-9]+'
+        r'|justify-center|items-center|w-full|h-full)[^"]*"',
+        re.I,
+    )
+    assert not old_ui_framework.search("<div class='flex'>"), (
+        "sanity check: bug must reproduce on old ui_framework pattern"
+    )
+
+    branch = HTML_RULES["branch"]
+    ui_framework = HTML_RULES["ui_framework"]
+    assert branch.search("<div v-if='cond'>")
+    assert ui_framework.search("<div class='flex'>")
+
+
+def test_html_ownership_single_quoted_capture_group_preserved():
+    """
+    `ownership` is the one rule in this sweep with a capture group
+    (`content="..."` captured via `([^"]+)`). Confirm the fix preserved a
+    single group (not duplicated per quote style) and that it captures
+    correctly under both quote forms.
+    """
+    ownership = HTML_RULES["ownership"]
+    m_double = ownership.search('<meta name="author" content="Jane Doe">')
+    m_single = ownership.search("<meta name='author' content='Jane Doe'>")
+    assert m_double and m_double.group(1) == "Jane Doe"
+    assert m_single and m_single.group(1) == "Jane Doe"
+
+
+def test_html_single_quote_fix_does_not_introduce_redos():
+    """
+    Widening `[^"]*` to `[^"']*` adds one more excluded character to an
+    existing single quantifier -- it doesn't add a quantifier or change the
+    adjacency shape, so ReDoS immunity should be unaffected. Confirmed via a
+    scaling sweep (n=2000/4000/8000, unterminated single-quoted payloads)
+    before writing this test: linear growth throughout, same as the
+    double-quote form already covered by test_html_redos_immunity_sweep.
+    """
+    assert_redos_immune(HTML_RULES["ui_framework"], "<div class='" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HTML_RULES["args"], "<input data-foo='" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HTML_RULES["telemetry"], "<script src='" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HTML_RULES["ownership"], "<meta name='author' content='" + "a" * 100000, timeout_sec=3.0)
+
+
+def test_css_attribute_selectors_already_quote_agnostic():
+    """
+    Issue #735 explicitly asked whether css shares html's double-quote-only
+    gap. It doesn't: css's only rules that touch attribute-selector syntax
+    (`test`, `test_skip`) never parse a quoted value in the first place --
+    `test`'s pattern stops right after the `=` (`[ \\t]*[=\\]]`), so it's
+    already agnostic to whatever quoting (or lack of it) follows. Confirmed
+    empirically here rather than left as an unstated assumption; no fix
+    needed on the css side.
+    """
+    test_rule = CSS_RULES["test"]
+    for snippet in (
+        '[data-testid="submit"] { color: red; }',
+        "[data-testid='submit'] { color: red; }",
+        "[data-testid] { color: red; }",
+    ):
+        assert test_rule.search(snippet), f"css test rule should match regardless of quoting: {snippet!r}"
+
+
+# ==============================================================================
 # CSS: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #577, part of epic #518)
 # ==============================================================================
 # NOTE: `branch`/`structural_boundaries` already carry BUG FIX comments from


### PR DESCRIPTION
## Summary
- Closes #735. 20 of html's rules hard-coded a literal `"..."` delimiter around attribute values (`"[^"]*"`), so real-world markup using single quotes (`<div class='flex'>`) never matched at all: `branch`, `args`, `safety`, `safety_bypasses`, `io`, `api`, `doc`, `concurrency`, `ui_framework`, `closures`, `decorators`, `reflection_metaprogramming`, `import`, `ownership`, `ssr_boundaries`, `events`, `dependency_injection`, `telemetry`, `immutability_locks`, `comprehensions`.
- Fixed by widening each to the `["'][^"']*["']` idiom already established in this file's `_dependency_capture` rule — a quote-character-class for the delimiters plus a content class excluding both quote characters, rather than a `(?:"..."|'...')` alternation. No added unbounded quantifier, so no new ReDoS surface.
- Checked `css` for the same gap (explicitly requested by the issue): it doesn't have one — css's only attribute-selector-adjacent rule (`test`) never parses a quoted value in the first place, so it's already quote-agnostic. Added a small test documenting this negative finding rather than leaving it an unstated assumption.
- Swept the rest of `LANGUAGE_DEFINITIONS` for the same double-quote-only shape; no other language has it.

## Verification
- Empirically verified all 20 fixed rules match realistic single- and double-quoted markup, and that `ownership`'s capture group still extracts correctly (not duplicated per quote style).
- ReDoS scaling spot-check (n=2000/4000/8000, unterminated single-quoted payloads): linear throughout, same as the existing double-quote coverage.
- `tests/tools/crucible_check.py`: zero diff on both venvs (full-precision, zero-dependency) — the real-world corpus apparently sticks to double-quote convention throughout, so this is a correctness fix for an edge case the corpus doesn't happen to exercise; confirmed both venvs' editable installs correctly resolve to this checkout before trusting the zero-diff result.
- `ruff format`, `ruff_audit.py --ci`, `mypy_audit.py --ci`: clean (2 pre-existing unrelated mypy findings on `guidestar_lens.py` confirmed present on main too, out of scope here).
- `tests/core_engine/test_language_standards_strict.py` (html + css subset): 121 passed.

## Test plan
- [x] New parametrized regression test (`test_html_single_quoted_attribute_values_regression`) across all 20 fixed rules
- [x] Old-pattern-reproduces-the-bug sanity test
- [x] `ownership` capture-group preservation test
- [x] ReDoS-immunity spot-check test
- [x] css negative-finding test
- [x] CI green