### PR TITLE
Fix #820: Extraction hardening for csharp

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -1732,8 +1732,17 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 re.M,
             ),
             # 5. class_start (Object / Entity Declarations)
+            # RULE 11 FIX (epic #813/#820): there was no generic-parameter step-over between the
+            # class/interface/etc. name and the base-list `:` check, so ANY generic type with a base
+            # list (`class Foo<T> : Base<T> {`, extremely common) left the class's own `<...>`
+            # unconsumed right before `:`, silently losing the entire base-list capture (group 2)
+            # even though the name (group 1) still matched fine -- same failure shape as java's
+            # #816 class_start bug. Also added a primary-constructor parameter-list step-over
+            # (`record Foo<T>(T Value) : Base<T>`, C# 9+ records / C# 12 primary constructors on
+            # classes/structs, mainstream and common) for the same reason -- the `(...)` between the
+            # generics and the `:` was equally unconsumed.
             "class_start": re.compile(
-                r"^[ \t]*(?:\[[^\]]*\][ \t]*){0,5}(?:(?:public|internal|private|protected|static|sealed|abstract|partial|file|unsafe|new)[ \t]+){0,5}(?:class|interface|struct|record|enum)\s+([A-Za-z_$][\w_$]*)(?:\s*:\s*([A-Za-z_$][\w_$, \t<>\?]*))?",
+                r"^[ \t]*(?:\[[^\]]*\][ \t]*){0,5}(?:(?:public|internal|private|protected|static|sealed|abstract|partial|file|unsafe|new)[ \t]+){0,5}(?:class|interface|struct|record|enum)\s+([A-Za-z_$][\w_$]*)(?:\s*<(?:[^<>]|<[^<>]*>)*>)?(?:\s*\((?:[^()]|\([^()]*\))*\))?(?:\s*:\s*([A-Za-z_$][\w_$, \t<>\?]*))?",
                 re.M,
             ),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
@@ -1835,8 +1844,19 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             ),
             # 24. import (Dependency Inclusions)
             "import": re.compile(r"^[ \t]*(?:global[ \t]+)?using\s+(?:static[ \t]+)?[\w.]+;", re.M),
+            # ALIAS DIRECTIVE FIX (epic #813/#820): `using Alias = Target.Namespace;` (a using-alias
+            # directive, common for shortening long generic types or disambiguating identical type
+            # names from different namespaces) didn't match AT ALL -- there was no allowance for the
+            # `IDENT =` prefix before the actual target, so the whole statement produced zero
+            # dependency-graph edges. Added an optional alias-prefix skip-over so the capture lands
+            # on the real target (`Target.Namespace`), not the local alias name. Also added an
+            # optional generic-suffix step-over after the target capture: an alias directive's
+            # target is very commonly a CLOSED generic type (`using StringList =
+            # System.Collections.Generic.List<string>;` -- the primary real-world reason alias
+            # directives exist, to shorten long generics), and the required trailing `;` check
+            # failed on the unconsumed `<...>` without it.
             "_dependency_capture": re.compile(
-                r"^[ \t]*(?:global[ \t\n]+)?using[ \t\n]+(?:static[ \t\n]+)?([\w.]+)[ \t\n]*;",
+                r"^[ \t]*(?:global[ \t\n]+)?using[ \t\n]+(?:static[ \t\n]+)?(?:[\w]+[ \t\n]*=[ \t\n]*)?([\w.]+)(?:[ \t\n]*<(?:[^<>]|<[^<>]*>)*>)?[ \t\n]*;",
                 re.M,
             ),
             # 25. ownership (Authorship Metadata)

--- a/tests/extraction/how_to_harden_extraction.md
+++ b/tests/extraction/how_to_harden_extraction.md
@@ -357,6 +357,22 @@ specifically. Check every language against these *first* before assuming a rule 
     if so, match the strictest shape real formatted code actually produces, not the most permissive
     shape the grammar technically allows. This is exactly why step 3's crucible-check requirement
     exists even for "obviously safe" widenings.
