### PR TITLE
Fix #816: Extraction hardening for java

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -1290,10 +1290,17 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # long `->`-less line, backtracking O(n) per position for
                 # O(n^2) total (same bug found and fixed in javascript's args).
                 # Bounded to {0,100}; real identifiers don't get that long.
+                # RULE 11 FIX (epic #813/#816): Branch 1's generic-bound modifier
+                # alternative was a flat `<[^>]*>`, truncating at the first `>` and
+                # breaking any single-line one-level-nested generic bound (e.g.
+                # `public static <T, U extends Comparable<U>> T Foo(T a, U b) {` --
+                # the same Rule 11 shape already fixed elsewhere; see
+                # how_to_add_a_language.md). Widened to the established
+                # one-level-nesting idiom `<(?:[^<>]|<[^<>]*>)*>`.
                 # =====================================================================
                 r"(?:"
                 # 1. Standard Methods
-                r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t\n]*){0,5}(?:(?:public|protected|private|static|final|abstract|synchronized|native|default|strictfp|<[^>]*>)[ \t\n]+){0,5}(?:[\w<>\[\]?]+[ \t\n]+)\w+[ \t\n]*\([^)]*\)|"
+                r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t\n]*){0,5}(?:(?:public|protected|private|static|final|abstract|synchronized|native|default|strictfp|<(?:[^<>]|<[^<>]*>)*>)[ \t\n]+){0,5}(?:[\w<>\[\]?]+[ \t\n]+)\w+[ \t\n]*\([^)]*\)|"
                 # 2. Constructors
                 r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t\n]*){0,5}(?:(?:public|protected|private|static)[ \t\n]+)?[A-Z]\w*[ \t\n]*\([^)]*\)[ \t\n]*(?:throws[ \t\n]+[\w., \t\n]+)?[{]|"
                 # 3. Lambdas & Method Refs
@@ -1320,14 +1327,27 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # execution keywords at the start of the sequence.
                 # =====================================================================
                 r"(?!(?:new|return|throw|if|else|while|for|switch|catch)\b)"
-                r"(?:(?:public|protected|private|static|final|abstract|synchronized|native|default|<[^>]*>)[ \t]+){0,5}"
+                # RULE 11 FIX (epic #813/#816): the generic-bound modifier
+                # alternative was a flat `<[^>]*>`, truncating at the first `>` and
+                # breaking any single-line one-level-nested generic bound (e.g.
+                # `public static <T, U extends Comparable<U>> T Foo(T a, U b) {`).
+                # Widened to the established one-level-nesting idiom.
+                r"(?:(?:public|protected|private|static|final|abstract|synchronized|native|default|<(?:[^<>]|<[^<>]*>)*>)[ \t]+){0,5}"
                 r"(?:[a-zA-Z_$][\w<>$\[\]?,]*[ \t]+){0,5}"
                 r"(?!(?:if|for|while|switch|catch|new|return|class|interface|enum|record)\b)([A-Za-z_$][\w_$]*)\s*\(",
                 re.M,
             ),
             # 5. class_start (Object / Entity Declarations)
+            # RULE 11 FIX (epic #813/#816): there was no generic-parameter
+            # step-over between the class name and the extends/implements
+            # check at all, so ANY generic class declaration (e.g.
+            # `class Foo<T> extends Base<T> {`, `class Foo<T extends
+            # Comparable<T>> implements Serializable {`) left the class's own
+            # `<...>` unconsumed right before `extends`/`implements`, silently
+            # losing the entire inheritance capture (group 2) even though the
+            # class name (group 1) still matched fine.
             "class_start": re.compile(
-                r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t]*){0,5}(?:(?:public|protected|private|static|final|sealed|non-sealed|abstract|strictfp)[ \t]+){0,5}(?:class|interface|enum|record)\s+([A-Za-z_$][\w_$]*)(?:\s+(?:extends|implements)\s+([A-Za-z_$][\w_$, \t<>\?]*))?",
+                r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t]*){0,5}(?:(?:public|protected|private|static|final|sealed|non-sealed|abstract|strictfp)[ \t]+){0,5}(?:class|interface|enum|record)\s+([A-Za-z_$][\w_$]*)(?:\s*<(?:[^<>]|<[^<>]*>)*>)?(?:\s+(?:extends|implements)\s+([A-Za-z_$][\w_$, \t<>\?]*))?",
                 re.M,
             ),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---

--- a/tests/extraction/how_to_harden_extraction.md
+++ b/tests/extraction/how_to_harden_extraction.md
@@ -268,6 +268,32 @@ specifically. Check every language against these *first* before assuming a rule 
    against symbolic or word-character boundaries, missing `re.M`, adjacent-overlapping-quantifier
    ReDoS — applies here too; these rules live in the same file and share the same authorship
    patterns.)*
