### PR TITLE
Fix #825: Extraction hardening for scala

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -8680,8 +8680,19 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 re.I,
             ),
             # 2. args: Parameters / Coupling. Captures parameters in method signatures and lambdas.
+            # RULE 11 FIX (epic #813/#825): the generic-parameter step-over was the flat
+            # `\[[^\]]*\]`, truncating at the FIRST `]` and breaking any nested generic bound
+            # (`def foo[T <: Comparable[T]](x: T): T = {`, a realistic bounded generic method --
+            # the square-bracket variant of the same Rule-11 bug class already fixed for
+            # java/typescript/python/rust/csharp/kotlin/swift).
+            # IDENTIFIER-GRAMMAR FIX (epic #813/#825): the name step-over required a plain
+            # `[a-zA-Z_]\w*`, so any backtick-quoted arbitrary identifier (Scala's escape hatch for
+            # reserved-word/space-containing method names, e.g. `` def `must not fail`(x: Int): Int
+            # = x ``, a realistic idiom for Java-interop/reserved-word names) never matched at all
+            # (doc's Rule 16 shape). Added as an alternative, not a widened class, so it can't loosen
+            # the plain-identifier path.
             "args": re.compile(
-                r"\bdef\s+[a-zA-Z_]\w*(?:\[[^\]]*\])?\s*\([^)]*\)|\([^)]*\)[ \t]*=>|\b[a-zA-Z_]\w*[ \t]*=>"
+                r"\bdef\s+(?:`[^`\n]{1,200}`|[a-zA-Z_]\w*)(?:\[(?:[^\[\]]|\[[^\[\]]*\])*\])?\s*\([^)]*\)|\([^)]*\)[ \t]*=>|\b[a-zA-Z_]\w*[ \t]*=>"
             ),
             # 3. linear: Sequential I/O & Network Boundaries. Structural boundaries. EXCLUDES access modifiers and val/var.
             "structural_boundaries": re.compile(
@@ -8697,9 +8708,14 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # across the attribute stepper and modifier capture, explicitly allowing
                 # the engine to wrap lines without triggering ReDoS.
                 # =====================================================================
+                # IDENTIFIER-GRAMMAR FIX (epic #813/#825): same backtick-identifier gap as `args`
+                # above (doc's Rule 16) -- added as an alternative capture group, not a widened
+                # class. detector.py already resolves the fired group via `match.lastindex` for
+                # exactly this kind of multi-alternative name capture (see java's `(init)|
+                # (constructor)` groups), so no downstream change is needed.
                 r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t\n]*){0,5}"
                 r"(?:(?:override|private|protected|final|implicit|inline|transparent|open|lazy)[ \t\n]+){0,3}"
-                r"def[ \t\n]+([a-zA-Z_]\w*)(?=[ \t\n]*[\[(:=]|$)",
+                r"def[ \t\n]+(?:`([^`\n]{1,200})`|([a-zA-Z_]\w*))(?=[ \t\n]*[\[(:=]|$)",
                 re.M,
             ),
             # 5. class_start: Object / Entity Declarations. Defines structural entities and OO boundaries.
@@ -8800,11 +8816,29 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 #
                 # [ THE BLOCK DESTRUCTURING SHIELD ]
                 # Scala relies heavily on bracketed block imports: `import java.util.{List, Map}`.
-                # The capture group `([\w.{}\s,]+)` is expanded to swallow the entire
-                # comma-separated block. The downstream parser must flatten this string
-                # and split on commas/brackets to extract the individual modules.
+                # A trailing `{...}` block is captured as its own alternative below so its content
+                # (which may span multiple lines and contain `=>` renames) is swallowed whole. The
+                # downstream parser (galaxyscope.py) flattens this string and splits on commas/
+                # brackets to extract the individual modules.
+                #
+                # BUG FIX (epic #813/#825): the previous capture, `[\w.{}\s,]+`, was a single flat
+                # character class with no statement boundary at all -- since `\s` matches newlines,
+                # it kept consuming across subsequent, unrelated lines (including a SECOND import
+                # statement) until it happened to hit some character outside the class. Confirmed on
+                # a realistic 2-import file: the first match's capture group swallowed the entire
+                # second `import` line plus part of the following `case class` line, so the second
+                # import was never separately detected at all. The same flat class also truncated at
+                # the first `*`/`=`/`>`, so Scala 3 wildcard imports (`import scala.util.chaining.*`)
+                # lost their trailing `*` and `=>`-renamed block imports (`import scala.util.{Try =>
+                # STry}`) were cut off mid-block. Replaced with a properly bounded
+                # segmented-dotted-path grammar: repeat `identifier.` segments, then end on either a
+                # `{...}` block (unrestricted content except braces themselves, so `=>` renames and
+                # multi-line layouts both work) or a bare trailing identifier/wildcard segment
+                # (`[\w*]+`, covering both Scala 2 `_` and Scala 3 `*` wildcards via `\w`/`*`). This
+                # is bounded per-statement by construction -- there is no `\s`/`.` left dangling
+                # outside an explicit brace block for it to bleed through.
                 # =====================================================================
-                r"\b(?:import|export)\s+([\w.{}\s,]+)",
+                r"\b(?:import|export)\s+((?:[\w]+\.)*(?:\{[^{}]*\}|[\w*]+))",
                 re.M,
             ),
             # 25. ownership: Authorship indicators.