+22. **(#820) `class_start`'s missing-generic-step-over bug keeps recurring independently across
+    unrelated languages.** java (#816), python (#818), and csharp (#820) all had it, each
+    discovered separately, from a 4-language sample of generics-capable languages checked so far.
+    **For any future language with generics, check `class_start`'s name-to-base-list gap FIRST**
+    given this hit rate, rather than treating it as a fresh discovery each time. csharp also needed
+    a companion fix no prior language required: a primary-constructor parameter-list step-over
+    (`record Foo<T>(T Value) : Base<T>`, C# 9+ records / C# 12 primary constructors) -- check for
+    this shape in any language with "primary constructor"-style class declarations (Kotlin, Scala).
+23. **(#820) A `_dependency_capture` rule can be missing an entire real-world statement SHAPE, not
+    just a character.** csharp's `using Alias = Target;` alias directive didn't match AT ALL --
+    no allowance for the `IDENT =` prefix at all (contrast with rust's #819 finding, which was just
+    a missing `*` in an existing shape). The alias target itself also needed its own generic-suffix
+    step-over (`using StringList = List<string>;`, the primary real-world reason alias directives
+    exist), confirmed via `crucible_check.py`. When reviewing `_dependency_capture`, check whether
+    the rule's grammar covers every statement FORM the language's import syntax supports (plain,
+    aliased, static, global, generic-targeted), not just variations on one form.
 
 ## Process: the epic and its sub-issues
 

--- a/tests/extraction/languages/test_csharp.py
+++ b/tests/extraction/languages/test_csharp.py
@@ -1,0 +1,349 @@
+"""
+C# extraction hardening (epic #813, issue #820). See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for csharp in one file: func_start,
+args, class_start, _dependency_capture. Migrated out of the four old
+monolithic dict files (test_function_extraction_strict.py,
+test_args_extraction_strict.py, test_class_extraction_strict.py,
+test_dependency_extraction_strict.py) -- csharp's entries were removed
+from those four when this file was added.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+# tests/ has no __init__.py anywhere in this repo, so a dotted
+# `tests.extraction._extraction_harness` import only works by accident
+# locally (e.g. `python -m pytest` from the repo root happens to put the
+# root on sys.path) and fails in CI, which invokes the `pytest` console
+# script directly. Insert this file's parent (tests/extraction/) onto
+# sys.path instead, so the harness imports as a plain top-level module.
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+CSHARP_RULES = LANGUAGE_DEFINITIONS["csharp"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start)
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        # Modern idiom (carried forward)
+        ("public async Task<List<string>> TargetFunc()", "TargetFunc"),
+        ("protected override void TargetFunc(int x)", "TargetFunc"),
+        ("internal static readonly Dictionary<int, string> TargetFunc()", "TargetFunc"),
+        # Syntax-era / feature coverage
+        (
+            "public List<T> TargetFunc<T>() where T : IComparable<T> {",
+            "TargetFunc",
+        ),  # generic method, where-clause constraint after params
+        ("public void TargetFunc() => DoWork();", "TargetFunc"),  # expression-bodied method
+        # Testing-framework-shaped functions that ARE real functions
+        ("[Fact]\npublic void TargetFunc() {", "TargetFunc"),  # xUnit [Fact]
+        ("[Theory]\n[InlineData(1, 2)]\npublic void TargetFunc(int a, int b) {", "TargetFunc"),  # xUnit [Theory]
+    ],
+    "invalid": [
+        "public class TargetFunc {",  # class decl lookalike
+        "if (TargetFunc == null)",  # if lookalike
+        "new TargetFunc()",  # instantiation
+    ],
+    "pathological": [
+        (
+            '[Obsolete]\n[Route("api/v1")]\npublic\nasync\nTask<Dictionary<string, List<int>>>\nTargetFunc\n(',
+            "TargetFunc",
+        ),  # carried-forward: attribute stacking, massive nested generics, vertical
+        (
+            "public static TargetEntity TargetFunc<T>() where T : class, IComparable<T>, IEnumerable<T> {",
+            "TargetFunc",
+        ),  # generic method w/ multi-constraint where-clause
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_csharp_func_start_valid(payload, expected_name):
+    assert_valid_match(CSHARP_RULES["func_start"], payload, expected_name, "csharp.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_csharp_func_start_invalid(payload):
+    assert_invalid_no_match(CSHARP_RULES["func_start"], payload, "csharp.func_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_csharp_func_start_pathological(payload, expected_name):
+    assert_pathological_match(CSHARP_RULES["func_start"], payload, expected_name, "csharp.func_start")
+
+
+def test_csharp_func_start_known_limitation_verbatim_and_raw_string_lookalikes_still_match_at_regex_level():
+    """
+    Documents a known, NOT-fixed limitation: func_start's own regex has no
+    string/comment awareness, so function-shaped text inside a C# verbatim
+    string (@-quoted) or C# 11+ raw string literal (triple-quoted) that
+    happens to land at true line start still matches -- the same
+    architectural class of bug confirmed for javascript/typescript template
+    literals, Java text blocks, Go raw strings, and Rust raw strings
+    (recurring bug class 3 in how_to_harden_extraction.md), now confirmed
+    on a FIFTH language. csharp routes through Mode B (_slice_by_braces,
+    lexical_family "standard_block"), which is currently gated to
+    javascript/typescript only. Not fixed here -- tracked as its own
+    future audited follow-up in the epic.
+    """
+    func_start = CSHARP_RULES["func_start"]
+    verbatim = 'string s = @"\npublic void TargetFunc() {\n";'
+    raw = 'string s = """\npublic void TargetFunc() {\n""";'
+    assert func_start.search(verbatim), "documents current (expected, pipeline-level-fixed-elsewhere) regex behavior"
+    assert func_start.search(raw), "documents current (expected, pipeline-level-fixed-elsewhere) regex behavior"
+
+
+# ==============================================================================
+# ARGS (args)
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        ("public void TargetFunc(int a, string b)", "TargetFunc"),
+        ("protected override Task<int> TargetFunc(CancellationToken token)", "TargetFunc"),
+        ("[Fact]\npublic void TargetFunc() {", "TargetFunc"),  # xUnit [Fact] args
+    ],
+    "invalid": [
+        "TargetFunc(a, b);",
+        "catch (Exception ex)",
+    ],
+    "pathological": [
+        (
+            "public \n async \n Task<IActionResult> \n TargetFunc \n (\n  [FromBody] User user,\n  [FromQuery] string? id,\n  Action<bool, string> callback\n)",
+            "TargetFunc",
+        ),  # carried-forward: vertical, attribute-decorated params, nested generic callback
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["valid"])
+def test_csharp_args_valid(payload, expected_name):
+    assert_valid_match(CSHARP_RULES["args"], payload, expected_name, "csharp.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_csharp_args_invalid(payload):
+    assert_invalid_no_match(CSHARP_RULES["args"], payload, "csharp.args")
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["pathological"])
+def test_csharp_args_pathological(payload, expected_name):
+    assert_pathological_match(CSHARP_RULES["args"], payload, expected_name, "csharp.args")
+
+
+# ==============================================================================
+# CLASS_START (class_start)
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("public class TargetEntity", "TargetEntity"),
+        ("internal record TargetEntity", "TargetEntity"),
+        ("public interface TargetEntity<T>", "TargetEntity"),
+        (
+            "public class TargetEntity<T> : Base<T> {",
+            "TargetEntity",
+        ),  # generic class + base -- was a real bug (base silently lost), now fixed
+        (
+            "public sealed record TargetEntity<T>(T Value) : IComparable<T> {",
+            "TargetEntity",
+        ),  # primary-constructor record, generic + base -- was a real bug, now fixed
+        (
+            "public class TargetEntity(int x) : Base(x) {",
+            "TargetEntity",
+        ),  # C# 12 primary-constructor class (non-generic), base
+    ],
+    "invalid": [
+        "var obj = new TargetEntity();",
+        "public classList",
+        "typeof(TargetEntity)",
+    ],
+    "pathological": [
+        (
+            '[Serializable]\n[Route("api/v1")]\npublic \n sealed \n class \n TargetEntity \n : \n IDisposable \n , \n ICloneable',
+            "TargetEntity",
+        ),  # carried-forward: attribute stacking, modifiers, inheritance interfaces
+        (
+            "public sealed record TargetEntity<T>(T Value) : IComparable<T>, IEnumerable<T> {",
+            "TargetEntity",
+        ),  # primary-ctor record w/ generic + multi-interface base, single line (the real bug this fixed)
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_csharp_class_start_valid(payload, expected_name):
+    assert_valid_match(CSHARP_RULES["class_start"], payload, expected_name, "csharp.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_csharp_class_start_invalid(payload):
+    assert_invalid_no_match(CSHARP_RULES["class_start"], payload, "csharp.class_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_csharp_class_start_pathological(payload, expected_name):
+    assert_pathological_match(CSHARP_RULES["class_start"], payload, expected_name, "csharp.class_start")
+
+
+def test_csharp_class_start_generic_base_regression():
+    """
+    Regression test for a real bug (epic #813/#820): there was no
+    generic-parameter step-over between the class/interface/etc. name and
+    the base-list `:` check, so ANY generic type with a base list
+    (`class Foo<T> : Base<T> {`, extremely common) left the class's own
+    `<...>` unconsumed right before `:`, silently losing the entire
+    base-list capture (group 2) even though the name (group 1) still
+    matched fine -- same failure shape as java's #816 class_start bug.
+    """
+    class_start = CSHARP_RULES["class_start"]
+    assert class_start.groups == 2, "sanity: the rule still has both capture groups"
+    m = class_start.search("public class Foo<T> : Base<T> {")
+    assert m and m.group(1) == "Foo", "class name capture regressed"
+    assert m.group(2) and "Base" in m.group(2), "base-list capture still lost behind a generic parameter list"
+
+
+def test_csharp_class_start_primary_constructor_regression():
+    """
+    Regression test for a related but distinct real bug (epic #813/#820):
+    a primary-constructor's parameter list (`record Foo<T>(T Value) : Base<T>`,
+    C# 9+ records / C# 12 primary constructors on classes and structs,
+    mainstream and common) was equally unconsumed between the generics and
+    the `:` check, independently of the generic-parameter fix above.
+    """
+    class_start = CSHARP_RULES["class_start"]
+    m = class_start.search("public sealed record Foo<T>(T Value) : IComparable<T> {")
+    assert m and m.group(1) == "Foo", "class name capture regressed"
+    assert m.group(2) and "IComparable" in m.group(2), (
+        "base-list capture still lost behind a primary-constructor parameter list"
+    )
+
+
+def test_csharp_class_start_redos_immunity():
+    """ReDoS sweep for the new generic-parameter and primary-constructor step-overs."""
+    class_start = CSHARP_RULES["class_start"]
+    assert_redos_immune(class_start, "public class Foo<" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(class_start, "public class Foo<T>(" + "a" * 100000, timeout_sec=3.0)
+    assert class_start.search("public class Foo<T>(T x) : Base<T> {")
+
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture)
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("using System.Threading.Tasks;", "System.Threading.Tasks"),
+        ("global using static System.Math;", "System.Math"),
+        (
+            "using Alias = Some.Namespace.Target;",
+            "Some.Namespace.Target",
+        ),  # using alias directive -- was a real bug (no match at all), now fixed
+        (
+            "global using JsonObj = System.Text.Json.Nodes.JsonObject;",
+            "System.Text.Json.Nodes.JsonObject",
+        ),  # global using alias directive
+        (
+            "using StringList = System.Collections.Generic.List<string>;",
+            "System.Collections.Generic.List",
+        ),  # alias directive with a CLOSED GENERIC target -- the primary real-world reason
+        # alias directives exist (shortening long generics) -- was also broken, now fixed
+    ],
+    "invalid": [
+        "using (var stream = new FileStream())",  # using STATEMENT (resource disposal), not a directive
+    ],
+    "pathological": [
+        (
+            "global \n using \n static \n Microsoft.AspNetCore.Mvc \n ;",
+            "Microsoft.AspNetCore.Mvc",
+        ),  # carried-forward: vertical global static using
+        (
+            "using \n StringList \n = \n System.Collections.Generic.List<string> \n ;",
+            "System.Collections.Generic.List",
+        ),  # alias directive with generic target, vertical (the real bug this fixed)
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_csharp_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(
+        CSHARP_RULES["_dependency_capture"], payload, expected_path, "csharp._dependency_capture"
+    )
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_csharp_dependency_capture_invalid(payload):
+    assert_invalid_no_match(CSHARP_RULES["_dependency_capture"], payload, "csharp._dependency_capture")
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_csharp_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(
+        CSHARP_RULES["_dependency_capture"], payload, expected_path, "csharp._dependency_capture"
+    )
+
+
+def test_csharp_dependency_capture_alias_directive_regression():
+    """
+    Regression test for a real bug (epic #813/#820): a using-alias
+    directive (`using Alias = Target.Namespace;`, common for shortening
+    long generic types or disambiguating identical type names from
+    different namespaces) didn't match AT ALL -- there was no allowance
+    for the `IDENT =` prefix before the actual target, so the whole
+    statement produced zero dependency-graph edges. Also verifies the
+    companion fix: the target itself is very commonly a CLOSED GENERIC
+    type (`using StringList = System.Collections.Generic.List<string>;`
+    -- the primary real-world motivation for alias directives), which
+    needed its own generic-suffix step-over before the required trailing
+    `;`.
+    """
+    pattern = CSHARP_RULES["_dependency_capture"]
+    m = pattern.search("using Alias = Some.Namespace.Target;")
+    assert m and "Some.Namespace.Target" in m.group(1), "plain alias directive capture regressed"
+
+    m2 = pattern.search("using StringList = System.Collections.Generic.List<string>;")
+    assert m2 and "System.Collections.Generic.List" in m2.group(1), "generic-target alias directive capture regressed"
+
+    # Sanity: plain (non-alias) using statements must still work.
+    m3 = pattern.search("using System;")
+    assert m3 and m3.group(1) == "System"
+
+
+def test_csharp_dependency_capture_redos_immunity():
+    """ReDoS sweep for the new alias-prefix and generic-suffix step-overs."""
+    pattern = CSHARP_RULES["_dependency_capture"]
+    assert_redos_immune(pattern, "using " + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(pattern, "using X = Y<" + "a" * 100000, timeout_sec=3.0)
+    assert pattern.search("using X = Y<string>;")
+
+
+def test_csharp_dependency_capture_known_limitation_verbatim_string_lookalike_still_matches_at_regex_level():
+    """
+    Companion to func_start's own known-limitation test above:
+    _dependency_capture is matched against fully unshielded raw file
+    content for every language (see the java pass's #816 finding), so a
+    `using ...;`-shaped line inside a C# verbatim string at true line
+    start still produces a phantom dependency-graph edge. Documented, not
+    fixed here -- see how_to_harden_extraction.md's recurring bug class 10.
+    """
+    dependency_capture = CSHARP_RULES["_dependency_capture"]
+    verbatim = 'string s = @"\nusing System.IO;\n";'
+    assert dependency_capture.search(verbatim), "documents current (accepted, unfixed) regex behavior"

--- a/tests/extraction/test_args_extraction_strict.py
+++ b/tests/extraction/test_args_extraction_strict.py
@@ -12,22 +12,6 @@ from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 # across major languages without triggering ReDoS on complex nested types.
 # ==============================================================================
 ARGS_EXTRACTION_CASES = {
-    "csharp": {
-        "valid": [
-            ("public void TargetFunc(int a, string b)", "TargetFunc"),
-            (
-                "protected override Task<int> TargetFunc(CancellationToken token)",
-                "TargetFunc",
-            ),
-        ],
-        "invalid": ["TargetFunc(a, b);", "catch (Exception ex)"],
-        "pathological": [
-            (
-                "public \n async \n Task<IActionResult> \n TargetFunc \n (\n  [FromBody] User user,\n  [FromQuery] string? id,\n  Action<bool, string> callback\n)",
-                "TargetFunc",
-            )
-        ],
-    },
     "cpp": {
         "valid": [
             ("void TargetFunc(int a, float b) {", "TargetFunc"),

--- a/tests/extraction/test_class_extraction_strict.py
+++ b/tests/extraction/test_class_extraction_strict.py
@@ -14,25 +14,6 @@ from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 # }
 # ==============================================================================
 CLASS_EXTRACTION_CASES = {
-    "csharp": {
-        "valid": [
-            ("public class TargetEntity", "TargetEntity"),
-            ("internal record TargetEntity", "TargetEntity"),
-            ("public interface TargetEntity<T>", "TargetEntity"),
-        ],
-        "invalid": [
-            "var obj = new TargetEntity();",
-            "public classList",
-            "typeof(TargetEntity)",
-        ],
-        "pathological": [
-            # Vertical attribute stacking, modifiers, and inheritance interfaces
-            (
-                '[Serializable]\n[Route("api/v1")]\npublic \n sealed \n class \n TargetEntity \n : \n IDisposable \n , \n ICloneable',
-                "TargetEntity",
-            )
-        ],
-    },
     "cpp": {
         "valid": [
             ("class TargetEntity {", "TargetEntity"),

--- a/tests/extraction/test_dependency_extraction_strict.py
+++ b/tests/extraction/test_dependency_extraction_strict.py
@@ -14,19 +14,6 @@ from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 # destructuring, aliases, and multi-line formatting without capturing the wrong variables.
 # ==============================================================================
 DEPENDENCY_EXTRACTION_CASES = {
-    "csharp": {
-        "valid": [
-            ("using System.Threading.Tasks;", "System.Threading.Tasks"),
-            ("global using static System.Math;", "System.Math"),
-        ],
-        "invalid": ["using (var stream = new FileStream())"],
-        "pathological": [
-            (
-                "global \n using \n static \n Microsoft.AspNetCore.Mvc \n ;",
-                "Microsoft.AspNetCore.Mvc",
-            )
-        ],
-    },
     "cpp": {
         "valid": [
             ("#include <sys/types.h>", "sys/types.h"),

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -25,28 +25,6 @@ from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 # }
 # ==============================================================================
 EXTRACTION_CASES = {
-    "csharp": {
-        "valid": [
-            ("public async Task<List<string>> TargetFunc()", "TargetFunc"),
-            ("protected override void TargetFunc(int x)", "TargetFunc"),
-            (
-                "internal static readonly Dictionary<int, string> TargetFunc()",
-                "TargetFunc",
-            ),
-        ],
-        "invalid": [
-            "public class TargetFunc {",
-            "if (TargetFunc == null)",
-            "new TargetFunc()",
-        ],
-        "pathological": [
-            # Vertical stacking, attribute bloat, and massive nested generics
-            (
-                '[Obsolete]\n[Route("api/v1")]\npublic\nasync\nTask<Dictionary<string, List<int>>>\nTargetFunc\n(',
-                "TargetFunc",
-            )
-        ],
-    },
     "cpp": {
         "valid": [
             ("int TargetFunc() {", "TargetFunc"),

--- a/tests/golden_master_audit.json
+++ b/tests/golden_master_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-31T02:30:48.619354+00:00",
-            "Total Scan Duration": "25.33 seconds"
+            "Analysis ISO Timestamp": "2026-07-31T03:39:58.285823+00:00",
+            "Total Scan Duration": "24.02 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -4129,7 +4129,7 @@
             },
             "firewall": {
                 "imports_whitelisted": 0,
-                "imports_unknown": 7358,
+                "imports_unknown": 7359,
                 "imports_blacklisted": 0,
                 "threats_found": 139,
                 "threats_allowed": 0
@@ -43758,26 +43758,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.348,
+                        "Repository Drift (Z-Score)": 12.362,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.567,
-                            "file_cluster_1": 12.913,
-                            "file_cluster_2": 13.117,
-                            "file_cluster_3": 13.881,
-                            "file_cluster_4": 12.609,
-                            "file_cluster_5": 13.272,
-                            "file_cluster_6": 13.1,
-                            "file_cluster_7": 12.601,
-                            "file_cluster_8": 12.559,
-                            "file_cluster_9": 13.152,
-                            "file_cluster_10": 13.746,
-                            "file_cluster_11": 12.696,
-                            "file_cluster_12": 13.27,
-                            "file_cluster_13": 12.348,
-                            "file_cluster_14": 16.568,
-                            "file_cluster_15": 12.693,
-                            "file_cluster_16": 12.589,
-                            "file_cluster_17": 13.125
+                            "file_cluster_0": 12.58,
+                            "file_cluster_1": 12.927,
+                            "file_cluster_2": 13.13,
+                            "file_cluster_3": 13.893,
+                            "file_cluster_4": 12.623,
+                            "file_cluster_5": 13.286,
+                            "file_cluster_6": 13.113,
+                            "file_cluster_7": 12.614,
+                            "file_cluster_8": 12.572,
+                            "file_cluster_9": 13.165,
+                            "file_cluster_10": 13.759,
+                            "file_cluster_11": 12.709,
+                            "file_cluster_12": 13.283,
+                            "file_cluster_13": 12.362,
+                            "file_cluster_14": 16.577,
+                            "file_cluster_15": 12.707,
+                            "file_cluster_16": 12.603,
+                            "file_cluster_17": 13.138
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -44024,13 +44024,14 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 14,
+                        "Direct Upstream (Fragility)": 15,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
                         "Microsoft.CodeAnalysis.CSharp.Syntax",
+                        "Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax",
                         "Microsoft.CodeAnalysis.Collections",
                         "Microsoft.CodeAnalysis.PooledObjects",
                         "Microsoft.CodeAnalysis.Text",

--- a/tests/golden_master_zero_dep_audit.json
+++ b/tests/golden_master_zero_dep_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-31T02:31:20.414655+00:00",
-            "Total Scan Duration": "23.43 seconds"
+            "Analysis ISO Timestamp": "2026-07-31T03:40:29.812842+00:00",
+            "Total Scan Duration": "22.46 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -4129,7 +4129,7 @@
             },
             "firewall": {
                 "imports_whitelisted": 0,
-                "imports_unknown": 7358,
+                "imports_unknown": 7359,
                 "imports_blacklisted": 0,
                 "threats_found": 139,
                 "threats_allowed": 0
@@ -43758,26 +43758,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.348,
+                        "Repository Drift (Z-Score)": 12.362,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.567,
-                            "file_cluster_1": 12.913,
-                            "file_cluster_2": 13.117,
-                            "file_cluster_3": 13.881,
-                            "file_cluster_4": 12.609,
-                            "file_cluster_5": 13.272,
-                            "file_cluster_6": 13.1,
-                            "file_cluster_7": 12.601,
-                            "file_cluster_8": 12.559,
-                            "file_cluster_9": 13.152,
-                            "file_cluster_10": 13.746,
-                            "file_cluster_11": 12.696,
-                            "file_cluster_12": 13.27,
-                            "file_cluster_13": 12.348,
-                            "file_cluster_14": 16.568,
-                            "file_cluster_15": 12.693,
-                            "file_cluster_16": 12.589,
-                            "file_cluster_17": 13.125
+                            "file_cluster_0": 12.58,
+                            "file_cluster_1": 12.927,
+                            "file_cluster_2": 13.13,
+                            "file_cluster_3": 13.893,
+                            "file_cluster_4": 12.623,
+                            "file_cluster_5": 13.286,
+                            "file_cluster_6": 13.113,
+                            "file_cluster_7": 12.614,
+                            "file_cluster_8": 12.572,
+                            "file_cluster_9": 13.165,
+                            "file_cluster_10": 13.759,
+                            "file_cluster_11": 12.709,
+                            "file_cluster_12": 13.283,
+                            "file_cluster_13": 12.362,
+                            "file_cluster_14": 16.577,
+                            "file_cluster_15": 12.707,
+                            "file_cluster_16": 12.603,
+                            "file_cluster_17": 13.138
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -44024,13 +44024,14 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 14,
+                        "Direct Upstream (Fragility)": 15,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
                         "Microsoft.CodeAnalysis.CSharp.Syntax",
+                        "Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax",
                         "Microsoft.CodeAnalysis.Collections",
                         "Microsoft.CodeAnalysis.PooledObjects",
                         "Microsoft.CodeAnalysis.Text",


### PR DESCRIPTION
## Summary
Part of the extraction-hardening epic (#813). Closes #820.

Hardens all four extraction gauntlets (`func_start`, `args`, `class_start`, `_dependency_capture`) for csharp per [`tests/extraction/how_to_harden_extraction.md`](tests/extraction/how_to_harden_extraction.md). This was a fresh sweep (no pre-flagged known bug) and surfaced three real bugs:

- **`class_start`** had the same missing-generic-step-over bug already seen in java (#816) and python (#818): no generic-parameter step-over between the class/interface/etc. name and the base-list `:` check, so ANY generic type with a base list (`class Foo<T> : Base<T> {`, extremely common) silently lost the entire base-list capture even though the name still matched fine.
- **`class_start`** also needed a companion fix no prior language required: a primary-constructor parameter-list step-over (`record Foo<T>(T Value) : Base<T>`, C# 9+ records / C# 12 primary constructors on classes and structs, mainstream and common) — the constructor's `(...)` was equally unconsumed between the generics and the base-list check, independently of the generic-parameter fix.
- **`_dependency_capture`** was entirely missing support for using-alias directives (`using Alias = Target;`, common for shortening long generic types or disambiguating identically-named types from different namespaces) — no match at all, not just a dirty capture. The alias target itself also needed its own generic-suffix step-over (`using StringList = List<string>;`, the primary real-world reason alias directives exist).

Also documents a known, **unfixed** architectural limitation (out of scope for a single-language pass, tracked in the epic): `func_start`/`_dependency_capture`'s Mode-B string-shielding gap reproduces on C# verbatim strings (`@"..."`) and C# 11+ raw string literals — now confirmed on a **fifth** language.

## Differential Scan
Ran `python tests/tools/crucible_check.py`: the only diff across the ~80-repo corpus is a real Roslyn corpus file (`CSharpSyntaxTree.cs`), which now correctly detects a dependency edge for `using InternalSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax;` — exactly the alias-directive shape this fixes, previously invisible. Confirmed no other language/file is affected. Golden masters re-blessed for this on-target, expected change via `crucible_check.py --update --yes`.

## Test plan
- [x] `pytest tests/extraction/languages/test_csharp.py` (44 new tests) — run via bare `pytest` from an unrelated CWD to reproduce CI's invocation style
- [x] `pytest tests/core_engine/ tests/extraction/ -q` — 3576 passed, 1 known pre-existing tiktoken-environment failure, 1 xfailed
- [x] `python tests/tools/audit_check.py` — clean (only the pre-existing, already-tracked `guidestar_lens.py` mypy findings, unrelated to this change)
- [x] `python tests/tools/crucible_check.py` — PASS on both venvs after re-blessing
- [x] Migrated csharp's cases out of the four monolithic dict files into `tests/extraction/languages/test_csharp.py`
- [x] Epic #813 and the methodology doc updated with the new findings (recurring bug classes 22-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)