+10. **(#816) `class_start`'s generic step-over can be MISSING entirely, not just flat.** TypeScript's
+    #815 bug (class 6 above) was a flat `<[^>]*>` that needed widening to the one-level-nesting
+    idiom. Java's version of the same underlying bug was a different shape: no generic-parameter
+    step-over between the class name and the extends/implements check at all, so ANY generic class
+    with a subsequent extends/implements clause (`class Foo<T> extends Base<T> {`) silently lost the
+    entire inheritance capture. Same fix (`(?:\s*<(?:[^<>]|<[^<>]*>)*>)?` inserted before the
+    extends/implements check), but **check whether the step-over exists at all before assuming it
+    just needs widening** — both failure shapes present identically at the test level (name capture
+    fine, inheritance capture silently empty).
+11. **(#816) `_dependency_capture` is matched against raw, unshielded file content for EVERY
+    language, unconditionally — broader than class 3.** Unlike `func_start`'s Mode-B
+    `_slice_by_braces` path (gated to js/ts, tracked via #859), `_dependency_capture` runs via
+    `import_regex.finditer(content_buffer)` in `galaxyscope.py` against the raw file content read
+    straight off disk, for every language, with no shielding gate at all. Confirmed reproducible for
+    java: an `import ...;`-shaped line inside a Java 15+ text block (`"""..."""`) at true line start
+    still produces a phantom dependency-graph edge. Not fixed (would require shielding
+    `content_buffer` before every language's `_dependency_capture.finditer()` call -- a pipeline-wide
+    change, not a per-language one) -- check for the same shape (comment/string content containing
+    import-statement-shaped text at true line start) on every future language's dependency pass and
+    record it as a known limitation rather than re-discovering it.
+12. **(#816) Class 3 (unshielded content reaching a Mode-B rule) reproduced on a second, unrelated
+    language feature**: Java 15+ text blocks produce the exact same `func_start` false positive as
+    js/ts template literals, confirming this is a genuine cross-language architectural gap rather
+    than a js/ts-specific quirk -- strengthens the case for broadening the `_slice_by_braces`
+    shielding gate as its own follow-up PR (tracked in the epic's "Related architectural issue"
+    section).
 
 ## Process: the epic and its sub-issues
 

--- a/tests/extraction/languages/test_java.py
+++ b/tests/extraction/languages/test_java.py
@@ -1,0 +1,399 @@
+"""
+Java extraction hardening (epic #813, issue #816). See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for java in one file: func_start, args,
+class_start, _dependency_capture. Migrated out of the four old monolithic
+dict files (test_function_extraction_strict.py, test_args_extraction_strict.py,
+test_class_extraction_strict.py, test_dependency_extraction_strict.py) --
+java's entries were removed from those four when this file was added.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+# tests/ has no __init__.py anywhere in this repo, so a dotted
+# `tests.extraction._extraction_harness` import only works by accident
+# locally (e.g. `python -m pytest` from the repo root happens to put the
+# root on sys.path) and fails in CI, which invokes the `pytest` console
+# script directly. Insert this file's parent (tests/extraction/) onto
+# sys.path instead, so the harness imports as a plain top-level module.
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+JAVA_RULES = LANGUAGE_DEFINITIONS["java"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start)
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        # Modern idiom (carried forward)
+        ("public static void TargetFunc()", "TargetFunc"),
+        ("protected List<String> TargetFunc(int x)", "TargetFunc"),
+        ("@Override\npublic void TargetFunc()", "TargetFunc"),
+        # Syntax-era / feature coverage
+        ("public void TargetFunc() throws IOException {", "TargetFunc"),  # pre-8, checked exception
+        ("default void TargetFunc() {", "TargetFunc"),  # Java 8 interface default method
+        ("static void TargetFunc() {", "TargetFunc"),  # Java 8 interface static method
+        (
+            "public static <T, U extends Comparable<U>> T TargetFunc(T a, U b) {",
+            "TargetFunc",
+        ),  # one-level-nested generic bound, single line -- was a real bug, now fixed
+        ("public <T> Optional<T> TargetFunc(Class<T> type) {", "TargetFunc"),  # bounded generic method
+        (
+            "public final synchronized <T extends Comparable<T>> T TargetFunc(T... items) {",
+            "TargetFunc",
+        ),  # varargs + generic bound + modifier stacking
+        # Testing-framework-shaped functions that ARE real functions
+        ("@Test\npublic void TargetFunc() {", "TargetFunc"),  # JUnit4
+        ("@Test\nvoid TargetFunc() {", "TargetFunc"),  # JUnit5, package-private
+        (
+            '@ParameterizedTest\n@ValueSource(strings = {"a", "b"})\nvoid TargetFunc(String input) {',
+            "TargetFunc",
+        ),  # JUnit5 parameterized test
+        ("public static void main(String[] args) {", "main"),  # main method sanity
+    ],
+    "invalid": [
+        "public class TargetFunc {",  # class decl lookalike
+        "new TargetFunc();",  # instantiation
+        "return TargetFunc();",  # return call
+        "throw TargetFunc();",  # throw call
+        'String s = "public void TargetFunc() {";',  # string literal lookalike, not at true line start
+        "Map.Entry<String,Integer> TargetFunc = getEntry();",  # generic-typed variable decl lookalike
+        "if ((TargetFunc = compute()) != null) {",  # assignment-in-condition lookalike
+    ],
+    "pathological": [
+        (
+            '@Override\n@SuppressWarnings("unchecked")\npublic static final <T, U extends Map<String, V>>\nList<T>\nTargetFunc\n(',
+            "TargetFunc",
+        ),  # carried-forward: massive generic soup + annotation stacking, multi-line
+        (
+            "public static <T, U extends Comparable<U>> T \n TargetFunc \n ( \n T a, U b \n ) \n {",
+            "TargetFunc",
+        ),  # nested generic bound split vertically after the bound itself
+        (
+            '@Deprecated\n@SafeVarargs\n@SuppressWarnings({"unchecked", "rawtypes"})\npublic final synchronized <T extends Comparable<T>> T TargetFunc(T... items) {',
+            "TargetFunc",
+        ),  # annotation stacking (3) + varargs + generic bound, single line
+        (
+            '@Entity\n@Table(name="foo")\n@JsonIgnoreProperties(ignoreUnknown = true)\n@SuppressWarnings("unchecked")\n@Deprecated\npublic void TargetFunc() {',
+            "TargetFunc",
+        ),  # 5+ stacked annotations with nested-paren arguments
+        (
+            "public \n static \n final \n synchronized \n <T> \n List<T> \n TargetFunc \n ( \n T \n item \n ) \n {",
+            "TargetFunc",
+        ),  # modifier stack split at every boundary
+        (
+            '@Test\n@DisplayName("should do the thing")\n@Timeout(value = 5, unit = TimeUnit.SECONDS)\nvoid TargetFunc() {',
+            "TargetFunc",
+        ),  # JUnit5 stacked test annotations with args
+        (
+            "protected \n abstract \n <K, V extends Comparable<V>> \n Map<K, V> \n TargetFunc \n (\n Set<K> keys\n) \n throws \n IOException \n ;",
+            "TargetFunc",
+        ),  # abstract generic method, vertical, with throws clause
+        (
+            "public TargetFunc(int x) {",
+            "TargetFunc",
+        ),  # constructor shape (IDENT() with no return type) -- matches like any bare signature
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_java_func_start_valid(payload, expected_name):
+    assert_valid_match(JAVA_RULES["func_start"], payload, expected_name, "java.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_java_func_start_invalid(payload):
+    assert_invalid_no_match(JAVA_RULES["func_start"], payload, "java.func_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_java_func_start_pathological(payload, expected_name):
+    assert_pathological_match(JAVA_RULES["func_start"], payload, expected_name, "java.func_start")
+
+
+def test_java_func_start_nested_generic_bound_regression():
+    """
+    Regression test for a real bug (epic #813/#816): the generic-bound
+    modifier alternative was a flat `<[^>]*>`, truncating at the FIRST `>` --
+    a one-level-nested generic bound (`public static <T, U extends
+    Comparable<U>> T Foo(T a, U b) {`, a realistic bounded-generic method
+    signature) left a stray `>` unconsumed, breaking the match entirely
+    (unlike class_start's equivalent bug, this one has no re.M line-restart
+    escape hatch when the whole signature is on one line -- the carried-
+    forward multi-line pathological case masked this because splitting the
+    signature across lines let `^[ \\t]*` re-anchor past the broken modifier
+    section instead of needing to cross it).
+    """
+    func_start = JAVA_RULES["func_start"]
+    m = func_start.search("public static <T, U extends Comparable<U>> T TargetFunc(T a, U b) {")
+    assert m and m.group(1) == "TargetFunc", "single-line nested generic bound regressed"
+
+
+def test_java_func_start_redos_immunity():
+    """ReDoS sweep for the widened one-level-nesting generic-bound modifier alternative."""
+    func_start = JAVA_RULES["func_start"]
+    assert_redos_immune(func_start, "public static <T, U extends " + "a" * 100000, timeout_sec=3.0)
+    assert func_start.search("public static <T, U extends Comparable<U>> T Foo(T a, U b) {")
+
+
+def test_java_func_start_known_limitation_text_block_string_lookalike_still_matches_at_regex_level():
+    """
+    Documents a known, NOT-fixed limitation: func_start's own regex has no
+    string/comment awareness, so function-shaped text inside a Java 15+ text
+    block (`\"\"\"..\"\"\"`) that happens to land at true line start still
+    matches -- the same architectural class of bug confirmed for javascript/
+    typescript template literals (recurring bug class #3 in
+    how_to_harden_extraction.md), now confirmed on a second, unrelated
+    syntax feature (Java text blocks) rather than just js/ts's template
+    literals. The real fix (matching against shielded code) lives in
+    detector.py's _slice_by_braces and is currently gated to javascript/
+    typescript only; broadening it to other Mode B languages (java included)
+    is tracked as its own future audited follow-up, not fixed here -- see
+    the epic's "Related architectural issue" section for #859's resolution
+    that unblocked that follow-up.
+    """
+    func_start = JAVA_RULES["func_start"]
+    text_block = 'String s = """\npublic void TargetFunc() {\n""";'
+    assert func_start.search(text_block), "documents current (expected, pipeline-level-fixed-elsewhere) regex behavior"
+
+
+# ==============================================================================
+# ARGS (args)
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        ("public void TargetFunc(String name, int age) {", "TargetFunc"),
+        ("protected List<T> TargetFunc(Predicate<T> filter)", "TargetFunc"),
+        (
+            "public static <T, U extends Comparable<U>> T TargetFunc(T a, U b) {",
+            "TargetFunc",
+        ),  # one-level-nested generic bound -- was a real bug, now fixed
+        (
+            "public <K, V extends Map<K, V>> void TargetFunc(K key, V value) {",
+            "TargetFunc",
+        ),  # another nested generic bound shape
+        ("TargetFunc(items) -> items.size()", None),  # lambda shape
+        ("list.forEach(TargetFunc::process)", None),  # method reference
+    ],
+    "invalid": [
+        "TargetFunc(name, age);",
+        "for (int i = 0; i < 10; i++)",
+    ],
+    "pathological": [
+        (
+            "public \n static \n <T, U extends Comparable<U>> \n void \n TargetFunc \n (\n  @NonNull final List<T> items,\n  @Nullable Function<T, String> mapper\n)",
+            "TargetFunc",
+        ),  # carried-forward + nested generic bound added, vertical
+        (
+            'public TargetFunc(\n  @Inject Foo foo,\n  @Named("bar") Bar bar\n) {',
+            "TargetFunc",
+        ),  # DI-annotated constructor params, vertical
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["valid"])
+def test_java_args_valid(payload, expected_name):
+    assert_valid_match(JAVA_RULES["args"], payload, expected_name, "java.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_java_args_invalid(payload):
+    assert_invalid_no_match(JAVA_RULES["args"], payload, "java.args")
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["pathological"])
+def test_java_args_pathological(payload, expected_name):
+    assert_pathological_match(JAVA_RULES["args"], payload, expected_name, "java.args")
+
+
+def test_java_args_nested_generic_bound_regression():
+    """
+    Regression test for the same root-cause bug as func_start's own
+    regression test above (epic #813/#816): args' Branch 1 shares the exact
+    same flat `<[^>]*>` generic-bound modifier alternative, so it broke on
+    the identical single-line nested-generic-bound signature.
+    """
+    args = JAVA_RULES["args"]
+    m = args.search("public static <T, U extends Comparable<U>> T TargetFunc(T a, U b) {")
+    assert m, "single-line nested generic bound regressed"
+
+
+def test_java_args_redos_immunity():
+    """ReDoS sweep for the widened one-level-nesting generic-bound modifier alternative."""
+    args = JAVA_RULES["args"]
+    assert_redos_immune(args, "public static <T, U extends " + "a" * 100000, timeout_sec=3.0)
+    assert args.search("public static <T, U extends Comparable<U>> T Foo(T a, U b) {")
+
+
+# ==============================================================================
+# CLASS_START (class_start)
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("public class TargetEntity {", "TargetEntity"),
+        ("protected abstract interface TargetEntity extends Base", "TargetEntity"),
+        ("public record TargetEntity(int x) {", "TargetEntity"),  # record, Java 16+
+        (
+            "public class TargetEntity<T> extends Base<T> {",
+            "TargetEntity",
+        ),  # generic class + extends -- was a real bug (extends silently lost), now fixed
+        (
+            "public class TargetEntity<T extends Comparable<T>> implements Serializable {",
+            "TargetEntity",
+        ),  # generic bound class + implements -- was a real bug, now fixed
+        ("sealed interface TargetEntity permits Foo, Bar {", "TargetEntity"),  # Java 17 sealed interface
+        (
+            "public record TargetEntity(int x, int y) implements Serializable {",
+            "TargetEntity",
+        ),  # record implementing an interface
+    ],
+    "invalid": [
+        "TargetEntity entity = new TargetEntity();",
+        "classyMethod()",
+        "return TargetEntity.class;",
+    ],
+    "pathological": [
+        (
+            '@Entity\n@Table(name="foo")\n@SuppressWarnings("unchecked")\npublic \n final \n class \n TargetEntity \n implements \n Serializable',
+            "TargetEntity",
+        ),  # carried-forward: annotation bloat + vertical stacking
+        (
+            "public \n class \n TargetEntity \n < \n T \n extends \n Comparable<T> \n > \n implements \n Serializable \n , \n Cloneable",
+            "TargetEntity",
+        ),  # nested generic bound + implements list, vertically split -- the real bug this fixed
+        (
+            '@Entity\n@Table(name = "targets")\n@JsonIgnoreProperties(ignoreUnknown = true)\n@Deprecated\npublic class TargetEntity<K, V extends Map<K, V>> extends AbstractEntity<K, V> implements Serializable, Cloneable {',
+            "TargetEntity",
+        ),  # annotation stacking (4) + nested generic bound + multi-interface implements, single line
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_java_class_start_valid(payload, expected_name):
+    assert_valid_match(JAVA_RULES["class_start"], payload, expected_name, "java.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_java_class_start_invalid(payload):
+    assert_invalid_no_match(JAVA_RULES["class_start"], payload, "java.class_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_java_class_start_pathological(payload, expected_name):
+    assert_pathological_match(JAVA_RULES["class_start"], payload, expected_name, "java.class_start")
+
+
+def test_java_class_start_generic_extends_regression():
+    """
+    Regression test for a real bug (epic #813/#816), distinct from the
+    func_start/args Rule-11 bug above: class_start had NO generic-parameter
+    step-over AT ALL between the class name and the extends/implements
+    check (unlike func_start/args, which had a flat-but-present `<[^>]*>`
+    that just needed widening). Any generic class declaration followed by
+    extends/implements (`class Foo<T> extends Base<T> {`, extremely common
+    real Java) left the class's own `<...>` unconsumed right before
+    `extends`, silently losing the ENTIRE inheritance capture (group 2) even
+    though the class name itself (group 1) still matched fine -- an easy bug
+    to miss since the primary capture looked correct.
+    """
+    class_start = JAVA_RULES["class_start"]
+    assert class_start.groups == 2, "sanity: the rule still has both capture groups"
+
+    m = class_start.search("class Foo<T extends Comparable<T>> extends Bar {")
+    assert m and m.group(1) == "Foo", "class name capture regressed"
+    assert m.group(2) and "Bar" in m.group(2), "extends clause still lost behind a nested generic bound"
+
+
+def test_java_class_start_redos_immunity():
+    """ReDoS sweep for the new generic-parameter step-over before extends/implements."""
+    class_start = JAVA_RULES["class_start"]
+    assert_redos_immune(class_start, "class Foo<" + "a" * 100000, timeout_sec=3.0)
+    assert class_start.search("class Foo<T extends Comparable<T>> extends Bar {")
+
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture)
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("import java.util.List;", "java.util.List"),
+        ("import static org.junit.Assert.*;", "org.junit.Assert.*"),
+        ("import java.util.*;", "java.util.*"),  # wildcard package import
+        ("import com.example.MyClass;", "com.example.MyClass"),  # single class import
+    ],
+    "invalid": [
+        "String importPath;",
+        "requires java.sql;",  # Java 9+ module-info directive -- out of scope for this rule (not an import statement)
+    ],
+    "pathological": [
+        (
+            "import \n static \n org.springframework.boot.SpringApplication \n ;",
+            "org.springframework.boot.SpringApplication",
+        ),  # carried-forward: vertical static import
+        (
+            "import \n com.example.deeply.nested.package.MyClass \n ;",
+            "com.example.deeply.nested.package.MyClass",
+        ),  # deeply nested package path, vertical
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_java_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(JAVA_RULES["_dependency_capture"], payload, expected_path, "java._dependency_capture")
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_java_dependency_capture_invalid(payload):
+    assert_invalid_no_match(JAVA_RULES["_dependency_capture"], payload, "java._dependency_capture")
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_java_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(
+        JAVA_RULES["_dependency_capture"], payload, expected_path, "java._dependency_capture"
+    )
+
+
+def test_java_dependency_capture_known_limitation_text_block_string_lookalike_still_matches_at_regex_level():
+    """
+    Documents a known, NOT-fixed limitation, broader than func_start's own
+    text-block finding above: `_dependency_capture` is matched against
+    `content_buffer` (the raw, unshielded whole-file content read straight
+    off disk in galaxyscope.py) for EVERY language unconditionally -- there
+    is no js/ts-style gate here at all, unlike func_start's Mode-B
+    `_slice_by_braces` path. An `import ...;`-shaped line inside a Java 15+
+    text block at true line start still produces a phantom dependency-graph
+    edge. Recorded as a refinement of recurring bug class #3 (the
+    "unshielded string/comment content reaching a rule's finditer" class
+    extends beyond Mode-B func_start to _dependency_capture's own,
+    separately-unshielded call site) rather than fixed here -- fixing it
+    would mean shielding `content_buffer` before every language's
+    `_dependency_capture.finditer()` call in galaxyscope.py, a pipeline-wide
+    architectural change well beyond a single language's extraction pass.
+    """
+    dependency_capture = JAVA_RULES["_dependency_capture"]
+    text_block = 'String s = """\nimport java.util.List;\n""";'
+    assert dependency_capture.search(text_block), "documents current (accepted, unfixed) regex behavior"

--- a/tests/extraction/test_args_extraction_strict.py
+++ b/tests/extraction/test_args_extraction_strict.py
@@ -69,19 +69,6 @@ ARGS_EXTRACTION_CASES = {
             )
         ],
     },
-    "java": {
-        "valid": [
-            ("public void TargetFunc(String name, int age) {", "TargetFunc"),
-            ("protected List<T> TargetFunc(Predicate<T> filter)", "TargetFunc"),
-        ],
-        "invalid": ["TargetFunc(name, age);", "for (int i = 0; i < 10; i++)"],
-        "pathological": [
-            (
-                "public \n static \n <T> \n void \n TargetFunc \n (\n  @NonNull final List<T> items,\n  @Nullable Function<T, String> mapper\n)",
-                "TargetFunc",
-            )
-        ],
-    },
     "php": {
         "valid": [
             ("function TargetFunc(int $a, ?string $b) {", "TargetFunc"),

--- a/tests/extraction/test_class_extraction_strict.py
+++ b/tests/extraction/test_class_extraction_strict.py
@@ -14,25 +14,6 @@ from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 # }
 # ==============================================================================
 CLASS_EXTRACTION_CASES = {
-    "java": {
-        "valid": [
-            ("public class TargetEntity {", "TargetEntity"),
-            ("protected abstract interface TargetEntity extends Base", "TargetEntity"),
-            ("public record TargetEntity(int x) {", "TargetEntity"),
-        ],
-        "invalid": [
-            "TargetEntity entity = new TargetEntity();",
-            "classyMethod()",
-            "return TargetEntity.class;",
-        ],
-        "pathological": [
-            # Vertical stacking, annotation bloat, and massive inheritance
-            (
-                '@Entity\n@Table(name="foo")\n@SuppressWarnings("unchecked")\npublic \n final \n class \n TargetEntity \n implements \n Serializable',
-                "TargetEntity",
-            )
-        ],
-    },
     "csharp": {
         "valid": [
             ("public class TargetEntity", "TargetEntity"),

--- a/tests/extraction/test_dependency_extraction_strict.py
+++ b/tests/extraction/test_dependency_extraction_strict.py
@@ -44,19 +44,6 @@ DEPENDENCY_EXTRACTION_CASES = {
             )
         ],
     },
-    "java": {
-        "valid": [
-            ("import java.util.List;", "java.util.List"),
-            ("import static org.junit.Assert.*;", "org.junit.Assert.*"),
-        ],
-        "invalid": ["String importPath;"],
-        "pathological": [
-            (
-                "import \n static \n org.springframework.boot.SpringApplication \n ;",
-                "org.springframework.boot.SpringApplication",
-            )
-        ],
-    },
     "csharp": {
         "valid": [
             ("using System.Threading.Tasks;", "System.Threading.Tasks"),

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -123,25 +123,6 @@ EXTRACTION_CASES = {
             )
         ],
     },
-    "java": {
-        "valid": [
-            ("public static void TargetFunc()", "TargetFunc"),
-            ("protected List<String> TargetFunc(int x)", "TargetFunc"),
-            ("@Override\npublic void TargetFunc()", "TargetFunc"),
-        ],
-        "invalid": [
-            "public class TargetFunc {",
-            "new TargetFunc();",
-            "return TargetFunc();",
-        ],
-        "pathological": [
-            # Massive generic soup before the return type and annotation stacking
-            (
-                '@Override\n@SuppressWarnings("unchecked")\npublic static final <T, U extends Map<String, V>>\nList<T>\nTargetFunc\n(',
-                "TargetFunc",
-            )
-        ],
-    },
     "go": {
         "valid": [
             ("func TargetFunc()", "TargetFunc"),

--- a/tests/golden_master_audit.json
+++ b/tests/golden_master_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-31T00:02:22.038273+00:00",
-            "Total Scan Duration": "24.82 seconds"
+            "Analysis ISO Timestamp": "2026-07-31T01:06:15.683316+00:00",
+            "Total Scan Duration": "25.42 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -198,7 +198,7 @@
         "health": {
             "avg_cognitive_load": 24.048,
             "avg_safety_score": 23.794,
-            "avg_tech_debt": 25.065,
+            "avg_tech_debt": 25.066,
             "avg_documentation": 29.832
         },
         "composition": {
@@ -335,7 +335,7 @@
             "java": {
                 "files": 14,
                 "loc": 4895,
-                "impact": 5687.7
+                "impact": 5710.700000000001
             },
             "haskell": {
                 "files": 7,
@@ -3012,11 +3012,11 @@
             },
             "groovy/gradle": {
                 "file_count": 3,
-                "total_mass": 2870.68,
+                "total_mass": 2893.68,
                 "avg_exposures": {
                     "cognitive_load": 33.18,
                     "safety_score": 71.61,
-                    "tech_debt": 98.45,
+                    "tech_debt": 98.87,
                     "verification": 80.0,
                     "api_exposure": 8.68,
                     "concurrency": 40.92,
@@ -6190,7 +6190,7 @@
                 {
                     "name": "DefaultPluginManager.java",
                     "path": "groovy/gradle/DefaultPluginManager.java",
-                    "value": 887.26
+                    "value": 888.54
                 },
                 {
                     "name": "gen_be_wrapper.ksh",
@@ -209968,7 +209968,7 @@
             }
         },
         "groovy/gradle": {
-            "Directory Group Magnitude": 2870.68,
+            "Directory Group Magnitude": 2893.68,
             "File Count": 3,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_0": "66.7%",
@@ -209977,7 +209977,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "33.18%",
                 "Error & Exception Exposure": "71.61%",
-                "Tech Debt Exposure": "98.45%",
+                "Tech Debt Exposure": "98.87%",
                 "Testing Exposure": "80.0%",
                 "API Exposure": "8.68%",
                 "Concurrency Exposure": "40.92%",
@@ -210009,32 +210009,32 @@
                         "Identity Proof": "Single Indicator (Ext: .java)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5452.57,
+                        "X": -5452.93,
                         "Y": 197.73,
-                        "Z": -118.86
+                        "Z": -118.53
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 11.205,
+                        "Repository Drift (Z-Score)": 11.229,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.222,
-                            "file_cluster_1": 12.532,
-                            "file_cluster_2": 12.505,
-                            "file_cluster_3": 13.261,
-                            "file_cluster_4": 11.452,
-                            "file_cluster_5": 12.995,
-                            "file_cluster_6": 12.271,
-                            "file_cluster_7": 12.218,
-                            "file_cluster_8": 11.719,
-                            "file_cluster_9": 12.233,
-                            "file_cluster_10": 13.255,
-                            "file_cluster_11": 11.596,
-                            "file_cluster_12": 12.472,
-                            "file_cluster_13": 11.205,
-                            "file_cluster_14": 15.774,
-                            "file_cluster_15": 12.617,
-                            "file_cluster_16": 11.52,
-                            "file_cluster_17": 12.095
+                            "file_cluster_0": 11.245,
+                            "file_cluster_1": 12.553,
+                            "file_cluster_2": 12.527,
+                            "file_cluster_3": 13.282,
+                            "file_cluster_4": 11.477,
+                            "file_cluster_5": 13.017,
+                            "file_cluster_6": 12.293,
+                            "file_cluster_7": 12.241,
+                            "file_cluster_8": 11.743,
+                            "file_cluster_9": 12.255,
+                            "file_cluster_10": 13.276,
+                            "file_cluster_11": 11.619,
+                            "file_cluster_12": 12.494,
+                            "file_cluster_13": 11.229,
+                            "file_cluster_14": 15.791,
+                            "file_cluster_15": 12.639,
+                            "file_cluster_16": 11.545,
+                            "file_cluster_17": 12.118
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -210042,7 +210042,7 @@
                         "Total LOC": 369,
                         "Coding LOC": 299,
                         "Documentation LOC": 20,
-                        "Structural Magnitude": 606.58,
+                        "Structural Magnitude": 629.58,
                         "Control Flow Ratio": "40.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -210053,7 +210053,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "48.91%",
                         "Error & Exception Exposure": "73.04%",
-                        "Tech Debt Exposure": "95.34%",
+                        "Tech Debt Exposure": "96.62%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "4.29%",
                         "Concurrency Exposure": "100.0%",
@@ -210121,6 +210121,16 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 308,
                             "End Line": 311
+                        },
+                        {
+                            "Function Name": "findPluginIdForClass",
+                            "Structural Impact": 23.0,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 7,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 115,
+                            "End Line": 121
                         },
                         {
                             "Function Name": "findInstance",
@@ -210347,8 +210357,8 @@
                     "7. Structural Signatures (Net Mitigated Signals)": {
                         "Control Flow Branches": 63,
                         "Sequential Logic Declarations": 94,
-                        "Function Parameters": 33,
-                        "Function/Method Declarations": 35,
+                        "Function Parameters": 34,
+                        "Function/Method Declarations": 36,
                         "Class/Entity Declarations": 3,
                         "Defensive Programming Constructs": 10,
                         "Type/Safety Bypasses": 15,
@@ -210419,7 +210429,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 5,
-                        "Orphaned Logic": 4,
+                        "Orphaned Logic": 5,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,

--- a/tests/golden_master_zero_dep_audit.json
+++ b/tests/golden_master_zero_dep_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-31T00:19:32.074234+00:00",
-            "Total Scan Duration": "23.42 seconds"
+            "Analysis ISO Timestamp": "2026-07-31T01:06:47.335405+00:00",
+            "Total Scan Duration": "23.29 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -198,7 +198,7 @@
         "health": {
             "avg_cognitive_load": 24.048,
             "avg_safety_score": 23.794,
-            "avg_tech_debt": 25.065,
+            "avg_tech_debt": 25.066,
             "avg_documentation": 29.832
         },
         "composition": {
@@ -335,7 +335,7 @@
             "java": {
                 "files": 14,
                 "loc": 4895,
-                "impact": 5687.7
+                "impact": 5710.700000000001
             },
             "haskell": {
                 "files": 7,
@@ -3012,11 +3012,11 @@
             },
             "groovy/gradle": {
                 "file_count": 3,
-                "total_mass": 2870.68,
+                "total_mass": 2893.68,
                 "avg_exposures": {
                     "cognitive_load": 33.18,
                     "safety_score": 71.61,
-                    "tech_debt": 98.45,
+                    "tech_debt": 98.87,
                     "verification": 80.0,
                     "api_exposure": 8.68,
                     "concurrency": 40.92,
@@ -6190,7 +6190,7 @@
                 {
                     "name": "DefaultPluginManager.java",
                     "path": "groovy/gradle/DefaultPluginManager.java",
-                    "value": 887.26
+                    "value": 888.54
                 },
                 {
                     "name": "gen_be_wrapper.ksh",
@@ -209968,7 +209968,7 @@
             }
         },
         "groovy/gradle": {
-            "Directory Group Magnitude": 2870.68,
+            "Directory Group Magnitude": 2893.68,
             "File Count": 3,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_0": "66.7%",
@@ -209977,7 +209977,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "33.18%",
                 "Error & Exception Exposure": "71.61%",
-                "Tech Debt Exposure": "98.45%",
+                "Tech Debt Exposure": "98.87%",
                 "Testing Exposure": "80.0%",
                 "API Exposure": "8.68%",
                 "Concurrency Exposure": "40.92%",
@@ -210009,32 +210009,32 @@
                         "Identity Proof": "Single Indicator (Ext: .java)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5452.57,
+                        "X": -5452.93,
                         "Y": 197.73,
-                        "Z": -118.86
+                        "Z": -118.53
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 11.205,
+                        "Repository Drift (Z-Score)": 11.229,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.222,
-                            "file_cluster_1": 12.532,
-                            "file_cluster_2": 12.505,
-                            "file_cluster_3": 13.261,
-                            "file_cluster_4": 11.452,
-                            "file_cluster_5": 12.995,
-                            "file_cluster_6": 12.271,
-                            "file_cluster_7": 12.218,
-                            "file_cluster_8": 11.719,
-                            "file_cluster_9": 12.233,
-                            "file_cluster_10": 13.255,
-                            "file_cluster_11": 11.596,
-                            "file_cluster_12": 12.472,
-                            "file_cluster_13": 11.205,
-                            "file_cluster_14": 15.774,
-                            "file_cluster_15": 12.617,
-                            "file_cluster_16": 11.52,
-                            "file_cluster_17": 12.095
+                            "file_cluster_0": 11.245,
+                            "file_cluster_1": 12.553,
+                            "file_cluster_2": 12.527,
+                            "file_cluster_3": 13.282,
+                            "file_cluster_4": 11.477,
+                            "file_cluster_5": 13.017,
+                            "file_cluster_6": 12.293,
+                            "file_cluster_7": 12.241,
+                            "file_cluster_8": 11.743,
+                            "file_cluster_9": 12.255,
+                            "file_cluster_10": 13.276,
+                            "file_cluster_11": 11.619,
+                            "file_cluster_12": 12.494,
+                            "file_cluster_13": 11.229,
+                            "file_cluster_14": 15.791,
+                            "file_cluster_15": 12.639,
+                            "file_cluster_16": 11.545,
+                            "file_cluster_17": 12.118
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -210042,7 +210042,7 @@
                         "Total LOC": 369,
                         "Coding LOC": 299,
                         "Documentation LOC": 20,
-                        "Structural Magnitude": 606.58,
+                        "Structural Magnitude": 629.58,
                         "Control Flow Ratio": "40.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -210053,7 +210053,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "48.91%",
                         "Error & Exception Exposure": "73.04%",
-                        "Tech Debt Exposure": "95.34%",
+                        "Tech Debt Exposure": "96.62%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "4.29%",
                         "Concurrency Exposure": "100.0%",
@@ -210121,6 +210121,16 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 308,
                             "End Line": 311
+                        },
+                        {
+                            "Function Name": "findPluginIdForClass",
+                            "Structural Impact": 23.0,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 7,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 115,
+                            "End Line": 121
                         },
                         {
                             "Function Name": "findInstance",
@@ -210347,8 +210357,8 @@
                     "7. Structural Signatures (Net Mitigated Signals)": {
                         "Control Flow Branches": 63,
                         "Sequential Logic Declarations": 94,
-                        "Function Parameters": 33,
-                        "Function/Method Declarations": 35,
+                        "Function Parameters": 34,
+                        "Function/Method Declarations": 36,
                         "Class/Entity Declarations": 3,
                         "Defensive Programming Constructs": 10,
                         "Type/Safety Bypasses": 15,
@@ -210419,7 +210429,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 5,
-                        "Orphaned Logic": 4,
+                        "Orphaned Logic": 5,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,


### PR DESCRIPTION
## Summary
Part of the extraction-hardening epic (#813). Closes #816.

Hardens all four extraction gauntlets (`func_start`, `args`, `class_start`, `_dependency_capture`) for java per [`tests/extraction/how_to_harden_extraction.md`](tests/extraction/how_to_harden_extraction.md), and fixes three real bugs found during empirical verification:

- **`func_start`/`args`** shared a flat `<[^>]*>` generic-bound modifier alternative (the "Rule 11" bug class) that truncated at the first `>`, breaking any single-line one-level-nested generic bound, e.g. `public static <T, U extends Comparable<U>> T Foo(T a, U b) {`. Widened to the established one-level-nesting idiom `<(?:[^<>]|<[^<>]*>)*>`.
- **`class_start`** had *no* generic-parameter step-over at all between the class name and its `extends`/`implements` check (a worse variant of the same bug class than TypeScript's #815 fix, which only needed widening an existing-but-flat step-over) — so any generic class declaration followed by `extends`/`implements` (`class Foo<T> extends Base<T> {`, common real Java) silently lost the entire inheritance capture even though the class name itself matched fine.

Also documents two known, **unfixed** architectural limitations (out of scope for a single-language pass, tracked in the epic for a future follow-up):
- `func_start`'s Mode-B string-shielding gap (`_slice_by_braces`, currently gated to js/ts only) reproduces on Java 15+ text blocks — confirms recurring bug class 3 is a genuine cross-language gap, not a js/ts quirk.
- `_dependency_capture` is matched against fully unshielded raw file content for *every* language (broader than the Mode-B gap, since there's no gate at all there) — new recurring bug class, recorded in the epic.

## Differential Scan
Ran `python tests/tools/crucible_check.py`: the only diff across the ~80-repo corpus is gradle's `DefaultPluginManager.java`, which now correctly detects `findPluginIdForClass` (`public <P extends Plugin<?>> Optional<PluginId> findPluginIdForClass(...)`) — exactly the nested-generic-bound shape this PR fixes, previously silently dropped from the function count (35 → 36 functions detected). Confirmed no other language/file is affected. Golden masters re-blessed for this on-target, expected change via `crucible_check.py --update --yes`.

## Test plan
- [x] `pytest tests/extraction/languages/test_java.py` (67 new tests) — run via bare `pytest` from an unrelated CWD to reproduce CI's invocation style
- [x] `pytest tests/core_engine/ tests/extraction/ -q` — 3381 passed, 1 known pre-existing tiktoken-environment failure, 1 xfailed
- [x] `python tests/tools/audit_check.py` — clean (only the pre-existing, already-tracked `guidestar_lens.py` mypy findings, unrelated to this change)
- [x] `python tests/tools/crucible_check.py` — PASS on both venvs after re-blessing
- [x] Migrated java's cases out of the four monolithic dict files into `tests/extraction/languages/test_java.py`
- [x] Epic #813 and the methodology doc updated with the new findings (recurring bug classes 9-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)