--- a/tests/extraction/how_to_harden_extraction.md
+++ b/tests/extraction/how_to_harden_extraction.md
@@ -440,6 +440,40 @@ specifically. Check every language against these *first* before assuming a rule 
 32. **(#824) Recurring class 3 confirmed on an EIGHTH language (swift) via TWO distinct string
     forms in the same language** -- both triple-quoted multi-line strings and `#"..."#` raw string
     literals reproduce the false positive independently.
+33. **(#825) The identifier-capture-class rule (`how_to_add_a_language.md`'s Rule 16) is a real,
+    recurring cross-language finding, not a one-off Scheme curiosity.** Scala's `func_start`/`args`
+    name capture required a plain `[a-zA-Z_]\w*`, so backtick-quoted arbitrary identifiers (Scala's
+    escape hatch for reserved-word/space-containing names, e.g. `` def `should handle edge cases`():
+    Unit = {} ``, a real ScalaTest/Java-interop idiom) never matched. Fixed as an alternative
+    capture group, resolved via `match.lastindex` (existing infrastructure, see java's
+    `(init)|(constructor)` groups) rather than widening the plain-identifier class. **Kotlin has the
+    identical backtick grammar and the identical gap, missed during #823's pass** -- when a language
+    supports backtick/escaped identifiers, check func_start/args/class_start's capture class against
+    that grammar explicitly, and don't assume a prior "closed" sub-issue for a sibling
+    backtick-identifier language already covers it.
+34. **(#825) A `_dependency_capture` rule can have NO statement-boundary logic at all -- a worse
+    failure mode than recurring class 19's missing-symbol gap.** Scala's capture was a flat
+    `[\w.{}\s,]+` class with no anchor stopping it at one logical import's end; since `\s` matches
+    newlines, it silently bled across a SECOND real import statement into the following unrelated
+    line on a realistic multi-import file, so the second import was never separately detected.
+    `crucible_check.py` against the real corpus (Kafka) confirmed the severity concretely: several
+    files' detected dependency counts roughly DOUBLED once fixed. Fix idiom: replace the flat class
+    with a bounded segmented-path grammar (repeat `identifier.` segments, end on either a `{...}`
+    block or a bare trailing identifier/wildcard) rather than just adding more characters to the
+    class. Check any `_dependency_capture` rule using bare `\s` instead of a real statement boundary
+    for this same bleed-over risk.
+35. **(#825) A confirmed real `_dependency_capture` fix's `crucible_check.py` diff can legitimately
+    ripple into completely unrelated languages/repos via the shared cross-repo dependency graph --
+    that is NOT automatically a confinement violation.** Unlike the other three rules (per-file
+    scoped), `_dependency_capture` feeds `network_risk_sensor.py`'s PageRank/blast-radius scoring
+    and `spatial_mapper.py`'s 3D projection, both computed over the WHOLE scanned corpus as one
+    graph. Fixing scala's bleed-over (class 34) shifted Topological Coordinates, PageRank-derived
+    blast-radius counts, and corpus-relative percentiles for 9 unrelated language/repo pairs plus
+    global ecosystem-summary aggregates. Verified genuine (not confinement-violating) by confirming
+    every non-target-language diff line was one of these global/derived metric types, never a raw
+    per-file signature count for an untouched language. When a fix touches `_dependency_capture`
+    specifically, expect and check for this ripple shape rather than treating any non-target-language
+    diff line as an automatic confinement bug.
 
 ## Process: the epic and its sub-issues
 

--- a/tests/extraction/languages/test_scala.py
+++ b/tests/extraction/languages/test_scala.py
@@ -1,0 +1,427 @@
+"""
+Scala extraction hardening (epic #813, issue #825). See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for scala in one file: func_start,
+args, class_start, _dependency_capture. Migrated out of the four old
+monolithic dict files (test_function_extraction_strict.py,
+test_args_extraction_strict.py, test_class_extraction_strict.py,
+test_dependency_extraction_strict.py) -- scala's entries were removed
+from those four when this file was added.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+# tests/ has no __init__.py anywhere in this repo, so a dotted
+# `tests.extraction._extraction_harness` import only works by accident
+# locally (e.g. `python -m pytest` from the repo root happens to put the
+# root on sys.path) and fails in CI, which invokes the `pytest` console
+# script directly. Insert this file's parent (tests/extraction/) onto
+# sys.path instead, so the harness imports as a plain top-level module.
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+SCALA_RULES = LANGUAGE_DEFINITIONS["scala"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start)
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        # Modern idiom (carried forward)
+        ("def TargetFunc()", "TargetFunc"),
+        ("override def TargetFunc()", "TargetFunc"),
+        ("transparent inline def TargetFunc", "TargetFunc"),
+        # Syntax-era / feature coverage
+        ("implicit def TargetFunc()", "TargetFunc"),  # Scala 2-era implicit conversion
+        ("inline def TargetFunc", "TargetFunc"),  # Scala 3 inline
+        (
+            "def TargetFunc[T <: Comparable[T]](x: T): T = {",
+            "TargetFunc",
+        ),  # nested generic bound -- was a real bug, now fixed
+        (
+            "def TargetFunc(x: Int)(using ctx: Context): Unit = {}",
+            "TargetFunc",
+        ),  # Scala 3 multiple/using parameter lists
+        ("@main def TargetFunc(args: String*): Unit = {}", "TargetFunc"),  # Scala 3 @main entry point
+        # Backtick-quoted arbitrary identifiers (doc's Rule 16 identifier-grammar shape)
+        ("def `TargetFunc with spaces`()", "TargetFunc with spaces"),
+        # Testing-framework-shaped functions that ARE real functions
+        (
+            "def `should return true`(): Unit = {}",
+            "should return true",
+        ),  # backtick-named test method, a common ScalaTest/JVM-interop idiom
+    ],
+    "invalid": [
+        "class TargetFunc",  # class decl lookalike
+        "val TargetFunc =",  # val decl lookalike
+        "trait TargetFunc",  # trait decl lookalike
+        'val query = "def TargetFunc() {"',  # string-literal lookalike, not at true line start
+        "// def TargetFunc()",  # commented-out def, correctly excluded by the leading-token anchor
+    ],
+    "pathological": [
+        (
+            '@deprecated("", "")\noverride \n protected \n inline \n def \n TargetFunc \n (',
+            "TargetFunc",
+        ),  # carried-forward: deep Scala 3 modifier stacking across lines
+        (
+            "def TargetFunc[T <: Comparable[T]](\n  x: T\n): T = {",
+            "TargetFunc",
+        ),  # nested generic bound, params split vertically
+        (
+            "@deprecated\noverride \n private \n def \n `Target Func` \n (",
+            "Target Func",
+        ),  # backtick name plus deep vertical modifier stacking
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_scala_func_start_valid(payload, expected_name):
+    assert_valid_match(SCALA_RULES["func_start"], payload, expected_name, "scala.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_scala_func_start_invalid(payload):
+    assert_invalid_no_match(SCALA_RULES["func_start"], payload, "scala.func_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_scala_func_start_pathological(payload, expected_name):
+    assert_pathological_match(SCALA_RULES["func_start"], payload, expected_name, "scala.func_start")
+
+
+def test_scala_func_start_nested_generic_bound_regression():
+    """
+    Regression test for a real bug (epic #813/#825): the args rule's
+    generic-parameter step-over was the flat `\\[[^\\]]*\\]`, truncating at
+    the FIRST `]` and breaking any nested generic bound (`def foo[T <:
+    Comparable[T]](x: T): T = {`, a realistic bounded generic method -- the
+    square-bracket variant of the same Rule-11 bug class already fixed for
+    java/typescript/python/rust/csharp/kotlin/swift). func_start itself only
+    ever used a lookahead here (never consumed the brackets), so it was
+    unaffected -- this regression test exists on func_start anyway to pin
+    down the fixed shape actually used by the pipeline.
+    """
+    func_start = SCALA_RULES["func_start"]
+    m = func_start.search("def TargetFunc[T <: Comparable[T]](x: T): T = {")
+    assert m and m.group(m.lastindex) == "TargetFunc", "nested generic bound detection regressed"
+
+
+def test_scala_func_start_backtick_identifier_regression():
+    """
+    Regression test for a real bug (epic #813/#825): the name step-over
+    required a plain `[a-zA-Z_]\\w*`, so any backtick-quoted arbitrary
+    identifier -- Scala's escape hatch for reserved-word or space-containing
+    method names, e.g. Java-interop methods or ScalaTest-style spec names --
+    never matched at all (doc's Rule 16 identifier-grammar shape).
+    """
+    func_start = SCALA_RULES["func_start"]
+    m = func_start.search("def `should handle edge cases`(): Unit = {}")
+    assert m and m.group(m.lastindex) == "should handle edge cases", "backtick identifier detection regressed"
+
+
+def test_scala_func_start_redos_immunity():
+    """ReDoS sweep for the backtick-identifier alternative."""
+    func_start = SCALA_RULES["func_start"]
+    assert_redos_immune(func_start, "def `" + "a" * 100000, timeout_sec=3.0)
+    assert func_start.search("def `should return true`(): Unit = {}")
+
+
+def test_scala_func_start_known_limitation_triple_quoted_string_lookalikes_still_match_at_regex_level():
+    """
+    Documents a known, NOT-fixed limitation: func_start's own regex has no
+    string/comment awareness, so function-shaped text inside a Scala
+    triple-quoted multi-line string that happens to land at true line start
+    still matches -- the same architectural class of bug confirmed for
+    javascript/typescript template literals, Java text blocks, Go/Rust raw
+    strings, C# verbatim/raw strings, Kotlin raw strings, and Swift
+    triple-quoted/raw strings (recurring bug class 3 in
+    how_to_harden_extraction.md), now confirmed on a NINTH language. scala
+    routes through Mode B (_slice_by_braces), currently gated to
+    javascript/typescript only. Not fixed here -- tracked as its own future
+    audited follow-up in the epic.
+    """
+    func_start = SCALA_RULES["func_start"]
+    triple_quoted = 'val s = """\ndef TargetFunc(): Unit = {}\n"""'
+    assert func_start.search(triple_quoted), (
+        "documents current (expected, pipeline-level-fixed-elsewhere) regex behavior"
+    )
+
+
+# ==============================================================================
+# ARGS (args)
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        ("def TargetFunc(a: Int, b: String): Unit =", "TargetFunc"),
+        ("def TargetFunc[T](items: List[T])", "TargetFunc"),
+        (
+            "def TargetFunc[T <: Comparable[T]](x: T): T =",
+            "TargetFunc",
+        ),  # nested generic bound -- was a real bug, now fixed
+        (
+            "def TargetFunc(x: Int)(using ctx: Context): Unit = {}",
+            "TargetFunc",
+        ),  # Scala 3 using clause (second param list not required to be captured)
+        ("def `should do something`(x: Int): Int = x", "should do something"),  # backtick identifier
+        ("(x: Int, y: Int) => x + y", "x: Int, y: Int"),  # bare lambda param list
+    ],
+    "invalid": [
+        "TargetFunc(a, b)",  # bare call lookalike (known limitation class 7, not this rule's concern)
+        "for (i <- 1 to 10) {",  # for-comprehension lookalike
+    ],
+    "pathological": [
+        (
+            "inline \n def \n TargetFunc[T] \n (\n  items: List[T],\n  callback: (Int, String) => Unit\n)",
+            "TargetFunc",
+        ),  # carried-forward: vertical modifiers and complex lambda parameters. NOTE: the
+        # name and its generic bracket are kept attached (no vertical split between
+        # `TargetFunc` and `[T]`) -- scalafmt never inserts a line break at that exact
+        # seam, so testing it would be an unrealistic seam per the doc's "realism
+        # triage" guidance (recurring class 17); confirmed empirically that a split
+        # there does NOT match (a pre-existing, non-regressed gap, not a new bug).
+        (
+            "def TargetFunc[T <: Comparable[T]](\n  x: T\n): T =",
+            "TargetFunc",
+        ),  # nested generic bound, params split vertically
+        (
+            "def \n `should not break` \n (x: Int): Int = x",
+            "should not break",
+        ),  # backtick name with vertical spacing around it (not INSIDE the backticks --
+        # a literal newline inside a backtick-quoted identifier is not realistic
+        # source Scala/scalafmt ever produces, so that seam is deliberately out of
+        # scope per the doc's "realism triage" guidance, recurring class 17).
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["valid"])
+def test_scala_args_valid(payload, expected_name):
+    assert_valid_match(SCALA_RULES["args"], payload, expected_name, "scala.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_scala_args_invalid(payload):
+    assert_invalid_no_match(SCALA_RULES["args"], payload, "scala.args")
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["pathological"])
+def test_scala_args_pathological(payload, expected_name):
+    assert_pathological_match(SCALA_RULES["args"], payload, expected_name, "scala.args")
+
+
+def test_scala_args_nested_generic_bound_regression():
+    """
+    Regression test for a real bug (epic #813/#825): the generic-parameter
+    step-over was the flat `\\[[^\\]]*\\]`, truncating at the FIRST `]` and
+    breaking any nested generic bound (`def foo[T <: Comparable[T]](x: T): T
+    = {`, a realistic bounded generic method -- the square-bracket variant of
+    the same Rule-11 bug class already fixed for
+    java/typescript/python/rust/csharp/kotlin/swift).
+    """
+    args = SCALA_RULES["args"]
+    assert args.search("def TargetFunc[T <: Comparable[T]](x: T): T = {"), "nested generic bound args detection regressed"
+
+
+def test_scala_args_backtick_identifier_regression():
+    """Regression test for the same root-cause bug as func_start's own regression test above."""
+    args = SCALA_RULES["args"]
+    assert args.search("def `should handle edge cases`(): Unit = {}"), "backtick identifier args detection regressed"
+
+
+def test_scala_args_redos_immunity():
+    """ReDoS sweep for both the widened generic-parameter step-over and the backtick alternative."""
+    args = SCALA_RULES["args"]
+    assert_redos_immune(args, "def Foo[T <: " + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(args, "def `" + "a" * 100000, timeout_sec=3.0)
+    assert args.search("def Foo[T <: Comparable[T]](x: T): T = {")
+
+
+# ==============================================================================
+# CLASS_START (class_start)
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("class TargetEntity {", "TargetEntity"),
+        ("sealed trait TargetEntity", "TargetEntity"),
+        ("case object TargetEntity", "TargetEntity"),
+        ("case class TargetEntity(x: Int)", "TargetEntity"),  # canonical Scala idiom
+        ("enum TargetEntity { case A, B }", "TargetEntity"),  # Scala 3 enums
+        (
+            "class TargetEntity[T](x: T) extends Base[T]",
+            "TargetEntity",
+        ),  # generic class with extends clause -- name capture unaffected by generics
+        # (class_start uses a pure lookahead here, not a consuming step-over, so
+        # there is no Rule-11 flat-bracket exposure to begin with; verified
+        # empirically, see regression test below)
+    ],
+    "invalid": [
+        "val x = new TargetEntity()",  # instantiation lookalike
+        "def classMethod()",  # method named "class*" lookalike
+        "type TargetEntity = String",  # type-alias lookalike (recurring class 4)
+        "opaque type TargetEntity = Int",  # Scala 3 opaque type alias, same exclusion
+    ],
+    "pathological": [
+        (
+            "@deprecated\nsealed \n abstract \n class \n TargetEntity \n extends \n Base",
+            "TargetEntity",
+        ),  # carried-forward: Scala 3 modifiers and vertical spacing
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_scala_class_start_valid(payload, expected_name):
+    assert_valid_match(SCALA_RULES["class_start"], payload, expected_name, "scala.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_scala_class_start_invalid(payload):
+    assert_invalid_no_match(SCALA_RULES["class_start"], payload, "scala.class_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_scala_class_start_pathological(payload, expected_name):
+    assert_pathological_match(SCALA_RULES["class_start"], payload, expected_name, "scala.class_start")
+
+
+def test_scala_class_start_generic_with_extends_no_rule11_exposure():
+    """
+    Unlike java/typescript/csharp's class_start (which capture an
+    extends/implements clause in a second group and therefore have real
+    Rule-11 exposure -- recurring classes 6/9 in how_to_harden_extraction.md),
+    scala's class_start only ever captures the entity NAME via a trailing
+    lookahead; it never consumes the generic-parameter list or the
+    extends/implements clause into a separate group. So a generic class with
+    a subsequent extends clause (`class Foo[T](x: T) extends Base[T]`) has no
+    flat-bracket truncation to break, because there's nothing after the name
+    for the regex to consume. Verified empirically -- documenting the
+    negative result so a future pass doesn't re-investigate this from
+    scratch.
+    """
+    class_start = SCALA_RULES["class_start"]
+    m = class_start.search("class TargetEntity[T <: Comparable[T]](x: T) extends Base[T]")
+    assert m and m.group(1) == "TargetEntity"
+
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture)
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("import cats.effect.IO", "cats.effect.IO"),
+        ("export scala.collection.mutable.Map", "scala.collection.mutable.Map"),
+        ("import scala.util.chaining.*", "scala.util.chaining.*"),  # Scala 3 wildcard -- was truncated, now fixed
+        ("import scala.collection.mutable._", "scala.collection.mutable._"),  # Scala 2 wildcard
+        (
+            "import scala.util.{Try => STry}",
+            "scala.util.{Try => STry}",
+        ),  # renamed import -- was truncated at `=>`, now fixed
+        ("import scala.collection.mutable.{Map, Set}", "scala.collection.mutable.{Map, Set}"),  # block import
+        (
+            "def foo(): Unit = {\n  import scala.util.Random\n  ()\n}",
+            "scala.util.Random",
+        ),  # locally-scoped import (the rule's own documented historical fix)
+    ],
+    "invalid": [
+        "val importCount = 0",
+        "important = 5",  # substring-of-keyword lookalike, correctly excluded by \b + required \s+
+    ],
+    "pathological": [
+        ("import \n scala.concurrent.Future", "scala.concurrent.Future"),  # carried-forward: vertical import
+        (
+            "import scala.util.{\n  Try,\n  Success\n}",
+            "Try",
+        ),  # multi-line braced block import
+        (
+            "import scala.util.{\n  Try => STry\n}",
+            "STry",
+        ),  # multi-line braced block import with a rename
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_scala_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(SCALA_RULES["_dependency_capture"], payload, expected_path, "scala._dependency_capture")
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_scala_dependency_capture_invalid(payload):
+    assert_invalid_no_match(SCALA_RULES["_dependency_capture"], payload, "scala._dependency_capture")
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_scala_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(
+        SCALA_RULES["_dependency_capture"], payload, expected_path, "scala._dependency_capture"
+    )
+
+
+def test_scala_dependency_capture_multi_import_no_longer_bleeds_across_statements_regression():
+    """
+    Regression test for a severe real bug (epic #813/#825): the previous
+    capture, `[\\w.{}\\s,]+`, was a single flat character class with no
+    statement boundary at all. Since `\\s` matches newlines, it kept
+    consuming across subsequent, unrelated lines -- including a SECOND
+    import statement -- until it happened to hit some character outside the
+    class. On a realistic 2-import file, the first match's capture group
+    swallowed the entire second `import` line plus part of the following
+    `case class` line, so the second import was never separately detected at
+    all. Fixed via a properly bounded segmented-dotted-path grammar that
+    cannot bleed past an explicit brace block.
+    """
+    dep = SCALA_RULES["_dependency_capture"]
+    realistic_file = (
+        "import scala.util.Try\nimport scala.collection.mutable.{Map, Set}\n\ncase class Foo(x: Int)\n"
+    )
+    matches = list(dep.finditer(realistic_file))
+    captured = [m.group(m.lastindex) for m in matches]
+    assert captured == ["scala.util.Try", "scala.collection.mutable.{Map, Set}"], (
+        f"expected both imports to be captured separately and cleanly, got {captured!r}"
+    )
+
+
+def test_scala_dependency_capture_redos_immunity():
+    """ReDoS sweep for the segmented-dotted-path replacement grammar."""
+    dep = SCALA_RULES["_dependency_capture"]
+    assert_redos_immune(dep, "import " + "a." * 100000, timeout_sec=3.0)
+    assert_redos_immune(dep, "import " + ("a." * 50000) + "{" + "b" * 50000, timeout_sec=3.0)
+    assert dep.search("import scala.util.chaining.*")
+
+
+def test_scala_dependency_capture_known_limitation_commented_import_still_matches_at_regex_level():
+    """
+    Documents a known, NOT-fixed limitation shared by every language, not
+    just scala (recurring bug class 10 in how_to_harden_extraction.md):
+    `_dependency_capture` is matched against raw, unshielded file content
+    (`content_buffer` in galaxyscope.py) for every language, unconditionally
+    -- there is no string/comment shielding gate for this rule at all. A
+    commented-out import (`// import scala.util.Try`) at true line start
+    still produces a phantom dependency-graph edge. Not fixed here (fixing it
+    means shielding `content_buffer` before every language's
+    `_dependency_capture.finditer()` call -- a pipeline-wide change, not a
+    per-language one).
+    """
+    dep = SCALA_RULES["_dependency_capture"]
+    commented = "// import scala.util.Try"
+    m = dep.search(commented)
+    assert m, "documents current (expected, pipeline-wide, not-yet-fixed) regex behavior"

--- a/tests/extraction/test_args_extraction_strict.py
+++ b/tests/extraction/test_args_extraction_strict.py
@@ -69,20 +69,6 @@ ARGS_EXTRACTION_CASES = {
             )
         ],
     },
-    "scala": {
-        "valid": [
-            ("def TargetFunc(a: Int, b: String): Unit =", "TargetFunc"),
-            ("def TargetFunc[T](items: List[T])", "TargetFunc"),
-        ],
-        "invalid": ["TargetFunc(a, b)", "for (i <- 1 to 10) {"],
-        "pathological": [
-            # Vertical modifiers and complex lambda parameters
-            (
-                "inline \n def \n TargetFunc \n [T] \n (\n  items: List[T],\n  callback: (Int, String) => Unit\n)",
-                "TargetFunc",
-            )
-        ],
-    },
     "zig": {
         "valid": [
             ("pub fn TargetFunc(a: i32, b: f32) void {", "TargetFunc"),

--- a/tests/extraction/test_class_extraction_strict.py
+++ b/tests/extraction/test_class_extraction_strict.py
@@ -33,25 +33,6 @@ CLASS_EXTRACTION_CASES = {
             )
         ],
     },
-    "scala": {
-        "valid": [
-            ("class TargetEntity {", "TargetEntity"),
-            ("sealed trait TargetEntity", "TargetEntity"),
-            ("case object TargetEntity", "TargetEntity"),
-        ],
-        "invalid": [
-            "val x = new TargetEntity()",
-            "def classMethod()",
-            "type TargetEntity = String",
-        ],
-        "pathological": [
-            # Scala 3 modifiers and vertical spacing
-            (
-                "@deprecated\nsealed \n abstract \n class \n TargetEntity \n extends \n Base",
-                "TargetEntity",
-            )
-        ],
-    },
     "dart": {
         "valid": [
             ("class TargetEntity {", "TargetEntity"),

--- a/tests/extraction/test_dependency_extraction_strict.py
+++ b/tests/extraction/test_dependency_extraction_strict.py
@@ -156,14 +156,6 @@ DEPENDENCY_EXTRACTION_CASES = {
             )
         ],
     },
-    "scala": {
-        "valid": [
-            ("import cats.effect.IO", "cats.effect.IO"),
-            ("export scala.collection.mutable.Map", "scala.collection.mutable.Map"),
-        ],
-        "invalid": ["val importCount = 0"],
-        "pathological": [("import \n scala.concurrent.Future", "scala.concurrent.Future")],
-    },
     "dockerfile": {
         "valid": [
             ("FROM ubuntu:latest", "ubuntu:latest"),

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -115,21 +115,6 @@ EXTRACTION_CASES = {
             )
         ],
     },
-    "scala": {
-        "valid": [
-            ("def TargetFunc()", "TargetFunc"),
-            ("override def TargetFunc()", "TargetFunc"),
-            ("transparent inline def TargetFunc", "TargetFunc"),
-        ],
-        "invalid": ["class TargetFunc", "val TargetFunc =", "trait TargetFunc"],
-        "pathological": [
-            # Deep Scala 3 modifiers
-            (
-                '@deprecated("", "")\noverride \n protected \n inline \n def \n TargetFunc \n (',
-                "TargetFunc",
-            )
-        ],
-    },
     "fortran": {
         "valid": [
             ("SUBROUTINE TargetFunc()", "TargetFunc"),

--- a/tests/golden_master_audit.json
+++ b/tests/golden_master_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-31T04:36:43.187719+00:00",
-            "Total Scan Duration": "24.05 seconds"
+            "Analysis ISO Timestamp": "2026-07-31T13:59:23.487902+00:00",
+            "Total Scan Duration": "25.43 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -198,8 +198,8 @@
         "health": {
             "avg_cognitive_load": 24.048,
             "avg_safety_score": 23.794,
-            "avg_tech_debt": 25.069,
-            "avg_documentation": 29.832
+            "avg_tech_debt": 25.202,
+            "avg_documentation": 29.818
         },
         "composition": {
             "xml": {
@@ -400,7 +400,7 @@
             "php": {
                 "files": 36,
                 "loc": 18919,
-                "impact": 37614.78
+                "impact": 37564.78
             },
             "proto": {
                 "files": 4,
@@ -420,7 +420,7 @@
             "scala": {
                 "files": 7,
                 "loc": 4264,
-                "impact": 5454.78
+                "impact": 5441.78
             },
             "scheme": {
                 "files": 4,
@@ -465,7 +465,7 @@
             "zig": {
                 "files": 32,
                 "loc": 68347,
-                "impact": 109004.64000000001
+                "impact": 109006.64000000001
             }
         },
         "ecosystem_fingerprint": {
@@ -937,20 +937,20 @@
             },
             "php/laravel_core": {
                 "file_count": 8,
-                "total_mass": 7536.46,
+                "total_mass": 7486.46,
                 "avg_exposures": {
                     "cognitive_load": 32.14,
                     "safety_score": 24.4,
-                    "tech_debt": 53.46,
+                    "tech_debt": 65.71,
                     "verification": 70.0,
-                    "api_exposure": 6.35,
+                    "api_exposure": 6.21,
                     "concurrency": 0.0,
                     "state_flux": 87.49,
                     "dead_code": 0.62,
                     "spec_match": 87.5,
                     "stability": 43.75,
                     "churn": 0.0,
-                    "documentation": 49.88,
+                    "documentation": 48.59,
                     "tabs_vs_spaces": 93.75,
                     "algorithmic_dos": 87.5,
                     "obscured_payload": 0.0,
@@ -3612,20 +3612,20 @@
             },
             "scala/kafka": {
                 "file_count": 7,
-                "total_mass": 5454.78,
+                "total_mass": 5441.78,
                 "avg_exposures": {
                     "cognitive_load": 10.21,
                     "safety_score": 11.38,
-                    "tech_debt": 42.21,
+                    "tech_debt": 46.35,
                     "verification": 68.92,
-                    "api_exposure": 3.91,
+                    "api_exposure": 3.76,
                     "concurrency": 0.0,
                     "state_flux": 10.05,
                     "dead_code": 1.44,
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 48.2,
+                    "documentation": 47.75,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 69.94,
                     "obscured_payload": 0.0,
@@ -4062,20 +4062,20 @@
             },
             "zig/zls": {
                 "file_count": 6,
-                "total_mass": 28978.36,
+                "total_mass": 28980.36,
                 "avg_exposures": {
                     "cognitive_load": 33.41,
                     "safety_score": 3.24,
-                    "tech_debt": 30.32,
+                    "tech_debt": 29.88,
                     "verification": 80.0,
-                    "api_exposure": 1.76,
+                    "api_exposure": 1.77,
                     "concurrency": 19.82,
                     "state_flux": 11.79,
                     "dead_code": 2.66,
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 76.14,
+                    "documentation": 76.25,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 99.92,
                     "obscured_payload": 0.0,
@@ -4112,11 +4112,11 @@
             }
         },
         "network_macro": {
-            "modularity": 0.7105,
-            "assortativity": -0.3455,
+            "modularity": 0.7118,
+            "assortativity": -0.3445,
             "cyclic_density": 0.0128,
-            "avg_path_length": 4.0114,
-            "articulation_points": 67
+            "avg_path_length": 4.0713,
+            "articulation_points": 69
         },
         "ecosystem_audits": {
             "api_mapper": {
@@ -4129,7 +4129,7 @@
             },
             "firewall": {
                 "imports_whitelisted": 0,
-                "imports_unknown": 7359,
+                "imports_unknown": 7626,
                 "imports_blacklisted": 0,
                 "threats_found": 139,
                 "threats_allowed": 0
@@ -6145,32 +6145,32 @@
             "undocumented_critical_path": [
                 {
                     "path": "python/fastapi/fastapi/exceptions.py",
-                    "score": 1526.888,
-                    "pr": 15.329,
+                    "score": 1522.804,
+                    "pr": 15.288,
                     "doc": 99.6078
                 },
                 {
                     "path": "python/fastapi/fastapi/responses.py",
-                    "score": 1206.794,
-                    "pr": 12.498,
+                    "score": 1203.608,
+                    "pr": 12.465,
                     "doc": 96.559
                 },
                 {
                     "path": "zig/zig/Zcu.zig",
-                    "score": 1078.071,
-                    "pr": 14.528,
+                    "score": 1075.251,
+                    "pr": 14.49,
                     "doc": 74.2064
                 },
                 {
                     "path": "zig/zig/InternPool.zig",
-                    "score": 903.183,
-                    "pr": 11.039,
+                    "score": 900.811,
+                    "pr": 11.01,
                     "doc": 81.8175
                 },
                 {
                     "path": "python/fastapi/fastapi/testclient.py",
-                    "score": 658.863,
-                    "pr": 98.829,
+                    "score": 657.103,
+                    "pr": 98.565,
                     "doc": 6.6667
                 }
             ]
@@ -27507,9 +27507,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2590.34,
+                        "X": 2589.85,
                         "Y": -18.79,
-                        "Z": 4688.65
+                        "Z": 4687.77
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -27728,9 +27728,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pxd)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2378.41,
+                        "X": 2377.92,
                         "Y": 2.15,
-                        "Z": 3788.6
+                        "Z": 3787.71
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -27915,9 +27915,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pyx)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2038.4,
+                        "X": 2037.91,
                         "Y": 23.76,
-                        "Z": 4476.67
+                        "Z": 4475.79
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -28408,9 +28408,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2342.27,
+                        "X": 2341.78,
                         "Y": 32.59,
-                        "Z": 4172.77
+                        "Z": 4171.88
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -30428,7 +30428,7 @@
             }
         },
         "zig/zls": {
-            "Directory Group Magnitude": 28978.36,
+            "Directory Group Magnitude": 28980.36,
             "File Count": 6,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -30436,16 +30436,16 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "33.41%",
                 "Error & Exception Exposure": "3.24%",
-                "Tech Debt Exposure": "30.32%",
+                "Tech Debt Exposure": "29.88%",
                 "Testing Exposure": "80.0%",
-                "API Exposure": "1.76%",
+                "API Exposure": "1.77%",
                 "Concurrency Exposure": "19.82%",
                 "State Flux Exposure": "11.79%",
                 "Commented Logic Exposure": "2.66%",
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "76.14%",
+                "Documentation Exposure": "76.25%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "99.92%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -31082,7 +31082,7 @@
                         "Direct Upstream (Fragility)": 4,
                         "Direct Downstream (Dependency Blast Radius)": 1,
                         "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 3
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
                     "9. Extracted Dependencies": [
                         "ast.zig",
@@ -31708,7 +31708,7 @@
                         "Direct Upstream (Fragility)": 12,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 3,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 2
+                        "Total Downstream (Absolute Dependency Blast Radius)": 3
                     },
                     "9. Extracted Dependencies": [
                         "BuildAssociatedConfig.zig",
@@ -31737,32 +31737,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1816.47,
+                        "X": -1816.48,
                         "Y": -185.39,
-                        "Z": 5892.9
+                        "Z": 5892.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.345,
+                        "Repository Drift (Z-Score)": 13.347,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.727,
-                            "file_cluster_1": 13.944,
-                            "file_cluster_2": 14.019,
-                            "file_cluster_3": 14.776,
-                            "file_cluster_4": 14.105,
+                            "file_cluster_0": 13.726,
+                            "file_cluster_1": 13.946,
+                            "file_cluster_2": 14.021,
+                            "file_cluster_3": 14.775,
+                            "file_cluster_4": 14.104,
                             "file_cluster_5": 14.338,
-                            "file_cluster_6": 13.865,
+                            "file_cluster_6": 13.864,
                             "file_cluster_7": 13.64,
-                            "file_cluster_8": 13.345,
+                            "file_cluster_8": 13.347,
                             "file_cluster_9": 13.904,
-                            "file_cluster_10": 14.751,
-                            "file_cluster_11": 13.727,
+                            "file_cluster_10": 14.75,
+                            "file_cluster_11": 13.726,
                             "file_cluster_12": 14.132,
                             "file_cluster_13": 13.509,
-                            "file_cluster_14": 17.137,
-                            "file_cluster_15": 14.209,
-                            "file_cluster_16": 13.898,
-                            "file_cluster_17": 13.874
+                            "file_cluster_14": 17.138,
+                            "file_cluster_15": 14.208,
+                            "file_cluster_16": 13.897,
+                            "file_cluster_17": 13.875
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -31770,9 +31770,9 @@
                         "Total LOC": 2030,
                         "Coding LOC": 1778,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3245.96,
+                        "Structural Magnitude": 3247.96,
                         "Control Flow Ratio": "74.4%",
-                        "Popularity Rank": 0,
+                        "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -31781,16 +31781,16 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "27.18%",
                         "Error & Exception Exposure": "2.03%",
-                        "Tech Debt Exposure": "20.75%",
+                        "Tech Debt Exposure": "18.11%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "0.47%",
+                        "API Exposure": "0.54%",
                         "Concurrency Exposure": "19.43%",
                         "State Flux Exposure": "13.56%",
                         "Commented Logic Exposure": "0.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "80.98%",
+                        "Documentation Exposure": "81.66%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -32512,7 +32512,7 @@
                         "Type/Safety Bypasses": 8,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 17,
+                        "Exposed API / Public Exports": 19,
                         "State Mutations / Variable Reassignments": 106,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 56,
@@ -32577,7 +32577,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 2,
-                        "Orphaned Logic": 2,
+                        "Orphaned Logic": 0,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -32600,9 +32600,9 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 27,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
                         "Total Upstream (Absolute Fragility)": 4,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                        "Total Downstream (Absolute Dependency Blast Radius)": 1
                     },
                     "9. Extracted Dependencies": [
                         "Config.zig",
@@ -34771,7 +34771,7 @@
                         "Direct Upstream (Fragility)": 11,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 3,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 2
+                        "Total Downstream (Absolute Dependency Blast Radius)": 3
                     },
                     "9. Extracted Dependencies": [
                         "DocumentStore.zig",
@@ -35524,7 +35524,7 @@
                         "Direct Upstream (Fragility)": 2,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 4
+                        "Total Downstream (Absolute Dependency Blast Radius)": 5
                     },
                     "9. Extracted Dependencies": [
                         "offsets.zig",
@@ -159970,7 +159970,7 @@
             }
         },
         "php/laravel_core": {
-            "Directory Group Magnitude": 7536.46,
+            "Directory Group Magnitude": 7486.46,
             "File Count": 8,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_13": "87.5%",
@@ -159979,16 +159979,16 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "32.14%",
                 "Error & Exception Exposure": "24.4%",
-                "Tech Debt Exposure": "53.46%",
+                "Tech Debt Exposure": "65.71%",
                 "Testing Exposure": "70.0%",
-                "API Exposure": "6.35%",
+                "API Exposure": "6.21%",
                 "Concurrency Exposure": "0.0%",
                 "State Flux Exposure": "87.49%",
                 "Commented Logic Exposure": "0.62%",
                 "Specification Exposure": "87.5%",
                 "Instability Exposure": "43.75%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "49.88%",
+                "Documentation Exposure": "48.59%",
                 "Civil War Exposure": "93.75%",
                 "Algorithmic DoS Exposure": "87.5%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -160010,9 +160010,9 @@
                         "Identity Proof": "Prose Extension (.md)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1335.78,
-                        "Y": -127.18,
-                        "Z": 1900.23
+                        "X": 1335.75,
+                        "Y": -127.21,
+                        "Z": 1900.25
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -160172,9 +160172,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2124.6,
+                        "X": 2124.02,
                         "Y": -109.19,
-                        "Z": 2081.44
+                        "Z": 2081.31
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -160489,9 +160489,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1692.41,
-                        "Y": -129.83,
-                        "Z": 2048.01
+                        "X": 1692.15,
+                        "Y": -129.85,
+                        "Z": 2048.08
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -161185,32 +161185,32 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1585.65,
+                        "X": 1585.42,
                         "Y": -115.21,
-                        "Z": 2520.9
+                        "Z": 2520.55
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 14.627,
+                        "Repository Drift (Z-Score)": 14.725,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.841,
-                            "file_cluster_1": 15.108,
-                            "file_cluster_2": 15.192,
-                            "file_cluster_3": 15.933,
-                            "file_cluster_4": 15.055,
-                            "file_cluster_5": 15.419,
-                            "file_cluster_6": 15.181,
-                            "file_cluster_7": 14.791,
-                            "file_cluster_8": 14.769,
-                            "file_cluster_9": 15.16,
-                            "file_cluster_10": 15.752,
-                            "file_cluster_11": 14.864,
-                            "file_cluster_12": 15.316,
-                            "file_cluster_13": 14.627,
-                            "file_cluster_14": 18.097,
-                            "file_cluster_15": 15.013,
-                            "file_cluster_16": 15.164,
-                            "file_cluster_17": 14.893
+                            "file_cluster_0": 14.929,
+                            "file_cluster_1": 15.181,
+                            "file_cluster_2": 15.265,
+                            "file_cluster_3": 16.022,
+                            "file_cluster_4": 15.158,
+                            "file_cluster_5": 15.505,
+                            "file_cluster_6": 15.276,
+                            "file_cluster_7": 14.883,
+                            "file_cluster_8": 14.853,
+                            "file_cluster_9": 15.248,
+                            "file_cluster_10": 15.842,
+                            "file_cluster_11": 14.959,
+                            "file_cluster_12": 15.401,
+                            "file_cluster_13": 14.725,
+                            "file_cluster_14": 18.163,
+                            "file_cluster_15": 15.111,
+                            "file_cluster_16": 15.263,
+                            "file_cluster_17": 14.976
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -161218,9 +161218,9 @@
                         "Total LOC": 2006,
                         "Coding LOC": 791,
                         "Documentation LOC": 921,
-                        "Structural Magnitude": 1848.62,
+                        "Structural Magnitude": 1798.62,
                         "Control Flow Ratio": "30.9%",
-                        "Popularity Rank": 9,
+                        "Popularity Rank": 8,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -161229,16 +161229,16 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "33.22%",
                         "Error & Exception Exposure": "48.93%",
-                        "Tech Debt Exposure": "0.0%",
+                        "Tech Debt Exposure": "97.99%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "12.97%",
+                        "API Exposure": "11.84%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "100.0%",
                         "Commented Logic Exposure": "4.95%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "98.99%",
+                        "Documentation Exposure": "88.67%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -162300,7 +162300,7 @@
                         "Type/Safety Bypasses": 4,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 152,
+                        "Exposed API / Public Exports": 102,
                         "State Mutations / Variable Reassignments": 501,
                         "Commented-out Code (Dead Logic)": 1,
                         "Structured Documentation Blocks": 350,
@@ -162365,7 +162365,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
+                        "Orphaned Logic": 50,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -162388,9 +162388,9 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 13,
-                        "Direct Downstream (Dependency Blast Radius)": 9,
+                        "Direct Downstream (Dependency Blast Radius)": 8,
                         "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 1
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
                         "ArrayAccess",
@@ -162421,9 +162421,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1070.59,
-                        "Y": -141.5,
-                        "Z": 2290.73
+                        "X": 1070.78,
+                        "Y": -141.53,
+                        "Z": 2290.45
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -162734,9 +162734,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1434.25,
-                        "Y": -148.19,
-                        "Z": 3131.6
+                        "X": 1434.14,
+                        "Y": -148.18,
+                        "Z": 3130.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -163130,9 +163130,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1351.43,
-                        "Y": -155.49,
-                        "Z": 2686.76
+                        "X": 1351.52,
+                        "Y": -155.5,
+                        "Z": 2686.12
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -164263,9 +164263,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1953.8,
-                        "Y": -128.07,
-                        "Z": 3005.36
+                        "X": 1953.32,
+                        "Y": -128.05,
+                        "Z": 3004.67
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -167266,9 +167266,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1916.76,
+                        "X": 1916.4,
                         "Y": 139.98,
-                        "Z": 5168.72
+                        "Z": 5167.7
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -167501,9 +167501,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1668.87,
+                        "X": 1668.52,
                         "Y": 123.13,
-                        "Z": 4027.64
+                        "Z": 4026.61
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -168036,9 +168036,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1584.1,
+                        "X": 1583.74,
                         "Y": 185.38,
-                        "Z": 4812.89
+                        "Z": 4811.86
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -168774,9 +168774,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1292.03,
+                        "X": 1291.67,
                         "Y": 206.18,
-                        "Z": 5050.92
+                        "Z": 5049.89
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
@@ -179697,7 +179697,7 @@
             }
         },
         "scala/kafka": {
-            "Directory Group Magnitude": 5454.78,
+            "Directory Group Magnitude": 5441.78,
             "File Count": 7,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "71.4%",
@@ -179706,16 +179706,16 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "10.21%",
                 "Error & Exception Exposure": "11.38%",
-                "Tech Debt Exposure": "42.21%",
+                "Tech Debt Exposure": "46.35%",
                 "Testing Exposure": "68.92%",
-                "API Exposure": "3.91%",
+                "API Exposure": "3.76%",
                 "Concurrency Exposure": "0.0%",
                 "State Flux Exposure": "10.05%",
                 "Commented Logic Exposure": "1.44%",
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "48.2%",
+                "Documentation Exposure": "47.75%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "69.94%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -179737,32 +179737,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7671.62,
-                        "Y": -303.02,
-                        "Z": 250.51
+                        "X": 7671.41,
+                        "Y": -303.0,
+                        "Z": 250.56
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 7.909,
+                        "Repository Drift (Z-Score)": 8.063,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.409,
-                            "file_cluster_1": 8.877,
-                            "file_cluster_2": 9.356,
-                            "file_cluster_3": 10.524,
-                            "file_cluster_4": 9.959,
-                            "file_cluster_5": 9.694,
-                            "file_cluster_6": 9.708,
-                            "file_cluster_7": 8.642,
-                            "file_cluster_8": 7.909,
-                            "file_cluster_9": 9.657,
-                            "file_cluster_10": 10.553,
-                            "file_cluster_11": 9.422,
-                            "file_cluster_12": 9.786,
-                            "file_cluster_13": 8.982,
-                            "file_cluster_14": 13.979,
-                            "file_cluster_15": 8.862,
-                            "file_cluster_16": 8.696,
-                            "file_cluster_17": 9.811
+                            "file_cluster_0": 9.531,
+                            "file_cluster_1": 9.015,
+                            "file_cluster_2": 9.485,
+                            "file_cluster_3": 10.64,
+                            "file_cluster_4": 10.082,
+                            "file_cluster_5": 9.819,
+                            "file_cluster_6": 9.832,
+                            "file_cluster_7": 8.781,
+                            "file_cluster_8": 8.063,
+                            "file_cluster_9": 9.78,
+                            "file_cluster_10": 10.669,
+                            "file_cluster_11": 9.548,
+                            "file_cluster_12": 9.911,
+                            "file_cluster_13": 9.116,
+                            "file_cluster_14": 14.053,
+                            "file_cluster_15": 9.0,
+                            "file_cluster_16": 8.836,
+                            "file_cluster_17": 9.934
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -179929,9 +179929,9 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 8,
+                        "Direct Upstream (Fragility)": 14,
                         "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
@@ -179939,10 +179939,16 @@
                         "KafkaRaftServer",
                         "LoggingSignalHandler",
                         "OperatingSystem",
-                        "Server\nimport kafka.utils.Implicits._\nimport kafka.utils.Logging\nimport org.apache.kafka.common.utils.Exit",
+                        "Server",
                         "Time",
-                        "Utils\nimport org.apache.kafka.server.util.CommandLineUtils\n\nobject Kafka extends Logging \n\n  def getPropsFromArgs",
-                        "java.util.Properties\nimport joptsimple.OptionParser\nimport kafka.server.KafkaConfig"
+                        "Utils",
+                        "java.util.Properties",
+                        "joptsimple.OptionParser",
+                        "kafka.server.KafkaConfig",
+                        "kafka.utils.Implicits._",
+                        "kafka.utils.Logging",
+                        "org.apache.kafka.common.utils.Exit",
+                        "org.apache.kafka.server.util.CommandLineUtils"
                     ]
                 },
                 "scala/kafka/KafkaApis.scala": {
@@ -179957,32 +179963,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 6893.98,
-                        "Y": -180.21,
-                        "Z": 662.81
+                        "X": 6893.95,
+                        "Y": -180.24,
+                        "Z": 662.73
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.672,
+                        "Repository Drift (Z-Score)": 11.019,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.428,
-                            "file_cluster_1": 11.456,
-                            "file_cluster_2": 11.404,
-                            "file_cluster_3": 12.537,
-                            "file_cluster_4": 11.952,
-                            "file_cluster_5": 12.015,
-                            "file_cluster_6": 11.659,
-                            "file_cluster_7": 11.182,
-                            "file_cluster_8": 10.672,
-                            "file_cluster_9": 11.65,
-                            "file_cluster_10": 12.415,
-                            "file_cluster_11": 11.252,
-                            "file_cluster_12": 11.889,
-                            "file_cluster_13": 11.364,
-                            "file_cluster_14": 15.049,
-                            "file_cluster_15": 10.981,
-                            "file_cluster_16": 10.998,
-                            "file_cluster_17": 11.325
+                            "file_cluster_0": 11.741,
+                            "file_cluster_1": 11.78,
+                            "file_cluster_2": 11.727,
+                            "file_cluster_3": 12.833,
+                            "file_cluster_4": 12.263,
+                            "file_cluster_5": 12.323,
+                            "file_cluster_6": 11.976,
+                            "file_cluster_7": 11.511,
+                            "file_cluster_8": 11.019,
+                            "file_cluster_9": 11.962,
+                            "file_cluster_10": 12.715,
+                            "file_cluster_11": 11.576,
+                            "file_cluster_12": 12.202,
+                            "file_cluster_13": 11.688,
+                            "file_cluster_14": 15.274,
+                            "file_cluster_15": 11.318,
+                            "file_cluster_16": 11.333,
+                            "file_cluster_17": 11.65
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -180419,56 +180425,121 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 44,
+                        "Direct Upstream (Fragility)": 109,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
-                        "AddPartitionsToTxnResultCollection\nimport org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult",
+                        "AddPartitionsToTxnResultCollection",
                         "ApiMessage",
                         "ClientMetricsManager",
-                        "ConcurrentHashMap\nimport java.util.stream.Collectors\nimport java.util.Collections",
-                        "DeleteRecordsTopicResult\nimport org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic\nimport org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic\nimport org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition\nimport org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
-                        "Errors\nimport org.apache.kafka.common.record.internal._\nimport org.apache.kafka.common.replica.ClientMetadata\nimport org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata\nimport org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType\nimport org.apache.kafka.common.requests.ProduceResponse.PartitionResponse\nimport org.apache.kafka.common.requests._\nimport org.apache.kafka.common.resource.Resource.CLUSTER_NAME\nimport org.apache.kafka.common.resource.ResourceType._\nimport org.apache.kafka.common.resource.Resource",
+                        "ConcurrentHashMap",
+                        "DeleteRecordsTopicResult",
+                        "Errors",
                         "FetchManager",
                         "FetchParams",
-                        "FetchPartitionData\nimport org.apache.kafka.server.transaction.AddPartitionsToTxnManager\nimport org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "FetchPartitionData",
                         "GroupConfig",
                         "GroupConfigManager",
-                        "GroupCoordinator\nimport org.apache.kafka.coordinator.share.ShareCoordinator\nimport org.apache.kafka.metadata.ConfigRepository",
-                        "ListOffsetsTopicResponse\nimport org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition",
-                        "MetadataCache\nimport org.apache.kafka.security.DelegationTokenManager\nimport org.apache.kafka.server.ApiVersionManager",
-                        "MetadataResponseTopic\nimport org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic\nimport org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "GroupCoordinator",
+                        "ListOffsetsTopicResponse",
+                        "MetadataCache",
+                        "MetadataResponseTopic",
                         "OffsetForLeaderTopicResult",
-                        "OffsetForLeaderTopicResultCollection\nimport org.apache.kafka.common.message._\nimport org.apache.kafka.common.metrics.Metrics\nimport org.apache.kafka.common.network.ListenerName\nimport org.apache.kafka.common.protocol.ApiKeys",
-                        "Optional\nimport scala.annotation.nowarn\nimport scala.collection.mutable.ArrayBuffer\nimport scala.collection.Map",
+                        "OffsetForLeaderTopicResultCollection",
+                        "Optional",
                         "Plugin",
-                        "ProcessRole\nimport org.apache.kafka.server.authorizer._\nimport org.apache.kafka.server.common.GroupVersion",
-                        "RecordValidationStats\nimport org.apache.kafka.storage.log.metrics.BrokerTopicStats\n\nimport java.util\nimport java.util.concurrent.atomic.AtomicInteger\nimport java.util.concurrent.CompletableFuture",
-                        "ReplicationQuotaManager\nimport org.apache.kafka.server.share.context.ShareFetchContext\nimport org.apache.kafka.server.share.ErroneousAndValidPartitionData",
+                        "ProcessRole",
+                        "RecordValidationStats",
+                        "ReplicationQuotaManager",
                         "RequestLocal",
-                        "ResourceType\nimport org.apache.kafka.common.security.auth.KafkaPrincipal",
+                        "ResourceType",
                         "SHARE_GROUP_STATE_TOPIC_NAME",
-                        "SecurityProtocol\nimport org.apache.kafka.common.security.token.delegation.DelegationToken",
+                        "SecurityProtocol",
                         "Seq",
                         "Set",
-                        "SharePartitionKey\nimport org.apache.kafka.server.share.acknowledge.ShareAcknowledgementBatch\nimport org.apache.kafka.server.storage.log.FetchIsolation",
+                        "SharePartitionKey",
                         "ShareVersion",
                         "StreamsVersion",
                         "TRANSACTION_STATE_TOPIC_NAME",
-                        "Time\nimport org.apache.kafka.common.Node",
-                        "TokenInformation\nimport org.apache.kafka.common.utils.ProducerIdAndEpoch",
-                        "Topic\nimport org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnResult",
+                        "Time",
+                        "TokenInformation",
+                        "Topic",
                         "TopicIdPartition",
                         "TopicPartition",
-                        "TransactionCoordinator\nimport kafka.network.RequestChannel\nimport kafka.server.QuotaFactory.QuotaManagers",
-                        "TransactionVersion\nimport org.apache.kafka.server.quota.ReplicaQuota",
-                        "UNBOUNDED_QUOTA\nimport kafka.server.handlers.DescribeTopicPartitionsRequestHandler\nimport kafka.server.share.SharePartitionManager\nimport kafka.utils.Logging\nimport org.apache.kafka.clients.CommonClientConfigs\nimport org.apache.kafka.clients.admin.EndpointType\nimport org.apache.kafka.common.acl.AclOperation\nimport org.apache.kafka.common.acl.AclOperation._\nimport org.apache.kafka.common.config.ConfigResource\nimport org.apache.kafka.common.errors._\nimport org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME",
-                        "Uuid\nimport org.apache.kafka.coordinator.group.modern.share.ShareGroupConfigProvider\nimport org.apache.kafka.coordinator.group.Group",
-                        "isInternal\nimport org.apache.kafka.common.internals.FatalExitError",
+                        "TransactionCoordinator",
+                        "TransactionVersion",
+                        "UNBOUNDED_QUOTA",
+                        "Uuid",
+                        "isInternal",
+                        "java.util",
+                        "java.util.Collections",
+                        "java.util.concurrent.CompletableFuture",
+                        "java.util.concurrent.atomic.AtomicInteger",
+                        "java.util.stream.Collectors",
                         "kafka.coordinator.transaction.InitProducerIdResult",
-                        "mutable\nimport scala.jdk.CollectionConverters._\nimport scala.jdk.javaapi.OptionConverters"
+                        "kafka.network.RequestChannel",
+                        "kafka.server.QuotaFactory.QuotaManagers",
+                        "kafka.server.handlers.DescribeTopicPartitionsRequestHandler",
+                        "kafka.server.share.SharePartitionManager",
+                        "kafka.utils.Logging",
+                        "mutable",
+                        "org.apache.kafka.clients.CommonClientConfigs",
+                        "org.apache.kafka.clients.admin.EndpointType",
+                        "org.apache.kafka.common.Node",
+                        "org.apache.kafka.common.acl.AclOperation",
+                        "org.apache.kafka.common.acl.AclOperation._",
+                        "org.apache.kafka.common.config.ConfigResource",
+                        "org.apache.kafka.common.errors._",
+                        "org.apache.kafka.common.internals.FatalExitError",
+                        "org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME",
+                        "org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnResult",
+                        "org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult",
+                        "org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic",
+                        "org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic",
+                        "org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition",
+                        "org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
+                        "org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "org.apache.kafka.common.message._",
+                        "org.apache.kafka.common.metrics.Metrics",
+                        "org.apache.kafka.common.network.ListenerName",
+                        "org.apache.kafka.common.protocol.ApiKeys",
+                        "org.apache.kafka.common.record.internal._",
+                        "org.apache.kafka.common.replica.ClientMetadata",
+                        "org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata",
+                        "org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType",
+                        "org.apache.kafka.common.requests.ProduceResponse.PartitionResponse",
+                        "org.apache.kafka.common.requests._",
+                        "org.apache.kafka.common.resource.Resource",
+                        "org.apache.kafka.common.resource.Resource.CLUSTER_NAME",
+                        "org.apache.kafka.common.resource.ResourceType._",
+                        "org.apache.kafka.common.security.auth.KafkaPrincipal",
+                        "org.apache.kafka.common.security.token.delegation.DelegationToken",
+                        "org.apache.kafka.common.utils.ProducerIdAndEpoch",
+                        "org.apache.kafka.coordinator.group.Group",
+                        "org.apache.kafka.coordinator.group.modern.share.ShareGroupConfigProvider",
+                        "org.apache.kafka.coordinator.share.ShareCoordinator",
+                        "org.apache.kafka.metadata.ConfigRepository",
+                        "org.apache.kafka.security.DelegationTokenManager",
+                        "org.apache.kafka.server.ApiVersionManager",
+                        "org.apache.kafka.server.authorizer._",
+                        "org.apache.kafka.server.common.GroupVersion",
+                        "org.apache.kafka.server.quota.ReplicaQuota",
+                        "org.apache.kafka.server.share.ErroneousAndValidPartitionData",
+                        "org.apache.kafka.server.share.acknowledge.ShareAcknowledgementBatch",
+                        "org.apache.kafka.server.share.context.ShareFetchContext",
+                        "org.apache.kafka.server.storage.log.FetchIsolation",
+                        "org.apache.kafka.server.transaction.AddPartitionsToTxnManager",
+                        "org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "org.apache.kafka.storage.log.metrics.BrokerTopicStats",
+                        "scala.annotation.nowarn",
+                        "scala.collection.Map",
+                        "scala.collection.mutable.ArrayBuffer",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.jdk.javaapi.OptionConverters"
                     ]
                 },
                 "scala/kafka/KafkaRaftManager.scala": {
@@ -180483,32 +180554,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7036.65,
-                        "Y": -117.93,
-                        "Z": 1155.39
+                        "X": 7036.57,
+                        "Y": -117.96,
+                        "Z": 1155.28
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 7.598,
+                        "Repository Drift (Z-Score)": 7.951,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.027,
-                            "file_cluster_1": 8.735,
-                            "file_cluster_2": 9.127,
-                            "file_cluster_3": 10.305,
-                            "file_cluster_4": 9.682,
-                            "file_cluster_5": 9.562,
-                            "file_cluster_6": 9.38,
-                            "file_cluster_7": 8.49,
-                            "file_cluster_8": 7.598,
-                            "file_cluster_9": 9.202,
-                            "file_cluster_10": 10.476,
-                            "file_cluster_11": 9.361,
-                            "file_cluster_12": 9.49,
-                            "file_cluster_13": 8.751,
-                            "file_cluster_14": 13.379,
-                            "file_cluster_15": 9.308,
-                            "file_cluster_16": 8.259,
-                            "file_cluster_17": 9.211
+                            "file_cluster_0": 9.314,
+                            "file_cluster_1": 9.044,
+                            "file_cluster_2": 9.421,
+                            "file_cluster_3": 10.567,
+                            "file_cluster_4": 9.962,
+                            "file_cluster_5": 9.843,
+                            "file_cluster_6": 9.666,
+                            "file_cluster_7": 8.804,
+                            "file_cluster_8": 7.951,
+                            "file_cluster_9": 9.488,
+                            "file_cluster_10": 10.735,
+                            "file_cluster_11": 9.643,
+                            "file_cluster_12": 9.775,
+                            "file_cluster_13": 9.056,
+                            "file_cluster_14": 13.56,
+                            "file_cluster_15": 9.598,
+                            "file_cluster_16": 8.584,
+                            "file_cluster_17": 9.502
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -180755,36 +180826,65 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 24,
+                        "Direct Upstream (Fragility)": 53,
                         "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
-                        "Collection",
+                        "Collection => JCollection",
                         "ExternalKRaftMetrics",
                         "FileQuorumStateStore",
                         "KafkaNetworkChannel",
                         "KafkaRaftClient",
                         "KafkaRaftClientDriver",
-                        "KafkaScheduler\nimport org.apache.kafka.server.fault.FaultHandler\nimport org.apache.kafka.server.util.timer.SystemTimer\nimport org.apache.kafka.storage.internals.log.LogManager",
+                        "KafkaScheduler",
                         "ListenerName",
                         "ManualMetadataUpdater",
+                        "Map => JMap",
                         "MetadataLogConfig",
                         "MetadataRecoveryStrategy",
-                        "NetworkClient\nimport org.apache.kafka.common.KafkaException\nimport org.apache.kafka.common.TopicPartition\nimport org.apache.kafka.common.Uuid\nimport org.apache.kafka.common.metrics.Metrics\nimport org.apache.kafka.common.network.ChannelBuilders",
+                        "NetworkClient",
                         "NetworkReceive",
                         "QuorumConfig",
                         "RaftLog",
                         "RaftManager",
                         "Selectable",
-                        "Selector\nimport org.apache.kafka.common.protocol.ApiMessage\nimport org.apache.kafka.common.requests.RequestContext\nimport org.apache.kafka.common.requests.RequestHeader\nimport org.apache.kafka.common.security.JaasContext\nimport org.apache.kafka.common.security.auth.SecurityProtocol\nimport org.apache.kafka.common.utils.LogContext",
+                        "Selector",
                         "Time",
-                        "TimingWheelExpirationService\nimport org.apache.kafka.server.ProcessRole\nimport org.apache.kafka.server.common.Feature\nimport org.apache.kafka.server.common.serialization.RecordSerde\nimport org.apache.kafka.server.util.FileLock",
-                        "UnifiedLog\n\nimport scala.jdk.CollectionConverters._\n\nobject KafkaRaftManager \n  private def createLogDirectory",
-                        "Utils\nimport org.apache.kafka.raft.internals.KafkaRaftLog\nimport org.apache.kafka.raft.Endpoints",
-                        "java.io.File\nimport java.net.InetSocketAddress\nimport java.nio.file.Files\nimport java.nio.file.Paths\nimport java.util.OptionalInt",
-                        "java.util.concurrent.CompletableFuture\nimport kafka.server.KafkaConfig\nimport kafka.utils.Logging\nimport org.apache.kafka.clients.ApiVersions"
+                        "TimingWheelExpirationService",
+                        "UnifiedLog",
+                        "Utils",
+                        "java.io.File",
+                        "java.net.InetSocketAddress",
+                        "java.nio.file.Files",
+                        "java.nio.file.Paths",
+                        "java.util.OptionalInt",
+                        "java.util.concurrent.CompletableFuture",
+                        "kafka.server.KafkaConfig",
+                        "kafka.utils.Logging",
+                        "org.apache.kafka.clients.ApiVersions",
+                        "org.apache.kafka.common.KafkaException",
+                        "org.apache.kafka.common.TopicPartition",
+                        "org.apache.kafka.common.Uuid",
+                        "org.apache.kafka.common.metrics.Metrics",
+                        "org.apache.kafka.common.network.ChannelBuilders",
+                        "org.apache.kafka.common.protocol.ApiMessage",
+                        "org.apache.kafka.common.requests.RequestContext",
+                        "org.apache.kafka.common.requests.RequestHeader",
+                        "org.apache.kafka.common.security.JaasContext",
+                        "org.apache.kafka.common.security.auth.SecurityProtocol",
+                        "org.apache.kafka.common.utils.LogContext",
+                        "org.apache.kafka.raft.Endpoints",
+                        "org.apache.kafka.raft.internals.KafkaRaftLog",
+                        "org.apache.kafka.server.ProcessRole",
+                        "org.apache.kafka.server.common.Feature",
+                        "org.apache.kafka.server.common.serialization.RecordSerde",
+                        "org.apache.kafka.server.fault.FaultHandler",
+                        "org.apache.kafka.server.util.FileLock",
+                        "org.apache.kafka.server.util.timer.SystemTimer",
+                        "org.apache.kafka.storage.internals.log.LogManager",
+                        "scala.jdk.CollectionConverters._"
                     ]
                 },
                 "scala/kafka/LogManager.scala": {
@@ -180799,32 +180899,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7194.63,
+                        "X": 7194.52,
                         "Y": -250.65,
-                        "Z": 551.69
+                        "Z": 551.68
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.807,
+                        "Repository Drift (Z-Score)": 12.01,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.068,
-                            "file_cluster_1": 12.404,
-                            "file_cluster_2": 12.541,
-                            "file_cluster_3": 13.348,
-                            "file_cluster_4": 12.619,
-                            "file_cluster_5": 12.845,
-                            "file_cluster_6": 12.574,
-                            "file_cluster_7": 12.102,
-                            "file_cluster_8": 11.807,
-                            "file_cluster_9": 12.565,
-                            "file_cluster_10": 13.208,
-                            "file_cluster_11": 12.069,
-                            "file_cluster_12": 12.601,
-                            "file_cluster_13": 12.196,
-                            "file_cluster_14": 15.782,
-                            "file_cluster_15": 11.877,
-                            "file_cluster_16": 11.851,
-                            "file_cluster_17": 12.222
+                            "file_cluster_0": 12.265,
+                            "file_cluster_1": 12.594,
+                            "file_cluster_2": 12.728,
+                            "file_cluster_3": 13.534,
+                            "file_cluster_4": 12.821,
+                            "file_cluster_5": 13.034,
+                            "file_cluster_6": 12.772,
+                            "file_cluster_7": 12.304,
+                            "file_cluster_8": 12.01,
+                            "file_cluster_9": 12.758,
+                            "file_cluster_10": 13.398,
+                            "file_cluster_11": 12.271,
+                            "file_cluster_12": 12.797,
+                            "file_cluster_13": 12.399,
+                            "file_cluster_14": 15.917,
+                            "file_cluster_15": 12.089,
+                            "file_cluster_16": 12.063,
+                            "file_cluster_17": 12.418
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -180832,9 +180932,9 @@
                         "Total LOC": 1590,
                         "Coding LOC": 1232,
                         "Documentation LOC": 194,
-                        "Structural Magnitude": 1622.14,
+                        "Structural Magnitude": 1610.14,
                         "Control Flow Ratio": "73.0%",
-                        "Popularity Rank": 1,
+                        "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -180843,16 +180943,16 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "15.26%",
                         "Error & Exception Exposure": "48.26%",
-                        "Tech Debt Exposure": "16.98%",
+                        "Tech Debt Exposure": "35.14%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "5.81%",
+                        "API Exposure": "4.87%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "12.06%",
                         "Commented Logic Exposure": "0.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "92.71%",
+                        "Documentation Exposure": "89.6%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -181404,7 +181504,7 @@
                         "Type/Safety Bypasses": 45,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 3,
-                        "Exposed API / Public Exports": 57,
+                        "Exposed API / Public Exports": 45,
                         "State Mutations / Variable Reassignments": 73,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 66,
@@ -181469,7 +181569,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 4,
-                        "Orphaned Logic": 0,
+                        "Orphaned Logic": 12,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -181491,40 +181591,67 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 28,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Direct Upstream (Fragility)": 55,
+                        "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
-                        "IOException\nimport java.nio.file.Files",
+                        "IOException",
                         "KafkaException",
-                        "KafkaRaftServer\nimport kafka.utils.Logging\nimport org.apache.kafka.common.DirectoryId",
+                        "KafkaRaftServer",
                         "KafkaStorageException",
                         "KafkaThread",
                         "LogCleaner",
                         "LogConfig",
                         "LogDirFailureChannel",
-                        "LogDirNotFoundException\nimport org.apache.kafka.coordinator.transaction.TransactionLogConfig",
-                        "LogManager",
+                        "LogDirNotFoundException",
+                        "LogManager => JLogManager",
+                        "LogOffsetsListener",
                         "MetaPropertiesEnsemble",
-                        "NoSuchFileException\nimport java.util.concurrent._\nimport java.util.concurrent.atomic.AtomicInteger\nimport kafka.server.KafkaConfig",
-                        "OffsetCheckpointFile\nimport org.apache.kafka.storage.log.metrics.BrokerTopicStats\n\nimport java.util\nimport java.util.stream.Collectors",
+                        "NoSuchFileException",
+                        "OffsetCheckpointFile",
                         "Optional",
                         "OptionalLong",
-                        "Properties\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.util.FileLock",
-                        "PropertiesUtils\n\nimport java.util.Collections",
-                        "Scheduler\nimport org.apache.kafka.storage.internals.log.CleanerConfig",
+                        "ProducerStateManagerConfig",
+                        "Properties",
+                        "PropertiesUtils",
+                        "RemoteIndexCache",
+                        "Scheduler",
                         "Success",
                         "Time",
                         "TopicPartition",
-                        "TransactionStateManagerConfig\n\nimport scala.jdk.CollectionConverters._\nimport scala.collection._\nimport scala.collection.mutable.ArrayBuffer\nimport scala.util.Failure",
-                        "Try\nimport org.apache.kafka.image.TopicsImage\nimport org.apache.kafka.metadata.ConfigRepository\nimport org.apache.kafka.metadata.properties.MetaProperties",
-                        "Utils\nimport org.apache.kafka.common.errors.InconsistentTopicIdException",
-                        "Uuid\nimport org.apache.kafka.common.utils.Exit",
+                        "TransactionStateManagerConfig",
+                        "Try",
+                        "UnifiedLog",
+                        "Utils",
+                        "Uuid",
                         "java.io.File",
-                        "java.lang.Long",
-                        "org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler"
+                        "java.lang.Long => JLong",
+                        "java.nio.file.Files",
+                        "java.util",
+                        "java.util.Collections",
+                        "java.util.concurrent._",
+                        "java.util.concurrent.atomic.AtomicInteger",
+                        "java.util.stream.Collectors",
+                        "kafka.server.KafkaConfig",
+                        "kafka.utils.Logging",
+                        "org.apache.kafka.common.DirectoryId",
+                        "org.apache.kafka.common.errors.InconsistentTopicIdException",
+                        "org.apache.kafka.common.utils.Exit",
+                        "org.apache.kafka.coordinator.transaction.TransactionLogConfig",
+                        "org.apache.kafka.image.TopicsImage",
+                        "org.apache.kafka.metadata.ConfigRepository",
+                        "org.apache.kafka.metadata.properties.MetaProperties",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.util.FileLock",
+                        "org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler",
+                        "org.apache.kafka.storage.internals.log.CleanerConfig",
+                        "org.apache.kafka.storage.log.metrics.BrokerTopicStats",
+                        "scala.collection._",
+                        "scala.collection.mutable.ArrayBuffer",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.util.Failure"
                     ]
                 },
                 "scala/kafka/Partition.scala": {
@@ -181539,32 +181666,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7511.99,
-                        "Y": -139.28,
-                        "Z": 846.98
+                        "X": 7511.81,
+                        "Y": -139.3,
+                        "Z": 846.89
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 13.213,
+                        "Repository Drift (Z-Score)": 13.395,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.337,
-                            "file_cluster_1": 13.775,
-                            "file_cluster_2": 13.866,
-                            "file_cluster_3": 14.575,
-                            "file_cluster_4": 13.888,
-                            "file_cluster_5": 14.157,
-                            "file_cluster_6": 13.785,
-                            "file_cluster_7": 13.483,
-                            "file_cluster_8": 13.231,
-                            "file_cluster_9": 13.789,
-                            "file_cluster_10": 14.497,
-                            "file_cluster_11": 13.32,
-                            "file_cluster_12": 14.049,
-                            "file_cluster_13": 13.455,
-                            "file_cluster_14": 16.746,
-                            "file_cluster_15": 13.214,
-                            "file_cluster_16": 13.213,
-                            "file_cluster_17": 13.436
+                            "file_cluster_0": 13.511,
+                            "file_cluster_1": 13.951,
+                            "file_cluster_2": 14.039,
+                            "file_cluster_3": 14.741,
+                            "file_cluster_4": 14.062,
+                            "file_cluster_5": 14.327,
+                            "file_cluster_6": 13.959,
+                            "file_cluster_7": 13.661,
+                            "file_cluster_8": 13.414,
+                            "file_cluster_9": 13.961,
+                            "file_cluster_10": 14.664,
+                            "file_cluster_11": 13.498,
+                            "file_cluster_12": 14.221,
+                            "file_cluster_13": 13.633,
+                            "file_cluster_14": 16.876,
+                            "file_cluster_15": 13.396,
+                            "file_cluster_16": 13.395,
+                            "file_cluster_17": 13.614
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -181574,7 +181701,7 @@
                         "Documentation LOC": 892,
                         "Structural Magnitude": 980.0,
                         "Control Flow Ratio": "61.8%",
-                        "Popularity Rank": 0,
+                        "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -182191,8 +182318,8 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 46,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Direct Upstream (Fragility)": 84,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
@@ -182201,12 +182328,12 @@
                         "AsyncOffsetReader",
                         "CommittedPartitionState",
                         "ConcurrentHashMap",
-                        "CopyOnWriteArrayList\nimport kafka.log._\nimport kafka.server._\nimport kafka.server.share.DelayedShareFetch\nimport kafka.utils._\nimport org.apache.kafka.common.DirectoryId",
+                        "CopyOnWriteArrayList",
                         "DelayedOperationPurgatory",
                         "DelayedProduce",
                         "FetchDataInfo",
                         "FetchParams",
-                        "FetchResponseData\nimport org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset\nimport org.apache.kafka.common.protocol.Errors\nimport org.apache.kafka.common.record.internal.FileRecords.TimestampAndOffset\nimport org.apache.kafka.common.record.internal.FileRecords",
+                        "FetchResponseData",
                         "IsolationLevel",
                         "LeaderHwChange",
                         "LeaderRecoveryState",
@@ -182220,29 +182347,67 @@
                         "MetadataCache",
                         "OffsetResultHolder",
                         "OngoingReassignmentState",
-                        "Partition.metricsGroup\n  def topic",
+                        "Partition.metricsGroup",
                         "PartitionListener",
-                        "PartitionRegistration\nimport org.apache.kafka.server.LogDeleteRecordsResult\nimport org.apache.kafka.server.common.RequestLocal",
+                        "PartitionRegistration",
                         "PartitionState",
                         "PendingExpandIsr",
                         "PendingPartitionChange",
                         "PendingShrinkIsr",
-                        "RecordBatch\nimport org.apache.kafka.common.requests._\nimport org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH",
-                        "RichOptional\nimport scala.jdk.javaapi.OptionConverters\n\n\nclass DelayedOperations",
-                        "SimpleAssignmentState\nimport org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "RecordBatch",
+                        "RichOptional",
+                        "SimpleAssignmentState",
                         "TopicIdPartition",
                         "TopicPartition",
-                        "TopicPartitionOperationKey\nimport org.apache.kafka.server.replica.Replica\nimport org.apache.kafka.server.share.fetch.DelayedShareFetchPartitionKey\nimport org.apache.kafka.server.storage.log.FetchIsolation",
-                        "TransactionVersion\nimport org.apache.kafka.server.log.remote.TopicPartitionLog\nimport org.apache.kafka.server.log.remote.storage.RemoteLogManager\nimport org.apache.kafka.storage.internals.log.AppendOrigin",
-                        "UNDEFINED_EPOCH_OFFSET\nimport org.apache.kafka.common.utils.Time",
-                        "UnexpectedAppendOffsetException\nimport org.apache.kafka.server.util.LockUtils.inReadLock",
+                        "TopicPartitionOperationKey",
+                        "TransactionVersion",
+                        "UNDEFINED_EPOCH_OFFSET",
+                        "UnexpectedAppendOffsetException",
                         "UnifiedLog",
-                        "Utils\nimport org.apache.kafka.logger.StateChangeLogger\nimport org.apache.kafka.metadata.LeaderAndIsr",
-                        "Uuid\nimport org.apache.kafka.common.errors._\nimport org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState\nimport org.apache.kafka.common.message.DescribeProducersResponseData",
-                        "VerificationGuard\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.partition.AlterPartitionListener",
-                        "inWriteLock\nimport org.apache.kafka.storage.internals.checkpoint.OffsetCheckpoints\nimport org.slf4j.event.Level\n\nimport java.util\nimport scala.collection.Seq\nimport scala.jdk.CollectionConverters._\nimport scala.jdk.OptionConverters.RichOption",
-                        "java.lang.Long",
-                        "java.util.concurrent.locks.ReentrantReadWriteLock\nimport java.util.Optional\nimport java.util.concurrent.CompletableFuture"
+                        "Utils",
+                        "Uuid",
+                        "VerificationGuard",
+                        "inWriteLock",
+                        "java.lang.Long => JLong",
+                        "java.util",
+                        "java.util.Optional",
+                        "java.util.concurrent.CompletableFuture",
+                        "java.util.concurrent.locks.ReentrantReadWriteLock",
+                        "kafka.log._",
+                        "kafka.server._",
+                        "kafka.server.share.DelayedShareFetch",
+                        "kafka.utils._",
+                        "org.apache.kafka.common.DirectoryId",
+                        "org.apache.kafka.common.errors._",
+                        "org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState",
+                        "org.apache.kafka.common.message.DescribeProducersResponseData",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "org.apache.kafka.common.protocol.Errors",
+                        "org.apache.kafka.common.record.internal.FileRecords",
+                        "org.apache.kafka.common.record.internal.FileRecords.TimestampAndOffset",
+                        "org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH",
+                        "org.apache.kafka.common.requests._",
+                        "org.apache.kafka.common.utils.Time",
+                        "org.apache.kafka.logger.StateChangeLogger",
+                        "org.apache.kafka.metadata.LeaderAndIsr",
+                        "org.apache.kafka.server.LogDeleteRecordsResult",
+                        "org.apache.kafka.server.common.RequestLocal",
+                        "org.apache.kafka.server.log.remote.TopicPartitionLog",
+                        "org.apache.kafka.server.log.remote.storage.RemoteLogManager",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.partition.AlterPartitionListener",
+                        "org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "org.apache.kafka.server.replica.Replica",
+                        "org.apache.kafka.server.share.fetch.DelayedShareFetchPartitionKey",
+                        "org.apache.kafka.server.storage.log.FetchIsolation",
+                        "org.apache.kafka.server.util.LockUtils.inReadLock",
+                        "org.apache.kafka.storage.internals.checkpoint.OffsetCheckpoints",
+                        "org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "org.slf4j.event.Level",
+                        "scala.collection.Seq",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.jdk.OptionConverters.RichOption",
+                        "scala.jdk.javaapi.OptionConverters"
                     ]
                 },
                 "scala/kafka/ReplicaManager.scala": {
@@ -182259,30 +182424,30 @@
                     "2. Topological Coordinates": {
                         "X": 6663.43,
                         "Y": -218.47,
-                        "Z": 183.62
+                        "Z": 183.63
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 11.388,
+                        "Repository Drift (Z-Score)": 11.627,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.955,
-                            "file_cluster_1": 11.906,
-                            "file_cluster_2": 12.116,
-                            "file_cluster_3": 13.037,
-                            "file_cluster_4": 12.546,
-                            "file_cluster_5": 12.371,
-                            "file_cluster_6": 12.266,
-                            "file_cluster_7": 11.665,
-                            "file_cluster_8": 11.44,
-                            "file_cluster_9": 12.322,
-                            "file_cluster_10": 13.091,
-                            "file_cluster_11": 12.048,
-                            "file_cluster_12": 12.534,
-                            "file_cluster_13": 11.864,
-                            "file_cluster_14": 15.579,
-                            "file_cluster_15": 11.713,
-                            "file_cluster_16": 11.388,
-                            "file_cluster_17": 12.157
+                            "file_cluster_0": 12.176,
+                            "file_cluster_1": 12.135,
+                            "file_cluster_2": 12.34,
+                            "file_cluster_3": 13.247,
+                            "file_cluster_4": 12.764,
+                            "file_cluster_5": 12.591,
+                            "file_cluster_6": 12.488,
+                            "file_cluster_7": 11.897,
+                            "file_cluster_8": 11.678,
+                            "file_cluster_9": 12.54,
+                            "file_cluster_10": 13.3,
+                            "file_cluster_11": 12.271,
+                            "file_cluster_12": 12.753,
+                            "file_cluster_13": 12.092,
+                            "file_cluster_14": 15.74,
+                            "file_cluster_15": 11.946,
+                            "file_cluster_16": 11.627,
+                            "file_cluster_17": 12.38
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -182539,9 +182704,9 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 79,
+                        "Direct Upstream (Fragility)": 144,
                         "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Upstream (Absolute Fragility)": 1,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
@@ -182551,12 +182716,12 @@
                         "DelayedProduce",
                         "DelayedRemoteFetch",
                         "DelayedRemoteListOffsets",
-                        "DelayedShareFetchPartitionKey\nimport org.apache.kafka.server.storage.log.FetchParams",
+                        "DelayedShareFetchPartitionKey",
                         "DeleteRecordsPartitionStatus",
-                        "DescribeProducersResponseData\nimport org.apache.kafka.common.metrics.Metrics\nimport org.apache.kafka.common.network.ListenerName\nimport org.apache.kafka.common.protocol.Errors\nimport org.apache.kafka.common.record.internal._\nimport org.apache.kafka.common.replica.PartitionView.DefaultPartitionView\nimport org.apache.kafka.common.replica.ReplicaView.DefaultReplicaView\nimport org.apache.kafka.common.replica._\nimport org.apache.kafka.common.requests.FetchRequest.PartitionData\nimport org.apache.kafka.common.requests.ProduceResponse.PartitionResponse\nimport org.apache.kafka.common.requests._\nimport org.apache.kafka.common.utils.Exit",
+                        "DescribeProducersResponseData",
                         "FailedIsrUpdatesPerSecMetricName",
                         "FetchDataInfo",
-                        "FetchPartitionData\nimport org.apache.kafka.server.transaction.AddPartitionsToTxnManager\nimport org.apache.kafka.server.transaction.AddPartitionsToTxnManager.TransactionSupportedOperation\nimport org.apache.kafka.server.util.timer.SystemTimer",
+                        "FetchPartitionData",
                         "FetchPartitionStatus",
                         "Future",
                         "HostedPartition",
@@ -182565,8 +182730,8 @@
                         "LeaderCountMetricName",
                         "LeaderHwChange",
                         "ListOffsetsPartitionStatus",
-                        "ListOffsetsTopic\nimport org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
-                        "ListOffsetsTopicResponse\nimport org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic\nimport org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "ListOffsetsTopic",
+                        "ListOffsetsTopicResponse",
                         "LogAppendInfo",
                         "LogAppendResult",
                         "LogConfig",
@@ -182579,15 +182744,15 @@
                         "Node",
                         "OfflineReplicaCountMetricName",
                         "OffsetCheckpointFile",
-                        "OffsetCheckpoints\nimport org.apache.kafka.storage.internals.log.AppendOrigin",
-                        "OffsetForLeaderTopicResult\nimport org.apache.kafka.common.message.DescribeLogDirsResponseData",
+                        "OffsetCheckpoints",
+                        "OffsetForLeaderTopicResult",
                         "OffsetResultHolder",
                         "Optional",
                         "OptionalInt",
-                        "OptionalLong\nimport java.util.function.Consumer\nimport scala.collection.Map",
+                        "OptionalLong",
                         "PartitionCountMetricName",
                         "PartitionsWithLateTransactionsCountMetricName",
-                        "Paths\nimport java.util\nimport java.util.concurrent.atomic.AtomicBoolean\nimport java.util.concurrent.CompletableFuture",
+                        "Paths",
                         "ProducerIdCountMetricName",
                         "ReassigningPartitionsMetricName",
                         "RecordValidationException",
@@ -182595,35 +182760,100 @@
                         "RejectedExecutionException",
                         "RemoteLogReadResult",
                         "RemoteStorageFetchInfo",
-                        "ReplicationQuotaManager\nimport org.apache.kafka.server.share.fetch.DelayedShareFetchKey",
+                        "ReplicationQuotaManager",
                         "RequestLocal",
                         "Seq",
                         "Set",
-                        "ShutdownableThread\nimport org.apache.kafka.server.ActionQueue",
+                        "ShutdownableThread",
                         "StopPartition",
                         "Time",
-                        "TimeUnit\nimport java.util.Collections",
-                        "TimerTask\nimport org.apache.kafka.server.util.Scheduler",
-                        "Topic\nimport org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult\nimport org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsTopic\nimport org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition",
+                        "TimeUnit",
+                        "TimerTask",
+                        "Topic",
                         "TopicIdPartition",
                         "TopicPartition",
-                        "TopicPartitionOperationKey\nimport org.apache.kafka.server.quota.ReplicaQuota",
-                        "TopicsDelta\nimport org.apache.kafka.logger.StateChangeLogger\nimport org.apache.kafka.metadata.LeaderConstants.NO_LEADER\nimport org.apache.kafka.metadata.MetadataCache\nimport org.apache.kafka.server.purgatory.DelayedProduce.ProducePartitionStatus\nimport org.apache.kafka.server.LogAppendResult.LogAppendSummary\nimport org.apache.kafka.server.common.DirectoryEventHandler",
-                        "TransactionLogConfig\nimport org.apache.kafka.image.LocalReplicaChanges",
-                        "TransactionVersion\nimport org.apache.kafka.server.log.remote.TopicPartitionLog\nimport org.apache.kafka.server.config.ReplicationConfigs\nimport org.apache.kafka.server.log.remote.storage.RemoteLogManager\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.network.BrokerEndPoint\nimport org.apache.kafka.server.partition.PartitionListener\nimport org.apache.kafka.server.purgatory.DelayedProduce.PartitionStatusValidator.Result\nimport org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "TopicPartitionOperationKey",
+                        "TopicsDelta",
+                        "TransactionLogConfig",
+                        "TransactionVersion",
                         "UnderMinIsrPartitionCountMetricName",
                         "UnderReplicatedPartitionsMetricName",
                         "UnifiedLog",
-                        "Utils\nimport org.apache.kafka.coordinator.transaction.AddPartitionsToTxnConfig",
-                        "Uuid\nimport org.apache.kafka.common.errors._\nimport org.apache.kafka.common.internals.Plugin",
-                        "VerificationGuard\nimport org.apache.kafka.storage.log.metrics.BrokerTopicStats\n\nimport java.io.File\nimport java.lang.Long",
-                        "com.yammer.metrics.core.Meter\nimport kafka.cluster.Partition\nimport kafka.log.LogManager\nimport kafka.server.QuotaFactory.QuotaManagers\nimport kafka.server.ReplicaManager.AtMinIsrPartitionCountMetricName",
-                        "common\nimport org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints",
+                        "Utils",
+                        "Uuid",
+                        "VerificationGuard",
+                        "com.yammer.metrics.core.Meter",
+                        "common",
                         "createLogReadResult",
                         "immutable",
-                        "isListOffsetsTimestampUnsupported\nimport kafka.server.share.DelayedShareFetch\nimport kafka.utils._\nimport org.apache.kafka.common.IsolationLevel",
+                        "isListOffsetsTimestampUnsupported",
+                        "java.io.File",
+                        "java.lang.Long => JLong",
                         "java.nio.file.Files",
-                        "mutable\nimport scala.jdk.CollectionConverters._\nimport scala.jdk.FunctionConverters.enrichAsJavaConsumer\nimport scala.jdk.OptionConverters.RichOptional\n\nobject ReplicaManager \n  val HighWatermarkFilename"
+                        "java.util",
+                        "java.util.Collections",
+                        "java.util.concurrent.CompletableFuture",
+                        "java.util.concurrent.atomic.AtomicBoolean",
+                        "java.util.function.Consumer",
+                        "kafka.cluster.Partition",
+                        "kafka.log.LogManager",
+                        "kafka.server.QuotaFactory.QuotaManagers",
+                        "kafka.server.ReplicaManager.AtMinIsrPartitionCountMetricName",
+                        "kafka.server.share.DelayedShareFetch",
+                        "kafka.utils._",
+                        "mutable",
+                        "org.apache.kafka.common.IsolationLevel",
+                        "org.apache.kafka.common.errors._",
+                        "org.apache.kafka.common.internals.Plugin",
+                        "org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult",
+                        "org.apache.kafka.common.message.DescribeLogDirsResponseData",
+                        "org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsTopic",
+                        "org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition",
+                        "org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "org.apache.kafka.common.metrics.Metrics",
+                        "org.apache.kafka.common.network.ListenerName",
+                        "org.apache.kafka.common.protocol.Errors",
+                        "org.apache.kafka.common.record.internal._",
+                        "org.apache.kafka.common.replica.PartitionView.DefaultPartitionView",
+                        "org.apache.kafka.common.replica.ReplicaView.DefaultReplicaView",
+                        "org.apache.kafka.common.replica._",
+                        "org.apache.kafka.common.requests.FetchRequest.PartitionData",
+                        "org.apache.kafka.common.requests.ProduceResponse.PartitionResponse",
+                        "org.apache.kafka.common.requests._",
+                        "org.apache.kafka.common.utils.Exit",
+                        "org.apache.kafka.coordinator.transaction.AddPartitionsToTxnConfig",
+                        "org.apache.kafka.image.LocalReplicaChanges",
+                        "org.apache.kafka.logger.StateChangeLogger",
+                        "org.apache.kafka.metadata.LeaderConstants.NO_LEADER",
+                        "org.apache.kafka.metadata.MetadataCache",
+                        "org.apache.kafka.server.ActionQueue",
+                        "org.apache.kafka.server.LogAppendResult.LogAppendSummary",
+                        "org.apache.kafka.server.common.DirectoryEventHandler",
+                        "org.apache.kafka.server.config.ReplicationConfigs",
+                        "org.apache.kafka.server.log.remote.TopicPartitionLog",
+                        "org.apache.kafka.server.log.remote.storage.RemoteLogManager",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.network.BrokerEndPoint",
+                        "org.apache.kafka.server.partition.PartitionListener",
+                        "org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "org.apache.kafka.server.purgatory.DelayedProduce.PartitionStatusValidator.Result",
+                        "org.apache.kafka.server.purgatory.DelayedProduce.ProducePartitionStatus",
+                        "org.apache.kafka.server.quota.ReplicaQuota",
+                        "org.apache.kafka.server.share.fetch.DelayedShareFetchKey",
+                        "org.apache.kafka.server.storage.log.FetchParams",
+                        "org.apache.kafka.server.transaction.AddPartitionsToTxnManager",
+                        "org.apache.kafka.server.transaction.AddPartitionsToTxnManager.TransactionSupportedOperation",
+                        "org.apache.kafka.server.util.Scheduler",
+                        "org.apache.kafka.server.util.timer.SystemTimer",
+                        "org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints",
+                        "org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "org.apache.kafka.storage.log.metrics.BrokerTopicStats",
+                        "scala.collection.Map",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.jdk.FunctionConverters.enrichAsJavaConsumer",
+                        "scala.jdk.OptionConverters.RichOptional"
                     ]
                 },
                 "scala/kafka/SocketServer.scala": {
@@ -182638,32 +182868,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7232.25,
-                        "Y": -371.49,
-                        "Z": 139.84
+                        "X": 7232.13,
+                        "Y": -371.46,
+                        "Z": 139.95
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.178,
+                        "Repository Drift (Z-Score)": 11.419,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.272,
-                            "file_cluster_1": 11.688,
-                            "file_cluster_2": 11.886,
-                            "file_cluster_3": 12.712,
-                            "file_cluster_4": 12.062,
-                            "file_cluster_5": 12.131,
-                            "file_cluster_6": 11.854,
-                            "file_cluster_7": 11.377,
-                            "file_cluster_8": 11.178,
-                            "file_cluster_9": 11.851,
-                            "file_cluster_10": 12.494,
-                            "file_cluster_11": 11.453,
-                            "file_cluster_12": 11.962,
-                            "file_cluster_13": 11.404,
-                            "file_cluster_14": 15.286,
-                            "file_cluster_15": 11.25,
-                            "file_cluster_16": 11.414,
-                            "file_cluster_17": 11.609
+                            "file_cluster_0": 11.503,
+                            "file_cluster_1": 11.918,
+                            "file_cluster_2": 12.111,
+                            "file_cluster_3": 12.926,
+                            "file_cluster_4": 12.289,
+                            "file_cluster_5": 12.353,
+                            "file_cluster_6": 12.082,
+                            "file_cluster_7": 11.613,
+                            "file_cluster_8": 11.419,
+                            "file_cluster_9": 12.075,
+                            "file_cluster_10": 12.712,
+                            "file_cluster_11": 11.686,
+                            "file_cluster_12": 12.188,
+                            "file_cluster_13": 11.64,
+                            "file_cluster_14": 15.445,
+                            "file_cluster_15": 11.491,
+                            "file_cluster_16": 11.652,
+                            "file_cluster_17": 11.839
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -182671,7 +182901,7 @@
                         "Total LOC": 1707,
                         "Coding LOC": 576,
                         "Documentation LOC": 967,
-                        "Structural Magnitude": 1223.62,
+                        "Structural Magnitude": 1222.62,
                         "Control Flow Ratio": "55.2%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -182682,9 +182912,9 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "7.45%",
                         "Error & Exception Exposure": "8.72%",
-                        "Tech Debt Exposure": "0.0%",
+                        "Tech Debt Exposure": "10.82%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "2.1%",
+                        "API Exposure": "1.98%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "0.0%",
                         "Commented Logic Exposure": "5.24%",
@@ -182743,7 +182973,7 @@
                         "Type/Safety Bypasses": 15,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 3,
-                        "Exposed API / Public Exports": 19,
+                        "Exposed API / Public Exports": 18,
                         "State Mutations / Variable Reassignments": 27,
                         "Commented-out Code (Dead Logic)": 2,
                         "Structured Documentation Blocks": 54,
@@ -182808,7 +183038,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -182830,7 +183060,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 35,
+                        "Direct Upstream (Fragility)": 72,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
@@ -182842,7 +183072,7 @@
                         "CumulativeSum",
                         "EndThrottlingResponse",
                         "KafkaChannel",
-                        "KafkaConfig\nimport org.apache.kafka.common.message.ApiMessageType.ListenerType\nimport kafka.utils._\nimport org.apache.kafka.common.config.ConfigException\nimport org.apache.kafka.common.errors.InvalidRequestException",
+                        "KafkaConfig",
                         "KafkaException",
                         "ListenerName",
                         "ListenerReconfigurable",
@@ -182851,26 +183081,63 @@
                         "MetricName",
                         "NetworkSend",
                         "NoOpResponse",
-                        "Rate\nimport org.apache.kafka.common.network.KafkaChannel.ChannelMuteEvent\nimport org.apache.kafka.common.network.ChannelBuilder",
-                        "Reconfigurable\nimport org.apache.kafka.network.ConnectionQuotaEntity",
+                        "Rate",
+                        "Reconfigurable",
                         "RequestContext",
-                        "RequestHeader\nimport org.apache.kafka.common.security.auth.SecurityProtocol\nimport org.apache.kafka.common.utils.KafkaThread",
+                        "RequestHeader",
                         "Selectable",
-                        "Selector",
+                        "Selector => KSelector",
                         "Send",
                         "SendResponse",
                         "ServerConnectionId",
-                        "ServerSocketFactory\nimport org.apache.kafka.server.config.QuotaConfig\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.network.ConnectionDisconnectListener\nimport org.apache.kafka.server.quota.QuotaUtils\nimport org.apache.kafka.server.util.FutureUtils\nimport org.slf4j.event.Level\n\nimport scala.collection._\nimport scala.collection.mutable.ArrayBuffer\nimport scala.jdk.CollectionConverters._\nimport scala.util.control.ControlThrowable",
-                        "SimpleMemoryPool\nimport org.apache.kafka.common.metrics._\nimport org.apache.kafka.common.metrics.stats.Avg",
-                        "SocketServer",
-                        "StartThrottlingResponse\nimport kafka.server.BrokerReconfigurable",
+                        "ServerSocketFactory",
+                        "SimpleMemoryPool",
+                        "SocketServer => JSocketServer",
+                        "SocketServerConfigs",
+                        "StartThrottlingResponse",
                         "Time",
-                        "UnsupportedVersionException\nimport org.apache.kafka.common.memory.MemoryPool",
-                        "Utils\nimport org.apache.kafka.common.Endpoint",
-                        "java.io.IOException\nimport java.net._\nimport java.nio.ByteBuffer\nimport java.nio.channels.Selector",
-                        "java.util\nimport java.util.Optional\nimport java.util.concurrent._\nimport java.util.concurrent.atomic._\nimport kafka.network.Processor._\nimport kafka.network.RequestChannel.CloseConnectionResponse",
-                        "org.apache.kafka.common.protocol.ApiKeys\nimport org.apache.kafka.common.requests.ApiVersionsRequest",
-                        "org.apache.kafka.security.CredentialProvider\nimport org.apache.kafka.server.ApiVersionManager"
+                        "TooManyConnectionsException",
+                        "UnsupportedVersionException",
+                        "Utils",
+                        "_",
+                        "java.io.IOException",
+                        "java.net._",
+                        "java.nio.ByteBuffer",
+                        "java.nio.channels.Selector => NSelector",
+                        "java.util",
+                        "java.util.Optional",
+                        "java.util.concurrent._",
+                        "java.util.concurrent.atomic._",
+                        "kafka.network.Processor._",
+                        "kafka.network.RequestChannel.CloseConnectionResponse",
+                        "kafka.server.BrokerReconfigurable",
+                        "kafka.utils._",
+                        "org.apache.kafka.common.Endpoint",
+                        "org.apache.kafka.common.config.ConfigException",
+                        "org.apache.kafka.common.errors.InvalidRequestException",
+                        "org.apache.kafka.common.memory.MemoryPool",
+                        "org.apache.kafka.common.message.ApiMessageType.ListenerType",
+                        "org.apache.kafka.common.metrics._",
+                        "org.apache.kafka.common.metrics.stats.Avg",
+                        "org.apache.kafka.common.network.ChannelBuilder",
+                        "org.apache.kafka.common.network.KafkaChannel.ChannelMuteEvent",
+                        "org.apache.kafka.common.protocol.ApiKeys",
+                        "org.apache.kafka.common.requests.ApiVersionsRequest",
+                        "org.apache.kafka.common.security.auth.SecurityProtocol",
+                        "org.apache.kafka.common.utils.KafkaThread",
+                        "org.apache.kafka.network.ConnectionQuotaEntity",
+                        "org.apache.kafka.security.CredentialProvider",
+                        "org.apache.kafka.server.ApiVersionManager",
+                        "org.apache.kafka.server.config.QuotaConfig",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.network.ConnectionDisconnectListener",
+                        "org.apache.kafka.server.quota.QuotaUtils",
+                        "org.apache.kafka.server.util.FutureUtils",
+                        "org.slf4j.event.Level",
+                        "scala.collection._",
+                        "scala.collection.mutable.ArrayBuffer",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.util.control.ControlThrowable"
                     ]
                 }
             }
@@ -242904,9 +243171,9 @@
                         "Identity Proof": "Prose Anchor (MIT-LICENSE)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1267.1,
+                        "X": 1266.67,
                         "Y": -216.09,
-                        "Z": 3114.13
+                        "Z": 3113.1
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -243065,9 +243332,9 @@
                         "Identity Proof": "Metadata Anchor (Rakefile)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1771.81,
+                        "X": 1771.38,
                         "Y": -113.99,
-                        "Z": 3839.3
+                        "Z": 3838.26
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -243286,9 +243553,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 994.27,
+                        "X": 993.83,
                         "Y": -200.24,
-                        "Z": 3678.8
+                        "Z": 3677.77
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -243494,9 +243761,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1585.68,
+                        "X": 1585.25,
                         "Y": -287.47,
-                        "Z": 3118.77
+                        "Z": 3117.73
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -243699,9 +243966,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1473.24,
+                        "X": 1472.81,
                         "Y": -156.99,
-                        "Z": 3597.69
+                        "Z": 3596.65
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -243913,9 +244180,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1950.87,
+                        "X": 1950.43,
                         "Y": -237.71,
-                        "Z": 3479.38
+                        "Z": 3478.34
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -244110,9 +244377,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1238.28,
+                        "X": 1237.84,
                         "Y": -157.77,
-                        "Z": 3895.66
+                        "Z": 3894.63
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
@@ -244314,9 +244581,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1398.15,
+                        "X": 1397.71,
                         "Y": -71.2,
-                        "Z": 4147.07
+                        "Z": 4146.04
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_9",
@@ -283135,9 +283402,9 @@
                         "Identity Proof": "Single Indicator (Exact Match)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7902.84,
+                        "X": 7902.55,
                         "Y": 39.33,
-                        "Z": 937.23
+                        "Z": 937.2
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -283315,9 +283582,9 @@
                         "Identity Proof": "Single Indicator (Ext: .s)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 8195.71,
+                        "X": 8195.42,
                         "Y": 89.29,
-                        "Z": 1272.33
+                        "Z": 1272.3
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -283495,9 +283762,9 @@
                         "Identity Proof": "Single Indicator (Ext: .s)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7912.82,
+                        "X": 7912.53,
                         "Y": 59.83,
-                        "Z": 534.35
+                        "Z": 534.31
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -283736,9 +284003,9 @@
                         "Identity Proof": "Single Indicator (Ext: .s)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7662.78,
+                        "X": 7662.48,
                         "Y": 69.35,
-                        "Z": 1389.29
+                        "Z": 1389.25
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -294522,9 +294789,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2120.57,
+                        "X": 2120.16,
                         "Y": 126.25,
-                        "Z": 5091.23
+                        "Z": 5090.35
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -294702,9 +294969,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2355.05,
+                        "X": 2354.64,
                         "Y": 157.13,
-                        "Z": 5143.62
+                        "Z": 5142.75
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -296064,9 +296331,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1524.5,
+                        "X": 1524.22,
                         "Y": -32.07,
-                        "Z": 5315.01
+                        "Z": 5314.02
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -296244,9 +296511,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1251.27,
+                        "X": 1251.0,
                         "Y": -37.1,
-                        "Z": 5562.44
+                        "Z": 5561.44
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -305955,9 +306222,9 @@
                         "Identity Proof": "Single Indicator (Ext: .css)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7800.31,
+                        "X": 7800.05,
                         "Y": -118.19,
-                        "Z": 388.16
+                        "Z": 388.15
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -306146,7 +306413,7 @@
                         "Identity Proof": "Single Indicator (Ext: .css)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7932.83,
+                        "X": 7932.57,
                         "Y": -124.89,
                         "Z": 266.19
                     },
@@ -306391,7 +306658,7 @@
                         "Documentation LOC": 0,
                         "Structural Magnitude": 0.39,
                         "Control Flow Ratio": "100.0%",
-                        "Popularity Rank": 4,
+                        "Popularity Rank": 5,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -306539,9 +306806,9 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 0,
-                        "Direct Downstream (Dependency Blast Radius)": 4,
+                        "Direct Downstream (Dependency Blast Radius)": 5,
                         "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                        "Total Downstream (Absolute Dependency Blast Radius)": 1
                     },
                     "9. Extracted Dependencies": []
                 },
@@ -307340,9 +307607,9 @@
                         "Identity Proof": "Single Indicator (Exact Match)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2058.8,
+                        "X": 2058.41,
                         "Y": 141.51,
-                        "Z": 5334.25
+                        "Z": 5333.25
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -308311,9 +308578,9 @@
                         "Identity Proof": "Single Indicator (Ext: .bat)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2874.45,
+                        "X": 2873.94,
                         "Y": -64.84,
-                        "Z": 4799.47
+                        "Z": 4798.61
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",

--- a/tests/golden_master_zero_dep_audit.json
+++ b/tests/golden_master_zero_dep_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-07-31T04:37:14.093597+00:00",
-            "Total Scan Duration": "22.62 seconds"
+            "Analysis ISO Timestamp": "2026-07-31T13:59:54.046897+00:00",
+            "Total Scan Duration": "23.5 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -198,8 +198,8 @@
         "health": {
             "avg_cognitive_load": 24.048,
             "avg_safety_score": 23.794,
-            "avg_tech_debt": 25.069,
-            "avg_documentation": 29.832
+            "avg_tech_debt": 25.202,
+            "avg_documentation": 29.818
         },
         "composition": {
             "xml": {
@@ -400,7 +400,7 @@
             "php": {
                 "files": 36,
                 "loc": 18919,
-                "impact": 37614.78
+                "impact": 37564.78
             },
             "proto": {
                 "files": 4,
@@ -420,7 +420,7 @@
             "scala": {
                 "files": 7,
                 "loc": 4264,
-                "impact": 5454.78
+                "impact": 5441.78
             },
             "scheme": {
                 "files": 4,
@@ -465,7 +465,7 @@
             "zig": {
                 "files": 32,
                 "loc": 68347,
-                "impact": 109004.64000000001
+                "impact": 109006.64000000001
             }
         },
         "ecosystem_fingerprint": {
@@ -937,20 +937,20 @@
             },
             "php/laravel_core": {
                 "file_count": 8,
-                "total_mass": 7536.46,
+                "total_mass": 7486.46,
                 "avg_exposures": {
                     "cognitive_load": 32.14,
                     "safety_score": 24.4,
-                    "tech_debt": 53.46,
+                    "tech_debt": 65.71,
                     "verification": 70.0,
-                    "api_exposure": 6.35,
+                    "api_exposure": 6.21,
                     "concurrency": 0.0,
                     "state_flux": 87.49,
                     "dead_code": 0.62,
                     "spec_match": 87.5,
                     "stability": 43.75,
                     "churn": 0.0,
-                    "documentation": 49.88,
+                    "documentation": 48.59,
                     "tabs_vs_spaces": 93.75,
                     "algorithmic_dos": 87.5,
                     "obscured_payload": 0.0,
@@ -3612,20 +3612,20 @@
             },
             "scala/kafka": {
                 "file_count": 7,
-                "total_mass": 5454.78,
+                "total_mass": 5441.78,
                 "avg_exposures": {
                     "cognitive_load": 10.21,
                     "safety_score": 11.38,
-                    "tech_debt": 42.21,
+                    "tech_debt": 46.35,
                     "verification": 68.92,
-                    "api_exposure": 3.91,
+                    "api_exposure": 3.76,
                     "concurrency": 0.0,
                     "state_flux": 10.05,
                     "dead_code": 1.44,
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 48.2,
+                    "documentation": 47.75,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 69.94,
                     "obscured_payload": 0.0,
@@ -4062,20 +4062,20 @@
             },
             "zig/zls": {
                 "file_count": 6,
-                "total_mass": 28978.36,
+                "total_mass": 28980.36,
                 "avg_exposures": {
                     "cognitive_load": 33.41,
                     "safety_score": 3.24,
-                    "tech_debt": 30.32,
+                    "tech_debt": 29.88,
                     "verification": 80.0,
-                    "api_exposure": 1.76,
+                    "api_exposure": 1.77,
                     "concurrency": 19.82,
                     "state_flux": 11.79,
                     "dead_code": 2.66,
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 76.14,
+                    "documentation": 76.25,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 99.92,
                     "obscured_payload": 0.0,
@@ -4129,7 +4129,7 @@
             },
             "firewall": {
                 "imports_whitelisted": 0,
-                "imports_unknown": 7359,
+                "imports_unknown": 7626,
                 "imports_blacklisted": 0,
                 "threats_found": 139,
                 "threats_allowed": 0
@@ -27507,9 +27507,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2590.34,
+                        "X": 2589.85,
                         "Y": -18.79,
-                        "Z": 4688.65
+                        "Z": 4687.77
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -27728,9 +27728,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pxd)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2378.41,
+                        "X": 2377.92,
                         "Y": 2.15,
-                        "Z": 3788.6
+                        "Z": 3787.71
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -27915,9 +27915,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pyx)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2038.4,
+                        "X": 2037.91,
                         "Y": 23.76,
-                        "Z": 4476.67
+                        "Z": 4475.79
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -28408,9 +28408,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2342.27,
+                        "X": 2341.78,
                         "Y": 32.59,
-                        "Z": 4172.77
+                        "Z": 4171.88
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -30428,7 +30428,7 @@
             }
         },
         "zig/zls": {
-            "Directory Group Magnitude": 28978.36,
+            "Directory Group Magnitude": 28980.36,
             "File Count": 6,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -30436,16 +30436,16 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "33.41%",
                 "Error & Exception Exposure": "3.24%",
-                "Tech Debt Exposure": "30.32%",
+                "Tech Debt Exposure": "29.88%",
                 "Testing Exposure": "80.0%",
-                "API Exposure": "1.76%",
+                "API Exposure": "1.77%",
                 "Concurrency Exposure": "19.82%",
                 "State Flux Exposure": "11.79%",
                 "Commented Logic Exposure": "2.66%",
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "76.14%",
+                "Documentation Exposure": "76.25%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "99.92%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -31082,7 +31082,7 @@
                         "Direct Upstream (Fragility)": 4,
                         "Direct Downstream (Dependency Blast Radius)": 1,
                         "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 3
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
                     "9. Extracted Dependencies": [
                         "ast.zig",
@@ -31708,7 +31708,7 @@
                         "Direct Upstream (Fragility)": 12,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 4,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 3
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
                     "9. Extracted Dependencies": [
                         "BuildAssociatedConfig.zig",
@@ -31737,32 +31737,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1816.47,
+                        "X": -1816.48,
                         "Y": -185.39,
-                        "Z": 5892.9
+                        "Z": 5892.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.345,
+                        "Repository Drift (Z-Score)": 13.347,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.727,
-                            "file_cluster_1": 13.944,
-                            "file_cluster_2": 14.019,
-                            "file_cluster_3": 14.776,
-                            "file_cluster_4": 14.105,
+                            "file_cluster_0": 13.726,
+                            "file_cluster_1": 13.946,
+                            "file_cluster_2": 14.021,
+                            "file_cluster_3": 14.775,
+                            "file_cluster_4": 14.104,
                             "file_cluster_5": 14.338,
-                            "file_cluster_6": 13.865,
+                            "file_cluster_6": 13.864,
                             "file_cluster_7": 13.64,
-                            "file_cluster_8": 13.345,
+                            "file_cluster_8": 13.347,
                             "file_cluster_9": 13.904,
-                            "file_cluster_10": 14.751,
-                            "file_cluster_11": 13.727,
+                            "file_cluster_10": 14.75,
+                            "file_cluster_11": 13.726,
                             "file_cluster_12": 14.132,
                             "file_cluster_13": 13.509,
-                            "file_cluster_14": 17.137,
-                            "file_cluster_15": 14.209,
-                            "file_cluster_16": 13.898,
-                            "file_cluster_17": 13.874
+                            "file_cluster_14": 17.138,
+                            "file_cluster_15": 14.208,
+                            "file_cluster_16": 13.897,
+                            "file_cluster_17": 13.875
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -31770,9 +31770,9 @@
                         "Total LOC": 2030,
                         "Coding LOC": 1778,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3245.96,
+                        "Structural Magnitude": 3247.96,
                         "Control Flow Ratio": "74.4%",
-                        "Popularity Rank": 0,
+                        "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -31781,16 +31781,16 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "27.18%",
                         "Error & Exception Exposure": "2.03%",
-                        "Tech Debt Exposure": "20.75%",
+                        "Tech Debt Exposure": "18.11%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "0.47%",
+                        "API Exposure": "0.54%",
                         "Concurrency Exposure": "19.43%",
                         "State Flux Exposure": "13.56%",
                         "Commented Logic Exposure": "0.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "80.98%",
+                        "Documentation Exposure": "81.66%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -32512,7 +32512,7 @@
                         "Type/Safety Bypasses": 8,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 17,
+                        "Exposed API / Public Exports": 19,
                         "State Mutations / Variable Reassignments": 106,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 56,
@@ -32577,7 +32577,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 2,
-                        "Orphaned Logic": 2,
+                        "Orphaned Logic": 0,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -32600,9 +32600,9 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 27,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
                         "Total Upstream (Absolute Fragility)": 4,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                        "Total Downstream (Absolute Dependency Blast Radius)": 1
                     },
                     "9. Extracted Dependencies": [
                         "Config.zig",
@@ -34771,7 +34771,7 @@
                         "Direct Upstream (Fragility)": 11,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 4,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 3
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
                     "9. Extracted Dependencies": [
                         "DocumentStore.zig",
@@ -35524,7 +35524,7 @@
                         "Direct Upstream (Fragility)": 2,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 4
+                        "Total Downstream (Absolute Dependency Blast Radius)": 5
                     },
                     "9. Extracted Dependencies": [
                         "offsets.zig",
@@ -159970,7 +159970,7 @@
             }
         },
         "php/laravel_core": {
-            "Directory Group Magnitude": 7536.46,
+            "Directory Group Magnitude": 7486.46,
             "File Count": 8,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_13": "87.5%",
@@ -159979,16 +159979,16 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "32.14%",
                 "Error & Exception Exposure": "24.4%",
-                "Tech Debt Exposure": "53.46%",
+                "Tech Debt Exposure": "65.71%",
                 "Testing Exposure": "70.0%",
-                "API Exposure": "6.35%",
+                "API Exposure": "6.21%",
                 "Concurrency Exposure": "0.0%",
                 "State Flux Exposure": "87.49%",
                 "Commented Logic Exposure": "0.62%",
                 "Specification Exposure": "87.5%",
                 "Instability Exposure": "43.75%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "49.88%",
+                "Documentation Exposure": "48.59%",
                 "Civil War Exposure": "93.75%",
                 "Algorithmic DoS Exposure": "87.5%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -160010,9 +160010,9 @@
                         "Identity Proof": "Prose Extension (.md)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1335.78,
-                        "Y": -127.18,
-                        "Z": 1900.23
+                        "X": 1335.75,
+                        "Y": -127.21,
+                        "Z": 1900.25
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -160172,9 +160172,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2124.6,
+                        "X": 2124.02,
                         "Y": -109.19,
-                        "Z": 2081.44
+                        "Z": 2081.31
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -160489,9 +160489,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1692.41,
-                        "Y": -129.83,
-                        "Z": 2048.01
+                        "X": 1692.15,
+                        "Y": -129.85,
+                        "Z": 2048.08
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -161185,32 +161185,32 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1585.65,
+                        "X": 1585.42,
                         "Y": -115.21,
-                        "Z": 2520.9
+                        "Z": 2520.55
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 14.627,
+                        "Repository Drift (Z-Score)": 14.725,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.841,
-                            "file_cluster_1": 15.108,
-                            "file_cluster_2": 15.192,
-                            "file_cluster_3": 15.933,
-                            "file_cluster_4": 15.055,
-                            "file_cluster_5": 15.419,
-                            "file_cluster_6": 15.181,
-                            "file_cluster_7": 14.791,
-                            "file_cluster_8": 14.769,
-                            "file_cluster_9": 15.16,
-                            "file_cluster_10": 15.752,
-                            "file_cluster_11": 14.864,
-                            "file_cluster_12": 15.316,
-                            "file_cluster_13": 14.627,
-                            "file_cluster_14": 18.097,
-                            "file_cluster_15": 15.013,
-                            "file_cluster_16": 15.164,
-                            "file_cluster_17": 14.893
+                            "file_cluster_0": 14.929,
+                            "file_cluster_1": 15.181,
+                            "file_cluster_2": 15.265,
+                            "file_cluster_3": 16.022,
+                            "file_cluster_4": 15.158,
+                            "file_cluster_5": 15.505,
+                            "file_cluster_6": 15.276,
+                            "file_cluster_7": 14.883,
+                            "file_cluster_8": 14.853,
+                            "file_cluster_9": 15.248,
+                            "file_cluster_10": 15.842,
+                            "file_cluster_11": 14.959,
+                            "file_cluster_12": 15.401,
+                            "file_cluster_13": 14.725,
+                            "file_cluster_14": 18.163,
+                            "file_cluster_15": 15.111,
+                            "file_cluster_16": 15.263,
+                            "file_cluster_17": 14.976
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -161218,9 +161218,9 @@
                         "Total LOC": 2006,
                         "Coding LOC": 791,
                         "Documentation LOC": 921,
-                        "Structural Magnitude": 1848.62,
+                        "Structural Magnitude": 1798.62,
                         "Control Flow Ratio": "30.9%",
-                        "Popularity Rank": 10,
+                        "Popularity Rank": 9,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -161229,16 +161229,16 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "33.22%",
                         "Error & Exception Exposure": "48.93%",
-                        "Tech Debt Exposure": "0.0%",
+                        "Tech Debt Exposure": "97.99%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "12.97%",
+                        "API Exposure": "11.84%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "100.0%",
                         "Commented Logic Exposure": "4.95%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "98.99%",
+                        "Documentation Exposure": "88.67%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -162300,7 +162300,7 @@
                         "Type/Safety Bypasses": 4,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 152,
+                        "Exposed API / Public Exports": 102,
                         "State Mutations / Variable Reassignments": 501,
                         "Commented-out Code (Dead Logic)": 1,
                         "Structured Documentation Blocks": 350,
@@ -162365,7 +162365,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
+                        "Orphaned Logic": 50,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -162388,9 +162388,9 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 13,
-                        "Direct Downstream (Dependency Blast Radius)": 10,
+                        "Direct Downstream (Dependency Blast Radius)": 9,
                         "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 1
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
                         "ArrayAccess",
@@ -162421,9 +162421,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1070.59,
-                        "Y": -141.5,
-                        "Z": 2290.73
+                        "X": 1070.78,
+                        "Y": -141.53,
+                        "Z": 2290.45
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -162734,9 +162734,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1434.25,
-                        "Y": -148.19,
-                        "Z": 3131.6
+                        "X": 1434.14,
+                        "Y": -148.18,
+                        "Z": 3130.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -163130,9 +163130,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1351.43,
-                        "Y": -155.49,
-                        "Z": 2686.76
+                        "X": 1351.52,
+                        "Y": -155.5,
+                        "Z": 2686.12
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -164263,9 +164263,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1953.8,
-                        "Y": -128.07,
-                        "Z": 3005.36
+                        "X": 1953.32,
+                        "Y": -128.05,
+                        "Z": 3004.67
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -167266,9 +167266,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1916.76,
+                        "X": 1916.4,
                         "Y": 139.98,
-                        "Z": 5168.72
+                        "Z": 5167.7
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -167501,9 +167501,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1668.87,
+                        "X": 1668.52,
                         "Y": 123.13,
-                        "Z": 4027.64
+                        "Z": 4026.61
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -168036,9 +168036,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1584.1,
+                        "X": 1583.74,
                         "Y": 185.38,
-                        "Z": 4812.89
+                        "Z": 4811.86
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -168774,9 +168774,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1292.03,
+                        "X": 1291.67,
                         "Y": 206.18,
-                        "Z": 5050.92
+                        "Z": 5049.89
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
@@ -179697,7 +179697,7 @@
             }
         },
         "scala/kafka": {
-            "Directory Group Magnitude": 5454.78,
+            "Directory Group Magnitude": 5441.78,
             "File Count": 7,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "71.4%",
@@ -179706,16 +179706,16 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "10.21%",
                 "Error & Exception Exposure": "11.38%",
-                "Tech Debt Exposure": "42.21%",
+                "Tech Debt Exposure": "46.35%",
                 "Testing Exposure": "68.92%",
-                "API Exposure": "3.91%",
+                "API Exposure": "3.76%",
                 "Concurrency Exposure": "0.0%",
                 "State Flux Exposure": "10.05%",
                 "Commented Logic Exposure": "1.44%",
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "48.2%",
+                "Documentation Exposure": "47.75%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "69.94%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -179737,32 +179737,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7671.62,
-                        "Y": -303.02,
-                        "Z": 250.51
+                        "X": 7671.41,
+                        "Y": -303.0,
+                        "Z": 250.56
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 7.909,
+                        "Repository Drift (Z-Score)": 8.063,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.409,
-                            "file_cluster_1": 8.877,
-                            "file_cluster_2": 9.356,
-                            "file_cluster_3": 10.524,
-                            "file_cluster_4": 9.959,
-                            "file_cluster_5": 9.694,
-                            "file_cluster_6": 9.708,
-                            "file_cluster_7": 8.642,
-                            "file_cluster_8": 7.909,
-                            "file_cluster_9": 9.657,
-                            "file_cluster_10": 10.553,
-                            "file_cluster_11": 9.422,
-                            "file_cluster_12": 9.786,
-                            "file_cluster_13": 8.982,
-                            "file_cluster_14": 13.979,
-                            "file_cluster_15": 8.862,
-                            "file_cluster_16": 8.696,
-                            "file_cluster_17": 9.811
+                            "file_cluster_0": 9.531,
+                            "file_cluster_1": 9.015,
+                            "file_cluster_2": 9.485,
+                            "file_cluster_3": 10.64,
+                            "file_cluster_4": 10.082,
+                            "file_cluster_5": 9.819,
+                            "file_cluster_6": 9.832,
+                            "file_cluster_7": 8.781,
+                            "file_cluster_8": 8.063,
+                            "file_cluster_9": 9.78,
+                            "file_cluster_10": 10.669,
+                            "file_cluster_11": 9.548,
+                            "file_cluster_12": 9.911,
+                            "file_cluster_13": 9.116,
+                            "file_cluster_14": 14.053,
+                            "file_cluster_15": 9.0,
+                            "file_cluster_16": 8.836,
+                            "file_cluster_17": 9.934
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -179929,9 +179929,9 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 8,
+                        "Direct Upstream (Fragility)": 14,
                         "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
@@ -179939,10 +179939,16 @@
                         "KafkaRaftServer",
                         "LoggingSignalHandler",
                         "OperatingSystem",
-                        "Server\nimport kafka.utils.Implicits._\nimport kafka.utils.Logging\nimport org.apache.kafka.common.utils.Exit",
+                        "Server",
                         "Time",
-                        "Utils\nimport org.apache.kafka.server.util.CommandLineUtils\n\nobject Kafka extends Logging \n\n  def getPropsFromArgs",
-                        "java.util.Properties\nimport joptsimple.OptionParser\nimport kafka.server.KafkaConfig"
+                        "Utils",
+                        "java.util.Properties",
+                        "joptsimple.OptionParser",
+                        "kafka.server.KafkaConfig",
+                        "kafka.utils.Implicits._",
+                        "kafka.utils.Logging",
+                        "org.apache.kafka.common.utils.Exit",
+                        "org.apache.kafka.server.util.CommandLineUtils"
                     ]
                 },
                 "scala/kafka/KafkaApis.scala": {
@@ -179957,32 +179963,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 6893.98,
-                        "Y": -180.21,
-                        "Z": 662.81
+                        "X": 6893.95,
+                        "Y": -180.24,
+                        "Z": 662.73
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.672,
+                        "Repository Drift (Z-Score)": 11.019,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.428,
-                            "file_cluster_1": 11.456,
-                            "file_cluster_2": 11.404,
-                            "file_cluster_3": 12.537,
-                            "file_cluster_4": 11.952,
-                            "file_cluster_5": 12.015,
-                            "file_cluster_6": 11.659,
-                            "file_cluster_7": 11.182,
-                            "file_cluster_8": 10.672,
-                            "file_cluster_9": 11.65,
-                            "file_cluster_10": 12.415,
-                            "file_cluster_11": 11.252,
-                            "file_cluster_12": 11.889,
-                            "file_cluster_13": 11.364,
-                            "file_cluster_14": 15.049,
-                            "file_cluster_15": 10.981,
-                            "file_cluster_16": 10.998,
-                            "file_cluster_17": 11.325
+                            "file_cluster_0": 11.741,
+                            "file_cluster_1": 11.78,
+                            "file_cluster_2": 11.727,
+                            "file_cluster_3": 12.833,
+                            "file_cluster_4": 12.263,
+                            "file_cluster_5": 12.323,
+                            "file_cluster_6": 11.976,
+                            "file_cluster_7": 11.511,
+                            "file_cluster_8": 11.019,
+                            "file_cluster_9": 11.962,
+                            "file_cluster_10": 12.715,
+                            "file_cluster_11": 11.576,
+                            "file_cluster_12": 12.202,
+                            "file_cluster_13": 11.688,
+                            "file_cluster_14": 15.274,
+                            "file_cluster_15": 11.318,
+                            "file_cluster_16": 11.333,
+                            "file_cluster_17": 11.65
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -180419,56 +180425,121 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 44,
+                        "Direct Upstream (Fragility)": 109,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
-                        "AddPartitionsToTxnResultCollection\nimport org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult",
+                        "AddPartitionsToTxnResultCollection",
                         "ApiMessage",
                         "ClientMetricsManager",
-                        "ConcurrentHashMap\nimport java.util.stream.Collectors\nimport java.util.Collections",
-                        "DeleteRecordsTopicResult\nimport org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic\nimport org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic\nimport org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition\nimport org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
-                        "Errors\nimport org.apache.kafka.common.record.internal._\nimport org.apache.kafka.common.replica.ClientMetadata\nimport org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata\nimport org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType\nimport org.apache.kafka.common.requests.ProduceResponse.PartitionResponse\nimport org.apache.kafka.common.requests._\nimport org.apache.kafka.common.resource.Resource.CLUSTER_NAME\nimport org.apache.kafka.common.resource.ResourceType._\nimport org.apache.kafka.common.resource.Resource",
+                        "ConcurrentHashMap",
+                        "DeleteRecordsTopicResult",
+                        "Errors",
                         "FetchManager",
                         "FetchParams",
-                        "FetchPartitionData\nimport org.apache.kafka.server.transaction.AddPartitionsToTxnManager\nimport org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "FetchPartitionData",
                         "GroupConfig",
                         "GroupConfigManager",
-                        "GroupCoordinator\nimport org.apache.kafka.coordinator.share.ShareCoordinator\nimport org.apache.kafka.metadata.ConfigRepository",
-                        "ListOffsetsTopicResponse\nimport org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition",
-                        "MetadataCache\nimport org.apache.kafka.security.DelegationTokenManager\nimport org.apache.kafka.server.ApiVersionManager",
-                        "MetadataResponseTopic\nimport org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic\nimport org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "GroupCoordinator",
+                        "ListOffsetsTopicResponse",
+                        "MetadataCache",
+                        "MetadataResponseTopic",
                         "OffsetForLeaderTopicResult",
-                        "OffsetForLeaderTopicResultCollection\nimport org.apache.kafka.common.message._\nimport org.apache.kafka.common.metrics.Metrics\nimport org.apache.kafka.common.network.ListenerName\nimport org.apache.kafka.common.protocol.ApiKeys",
-                        "Optional\nimport scala.annotation.nowarn\nimport scala.collection.mutable.ArrayBuffer\nimport scala.collection.Map",
+                        "OffsetForLeaderTopicResultCollection",
+                        "Optional",
                         "Plugin",
-                        "ProcessRole\nimport org.apache.kafka.server.authorizer._\nimport org.apache.kafka.server.common.GroupVersion",
-                        "RecordValidationStats\nimport org.apache.kafka.storage.log.metrics.BrokerTopicStats\n\nimport java.util\nimport java.util.concurrent.atomic.AtomicInteger\nimport java.util.concurrent.CompletableFuture",
-                        "ReplicationQuotaManager\nimport org.apache.kafka.server.share.context.ShareFetchContext\nimport org.apache.kafka.server.share.ErroneousAndValidPartitionData",
+                        "ProcessRole",
+                        "RecordValidationStats",
+                        "ReplicationQuotaManager",
                         "RequestLocal",
-                        "ResourceType\nimport org.apache.kafka.common.security.auth.KafkaPrincipal",
+                        "ResourceType",
                         "SHARE_GROUP_STATE_TOPIC_NAME",
-                        "SecurityProtocol\nimport org.apache.kafka.common.security.token.delegation.DelegationToken",
+                        "SecurityProtocol",
                         "Seq",
                         "Set",
-                        "SharePartitionKey\nimport org.apache.kafka.server.share.acknowledge.ShareAcknowledgementBatch\nimport org.apache.kafka.server.storage.log.FetchIsolation",
+                        "SharePartitionKey",
                         "ShareVersion",
                         "StreamsVersion",
                         "TRANSACTION_STATE_TOPIC_NAME",
-                        "Time\nimport org.apache.kafka.common.Node",
-                        "TokenInformation\nimport org.apache.kafka.common.utils.ProducerIdAndEpoch",
-                        "Topic\nimport org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnResult",
+                        "Time",
+                        "TokenInformation",
+                        "Topic",
                         "TopicIdPartition",
                         "TopicPartition",
-                        "TransactionCoordinator\nimport kafka.network.RequestChannel\nimport kafka.server.QuotaFactory.QuotaManagers",
-                        "TransactionVersion\nimport org.apache.kafka.server.quota.ReplicaQuota",
-                        "UNBOUNDED_QUOTA\nimport kafka.server.handlers.DescribeTopicPartitionsRequestHandler\nimport kafka.server.share.SharePartitionManager\nimport kafka.utils.Logging\nimport org.apache.kafka.clients.CommonClientConfigs\nimport org.apache.kafka.clients.admin.EndpointType\nimport org.apache.kafka.common.acl.AclOperation\nimport org.apache.kafka.common.acl.AclOperation._\nimport org.apache.kafka.common.config.ConfigResource\nimport org.apache.kafka.common.errors._\nimport org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME",
-                        "Uuid\nimport org.apache.kafka.coordinator.group.modern.share.ShareGroupConfigProvider\nimport org.apache.kafka.coordinator.group.Group",
-                        "isInternal\nimport org.apache.kafka.common.internals.FatalExitError",
+                        "TransactionCoordinator",
+                        "TransactionVersion",
+                        "UNBOUNDED_QUOTA",
+                        "Uuid",
+                        "isInternal",
+                        "java.util",
+                        "java.util.Collections",
+                        "java.util.concurrent.CompletableFuture",
+                        "java.util.concurrent.atomic.AtomicInteger",
+                        "java.util.stream.Collectors",
                         "kafka.coordinator.transaction.InitProducerIdResult",
-                        "mutable\nimport scala.jdk.CollectionConverters._\nimport scala.jdk.javaapi.OptionConverters"
+                        "kafka.network.RequestChannel",
+                        "kafka.server.QuotaFactory.QuotaManagers",
+                        "kafka.server.handlers.DescribeTopicPartitionsRequestHandler",
+                        "kafka.server.share.SharePartitionManager",
+                        "kafka.utils.Logging",
+                        "mutable",
+                        "org.apache.kafka.clients.CommonClientConfigs",
+                        "org.apache.kafka.clients.admin.EndpointType",
+                        "org.apache.kafka.common.Node",
+                        "org.apache.kafka.common.acl.AclOperation",
+                        "org.apache.kafka.common.acl.AclOperation._",
+                        "org.apache.kafka.common.config.ConfigResource",
+                        "org.apache.kafka.common.errors._",
+                        "org.apache.kafka.common.internals.FatalExitError",
+                        "org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME",
+                        "org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnResult",
+                        "org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult",
+                        "org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData.DeleteShareGroupOffsetsRequestTopic",
+                        "org.apache.kafka.common.message.DeleteShareGroupOffsetsResponseData.DeleteShareGroupOffsetsResponseTopic",
+                        "org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition",
+                        "org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
+                        "org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "org.apache.kafka.common.message._",
+                        "org.apache.kafka.common.metrics.Metrics",
+                        "org.apache.kafka.common.network.ListenerName",
+                        "org.apache.kafka.common.protocol.ApiKeys",
+                        "org.apache.kafka.common.record.internal._",
+                        "org.apache.kafka.common.replica.ClientMetadata",
+                        "org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata",
+                        "org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType",
+                        "org.apache.kafka.common.requests.ProduceResponse.PartitionResponse",
+                        "org.apache.kafka.common.requests._",
+                        "org.apache.kafka.common.resource.Resource",
+                        "org.apache.kafka.common.resource.Resource.CLUSTER_NAME",
+                        "org.apache.kafka.common.resource.ResourceType._",
+                        "org.apache.kafka.common.security.auth.KafkaPrincipal",
+                        "org.apache.kafka.common.security.token.delegation.DelegationToken",
+                        "org.apache.kafka.common.utils.ProducerIdAndEpoch",
+                        "org.apache.kafka.coordinator.group.Group",
+                        "org.apache.kafka.coordinator.group.modern.share.ShareGroupConfigProvider",
+                        "org.apache.kafka.coordinator.share.ShareCoordinator",
+                        "org.apache.kafka.metadata.ConfigRepository",
+                        "org.apache.kafka.security.DelegationTokenManager",
+                        "org.apache.kafka.server.ApiVersionManager",
+                        "org.apache.kafka.server.authorizer._",
+                        "org.apache.kafka.server.common.GroupVersion",
+                        "org.apache.kafka.server.quota.ReplicaQuota",
+                        "org.apache.kafka.server.share.ErroneousAndValidPartitionData",
+                        "org.apache.kafka.server.share.acknowledge.ShareAcknowledgementBatch",
+                        "org.apache.kafka.server.share.context.ShareFetchContext",
+                        "org.apache.kafka.server.storage.log.FetchIsolation",
+                        "org.apache.kafka.server.transaction.AddPartitionsToTxnManager",
+                        "org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "org.apache.kafka.storage.log.metrics.BrokerTopicStats",
+                        "scala.annotation.nowarn",
+                        "scala.collection.Map",
+                        "scala.collection.mutable.ArrayBuffer",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.jdk.javaapi.OptionConverters"
                     ]
                 },
                 "scala/kafka/KafkaRaftManager.scala": {
@@ -180483,32 +180554,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7036.65,
-                        "Y": -117.93,
-                        "Z": 1155.39
+                        "X": 7036.57,
+                        "Y": -117.96,
+                        "Z": 1155.28
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 7.598,
+                        "Repository Drift (Z-Score)": 7.951,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.027,
-                            "file_cluster_1": 8.735,
-                            "file_cluster_2": 9.127,
-                            "file_cluster_3": 10.305,
-                            "file_cluster_4": 9.682,
-                            "file_cluster_5": 9.562,
-                            "file_cluster_6": 9.38,
-                            "file_cluster_7": 8.49,
-                            "file_cluster_8": 7.598,
-                            "file_cluster_9": 9.202,
-                            "file_cluster_10": 10.476,
-                            "file_cluster_11": 9.361,
-                            "file_cluster_12": 9.49,
-                            "file_cluster_13": 8.751,
-                            "file_cluster_14": 13.379,
-                            "file_cluster_15": 9.308,
-                            "file_cluster_16": 8.259,
-                            "file_cluster_17": 9.211
+                            "file_cluster_0": 9.314,
+                            "file_cluster_1": 9.044,
+                            "file_cluster_2": 9.421,
+                            "file_cluster_3": 10.567,
+                            "file_cluster_4": 9.962,
+                            "file_cluster_5": 9.843,
+                            "file_cluster_6": 9.666,
+                            "file_cluster_7": 8.804,
+                            "file_cluster_8": 7.951,
+                            "file_cluster_9": 9.488,
+                            "file_cluster_10": 10.735,
+                            "file_cluster_11": 9.643,
+                            "file_cluster_12": 9.775,
+                            "file_cluster_13": 9.056,
+                            "file_cluster_14": 13.56,
+                            "file_cluster_15": 9.598,
+                            "file_cluster_16": 8.584,
+                            "file_cluster_17": 9.502
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -180755,36 +180826,65 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 24,
+                        "Direct Upstream (Fragility)": 53,
                         "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
-                        "Collection",
+                        "Collection => JCollection",
                         "ExternalKRaftMetrics",
                         "FileQuorumStateStore",
                         "KafkaNetworkChannel",
                         "KafkaRaftClient",
                         "KafkaRaftClientDriver",
-                        "KafkaScheduler\nimport org.apache.kafka.server.fault.FaultHandler\nimport org.apache.kafka.server.util.timer.SystemTimer\nimport org.apache.kafka.storage.internals.log.LogManager",
+                        "KafkaScheduler",
                         "ListenerName",
                         "ManualMetadataUpdater",
+                        "Map => JMap",
                         "MetadataLogConfig",
                         "MetadataRecoveryStrategy",
-                        "NetworkClient\nimport org.apache.kafka.common.KafkaException\nimport org.apache.kafka.common.TopicPartition\nimport org.apache.kafka.common.Uuid\nimport org.apache.kafka.common.metrics.Metrics\nimport org.apache.kafka.common.network.ChannelBuilders",
+                        "NetworkClient",
                         "NetworkReceive",
                         "QuorumConfig",
                         "RaftLog",
                         "RaftManager",
                         "Selectable",
-                        "Selector\nimport org.apache.kafka.common.protocol.ApiMessage\nimport org.apache.kafka.common.requests.RequestContext\nimport org.apache.kafka.common.requests.RequestHeader\nimport org.apache.kafka.common.security.JaasContext\nimport org.apache.kafka.common.security.auth.SecurityProtocol\nimport org.apache.kafka.common.utils.LogContext",
+                        "Selector",
                         "Time",
-                        "TimingWheelExpirationService\nimport org.apache.kafka.server.ProcessRole\nimport org.apache.kafka.server.common.Feature\nimport org.apache.kafka.server.common.serialization.RecordSerde\nimport org.apache.kafka.server.util.FileLock",
-                        "UnifiedLog\n\nimport scala.jdk.CollectionConverters._\n\nobject KafkaRaftManager \n  private def createLogDirectory",
-                        "Utils\nimport org.apache.kafka.raft.internals.KafkaRaftLog\nimport org.apache.kafka.raft.Endpoints",
-                        "java.io.File\nimport java.net.InetSocketAddress\nimport java.nio.file.Files\nimport java.nio.file.Paths\nimport java.util.OptionalInt",
-                        "java.util.concurrent.CompletableFuture\nimport kafka.server.KafkaConfig\nimport kafka.utils.Logging\nimport org.apache.kafka.clients.ApiVersions"
+                        "TimingWheelExpirationService",
+                        "UnifiedLog",
+                        "Utils",
+                        "java.io.File",
+                        "java.net.InetSocketAddress",
+                        "java.nio.file.Files",
+                        "java.nio.file.Paths",
+                        "java.util.OptionalInt",
+                        "java.util.concurrent.CompletableFuture",
+                        "kafka.server.KafkaConfig",
+                        "kafka.utils.Logging",
+                        "org.apache.kafka.clients.ApiVersions",
+                        "org.apache.kafka.common.KafkaException",
+                        "org.apache.kafka.common.TopicPartition",
+                        "org.apache.kafka.common.Uuid",
+                        "org.apache.kafka.common.metrics.Metrics",
+                        "org.apache.kafka.common.network.ChannelBuilders",
+                        "org.apache.kafka.common.protocol.ApiMessage",
+                        "org.apache.kafka.common.requests.RequestContext",
+                        "org.apache.kafka.common.requests.RequestHeader",
+                        "org.apache.kafka.common.security.JaasContext",
+                        "org.apache.kafka.common.security.auth.SecurityProtocol",
+                        "org.apache.kafka.common.utils.LogContext",
+                        "org.apache.kafka.raft.Endpoints",
+                        "org.apache.kafka.raft.internals.KafkaRaftLog",
+                        "org.apache.kafka.server.ProcessRole",
+                        "org.apache.kafka.server.common.Feature",
+                        "org.apache.kafka.server.common.serialization.RecordSerde",
+                        "org.apache.kafka.server.fault.FaultHandler",
+                        "org.apache.kafka.server.util.FileLock",
+                        "org.apache.kafka.server.util.timer.SystemTimer",
+                        "org.apache.kafka.storage.internals.log.LogManager",
+                        "scala.jdk.CollectionConverters._"
                     ]
                 },
                 "scala/kafka/LogManager.scala": {
@@ -180799,32 +180899,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7194.63,
+                        "X": 7194.52,
                         "Y": -250.65,
-                        "Z": 551.69
+                        "Z": 551.68
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.807,
+                        "Repository Drift (Z-Score)": 12.01,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.068,
-                            "file_cluster_1": 12.404,
-                            "file_cluster_2": 12.541,
-                            "file_cluster_3": 13.348,
-                            "file_cluster_4": 12.619,
-                            "file_cluster_5": 12.845,
-                            "file_cluster_6": 12.574,
-                            "file_cluster_7": 12.102,
-                            "file_cluster_8": 11.807,
-                            "file_cluster_9": 12.565,
-                            "file_cluster_10": 13.208,
-                            "file_cluster_11": 12.069,
-                            "file_cluster_12": 12.601,
-                            "file_cluster_13": 12.196,
-                            "file_cluster_14": 15.782,
-                            "file_cluster_15": 11.877,
-                            "file_cluster_16": 11.851,
-                            "file_cluster_17": 12.222
+                            "file_cluster_0": 12.265,
+                            "file_cluster_1": 12.594,
+                            "file_cluster_2": 12.728,
+                            "file_cluster_3": 13.534,
+                            "file_cluster_4": 12.821,
+                            "file_cluster_5": 13.034,
+                            "file_cluster_6": 12.772,
+                            "file_cluster_7": 12.304,
+                            "file_cluster_8": 12.01,
+                            "file_cluster_9": 12.758,
+                            "file_cluster_10": 13.398,
+                            "file_cluster_11": 12.271,
+                            "file_cluster_12": 12.797,
+                            "file_cluster_13": 12.399,
+                            "file_cluster_14": 15.917,
+                            "file_cluster_15": 12.089,
+                            "file_cluster_16": 12.063,
+                            "file_cluster_17": 12.418
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -180832,9 +180932,9 @@
                         "Total LOC": 1590,
                         "Coding LOC": 1232,
                         "Documentation LOC": 194,
-                        "Structural Magnitude": 1622.14,
+                        "Structural Magnitude": 1610.14,
                         "Control Flow Ratio": "73.0%",
-                        "Popularity Rank": 1,
+                        "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -180843,16 +180943,16 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "15.26%",
                         "Error & Exception Exposure": "48.26%",
-                        "Tech Debt Exposure": "16.98%",
+                        "Tech Debt Exposure": "35.14%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "5.81%",
+                        "API Exposure": "4.87%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "12.06%",
                         "Commented Logic Exposure": "0.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "92.71%",
+                        "Documentation Exposure": "89.6%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -181404,7 +181504,7 @@
                         "Type/Safety Bypasses": 45,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 3,
-                        "Exposed API / Public Exports": 57,
+                        "Exposed API / Public Exports": 45,
                         "State Mutations / Variable Reassignments": 73,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 66,
@@ -181469,7 +181569,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 4,
-                        "Orphaned Logic": 0,
+                        "Orphaned Logic": 12,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -181491,40 +181591,67 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 28,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Direct Upstream (Fragility)": 55,
+                        "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
-                        "IOException\nimport java.nio.file.Files",
+                        "IOException",
                         "KafkaException",
-                        "KafkaRaftServer\nimport kafka.utils.Logging\nimport org.apache.kafka.common.DirectoryId",
+                        "KafkaRaftServer",
                         "KafkaStorageException",
                         "KafkaThread",
                         "LogCleaner",
                         "LogConfig",
                         "LogDirFailureChannel",
-                        "LogDirNotFoundException\nimport org.apache.kafka.coordinator.transaction.TransactionLogConfig",
-                        "LogManager",
+                        "LogDirNotFoundException",
+                        "LogManager => JLogManager",
+                        "LogOffsetsListener",
                         "MetaPropertiesEnsemble",
-                        "NoSuchFileException\nimport java.util.concurrent._\nimport java.util.concurrent.atomic.AtomicInteger\nimport kafka.server.KafkaConfig",
-                        "OffsetCheckpointFile\nimport org.apache.kafka.storage.log.metrics.BrokerTopicStats\n\nimport java.util\nimport java.util.stream.Collectors",
+                        "NoSuchFileException",
+                        "OffsetCheckpointFile",
                         "Optional",
                         "OptionalLong",
-                        "Properties\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.util.FileLock",
-                        "PropertiesUtils\n\nimport java.util.Collections",
-                        "Scheduler\nimport org.apache.kafka.storage.internals.log.CleanerConfig",
+                        "ProducerStateManagerConfig",
+                        "Properties",
+                        "PropertiesUtils",
+                        "RemoteIndexCache",
+                        "Scheduler",
                         "Success",
                         "Time",
                         "TopicPartition",
-                        "TransactionStateManagerConfig\n\nimport scala.jdk.CollectionConverters._\nimport scala.collection._\nimport scala.collection.mutable.ArrayBuffer\nimport scala.util.Failure",
-                        "Try\nimport org.apache.kafka.image.TopicsImage\nimport org.apache.kafka.metadata.ConfigRepository\nimport org.apache.kafka.metadata.properties.MetaProperties",
-                        "Utils\nimport org.apache.kafka.common.errors.InconsistentTopicIdException",
-                        "Uuid\nimport org.apache.kafka.common.utils.Exit",
+                        "TransactionStateManagerConfig",
+                        "Try",
+                        "UnifiedLog",
+                        "Utils",
+                        "Uuid",
                         "java.io.File",
-                        "java.lang.Long",
-                        "org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler"
+                        "java.lang.Long => JLong",
+                        "java.nio.file.Files",
+                        "java.util",
+                        "java.util.Collections",
+                        "java.util.concurrent._",
+                        "java.util.concurrent.atomic.AtomicInteger",
+                        "java.util.stream.Collectors",
+                        "kafka.server.KafkaConfig",
+                        "kafka.utils.Logging",
+                        "org.apache.kafka.common.DirectoryId",
+                        "org.apache.kafka.common.errors.InconsistentTopicIdException",
+                        "org.apache.kafka.common.utils.Exit",
+                        "org.apache.kafka.coordinator.transaction.TransactionLogConfig",
+                        "org.apache.kafka.image.TopicsImage",
+                        "org.apache.kafka.metadata.ConfigRepository",
+                        "org.apache.kafka.metadata.properties.MetaProperties",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.util.FileLock",
+                        "org.apache.kafka.storage.internals.checkpoint.CleanShutdownFileHandler",
+                        "org.apache.kafka.storage.internals.log.CleanerConfig",
+                        "org.apache.kafka.storage.log.metrics.BrokerTopicStats",
+                        "scala.collection._",
+                        "scala.collection.mutable.ArrayBuffer",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.util.Failure"
                     ]
                 },
                 "scala/kafka/Partition.scala": {
@@ -181539,32 +181666,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7511.99,
-                        "Y": -139.28,
-                        "Z": 846.98
+                        "X": 7511.81,
+                        "Y": -139.3,
+                        "Z": 846.89
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 13.213,
+                        "Repository Drift (Z-Score)": 13.395,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.337,
-                            "file_cluster_1": 13.775,
-                            "file_cluster_2": 13.866,
-                            "file_cluster_3": 14.575,
-                            "file_cluster_4": 13.888,
-                            "file_cluster_5": 14.157,
-                            "file_cluster_6": 13.785,
-                            "file_cluster_7": 13.483,
-                            "file_cluster_8": 13.231,
-                            "file_cluster_9": 13.789,
-                            "file_cluster_10": 14.497,
-                            "file_cluster_11": 13.32,
-                            "file_cluster_12": 14.049,
-                            "file_cluster_13": 13.455,
-                            "file_cluster_14": 16.746,
-                            "file_cluster_15": 13.214,
-                            "file_cluster_16": 13.213,
-                            "file_cluster_17": 13.436
+                            "file_cluster_0": 13.511,
+                            "file_cluster_1": 13.951,
+                            "file_cluster_2": 14.039,
+                            "file_cluster_3": 14.741,
+                            "file_cluster_4": 14.062,
+                            "file_cluster_5": 14.327,
+                            "file_cluster_6": 13.959,
+                            "file_cluster_7": 13.661,
+                            "file_cluster_8": 13.414,
+                            "file_cluster_9": 13.961,
+                            "file_cluster_10": 14.664,
+                            "file_cluster_11": 13.498,
+                            "file_cluster_12": 14.221,
+                            "file_cluster_13": 13.633,
+                            "file_cluster_14": 16.876,
+                            "file_cluster_15": 13.396,
+                            "file_cluster_16": 13.395,
+                            "file_cluster_17": 13.614
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -181574,7 +181701,7 @@
                         "Documentation LOC": 892,
                         "Structural Magnitude": 980.0,
                         "Control Flow Ratio": "61.8%",
-                        "Popularity Rank": 0,
+                        "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -182191,8 +182318,8 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 46,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Direct Upstream (Fragility)": 84,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
@@ -182201,12 +182328,12 @@
                         "AsyncOffsetReader",
                         "CommittedPartitionState",
                         "ConcurrentHashMap",
-                        "CopyOnWriteArrayList\nimport kafka.log._\nimport kafka.server._\nimport kafka.server.share.DelayedShareFetch\nimport kafka.utils._\nimport org.apache.kafka.common.DirectoryId",
+                        "CopyOnWriteArrayList",
                         "DelayedOperationPurgatory",
                         "DelayedProduce",
                         "FetchDataInfo",
                         "FetchParams",
-                        "FetchResponseData\nimport org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset\nimport org.apache.kafka.common.protocol.Errors\nimport org.apache.kafka.common.record.internal.FileRecords.TimestampAndOffset\nimport org.apache.kafka.common.record.internal.FileRecords",
+                        "FetchResponseData",
                         "IsolationLevel",
                         "LeaderHwChange",
                         "LeaderRecoveryState",
@@ -182220,29 +182347,67 @@
                         "MetadataCache",
                         "OffsetResultHolder",
                         "OngoingReassignmentState",
-                        "Partition.metricsGroup\n  def topic",
+                        "Partition.metricsGroup",
                         "PartitionListener",
-                        "PartitionRegistration\nimport org.apache.kafka.server.LogDeleteRecordsResult\nimport org.apache.kafka.server.common.RequestLocal",
+                        "PartitionRegistration",
                         "PartitionState",
                         "PendingExpandIsr",
                         "PendingPartitionChange",
                         "PendingShrinkIsr",
-                        "RecordBatch\nimport org.apache.kafka.common.requests._\nimport org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH",
-                        "RichOptional\nimport scala.jdk.javaapi.OptionConverters\n\n\nclass DelayedOperations",
-                        "SimpleAssignmentState\nimport org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "RecordBatch",
+                        "RichOptional",
+                        "SimpleAssignmentState",
                         "TopicIdPartition",
                         "TopicPartition",
-                        "TopicPartitionOperationKey\nimport org.apache.kafka.server.replica.Replica\nimport org.apache.kafka.server.share.fetch.DelayedShareFetchPartitionKey\nimport org.apache.kafka.server.storage.log.FetchIsolation",
-                        "TransactionVersion\nimport org.apache.kafka.server.log.remote.TopicPartitionLog\nimport org.apache.kafka.server.log.remote.storage.RemoteLogManager\nimport org.apache.kafka.storage.internals.log.AppendOrigin",
-                        "UNDEFINED_EPOCH_OFFSET\nimport org.apache.kafka.common.utils.Time",
-                        "UnexpectedAppendOffsetException\nimport org.apache.kafka.server.util.LockUtils.inReadLock",
+                        "TopicPartitionOperationKey",
+                        "TransactionVersion",
+                        "UNDEFINED_EPOCH_OFFSET",
+                        "UnexpectedAppendOffsetException",
                         "UnifiedLog",
-                        "Utils\nimport org.apache.kafka.logger.StateChangeLogger\nimport org.apache.kafka.metadata.LeaderAndIsr",
-                        "Uuid\nimport org.apache.kafka.common.errors._\nimport org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState\nimport org.apache.kafka.common.message.DescribeProducersResponseData",
-                        "VerificationGuard\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.partition.AlterPartitionListener",
-                        "inWriteLock\nimport org.apache.kafka.storage.internals.checkpoint.OffsetCheckpoints\nimport org.slf4j.event.Level\n\nimport java.util\nimport scala.collection.Seq\nimport scala.jdk.CollectionConverters._\nimport scala.jdk.OptionConverters.RichOption",
-                        "java.lang.Long",
-                        "java.util.concurrent.locks.ReentrantReadWriteLock\nimport java.util.Optional\nimport java.util.concurrent.CompletableFuture"
+                        "Utils",
+                        "Uuid",
+                        "VerificationGuard",
+                        "inWriteLock",
+                        "java.lang.Long => JLong",
+                        "java.util",
+                        "java.util.Optional",
+                        "java.util.concurrent.CompletableFuture",
+                        "java.util.concurrent.locks.ReentrantReadWriteLock",
+                        "kafka.log._",
+                        "kafka.server._",
+                        "kafka.server.share.DelayedShareFetch",
+                        "kafka.utils._",
+                        "org.apache.kafka.common.DirectoryId",
+                        "org.apache.kafka.common.errors._",
+                        "org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState",
+                        "org.apache.kafka.common.message.DescribeProducersResponseData",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "org.apache.kafka.common.protocol.Errors",
+                        "org.apache.kafka.common.record.internal.FileRecords",
+                        "org.apache.kafka.common.record.internal.FileRecords.TimestampAndOffset",
+                        "org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH",
+                        "org.apache.kafka.common.requests._",
+                        "org.apache.kafka.common.utils.Time",
+                        "org.apache.kafka.logger.StateChangeLogger",
+                        "org.apache.kafka.metadata.LeaderAndIsr",
+                        "org.apache.kafka.server.LogDeleteRecordsResult",
+                        "org.apache.kafka.server.common.RequestLocal",
+                        "org.apache.kafka.server.log.remote.TopicPartitionLog",
+                        "org.apache.kafka.server.log.remote.storage.RemoteLogManager",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.partition.AlterPartitionListener",
+                        "org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "org.apache.kafka.server.replica.Replica",
+                        "org.apache.kafka.server.share.fetch.DelayedShareFetchPartitionKey",
+                        "org.apache.kafka.server.storage.log.FetchIsolation",
+                        "org.apache.kafka.server.util.LockUtils.inReadLock",
+                        "org.apache.kafka.storage.internals.checkpoint.OffsetCheckpoints",
+                        "org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "org.slf4j.event.Level",
+                        "scala.collection.Seq",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.jdk.OptionConverters.RichOption",
+                        "scala.jdk.javaapi.OptionConverters"
                     ]
                 },
                 "scala/kafka/ReplicaManager.scala": {
@@ -182259,30 +182424,30 @@
                     "2. Topological Coordinates": {
                         "X": 6663.43,
                         "Y": -218.47,
-                        "Z": 183.62
+                        "Z": 183.63
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 11.388,
+                        "Repository Drift (Z-Score)": 11.627,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.955,
-                            "file_cluster_1": 11.906,
-                            "file_cluster_2": 12.116,
-                            "file_cluster_3": 13.037,
-                            "file_cluster_4": 12.546,
-                            "file_cluster_5": 12.371,
-                            "file_cluster_6": 12.266,
-                            "file_cluster_7": 11.665,
-                            "file_cluster_8": 11.44,
-                            "file_cluster_9": 12.322,
-                            "file_cluster_10": 13.091,
-                            "file_cluster_11": 12.048,
-                            "file_cluster_12": 12.534,
-                            "file_cluster_13": 11.864,
-                            "file_cluster_14": 15.579,
-                            "file_cluster_15": 11.713,
-                            "file_cluster_16": 11.388,
-                            "file_cluster_17": 12.157
+                            "file_cluster_0": 12.176,
+                            "file_cluster_1": 12.135,
+                            "file_cluster_2": 12.34,
+                            "file_cluster_3": 13.247,
+                            "file_cluster_4": 12.764,
+                            "file_cluster_5": 12.591,
+                            "file_cluster_6": 12.488,
+                            "file_cluster_7": 11.897,
+                            "file_cluster_8": 11.678,
+                            "file_cluster_9": 12.54,
+                            "file_cluster_10": 13.3,
+                            "file_cluster_11": 12.271,
+                            "file_cluster_12": 12.753,
+                            "file_cluster_13": 12.092,
+                            "file_cluster_14": 15.74,
+                            "file_cluster_15": 11.946,
+                            "file_cluster_16": 11.627,
+                            "file_cluster_17": 12.38
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -182539,9 +182704,9 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 79,
+                        "Direct Upstream (Fragility)": 144,
                         "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Upstream (Absolute Fragility)": 1,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
                     },
                     "9. Extracted Dependencies": [
@@ -182551,12 +182716,12 @@
                         "DelayedProduce",
                         "DelayedRemoteFetch",
                         "DelayedRemoteListOffsets",
-                        "DelayedShareFetchPartitionKey\nimport org.apache.kafka.server.storage.log.FetchParams",
+                        "DelayedShareFetchPartitionKey",
                         "DeleteRecordsPartitionStatus",
-                        "DescribeProducersResponseData\nimport org.apache.kafka.common.metrics.Metrics\nimport org.apache.kafka.common.network.ListenerName\nimport org.apache.kafka.common.protocol.Errors\nimport org.apache.kafka.common.record.internal._\nimport org.apache.kafka.common.replica.PartitionView.DefaultPartitionView\nimport org.apache.kafka.common.replica.ReplicaView.DefaultReplicaView\nimport org.apache.kafka.common.replica._\nimport org.apache.kafka.common.requests.FetchRequest.PartitionData\nimport org.apache.kafka.common.requests.ProduceResponse.PartitionResponse\nimport org.apache.kafka.common.requests._\nimport org.apache.kafka.common.utils.Exit",
+                        "DescribeProducersResponseData",
                         "FailedIsrUpdatesPerSecMetricName",
                         "FetchDataInfo",
-                        "FetchPartitionData\nimport org.apache.kafka.server.transaction.AddPartitionsToTxnManager\nimport org.apache.kafka.server.transaction.AddPartitionsToTxnManager.TransactionSupportedOperation\nimport org.apache.kafka.server.util.timer.SystemTimer",
+                        "FetchPartitionData",
                         "FetchPartitionStatus",
                         "Future",
                         "HostedPartition",
@@ -182565,8 +182730,8 @@
                         "LeaderCountMetricName",
                         "LeaderHwChange",
                         "ListOffsetsPartitionStatus",
-                        "ListOffsetsTopic\nimport org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
-                        "ListOffsetsTopicResponse\nimport org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic\nimport org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "ListOffsetsTopic",
+                        "ListOffsetsTopicResponse",
                         "LogAppendInfo",
                         "LogAppendResult",
                         "LogConfig",
@@ -182579,15 +182744,15 @@
                         "Node",
                         "OfflineReplicaCountMetricName",
                         "OffsetCheckpointFile",
-                        "OffsetCheckpoints\nimport org.apache.kafka.storage.internals.log.AppendOrigin",
-                        "OffsetForLeaderTopicResult\nimport org.apache.kafka.common.message.DescribeLogDirsResponseData",
+                        "OffsetCheckpoints",
+                        "OffsetForLeaderTopicResult",
                         "OffsetResultHolder",
                         "Optional",
                         "OptionalInt",
-                        "OptionalLong\nimport java.util.function.Consumer\nimport scala.collection.Map",
+                        "OptionalLong",
                         "PartitionCountMetricName",
                         "PartitionsWithLateTransactionsCountMetricName",
-                        "Paths\nimport java.util\nimport java.util.concurrent.atomic.AtomicBoolean\nimport java.util.concurrent.CompletableFuture",
+                        "Paths",
                         "ProducerIdCountMetricName",
                         "ReassigningPartitionsMetricName",
                         "RecordValidationException",
@@ -182595,35 +182760,100 @@
                         "RejectedExecutionException",
                         "RemoteLogReadResult",
                         "RemoteStorageFetchInfo",
-                        "ReplicationQuotaManager\nimport org.apache.kafka.server.share.fetch.DelayedShareFetchKey",
+                        "ReplicationQuotaManager",
                         "RequestLocal",
                         "Seq",
                         "Set",
-                        "ShutdownableThread\nimport org.apache.kafka.server.ActionQueue",
+                        "ShutdownableThread",
                         "StopPartition",
                         "Time",
-                        "TimeUnit\nimport java.util.Collections",
-                        "TimerTask\nimport org.apache.kafka.server.util.Scheduler",
-                        "Topic\nimport org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult\nimport org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsTopic\nimport org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition",
+                        "TimeUnit",
+                        "TimerTask",
+                        "Topic",
                         "TopicIdPartition",
                         "TopicPartition",
-                        "TopicPartitionOperationKey\nimport org.apache.kafka.server.quota.ReplicaQuota",
-                        "TopicsDelta\nimport org.apache.kafka.logger.StateChangeLogger\nimport org.apache.kafka.metadata.LeaderConstants.NO_LEADER\nimport org.apache.kafka.metadata.MetadataCache\nimport org.apache.kafka.server.purgatory.DelayedProduce.ProducePartitionStatus\nimport org.apache.kafka.server.LogAppendResult.LogAppendSummary\nimport org.apache.kafka.server.common.DirectoryEventHandler",
-                        "TransactionLogConfig\nimport org.apache.kafka.image.LocalReplicaChanges",
-                        "TransactionVersion\nimport org.apache.kafka.server.log.remote.TopicPartitionLog\nimport org.apache.kafka.server.config.ReplicationConfigs\nimport org.apache.kafka.server.log.remote.storage.RemoteLogManager\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.network.BrokerEndPoint\nimport org.apache.kafka.server.partition.PartitionListener\nimport org.apache.kafka.server.purgatory.DelayedProduce.PartitionStatusValidator.Result\nimport org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "TopicPartitionOperationKey",
+                        "TopicsDelta",
+                        "TransactionLogConfig",
+                        "TransactionVersion",
                         "UnderMinIsrPartitionCountMetricName",
                         "UnderReplicatedPartitionsMetricName",
                         "UnifiedLog",
-                        "Utils\nimport org.apache.kafka.coordinator.transaction.AddPartitionsToTxnConfig",
-                        "Uuid\nimport org.apache.kafka.common.errors._\nimport org.apache.kafka.common.internals.Plugin",
-                        "VerificationGuard\nimport org.apache.kafka.storage.log.metrics.BrokerTopicStats\n\nimport java.io.File\nimport java.lang.Long",
-                        "com.yammer.metrics.core.Meter\nimport kafka.cluster.Partition\nimport kafka.log.LogManager\nimport kafka.server.QuotaFactory.QuotaManagers\nimport kafka.server.ReplicaManager.AtMinIsrPartitionCountMetricName",
-                        "common\nimport org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints",
+                        "Utils",
+                        "Uuid",
+                        "VerificationGuard",
+                        "com.yammer.metrics.core.Meter",
+                        "common",
                         "createLogReadResult",
                         "immutable",
-                        "isListOffsetsTimestampUnsupported\nimport kafka.server.share.DelayedShareFetch\nimport kafka.utils._\nimport org.apache.kafka.common.IsolationLevel",
+                        "isListOffsetsTimestampUnsupported",
+                        "java.io.File",
+                        "java.lang.Long => JLong",
                         "java.nio.file.Files",
-                        "mutable\nimport scala.jdk.CollectionConverters._\nimport scala.jdk.FunctionConverters.enrichAsJavaConsumer\nimport scala.jdk.OptionConverters.RichOptional\n\nobject ReplicaManager \n  val HighWatermarkFilename"
+                        "java.util",
+                        "java.util.Collections",
+                        "java.util.concurrent.CompletableFuture",
+                        "java.util.concurrent.atomic.AtomicBoolean",
+                        "java.util.function.Consumer",
+                        "kafka.cluster.Partition",
+                        "kafka.log.LogManager",
+                        "kafka.server.QuotaFactory.QuotaManagers",
+                        "kafka.server.ReplicaManager.AtMinIsrPartitionCountMetricName",
+                        "kafka.server.share.DelayedShareFetch",
+                        "kafka.utils._",
+                        "mutable",
+                        "org.apache.kafka.common.IsolationLevel",
+                        "org.apache.kafka.common.errors._",
+                        "org.apache.kafka.common.internals.Plugin",
+                        "org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult",
+                        "org.apache.kafka.common.message.DescribeLogDirsResponseData",
+                        "org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsTopic",
+                        "org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition",
+                        "org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic",
+                        "org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset",
+                        "org.apache.kafka.common.metrics.Metrics",
+                        "org.apache.kafka.common.network.ListenerName",
+                        "org.apache.kafka.common.protocol.Errors",
+                        "org.apache.kafka.common.record.internal._",
+                        "org.apache.kafka.common.replica.PartitionView.DefaultPartitionView",
+                        "org.apache.kafka.common.replica.ReplicaView.DefaultReplicaView",
+                        "org.apache.kafka.common.replica._",
+                        "org.apache.kafka.common.requests.FetchRequest.PartitionData",
+                        "org.apache.kafka.common.requests.ProduceResponse.PartitionResponse",
+                        "org.apache.kafka.common.requests._",
+                        "org.apache.kafka.common.utils.Exit",
+                        "org.apache.kafka.coordinator.transaction.AddPartitionsToTxnConfig",
+                        "org.apache.kafka.image.LocalReplicaChanges",
+                        "org.apache.kafka.logger.StateChangeLogger",
+                        "org.apache.kafka.metadata.LeaderConstants.NO_LEADER",
+                        "org.apache.kafka.metadata.MetadataCache",
+                        "org.apache.kafka.server.ActionQueue",
+                        "org.apache.kafka.server.LogAppendResult.LogAppendSummary",
+                        "org.apache.kafka.server.common.DirectoryEventHandler",
+                        "org.apache.kafka.server.config.ReplicationConfigs",
+                        "org.apache.kafka.server.log.remote.TopicPartitionLog",
+                        "org.apache.kafka.server.log.remote.storage.RemoteLogManager",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.network.BrokerEndPoint",
+                        "org.apache.kafka.server.partition.PartitionListener",
+                        "org.apache.kafka.server.purgatory.DelayedDeleteRecords",
+                        "org.apache.kafka.server.purgatory.DelayedProduce.PartitionStatusValidator.Result",
+                        "org.apache.kafka.server.purgatory.DelayedProduce.ProducePartitionStatus",
+                        "org.apache.kafka.server.quota.ReplicaQuota",
+                        "org.apache.kafka.server.share.fetch.DelayedShareFetchKey",
+                        "org.apache.kafka.server.storage.log.FetchParams",
+                        "org.apache.kafka.server.transaction.AddPartitionsToTxnManager",
+                        "org.apache.kafka.server.transaction.AddPartitionsToTxnManager.TransactionSupportedOperation",
+                        "org.apache.kafka.server.util.Scheduler",
+                        "org.apache.kafka.server.util.timer.SystemTimer",
+                        "org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints",
+                        "org.apache.kafka.storage.internals.log.AppendOrigin",
+                        "org.apache.kafka.storage.log.metrics.BrokerTopicStats",
+                        "scala.collection.Map",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.jdk.FunctionConverters.enrichAsJavaConsumer",
+                        "scala.jdk.OptionConverters.RichOptional"
                     ]
                 },
                 "scala/kafka/SocketServer.scala": {
@@ -182638,32 +182868,32 @@
                         "Identity Proof": "Single Indicator (Ext: .scala)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7232.25,
-                        "Y": -371.49,
-                        "Z": 139.84
+                        "X": 7232.13,
+                        "Y": -371.46,
+                        "Z": 139.95
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.178,
+                        "Repository Drift (Z-Score)": 11.419,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.272,
-                            "file_cluster_1": 11.688,
-                            "file_cluster_2": 11.886,
-                            "file_cluster_3": 12.712,
-                            "file_cluster_4": 12.062,
-                            "file_cluster_5": 12.131,
-                            "file_cluster_6": 11.854,
-                            "file_cluster_7": 11.377,
-                            "file_cluster_8": 11.178,
-                            "file_cluster_9": 11.851,
-                            "file_cluster_10": 12.494,
-                            "file_cluster_11": 11.453,
-                            "file_cluster_12": 11.962,
-                            "file_cluster_13": 11.404,
-                            "file_cluster_14": 15.286,
-                            "file_cluster_15": 11.25,
-                            "file_cluster_16": 11.414,
-                            "file_cluster_17": 11.609
+                            "file_cluster_0": 11.503,
+                            "file_cluster_1": 11.918,
+                            "file_cluster_2": 12.111,
+                            "file_cluster_3": 12.926,
+                            "file_cluster_4": 12.289,
+                            "file_cluster_5": 12.353,
+                            "file_cluster_6": 12.082,
+                            "file_cluster_7": 11.613,
+                            "file_cluster_8": 11.419,
+                            "file_cluster_9": 12.075,
+                            "file_cluster_10": 12.712,
+                            "file_cluster_11": 11.686,
+                            "file_cluster_12": 12.188,
+                            "file_cluster_13": 11.64,
+                            "file_cluster_14": 15.445,
+                            "file_cluster_15": 11.491,
+                            "file_cluster_16": 11.652,
+                            "file_cluster_17": 11.839
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -182671,7 +182901,7 @@
                         "Total LOC": 1707,
                         "Coding LOC": 576,
                         "Documentation LOC": 967,
-                        "Structural Magnitude": 1223.62,
+                        "Structural Magnitude": 1222.62,
                         "Control Flow Ratio": "55.2%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -182682,9 +182912,9 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "7.45%",
                         "Error & Exception Exposure": "8.72%",
-                        "Tech Debt Exposure": "0.0%",
+                        "Tech Debt Exposure": "10.82%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "2.1%",
+                        "API Exposure": "1.98%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "0.0%",
                         "Commented Logic Exposure": "5.24%",
@@ -182743,7 +182973,7 @@
                         "Type/Safety Bypasses": 15,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 3,
-                        "Exposed API / Public Exports": 19,
+                        "Exposed API / Public Exports": 18,
                         "State Mutations / Variable Reassignments": 27,
                         "Commented-out Code (Dead Logic)": 2,
                         "Structured Documentation Blocks": 54,
@@ -182808,7 +183038,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -182830,7 +183060,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 35,
+                        "Direct Upstream (Fragility)": 72,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
@@ -182842,7 +183072,7 @@
                         "CumulativeSum",
                         "EndThrottlingResponse",
                         "KafkaChannel",
-                        "KafkaConfig\nimport org.apache.kafka.common.message.ApiMessageType.ListenerType\nimport kafka.utils._\nimport org.apache.kafka.common.config.ConfigException\nimport org.apache.kafka.common.errors.InvalidRequestException",
+                        "KafkaConfig",
                         "KafkaException",
                         "ListenerName",
                         "ListenerReconfigurable",
@@ -182851,26 +183081,63 @@
                         "MetricName",
                         "NetworkSend",
                         "NoOpResponse",
-                        "Rate\nimport org.apache.kafka.common.network.KafkaChannel.ChannelMuteEvent\nimport org.apache.kafka.common.network.ChannelBuilder",
-                        "Reconfigurable\nimport org.apache.kafka.network.ConnectionQuotaEntity",
+                        "Rate",
+                        "Reconfigurable",
                         "RequestContext",
-                        "RequestHeader\nimport org.apache.kafka.common.security.auth.SecurityProtocol\nimport org.apache.kafka.common.utils.KafkaThread",
+                        "RequestHeader",
                         "Selectable",
-                        "Selector",
+                        "Selector => KSelector",
                         "Send",
                         "SendResponse",
                         "ServerConnectionId",
-                        "ServerSocketFactory\nimport org.apache.kafka.server.config.QuotaConfig\nimport org.apache.kafka.server.metrics.KafkaMetricsGroup\nimport org.apache.kafka.server.network.ConnectionDisconnectListener\nimport org.apache.kafka.server.quota.QuotaUtils\nimport org.apache.kafka.server.util.FutureUtils\nimport org.slf4j.event.Level\n\nimport scala.collection._\nimport scala.collection.mutable.ArrayBuffer\nimport scala.jdk.CollectionConverters._\nimport scala.util.control.ControlThrowable",
-                        "SimpleMemoryPool\nimport org.apache.kafka.common.metrics._\nimport org.apache.kafka.common.metrics.stats.Avg",
-                        "SocketServer",
-                        "StartThrottlingResponse\nimport kafka.server.BrokerReconfigurable",
+                        "ServerSocketFactory",
+                        "SimpleMemoryPool",
+                        "SocketServer => JSocketServer",
+                        "SocketServerConfigs",
+                        "StartThrottlingResponse",
                         "Time",
-                        "UnsupportedVersionException\nimport org.apache.kafka.common.memory.MemoryPool",
-                        "Utils\nimport org.apache.kafka.common.Endpoint",
-                        "java.io.IOException\nimport java.net._\nimport java.nio.ByteBuffer\nimport java.nio.channels.Selector",
-                        "java.util\nimport java.util.Optional\nimport java.util.concurrent._\nimport java.util.concurrent.atomic._\nimport kafka.network.Processor._\nimport kafka.network.RequestChannel.CloseConnectionResponse",
-                        "org.apache.kafka.common.protocol.ApiKeys\nimport org.apache.kafka.common.requests.ApiVersionsRequest",
-                        "org.apache.kafka.security.CredentialProvider\nimport org.apache.kafka.server.ApiVersionManager"
+                        "TooManyConnectionsException",
+                        "UnsupportedVersionException",
+                        "Utils",
+                        "_",
+                        "java.io.IOException",
+                        "java.net._",
+                        "java.nio.ByteBuffer",
+                        "java.nio.channels.Selector => NSelector",
+                        "java.util",
+                        "java.util.Optional",
+                        "java.util.concurrent._",
+                        "java.util.concurrent.atomic._",
+                        "kafka.network.Processor._",
+                        "kafka.network.RequestChannel.CloseConnectionResponse",
+                        "kafka.server.BrokerReconfigurable",
+                        "kafka.utils._",
+                        "org.apache.kafka.common.Endpoint",
+                        "org.apache.kafka.common.config.ConfigException",
+                        "org.apache.kafka.common.errors.InvalidRequestException",
+                        "org.apache.kafka.common.memory.MemoryPool",
+                        "org.apache.kafka.common.message.ApiMessageType.ListenerType",
+                        "org.apache.kafka.common.metrics._",
+                        "org.apache.kafka.common.metrics.stats.Avg",
+                        "org.apache.kafka.common.network.ChannelBuilder",
+                        "org.apache.kafka.common.network.KafkaChannel.ChannelMuteEvent",
+                        "org.apache.kafka.common.protocol.ApiKeys",
+                        "org.apache.kafka.common.requests.ApiVersionsRequest",
+                        "org.apache.kafka.common.security.auth.SecurityProtocol",
+                        "org.apache.kafka.common.utils.KafkaThread",
+                        "org.apache.kafka.network.ConnectionQuotaEntity",
+                        "org.apache.kafka.security.CredentialProvider",
+                        "org.apache.kafka.server.ApiVersionManager",
+                        "org.apache.kafka.server.config.QuotaConfig",
+                        "org.apache.kafka.server.metrics.KafkaMetricsGroup",
+                        "org.apache.kafka.server.network.ConnectionDisconnectListener",
+                        "org.apache.kafka.server.quota.QuotaUtils",
+                        "org.apache.kafka.server.util.FutureUtils",
+                        "org.slf4j.event.Level",
+                        "scala.collection._",
+                        "scala.collection.mutable.ArrayBuffer",
+                        "scala.jdk.CollectionConverters._",
+                        "scala.util.control.ControlThrowable"
                     ]
                 }
             }
