### PR TITLE
ci: split smoke-test's full pytest run out of the 12-way OS/Python matrix

### DIFF
--- a/.github/workflows/full-suite-gate.yml
+++ b/.github/workflows/full-suite-gate.yml
@@ -1,0 +1,59 @@
+name: Full Suite Gate (All OS x Python)
+
+# Backup safety net for the full OS x Python-version matrix, now that
+# smoke-test.yml only runs the full pytest suite once per push (see that
+# file's comments for why). This workflow restores full 12-way matrix
+# coverage of the entire suite at two checkpoints instead of every push:
+#   - Any label added to a pull request (an explicit "give this the full
+#     validation pass" signal -- not filtered to a specific label name, so
+#     applying ANY label triggers it).
+#   - Any release tag push (`v*`), matching publish.yml's own release
+#     trigger, as a pre-release confidence check across every supported
+#     environment.
+on:
+  pull_request:
+    types: [labeled]
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  full-suite-matrix:
+    runs-on: ${{ matrix.os }}
+    env:
+      PYTHONUTF8: "1"
+      GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install macOS dependencies (OpenMP for XGBoost)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install PyYAML networkx tiktoken pandas xgboost pytest
+          pip install --no-build-isolation -e .
+
+      - name: Full Suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
+        run: pytest tests/ -v

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,6 +9,15 @@ permissions:
   contents: read
 
 jobs:
+  # TRUE smoke test: cheap, OS/Python-version-sensitive checks only (package
+  # installs, CLI entry points, syntax floor) across the full matrix. Does
+  # NOT run the full pytest suite -- see full-suite (single env, below) for
+  # every-push regression coverage, and full-suite-gate.yml for the full
+  # matrix x full-suite backup run (fires on any PR label or a release tag).
+  # This split exists because most of tests/ (extraction/core_engine regex
+  # rules) has zero OS-dependency: running it 12x per push added CI cost
+  # that scaled with every language added to the extraction-hardening epic
+  # (#813) without adding real signal over running it once.
   smoke-test:
     runs-on: ${{ matrix.os }}
     env:
@@ -67,6 +76,35 @@ jobs:
 
       - name: Smoke Test - API Network Map
         run: python -m gitgalaxy.tools.network_auditing.full_api_network_map --help
+
+  # Full pytest suite, ONE representative environment (ubuntu/3.12), on
+  # every push. This is the fast-feedback regression net that used to run
+  # 12x inside the smoke-test matrix above; running it once here keeps that
+  # signal on every push without the 12x cost. The full OS x Python-version
+  # matrix still gets exercised, just not on every push -- see
+  # full-suite-gate.yml.
+  full-suite:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUTF8: "1"
+      GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 #
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install PyYAML networkx tiktoken pandas xgboost pytest
+          pip install --no-build-isolation -e .
 
       - name: Golden Record Integration Test (Pytest)
         run: pytest tests/ -v


### PR DESCRIPTION
## Summary
Follow-up to a conversation about CI cost as the extraction-hardening epic (#813) keeps growing the test suite (extraction tests alone: 595+ so far, ~38 languages still to go).

`smoke-test.yml`'s final step ran the **entire** pytest suite (`pytest tests/ -v`) inside the 3-OS × 4-Python-version matrix — 12 full-suite runs per push. Most of `tests/` (extraction/core_engine regex rules) has zero OS-dependency, so this added CI cost without adding real signal over running it once.

- **`smoke-test.yml`** split into two jobs:
  - `smoke-test`: unchanged 12-way matrix, but now only the genuinely OS/version-sensitive checks (package install, CLI `--help` entry points, syntax floor sweep) — the actual "smoke test."
  - `full-suite`: the full pytest run, once, on a single representative environment (ubuntu-latest/3.12) — keeps full-suite regression feedback on every push without the 12× duplication.
- **New `full-suite-gate.yml`**: backup safety net restoring full 12-way matrix × full-suite coverage at two checkpoints instead of every push:
  - Any label added to a PR (not filtered to a specific label — applying any label triggers it).
  - Any release tag push (`v*`), matching `publish.yml`'s own release trigger, as a pre-release confidence check across every supported environment.

Note: the release-tag trigger runs in parallel with `publish.yml`'s own tag-triggered publish (not a hard blocking pre-gate on PyPI publish itself — that would require restructuring `publish.yml` to depend on this job, which felt like a bigger, separate change). Flagging this now in case a true blocking pre-release gate is wanted later.

## Test plan
- [x] Both new/changed workflow YAML files parse cleanly (`yaml.safe_load`)
- [ ] This PR's own CI run exercises the new `smoke-test`/`full-suite` split live
- [ ] `full-suite-gate.yml` isn't exercised by this PR itself (no label applied, no tag pushed) — will verify behavior by applying a label to this PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)