### PR TITLE
Fix #823: Extraction hardening for kotlin

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -4771,7 +4771,11 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # FIX: Implemented the 1-Level Nesting Trick `(?:[^)(]+|\([^)]*\))*` to
                 # absorb the inner parentheses. Upgraded spaces to `[ \t\n]*` for vertical layouts.
                 # =====================================================================
-                r"\b(?:fun|constructor)(?:[ \t\n]*<[^>]{0,100}>)?[ \t\n]*(?:[a-zA-Z_]\w*\.)?[a-zA-Z_]\w*[ \t\n]*\((?:[^)(]|\([^)]*\))*\)|\{[ \t\n]*[a-zA-Z_][a-zA-Z0-9_ \t\n:<>,.?]{0,150}?->",
+                # RULE 11 FIX (epic #813/#823): the generic-parameter step-over was the flat
+                # `<[^>]{0,100}>`, truncating at the FIRST `>` and breaking any nested generic
+                # bound (`fun <T, U : Comparable<U>> foo(x: T, y: U): T {`, a realistic bounded
+                # generic function). Widened to the established one-level-nesting idiom.
+                r"\b(?:fun|constructor)(?:[ \t\n]*<(?:[^<>]|<[^<>]*>)*>)?[ \t\n]*(?:[a-zA-Z_]\w*\.)?[a-zA-Z_]\w*[ \t\n]*\((?:[^)(]|\([^)]*\))*\)|\{[ \t\n]*[a-zA-Z_][a-zA-Z0-9_ \t\n:<>,.?]{0,150}?->",
                 re.M,
             ),
             # 4. func_start (Executable Logic Anchors)
@@ -4786,16 +4790,26 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # (removing the `\n` restriction) and updated the trailing lookahead
                 # to `[ \t\n]*[\(\{]` so it can safely jump vertical gaps to the parameters.
                 # =====================================================================
+                # RULE 11 FIX (epic #813/#823): same generic-parameter nesting gap as args above
+                # -- widened to the established one-level-nesting idiom.
                 r"^[ \t]*(?:@[\w.]+(?:\([^)\{]{0,300}\))?[ \t\n]*){0,10}"
                 r"(?:(?:public|private|protected|internal|open|override|abstract|final|suspend|inline|tailrec|infix|operator|external|expect|actual)[ \t\n]+){0,5}"
                 r"(?:context\s*\([^)]*\)\s*)?"
-                r"(?:fun[ \t\n]+(?:<[^>]{0,100}>[ \t\n]*)?(?:[a-zA-Z_]\w*\.)?([a-zA-Z_]\w*)|(init)|(constructor))(?=[ \t\n]*[\(\{])",
+                r"(?:fun[ \t\n]+(?:<(?:[^<>]|<[^<>]*>)*>[ \t\n]*)?(?:[a-zA-Z_]\w*\.)?([a-zA-Z_]\w*)|(init)|(constructor))(?=[ \t\n]*[\(\{])",
                 re.M,
             ),
             # 5. class_start (Object / Entity Declarations)
             # OPTIMIZED: Applied the same 300-char bounds to class annotations.
+            # COMPANION OBJECT FIX (epic #813/#823): `companion object { ... }` (almost always
+            # anonymous -- a name is rare and optional) never matched at all: "companion" wasn't in
+            # the modifier list, and even if it were, the class/interface/object/enum-class branch's
+            # name was mandatory. Added a dedicated alternative for it with an OPTIONAL name, kept
+            # narrowly scoped to the literal `companion object` shape rather than making the name
+            # optional for the general branch -- doing that broadly would have opened a new false
+            # positive on object EXPRESSIONS (`object : Base() {`, an anonymous object literal used
+            # inline, a different construct from an object DECLARATION).
             "class_start": re.compile(
-                r"^[ \t]*(?:@[\w.]+(?:\([^)\{]{0,300}\))?[ \t]*){0,10}(?:(?:public|private|protected|internal|open|abstract|final|sealed|data|value|annotation|expect|actual|inner)[ \t]+){0,5}(?:class|interface|object|enum\s+class)\s+[a-zA-Z_]\w*",
+                r"^[ \t]*(?:@[\w.]+(?:\([^)\{]{0,300}\))?[ \t]*){0,10}(?:(?:public|private|protected|internal|open|abstract|final|sealed|data|value|annotation|expect|actual|inner)[ \t]+){0,5}(?:(?:class|interface|object|enum\s+class)\s+[a-zA-Z_]\w*|companion[ \t\n]+object(?:\s+[a-zA-Z_]\w*)?)",
                 re.M,
             ),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---