@@ -242904,9 +243171,9 @@
                         "Identity Proof": "Prose Anchor (MIT-LICENSE)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1267.1,
+                        "X": 1266.67,
                         "Y": -216.09,
-                        "Z": 3114.13
+                        "Z": 3113.1
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -243065,9 +243332,9 @@
                         "Identity Proof": "Metadata Anchor (Rakefile)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1771.81,
+                        "X": 1771.38,
                         "Y": -113.99,
-                        "Z": 3839.3
+                        "Z": 3838.26
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -243286,9 +243553,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 994.27,
+                        "X": 993.83,
                         "Y": -200.24,
-                        "Z": 3678.8
+                        "Z": 3677.77
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -243494,9 +243761,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1585.68,
+                        "X": 1585.25,
                         "Y": -287.47,
-                        "Z": 3118.77
+                        "Z": 3117.73
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -243699,9 +243966,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1473.24,
+                        "X": 1472.81,
                         "Y": -156.99,
-                        "Z": 3597.69
+                        "Z": 3596.65
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -243913,9 +244180,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1950.87,
+                        "X": 1950.43,
                         "Y": -237.71,
-                        "Z": 3479.38
+                        "Z": 3478.34
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -244110,9 +244377,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1238.28,
+                        "X": 1237.84,
                         "Y": -157.77,
-                        "Z": 3895.66
+                        "Z": 3894.63
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
@@ -244314,9 +244581,9 @@
                         "Identity Proof": "Single Indicator (Ext: .rb)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1398.15,
+                        "X": 1397.71,
                         "Y": -71.2,
-                        "Z": 4147.07
+                        "Z": 4146.04
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_9",
@@ -283135,9 +283402,9 @@
                         "Identity Proof": "Single Indicator (Exact Match)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7902.84,
+                        "X": 7902.55,
                         "Y": 39.33,
-                        "Z": 937.23
+                        "Z": 937.2
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -283315,9 +283582,9 @@
                         "Identity Proof": "Single Indicator (Ext: .s)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 8195.71,
+                        "X": 8195.42,
                         "Y": 89.29,
-                        "Z": 1272.33
+                        "Z": 1272.3
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -283495,9 +283762,9 @@
                         "Identity Proof": "Single Indicator (Ext: .s)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7912.82,
+                        "X": 7912.53,
                         "Y": 59.83,
-                        "Z": 534.35
+                        "Z": 534.31
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -283736,9 +284003,9 @@
                         "Identity Proof": "Single Indicator (Ext: .s)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7662.78,
+                        "X": 7662.48,
                         "Y": 69.35,
-                        "Z": 1389.29
+                        "Z": 1389.25
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -294522,9 +294789,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2120.57,
+                        "X": 2120.16,
                         "Y": 126.25,