--- a/tests/extraction/how_to_harden_extraction.md
+++ b/tests/extraction/how_to_harden_extraction.md
@@ -419,6 +419,16 @@ specifically. Check every language against these *first* before assuming a rule 
     "fixing" what looks like an obviously-wrong match. The full pytest suite step (already
     required) does catch this eventually, but checking proactively is cheaper than a red test
     after the fact.
+29. **(#823) When fixing a missing-declaration-shape gap that would require making a shared
+    branch's name optional, check whether a NARROWLY-SCOPED new alternative achieves the same fix
+    without loosening anything else.** kotlin's `companion object { ... }` (almost always
+    anonymous) never matched `class_start`. Making the general `class|interface|object|enum class`
+    branch's name optional would have opened a new false positive on object EXPRESSIONS
+    (`object : Base() {`). A dedicated alternative scoped to the literal `companion object` shape
+    with its own optional name fixed it without touching the general branch at all.
+30. **(#823) Recurring class 3 confirmed on a SEVENTH language (kotlin, via triple-quoted raw
+    strings)** -- same shape as js/ts/java/go/rust/csharp/cpp, another confirming data point for
+    the eventual `_slice_by_braces`-broadening follow-up.
 
 ## Process: the epic and its sub-issues
 

--- a/tests/extraction/languages/test_kotlin.py
+++ b/tests/extraction/languages/test_kotlin.py
@@ -1,0 +1,306 @@
+"""
+Kotlin extraction hardening (epic #813, issue #823). See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for kotlin in one file: func_start,
+args, class_start, _dependency_capture. Migrated out of the four old
+monolithic dict files (test_function_extraction_strict.py,
+test_args_extraction_strict.py, test_class_extraction_strict.py,
+test_dependency_extraction_strict.py) -- kotlin's entries were removed
+from those four when this file was added.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+# tests/ has no __init__.py anywhere in this repo, so a dotted
+# `tests.extraction._extraction_harness` import only works by accident
+# locally (e.g. `python -m pytest` from the repo root happens to put the
+# root on sys.path) and fails in CI, which invokes the `pytest` console
+# script directly. Insert this file's parent (tests/extraction/) onto
+# sys.path instead, so the harness imports as a plain top-level module.
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+KOTLIN_RULES = LANGUAGE_DEFINITIONS["kotlin"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start)
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        # Modern idiom (carried forward)
+        ("fun TargetFunc()", "TargetFunc"),
+        ("suspend fun TargetFunc()", "TargetFunc"),
+        ("internal inline fun TargetFunc()", "TargetFunc"),
+        # Syntax-era / feature coverage
+        (
+            "fun <T, U : Comparable<U>> TargetFunc(x: T, y: U): T {",
+            "TargetFunc",
+        ),  # nested generic bound -- was a real bug, now fixed
+        ("fun String.TargetFunc(): Int {", "TargetFunc"),  # extension function
+        # Testing-framework-shaped functions that ARE real functions
+        ("@Test\nfun TargetFunc() {", "TargetFunc"),  # JUnit @Test
+    ],
+    "invalid": [
+        "class TargetFunc",  # class decl lookalike
+        "val TargetFunc =",  # val decl lookalike
+        "if (TargetFunc)",  # if lookalike
+    ],
+    "pathological": [
+        (
+            "@JvmStatic\n@Throws(Exception::class)\npublic \n suspend \n inline \n fun \n < \n T \n > \n TargetFunc \n (",
+            "TargetFunc",
+        ),  # carried-forward: JVM annotations and extreme generic spacing
+        (
+            "fun <T, U : Comparable<U>> TargetFunc(\n    x: T,\n    y: U,\n): T {",
+            "TargetFunc",
+        ),  # nested generic bound, params split vertically
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_kotlin_func_start_valid(payload, expected_name):
+    assert_valid_match(KOTLIN_RULES["func_start"], payload, expected_name, "kotlin.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_kotlin_func_start_invalid(payload):
+    assert_invalid_no_match(KOTLIN_RULES["func_start"], payload, "kotlin.func_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_kotlin_func_start_pathological(payload, expected_name):
+    assert_pathological_match(KOTLIN_RULES["func_start"], payload, expected_name, "kotlin.func_start")
+
+
+def test_kotlin_func_start_nested_generic_bound_regression():
+    """
+    Regression test for a real bug (epic #813/#823): the generic-parameter
+    step-over was the flat `<[^>]{0,100}>`, truncating at the FIRST `>` and
+    breaking any nested generic bound (`fun <T, U : Comparable<U>>
+    foo(x: T, y: U): T {`, a realistic bounded generic function -- the
+    same Rule-11 bug class already fixed for java/python/csharp/rust).
+    """
+    func_start = KOTLIN_RULES["func_start"]
+    m = func_start.search("fun <T, U : Comparable<U>> TargetFunc(x: T, y: U): T {")
+    assert m and m.group(1) == "TargetFunc", "nested generic bound detection regressed"
+
+
+def test_kotlin_func_start_redos_immunity():
+    """ReDoS sweep for the widened generic-parameter step-over."""
+    func_start = KOTLIN_RULES["func_start"]
+    assert_redos_immune(func_start, "fun <T, U : " + "a" * 100000, timeout_sec=3.0)
+    assert func_start.search("fun <T, U : Comparable<U>> Foo(x: T, y: U): T {")
+
+
+def test_kotlin_func_start_known_limitation_raw_string_lookalike_still_matches_at_regex_level():
+    """
+    Documents a known, NOT-fixed limitation: func_start's own regex has no
+    string/comment awareness, so function-shaped text inside a Kotlin raw
+    (triple-quoted) string literal that happens to land at true line start
+    still matches -- the same architectural class of bug confirmed for
+    javascript/typescript template literals, Java text blocks, Go/Rust raw
+    strings, and C# verbatim/raw strings (recurring bug class 3 in
+    how_to_harden_extraction.md), now confirmed on a SEVENTH language.
+    kotlin routes through Mode B (_slice_by_braces), currently gated to
+    javascript/typescript only. Not fixed here -- tracked as its own
+    future audited follow-up in the epic.
+    """
+    func_start = KOTLIN_RULES["func_start"]
+    raw_string = 'val s = """\nfun TargetFunc() {\n"""'
+    assert func_start.search(raw_string), "documents current (expected, pipeline-level-fixed-elsewhere) regex behavior"
+
+
+# ==============================================================================
+# ARGS (args)
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        ("fun TargetFunc(a: Int, b: String) {", "TargetFunc"),
+        ("suspend fun TargetFunc(items: List<String>) {", "TargetFunc"),
+        (
+            "fun <T, U : Comparable<U>> TargetFunc(x: T, y: U): T {",
+            "TargetFunc",
+        ),  # nested generic bound -- was a real bug, now fixed
+    ],
+    "invalid": [
+        "TargetFunc(a, b)",
+        "when (x) {",
+    ],
+    "pathological": [
+        (
+            "internal \n suspend \n fun \n <T> \n TargetFunc \n (\n  items: List<T> = emptyList(),\n  callback: (Result<T>) -> Unit\n)",
+            "TargetFunc",
+        ),  # carried-forward: vertical generics, default arguments, lambda parameters
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["valid"])
+def test_kotlin_args_valid(payload, expected_name):
+    assert_valid_match(KOTLIN_RULES["args"], payload, expected_name, "kotlin.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_kotlin_args_invalid(payload):
+    assert_invalid_no_match(KOTLIN_RULES["args"], payload, "kotlin.args")
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["pathological"])
+def test_kotlin_args_pathological(payload, expected_name):
+    assert_pathological_match(KOTLIN_RULES["args"], payload, expected_name, "kotlin.args")
+
+
+def test_kotlin_args_nested_generic_bound_regression():
+    """Regression test for the same root-cause bug as func_start's own regression test above."""
+    args = KOTLIN_RULES["args"]
+    assert args.search("fun <T, U : Comparable<U>> TargetFunc(x: T, y: U): T {"), (
+        "nested generic bound args detection regressed"
+    )
+
+
+def test_kotlin_args_redos_immunity():
+    """ReDoS sweep for the widened generic-parameter step-over."""
+    args = KOTLIN_RULES["args"]
+    assert_redos_immune(args, "fun <T, U : " + "a" * 100000, timeout_sec=3.0)
+    assert args.search("fun <T, U : Comparable<U>> Foo(x: T, y: U): T {")
+
+
+# ==============================================================================
+# CLASS_START (class_start)
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("class TargetEntity {", None),
+        ("data class TargetEntity(", None),
+        ("sealed interface TargetEntity", None),
+        ("enum class TargetEntity {", None),  # scoped enum class
+        (
+            "companion object {",
+            None,
+        ),  # anonymous companion object -- was a real bug, now fixed
+        (
+            "companion object TargetEntity {",
+            None,
+        ),  # named companion object -- was a real bug, now fixed
+        ("companion object : Factory<TargetEntity> {", None),  # companion object with supertype
+    ],
+    "invalid": [
+        "val x = TargetEntity()",
+        "fun classLike()",
+        "object: TargetEntity",
+        "val x = object : Base() {",  # object expression, not a declaration
+    ],
+    "pathological": [
+        (
+            "@JvmInline\npublic \n data \n class \n TargetEntity \n (",
+            None,
+        ),  # carried-forward: Kotlin annotations and vertical modifier stacking
+        (
+            "companion \n object \n TargetEntity \n {",
+            None,
+        ),  # named companion object, vertically split
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_kotlin_class_start_valid(payload, expected_name):
+    assert_valid_match(KOTLIN_RULES["class_start"], payload, expected_name, "kotlin.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_kotlin_class_start_invalid(payload):
+    assert_invalid_no_match(KOTLIN_RULES["class_start"], payload, "kotlin.class_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_kotlin_class_start_pathological(payload, expected_name):
+    assert_pathological_match(KOTLIN_RULES["class_start"], payload, expected_name, "kotlin.class_start")
+
+
+def test_kotlin_class_start_companion_object_regression():
+    """
+    Regression test for a real bug (epic #813/#823): `companion object {
+    ... }` (almost always anonymous -- a name is rare and optional in real
+    Kotlin) never matched class_start at all. "companion" wasn't in the
+    modifier list, and even adding it wouldn't have been sufficient since
+    the class/interface/object/enum-class branch's name was mandatory.
+    Fixed with a dedicated alternative narrowly scoped to the literal
+    `companion object` shape with an optional name -- NOT by making the
+    general branch's name optional, which would have opened a new false
+    positive on object EXPRESSIONS (`object : Base() {`, an anonymous
+    object literal used inline, a different construct from an object
+    DECLARATION). Confirmed both directions still behave correctly.
+    """
+    class_start = KOTLIN_RULES["class_start"]
+    assert class_start.search("companion object {"), "anonymous companion object regressed"
+    assert class_start.search("companion object TargetEntity {"), "named companion object regressed"
+    assert not class_start.search("val x = object : Base() {"), (
+        "object expression must still NOT match (companion-object fix must not have broadened this)"
+    )
+
+
+def test_kotlin_class_start_redos_immunity():
+    """ReDoS sweep for the new companion-object alternative."""
+    class_start = KOTLIN_RULES["class_start"]
+    assert_redos_immune(class_start, "companion object " + "a" * 100000, timeout_sec=3.0)
+    assert class_start.search("companion object Foo {")
+
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture)
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("import java.util.*", "java.util.*"),
+        ("import static org.mockito.Mockito.*", "org.mockito.Mockito.*"),
+        ("import foo.Bar as Baz", "foo.Bar"),  # aliased import
+    ],
+    "invalid": [
+        "val importPath = false",
+    ],
+    "pathological": [
+        (
+            "import \n kotlinx.coroutines.flow.*",
+            "kotlinx.coroutines.flow.*",
+        ),  # carried-forward: vertical wildcard import
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_kotlin_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(
+        KOTLIN_RULES["_dependency_capture"], payload, expected_path, "kotlin._dependency_capture"
+    )
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_kotlin_dependency_capture_invalid(payload):
+    assert_invalid_no_match(KOTLIN_RULES["_dependency_capture"], payload, "kotlin._dependency_capture")
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_kotlin_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(
+        KOTLIN_RULES["_dependency_capture"], payload, expected_path, "kotlin._dependency_capture"
+    )

--- a/tests/extraction/test_args_extraction_strict.py
+++ b/tests/extraction/test_args_extraction_strict.py
@@ -40,20 +40,6 @@ ARGS_EXTRACTION_CASES = {
             )
         ],
     },