-                        "Z": 5091.23
+                        "Z": 5090.35
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -294702,9 +294969,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2355.05,
+                        "X": 2354.64,
                         "Y": 157.13,
-                        "Z": 5143.62
+                        "Z": 5142.75
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -296064,9 +296331,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1524.5,
+                        "X": 1524.22,
                         "Y": -32.07,
-                        "Z": 5315.01
+                        "Z": 5314.02
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -296244,9 +296511,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 1251.27,
+                        "X": 1251.0,
                         "Y": -37.1,
-                        "Z": 5562.44
+                        "Z": 5561.44
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -305955,9 +306222,9 @@
                         "Identity Proof": "Single Indicator (Ext: .css)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7800.31,
+                        "X": 7800.05,
                         "Y": -118.19,
-                        "Z": 388.16
+                        "Z": 388.15
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -306146,7 +306413,7 @@
                         "Identity Proof": "Single Indicator (Ext: .css)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 7932.83,
+                        "X": 7932.57,
                         "Y": -124.89,
                         "Z": 266.19
                     },
@@ -306391,7 +306658,7 @@
                         "Documentation LOC": 0,
                         "Structural Magnitude": 0.39,
                         "Control Flow Ratio": "100.0%",
-                        "Popularity Rank": 4,
+                        "Popularity Rank": 5,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -306539,9 +306806,9 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 0,
-                        "Direct Downstream (Dependency Blast Radius)": 4,
+                        "Direct Downstream (Dependency Blast Radius)": 5,
                         "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                        "Total Downstream (Absolute Dependency Blast Radius)": 1
                     },
                     "9. Extracted Dependencies": []
                 },
@@ -307340,9 +307607,9 @@
                         "Identity Proof": "Single Indicator (Exact Match)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2058.8,
+                        "X": 2058.41,
                         "Y": 141.51,
-                        "Z": 5334.25
+                        "Z": 5333.25
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -308311,9 +308578,9 @@
                         "Identity Proof": "Single Indicator (Ext: .bat)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 2874.45,
+                        "X": 2873.94,
                         "Y": -64.84,
-                        "Z": 4799.47
+                        "Z": 4798.61
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",


### PR DESCRIPTION
## Summary
Part of the extraction-hardening epic (#813). Closes #825.

Hardens all four extraction gauntlets (`func_start`, `args`, `class_start`, `_dependency_capture`) for scala per [`tests/extraction/how_to_harden_extraction.md`](tests/extraction/how_to_harden_extraction.md). This was a fresh sweep (no pre-flagged known bug) and surfaced three real bugs:

- **`func_start`/`args`** shared a flat `\[[^\]]*\]` Rule-11 square-bracket generic-parameter step-over, breaking any nested generic bound (`def foo[T <: Comparable[T]](x: T): T = {`, a realistic bounded generic method) — the same bug class already fixed for java/typescript/python/rust/csharp/kotlin/swift.
- **`func_start`/`args`** never accepted backtick-quoted arbitrary identifiers at all — Scala's escape hatch for reserved-word/space-containing method names (e.g. Java-interop methods or ScalaTest-style spec names like `` def `should handle edge cases`(): Unit = {} ``). Fixed as an alternative capture group resolved via `match.lastindex` (existing infrastructure the pipeline already had for this shape, e.g. java's `(init)|(constructor)` groups), not a widened class. **Kotlin shares this exact identifier-grammar gap, missed during #823's pass** — filed as a separate follow-up (#899) rather than reopening #823.
- **`_dependency_capture`** had no statement-boundary logic at all: the previous flat `[\w.{}\s,]+` class let `\s` (which matches newlines) bleed across a SECOND real import statement into the following unrelated line on multi-import files, so the second import was silently never detected. It also truncated Scala 3 wildcard imports (`import scala.util.chaining.*`) at the `*` and `=>`-renamed block imports (`import scala.util.{Try => STry}`) at the `=>`. Replaced with a properly bounded segmented-dotted-path grammar instead of just widening the character class further.