-    "kotlin": {
-        "valid": [
-            ("fun TargetFunc(a: Int, b: String) {", "TargetFunc"),
-            ("suspend fun TargetFunc(items: List<String>) {", "TargetFunc"),
-        ],
-        "invalid": ["TargetFunc(a, b)", "when (x) {"],
-        "pathological": [
-            # Vertical generics, default arguments, and lambda parameters
-            (
-                "internal \n suspend \n fun \n <T> \n TargetFunc \n (\n  items: List<T> = emptyList(),\n  callback: (Result<T>) -> Unit\n)",
-                "TargetFunc",
-            )
-        ],
-    },
     "ruby": {
         "valid": [
             ("def TargetFunc(a, b = 5)", "TargetFunc"),

--- a/tests/extraction/test_class_extraction_strict.py
+++ b/tests/extraction/test_class_extraction_strict.py
@@ -52,22 +52,6 @@ CLASS_EXTRACTION_CASES = {
             )
         ],
     },
-    "kotlin": {
-        "valid": [
-            ("class TargetEntity {", "TargetEntity"),
-            ("data class TargetEntity(", "TargetEntity"),
-            ("sealed interface TargetEntity", "TargetEntity"),
-        ],
-        "invalid": [
-            "val x = TargetEntity()",
-            "fun classLike()",
-            "object: TargetEntity",
-        ],
-        "pathological": [
-            # Kotlin annotations and vertical modifier stacking
-            ("@JvmInline\npublic \n data \n class \n TargetEntity \n (", "TargetEntity")
-        ],
-    },
     "scala": {
         "valid": [
             ("class TargetEntity {", "TargetEntity"),

--- a/tests/extraction/test_dependency_extraction_strict.py
+++ b/tests/extraction/test_dependency_extraction_strict.py
@@ -69,14 +69,6 @@ DEPENDENCY_EXTRACTION_CASES = {
             )
         ],
     },
-    "kotlin": {
-        "valid": [
-            ("import java.util.*", "java.util.*"),
-            ("import static org.mockito.Mockito.*", "org.mockito.Mockito.*"),
-        ],
-        "invalid": ["val importPath = false"],
-        "pathological": [("import \n kotlinx.coroutines.flow.*", "kotlinx.coroutines.flow.*")],
-    },
     "sqlite": {
         "valid": [
             ("ATTACH DATABASE 'file.db' AS file;", "file.db"),

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -40,21 +40,6 @@ EXTRACTION_CASES = {
             )
         ],
     },
-    "kotlin": {
-        "valid": [
-            ("fun TargetFunc()", "TargetFunc"),
-            ("suspend fun TargetFunc()", "TargetFunc"),
-            ("internal inline fun TargetFunc()", "TargetFunc"),
-        ],
-        "invalid": ["class TargetFunc", "val TargetFunc =", "if (TargetFunc)"],
-        "pathological": [
-            # JVM annotations and extreme generic spacing
-            (
-                "@JvmStatic\n@Throws(Exception::class)\npublic \n suspend \n inline \n fun \n < \n T \n > \n TargetFunc \n (",
-                "TargetFunc",
-            )
-        ],
-    },
     "php": {
         "valid": [
             ("function TargetFunc()", "TargetFunc"),


### PR DESCRIPTION
## Summary
Part of the extraction-hardening epic (#813). Closes #823.

Hardens all four extraction gauntlets (`func_start`, `args`, `class_start`, `_dependency_capture`) for kotlin per [`tests/extraction/how_to_harden_extraction.md`](tests/extraction/how_to_harden_extraction.md). This was a fresh sweep (no pre-flagged known bug) and surfaced two real bugs:

- **`func_start`/`args`** shared a flat `<[^>]{0,100}>` Rule-11 generic-parameter step-over, breaking any nested generic bound (`fun <T, U : Comparable<U>> foo(x: T, y: U): T {`, a realistic bounded generic function) — the same bug class already fixed for java/python/csharp/rust.
- **`class_start`** had no support for `companion object { ... }` at all (almost always anonymous in real Kotlin — a name is rare). The tempting fix (making the general `class|interface|object|enum class` branch's name optional) would have opened a new false positive on object **expressions** (`object : Base() {`, an anonymous object literal used inline, a different construct from an object declaration). Fixed instead with a dedicated alternative narrowly scoped to the literal `companion object` shape with its own optional name, leaving the general branch untouched.

Checked `test_language_standards_strict.py` for intentional kotlin behavior before finalizing (per the lesson from c's #822 pass, where an overly-broad fix broke a test documenting deliberate cross-rule ambiguity) — no conflicts found; the existing `test_kotlin_ambiguity_sweep_shared_literals_are_not_bugs` test passes unmodified.

Also documents a known, **unfixed** architectural limitation: `func_start`'s Mode-B string-shielding gap reproduces via triple-quoted raw strings — now confirmed on a **seventh** language.

## Differential Scan
Ran `python tests/tools/crucible_check.py`: **zero diff**. Confirmed expected — the corpus has only 5 kotlin files (okhttp), with zero companion objects among them (confirmed by grep). Verification relied on regex-level empirical checks plus ReDoS scaling sweeps, consistent with recurring bug class 8 ("a zero diff can mean the corpus doesn't exercise the feature"). No golden master changes in this PR.

## Test plan
- [x] `pytest tests/extraction/languages/test_kotlin.py` (42 new tests) — run via bare `pytest` from an unrelated CWD to reproduce CI's invocation style
- [x] `pytest tests/core_engine/ tests/extraction/ -q` — 3664 passed, 1 known pre-existing tiktoken-environment failure, 1 xfailed — including all existing kotlin ambiguity-sweep tests
- [x] `python tests/tools/audit_check.py` — clean (only the pre-existing, already-tracked `guidestar_lens.py` mypy findings, unrelated to this change)
- [x] `python tests/tools/crucible_check.py` — PASS on both venvs (zero diff, as expected — see above)
- [x] Migrated kotlin's cases out of the four monolithic dict files into `tests/extraction/languages/test_kotlin.py`
- [x] Epic #813 and the methodology doc updated with the new findings (recurring bug classes 29-30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)