## Differential Scan
`crucible_check.py` showed a **real diff this time, not a zero diff** — confirmed genuine, not a regression:
- Verified against the real Kafka scala corpus: several files' detected dependency counts roughly **doubled** once the bleed-over bug was fixed (e.g. `KafkaRaftManager.scala`'s direct-upstream count jumped 24 → 53, `ReplicaManager.scala` jumped 79 → 144).
- The diff also rippled into 9 unrelated language/repo pairs (php/laravel_core, zig/zls, ruby/rails, yaml/ansible, rust/wasmtime, python/cython, assembly/hellosilicon, css/odoo, css/element) plus global ecosystem-summary aggregates. Confirmed this is expected, not a confinement violation: every one of those diff lines was a global/derived metric (Topological Coordinates, PageRank-derived blast-radius counts, corpus-relative percentiles, network-graph modularity/assortativity) — never a raw per-file signature count for a file in an untouched language. `_dependency_capture` feeds the cross-repo dependency DAG (`network_risk_sensor.py`'s PageRank + `spatial_mapper.py`'s 3D projection), which is computed over the whole scanned corpus as one graph, so this ripple is the expected behavior of fixing a real dependency-detection bug, not a bug of its own.
- Golden master fixtures (`tests/golden_master_audit.json`, `tests/golden_master_zero_dep_audit.json`) re-blessed via `crucible_check.py --update --yes`; both modes now PASS cleanly.

Checked `test_language_standards_strict.py` for intentional scala behavior before finalizing (per c's #822 lesson) — no conflicts found; existing scala regression tests pass unmodified.

Also documents two known, **unfixed** limitations: `func_start`'s Mode-B string-shielding gap reproduces via triple-quoted strings (now confirmed on a **ninth** language); `_dependency_capture`'s unshielded-`content_buffer` gap reproduces via a commented-out import (same pipeline-wide issue already documented for every other language).

## Test plan
- [x] `pytest tests/extraction/languages/test_scala.py` (63 tests) — run via bare `pytest` from an unrelated CWD to reproduce CI's invocation style
- [x] `python -m pytest tests/` — 3995 passed, 1 deselected, 1 xfailed (pre-existing, unrelated)
- [x] `python tests/tools/audit_check.py` — clean (ruff/mypy/dead-key baselines unchanged)
- [x] `python tests/tools/crucible_check.py` — PASS on both venvs after re-blessing (see Differential Scan above)
- [x] Migrated scala's cases out of the four monolithic dict files into `tests/extraction/languages/test_scala.py`
- [x] Epic #813 and the methodology doc updated with new recurring bug classes 33-35
- [x] ReDoS scaling sweeps (n=2000→32000, linear) for all three regex changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)