### PR TITLE
Fix #843: Extraction hardening for yaml

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -10870,15 +10870,27 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
         "rules": {
             # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
             "branch": re.compile(r"\b(?:if|else|elif|fi|case|esac|for|while|do|done)\b|&&|\|\|", re.I),
-            "args": re.compile(r"^[ \t]*with:[ \t]*\n(?:[ \t]+[a-zA-Z0-9_-]+:[ \t]*.*)+", re.M | re.I),
+            # BUG FIX (epic #813/#843): required `with:` to be immediately followed by a newline,
+            # so a trailing same-line comment (`with: # inputs for this action`, a real authoring
+            # style) broke the match entirely -- the block's own header line has to tolerate a
+            # comment the same way a job/step name line would.
+            "args": re.compile(r"^[ \t]*with:[ \t]*(?:#.*)?\n(?:[ \t]+[a-zA-Z0-9_-]+:[ \t]*.*)+", re.M | re.I),
             "structural_boundaries": re.compile(r"^[ \t]*(?:env|needs|runs-on|steps|strategy|matrix):", re.M | re.I),
             # Executable Logic Anchors: Explicit execution blocks
             "func_start": re.compile(
                 r"^[ \t]*(?:-?[ \t]*run:|script:|before_script:|after_script:)[ \t]*[|>]*",
                 re.M | re.I,
             ),
+            # MISSING-DECLARATION-SHAPE FIX (epic #813/#843): the reusable-workflow-call/
+            # container-job detection required `uses:`/`image:` to be the LITERAL FIRST line
+            # after the job name -- but real jobs of this shape routinely have other keys
+            # (`needs:`, `if:`, `permissions:`, etc.) before `uses:`/`image:`, e.g.
+            # `call-workflow:\n  needs: [build]\n  uses: ./reusable.yml`. Added a bounded
+            # (max 10, to stay safely linear -- real jobs never have anywhere near that many
+            # top-level keys before uses:/image:) step-over for intervening key:value lines.
             "class_start": re.compile(
-                r"^[ \t]*(?:jobs:|workflow_call:|[a-zA-Z0-9_-]+:[ \t]*\n[ \t]+(?:uses|image):)",
+                r"^[ \t]*(?:jobs:|workflow_call:"
+                r"|[a-zA-Z0-9_-]+:[ \t]*\n(?:[ \t]+[a-zA-Z0-9_-]+:[ \t]*.*\n){0,10}[ \t]+(?:uses|image):)",
                 re.M | re.I,
             ),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
@@ -10936,8 +10948,16 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 r"^[ \t]*(?:-?[ \t]*uses:|image:)[ \t]+([a-zA-Z0-9_./@:-]+)",
                 re.M | re.I,
             ),
+            # BUG FIX (epic #813/#843): the bare capture class required the value to start
+            # immediately with an identifier character, so a quoted `uses:`/`image:` value
+            # (`uses: "actions/checkout@v4"`, a real -- if less common -- authoring style, e.g.
+            # for YAML-lint rules that require consistent scalar quoting) never matched at all,
+            # since the leading quote character isn't in the class. Added quoted alternatives
+            # (permitting the same identifier charset inside real quotes) alongside the original
+            # bare form.
             "_dependency_capture": re.compile(
-                r"^[ \t]*(?:-?[ \t]*uses:|image:)[ \t\n]+([a-zA-Z0-9_./@:-]+)",
+                r"^[ \t]*(?:-?[ \t]*uses:|image:)[ \t\n]+"
+                r"(?:'([a-zA-Z0-9_./@:-]+)'|\"([a-zA-Z0-9_./@:-]+)\"|([a-zA-Z0-9_./@:-]+))",
                 re.M | re.I,
             ),
             "ownership": None,

--- a/tests/extraction/how_to_harden_extraction.md
+++ b/tests/extraction/how_to_harden_extraction.md
@@ -516,6 +516,31 @@ specifically. Check every language against these *first* before assuming a rule 
     line start with no blocking marker, so import-shaped text inside one still produces a phantom
     dependency edge. Check comment- and string-literal vectors independently per language/rule --
     confirmed immunity to one vector doesn't imply immunity to the other.
+41. **(#843) A "block requires an immediate newline after its header key" idiom breaks on a
+    trailing same-line comment on the header itself.** YAML's `args` rule (`with:[ \t]*\n...`)
+    required an immediate newline after `with:`, so `with: # inputs for this action\n  node-version:
+    '18'` (a real CI-YAML authoring style) never matched. Same general shape as classes 5/6 (an
+    unaccounted-for optional element between two required tokens) but for a block-header-to-body
+    transition. Fix: an optional `(?:#.*)?` before the newline. Check any "header line, then
+    indented body" rule for the same gap if that language's comment marker can appear on the header
+    line.
+42. **(#843) A "declaration name, then immediately the thing we care about" shape can be too strict
+    when real usage inserts OTHER keys/statements in between -- a SEQUENCING problem, distinct from
+    Rule 11's nesting problem.** YAML's `class_start` required `uses:`/`image:` to be the literal
+    first line after a job name, but real reusable-workflow-call/container jobs routinely have
+    `needs:`/`if:`/`permissions:` first. Fixed with a BOUNDED (max 10) step-over for intervening
+    key:value lines -- bounded so it can't bleed into an unrelated subsequent job's own content once
+    no `uses:`/`image:` is found. Check for this shape whenever a rule assumes its target keyword is
+    the immediate next line/token after an anchor, when the real language allows other optional
+    statements in between.
+43. **(#843) An "optional-quote" idiom can be missing ENTIRELY, not just shaped wrong (class 39's
+    finding for PowerShell was a wrong shape; this is a total absence).** YAML's
+    `_dependency_capture` had no quote-tolerance at all for `uses:`/`image:` values, so a quoted
+    value (`uses: "actions/checkout@v4"`, a real yamllint-driven authoring style) never matched.
+    Fixed with the same real per-quote-style-alternative idiom as #834's fix. Note: `import` (a
+    sibling, non-gauntlet-scoped rule with nearly the same pattern) was deliberately left unfixed --
+    out of the four-gauntlet scope for a given issue, not an oversight; don't feel obligated to fix
+    every structurally-similar sibling rule outside the four gauntlets in the same pass.
 
 ## Process: the epic and its sub-issues
 

--- a/tests/extraction/languages/test_yaml.py
+++ b/tests/extraction/languages/test_yaml.py
@@ -1,0 +1,333 @@
+"""
+YAML (GitHub Actions / GitLab CI) extraction hardening (epic #813, issue
+#843). See tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for yaml in one file: func_start, args,
+class_start, _dependency_capture. Migrated out of the four old monolithic
+dict files (test_function_extraction_strict.py, test_args_extraction_strict.py,
+test_class_extraction_strict.py, test_dependency_extraction_strict.py) --
+yaml's entries were removed from those four when this file was added.
+(test_args_extraction_strict.py and test_class_extraction_strict.py had no
+yaml entry at all -- args and class_start had zero prior test coverage.)
+
+Unlike most other languages in this epic, yaml's four rules don't map onto
+"function/args/class/dependency" in the traditional sense -- this dict's
+`_meta.target_version` scopes it specifically to CI/CD YAML (GitHub Actions /
+GitLab CI), so the four gauntlets instead detect: a step's run/script block
+(func_start), a step's `with:` input block (args), a job-block boundary
+(class_start, including the reusable-workflow-call/container-job shape),
+and an action/image reference (_dependency_capture). None of class_start's
+alternatives capture a name (whole-match only, `pattern.groups == 0`), so
+its cases use `expected_name=None` throughout.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+# tests/ has no __init__.py anywhere in this repo, so a dotted
+# `tests.extraction._extraction_harness` import only works by accident
+# locally (e.g. `python -m pytest` from the repo root happens to put the
+# root on sys.path) and fails in CI, which invokes the `pytest` console
+# script directly. Insert this file's parent (tests/extraction/) onto
+# sys.path instead, so the harness imports as a plain top-level module.
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+YAML_RULES = LANGUAGE_DEFINITIONS["yaml"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start) -- a step's run:/script: execution block
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        # Modern idiom (carried forward)
+        ("- run: echo hello", "run:"),
+        ("script:", "script:"),
+        # Syntax-era / dialect coverage
+        ("- run: |\n    npm ci\n    npm test", "run:"),  # GH Actions block-scalar multi-line run
+        ("before_script:\n  - npm ci", "before_script:"),  # GitLab CI
+        ("after_script:\n  - cleanup.sh", "after_script:"),  # GitLab CI
+        ("- name: Build\n  run: make", "run:"),  # run: as the second key under a named step
+    ],
+    "invalid": [
+        "TargetFunc:",  # carried-forward: unrelated key lookalike
+        "steps:",  # carried-forward: structural key, not an execution block
+        "runs-on: ubuntu-latest",  # `run` substring lookalike -- must not match "run:"
+        "# - run: rm -rf /",  # commented-out step
+        "my-run: foo",  # `run:` substring lookalike inside a longer key name
+    ],
+    "pathological": [
+        ("- \t run: \n", "run:"),  # carried-forward
+        ("-   run:   |\n  npm test", "run:"),  # extreme horizontal spacing before block scalar
+        ("  -\trun:\t>\n    echo hi", "run:"),  # tab spacing, folded-scalar indicator
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_yaml_func_start_valid(payload, expected_name):
+    assert_valid_match(YAML_RULES["func_start"], payload, expected_name, "yaml.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_yaml_func_start_invalid(payload):
+    assert_invalid_no_match(YAML_RULES["func_start"], payload, "yaml.func_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_yaml_func_start_pathological(payload, expected_name):
+    assert_pathological_match(YAML_RULES["func_start"], payload, expected_name, "yaml.func_start")
+
+
+def test_yaml_func_start_redos_immunity():
+    func_start = YAML_RULES["func_start"]
+    assert_redos_immune(func_start, "- " * 100000 + "run:", timeout_sec=3.0)
+    assert func_start.search("- run: echo hello")
+
+
+# ==============================================================================
+# ARGS (args) -- a step's `with:` input block
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        (
+            "- uses: actions/setup-node@v4\n  with:\n    node-version: '18'\n    cache: 'npm'",
+            "with:",
+        ),
+        (
+            "with: # inputs for this action\n  node-version: '18'",
+            "with:",
+        ),  # trailing same-line comment on the `with:` header -- was a real bug, now fixed
+    ],
+    "invalid": [
+        "with: []",  # empty inline mapping, no indented key:value lines follow
+        "steps:\n  - run: npm test",  # unrelated section
+    ],
+    "pathological": [
+        (
+            "- uses: actions/setup-node@v4\n  with: #\n    node-version: '18'\n    cache: 'npm'\n    always-auth: 'false'",
+            "with:",
+        ),  # bare trailing `#` with no comment text, plus a deep multi-key block
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["valid"])
+def test_yaml_args_valid(payload, expected_name):
+    assert_valid_match(YAML_RULES["args"], payload, expected_name, "yaml.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_yaml_args_invalid(payload):
+    assert_invalid_no_match(YAML_RULES["args"], payload, "yaml.args")
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["pathological"])
+def test_yaml_args_pathological(payload, expected_name):
+    assert_pathological_match(YAML_RULES["args"], payload, expected_name, "yaml.args")
+
+
+def test_yaml_args_trailing_comment_regression():
+    """
+    Regression test for a real bug (epic #813/#843): `with:` required an
+    immediately-following newline, so a trailing same-line comment (`with: #
+    inputs for this action`, a real authoring style) broke the match
+    entirely.
+    """
+    args = YAML_RULES["args"]
+    assert args.search("with: # inputs\n  node-version: '18'"), "trailing comment on with: header regressed"
+
+
+def test_yaml_args_known_limitation_comment_only_line_before_first_key_not_supported():
+    """
+    Documents a known, deliberately-NOT-fixed limitation: a full-line
+    comment BETWEEN the `with:` header and the first real input key (`with:
+    \\n  # first input\\n  node-version: '18'`) does not match, unlike a
+    trailing same-line comment on the `with:` line itself (fixed above).
+    Judged not worth the added regex complexity for a rarer authoring
+    pattern than the trailing-comment case -- a per-line "skip comment
+    lines" allowance would also make it harder to require at least one real
+    key line, which the current simple `+` repetition gets for free.
+    """
+    args = YAML_RULES["args"]
+    comment_before_first_key = "with:\n  # first input\n  node-version: '18'"
+    assert not args.search(comment_before_first_key), "documents current (expected, not-yet-fixed) regex behavior"
+
+
+def test_yaml_args_redos_immunity():
+    args = YAML_RULES["args"]
+    assert_redos_immune(args, "with:\n" + "  key: val\n" * 100000, timeout_sec=3.0)
+    assert args.search("with:\n  node-version: '18'")
+
+
+# ==============================================================================
+# CLASS_START (class_start) -- a job-block boundary (jobs:, workflow_call:,
+# or a reusable-workflow-call/container job identified by its uses:/image:)
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("jobs:\n  build:\n    runs-on: ubuntu-latest", None),
+        ("on:\n  workflow_call:", None),
+        (
+            "test:\n  image: node:18\n  script:\n    - npm test",
+            None,
+        ),  # GitLab CI job with a direct image: child
+        (
+            "call-workflow:\n  uses: ./.github/workflows/reusable.yml",
+            None,
+        ),  # reusable-workflow-call job, uses: as the immediate first key
+    ],
+    "invalid": [
+        "deploy:\n  runs-on: ubuntu-latest\n  steps:\n    - run: echo hi",  # ordinary job, not a call/container shape
+        "# jobs:",  # commented-out declaration
+    ],
+    "pathological": [
+        (
+            "call-workflow:\n  needs: [build]\n  if: success()\n  uses: ./.github/workflows/reusable.yml",
+            None,
+        ),  # reusable-workflow-call job with intervening keys before uses: -- was a real bug, now fixed
+        (
+            "call-workflow:\n  needs: [build]\n  if: success()\n  permissions:\n    contents: read\n  uses: ./.github/workflows/reusable.yml",
+            None,
+        ),  # deeper intervening-key stacking
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_yaml_class_start_valid(payload, expected_name):
+    assert_valid_match(YAML_RULES["class_start"], payload, expected_name, "yaml.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_yaml_class_start_invalid(payload):
+    assert_invalid_no_match(YAML_RULES["class_start"], payload, "yaml.class_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_yaml_class_start_pathological(payload, expected_name):
+    assert_pathological_match(YAML_RULES["class_start"], payload, expected_name, "yaml.class_start")
+
+
+def test_yaml_class_start_intervening_keys_regression():
+    """
+    Regression test for a real bug (epic #813/#843): the reusable-workflow-
+    call/container-job detection required `uses:`/`image:` to be the
+    LITERAL FIRST line after the job name -- but real jobs of this shape
+    routinely have other keys (`needs:`, `if:`, `permissions:`, etc.)
+    before `uses:`/`image:`. Fixed with a bounded (max 10) step-over for
+    intervening key:value lines.
+    """
+    class_start = YAML_RULES["class_start"]
+    assert class_start.search("call-workflow:\n  needs: [build]\n  uses: ./.github/workflows/reusable.yml"), (
+        "intervening-key job detection regressed"
+    )
+    # Must still NOT match an ordinary job with a steps: list -- the bounded
+    # step-over must not bleed past unrelated job content into a false positive.
+    assert not class_start.search(
+        "deploy:\n  runs-on: ubuntu-latest\n  steps:\n    - name: Deploy\n      run: ./deploy.sh"
+    ), "bounded intervening-key step-over incorrectly matched an ordinary job"
+
+
+def test_yaml_class_start_redos_immunity():
+    class_start = YAML_RULES["class_start"]
+    assert_redos_immune(class_start, "job:\n" + "  key: val\n" * 100000, timeout_sec=3.0)
+    assert class_start.search("call-workflow:\n  needs: [build]\n  uses: ./.github/workflows/reusable.yml")
+
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture) -- an action or container image reference
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("uses: actions/checkout@v3", "actions/checkout@v3"),
+        ("image: node:18-alpine", "node:18-alpine"),
+        (
+            'uses: "actions/checkout@v4"',
+            "actions/checkout@v4",
+        ),  # double-quoted value -- was a real bug, now fixed
+        (
+            "uses: 'actions/checkout@v4'",
+            "actions/checkout@v4",
+        ),  # single-quoted variant of the same fix
+        ("- uses: actions/checkout@v4 # pinned", "actions/checkout@v4"),  # trailing comment must not get swallowed
+    ],
+    "invalid": [
+        "description: 'image setup'",  # carried-forward: unrelated key lookalike
+        "important: uses",  # substring-of-keyword lookalike
+    ],
+    "pathological": [
+        ("image: \n postgres:15", "postgres:15"),  # carried-forward: vertical spacing
+        ("uses: \n  'actions/checkout@v4'", "actions/checkout@v4"),  # vertical spacing + quoted value
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_yaml_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(YAML_RULES["_dependency_capture"], payload, expected_path, "yaml._dependency_capture")
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_yaml_dependency_capture_invalid(payload):
+    assert_invalid_no_match(YAML_RULES["_dependency_capture"], payload, "yaml._dependency_capture")
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_yaml_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(
+        YAML_RULES["_dependency_capture"], payload, expected_path, "yaml._dependency_capture"
+    )
+
+
+def test_yaml_dependency_capture_quoted_value_regression():
+    """
+    Regression test for a real bug (epic #813/#843): the bare capture class
+    required the value to start immediately with an identifier character, so
+    a quoted `uses:`/`image:` value (a real, if less common, authoring style
+    -- e.g. for yamllint rules requiring consistent scalar quoting) never
+    matched at all.
+    """
+    dep = YAML_RULES["_dependency_capture"]
+    m = dep.search('uses: "actions/checkout@v4"')
+    captured = next((g for g in m.groups() if g), None) if m else None
+    assert captured == "actions/checkout@v4", "quoted uses: value capture regressed"
+
+
+def test_yaml_dependency_capture_known_limitation_templated_value_not_supported():
+    """
+    Documents a known, deliberately-NOT-fixed limitation: a GitHub Actions
+    expression used as the entire image reference (`image: ${{
+    vars.REGISTRY }}/myimage:latest`, a real but comparatively rare pattern
+    for dynamic/templated container images in advanced reusable workflows)
+    does not match -- `${`/`}` aren't in the identifier character class.
+    Judged out of scope: broadening the class to admit `$`/`{`/`}` risks
+    capturing unrelated GitHub Actions expression syntax as if it were part
+    of a plain path, for a pattern that's uncommon relative to the
+    quoted-value fix above.
+    """
+    dep = YAML_RULES["_dependency_capture"]
+    templated = "image: ${{ vars.REGISTRY }}/myimage:latest"
+    assert not dep.search(templated), "documents current (expected, not-yet-fixed) regex behavior"
+
+
+def test_yaml_dependency_capture_redos_immunity():
+    dep = YAML_RULES["_dependency_capture"]
+    assert_redos_immune(dep, "uses: '" + "a" * 100000, timeout_sec=3.0)
+    assert dep.search("uses: actions/checkout@v4")

--- a/tests/extraction/test_dependency_extraction_strict.py
+++ b/tests/extraction/test_dependency_extraction_strict.py
@@ -203,14 +203,6 @@ DEPENDENCY_EXTRACTION_CASES = {
         "invalid": ["DATA include_name TYPE string."],
         "pathological": [("TYPE-POOLS \n slis \n .", "slis")],
     },
-    "yaml": {
-        "valid": [
-            ("uses: actions/checkout@v3", "actions/checkout@v3"),
-            ("image: node:18-alpine", "node:18-alpine"),
-        ],
-        "invalid": ["description: 'image setup'"],
-        "pathological": [("image: \n postgres:15", "postgres:15")],
-    },
 }
 
 

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -292,11 +292,6 @@ EXTRACTION_CASES = {
         "invalid": ["<div id='script'>", "<span class='style'>"],
         "pathological": [("<script \n >", "script")]
     },
-    "yaml": {
-        "valid": [("- run: echo hello", "run:"), ("script:", "script:")],
-        "invalid": ["TargetFunc:", "steps:"],
-        "pathological": [("- \t run: \n", "run:")]
-    },
     "tcl": {
         "valid": [("proc TargetFunc {", "TargetFunc")],
         "invalid": ["set TargetFunc", "if {$TargetFunc}"],


### PR DESCRIPTION
## Summary
Part of the extraction-hardening epic (#813). Closes #843.

Hardens all four extraction gauntlets (`func_start`, `args`, `class_start`, `_dependency_capture`) for yaml per [`tests/extraction/how_to_harden_extraction.md`](tests/extraction/how_to_harden_extraction.md). Unlike most languages in this epic, yaml's `_meta.target_version` scopes its rules specifically to CI/CD YAML (GitHub Actions/GitLab CI) — the four gauntlets map onto a step's run/script block (`func_start`), a step's `with:` input block (`args`), a job-block boundary including the reusable-workflow-call/container-job shape (`class_start`), and an action/image reference (`_dependency_capture`), not traditional function/class declarations.

A fresh sweep (no pre-flagged known bug) surfaced three real bugs:

- **`args`**'s `with:` block required an immediate newline after the header, breaking on a trailing same-line comment (`with: # inputs for this action`, a real CI-YAML authoring style).
- **`class_start`**'s reusable-workflow-call/container-job detection required `uses:`/`image:` to be the literal first line after the job name, missing the common real pattern of `needs:`/`if:`/`permissions:` appearing first (`call-workflow:\n  needs: [build]\n  uses: ./.github/workflows/reusable.yml`). Fixed with a bounded (max 10) step-over for intervening key:value lines — bounded specifically so it can't bleed into an unrelated subsequent job's own content once no `uses:`/`image:` is found (verified with a dedicated regression test).
- **`_dependency_capture`** had no quote tolerance at all for `uses:`/`image:` values, missing a real yamllint-driven quoted-scalar authoring style (`uses: "actions/checkout@v4"`).

## Differential Scan
`crucible_check.py` showed a **zero diff** on both venvs — confirmed this is expected (not "the feature is wrong," per recurring bug class 8) by grepping the actual `language-crucible` corpus for all three trigger shapes (intervening keys before `uses:`, quoted `uses:`/`image:` values, a trailing comment on `with:`) and confirming none of them appear anywhere in it. No golden master changes in this PR.

Checked `test_language_standards_strict.py` for intentional yaml behavior before finalizing (per c's #822 lesson) — no conflicts; existing regression tests, including the `class_start`↔`import` ambiguity-sweep test documenting their intentional double-classification, pass unmodified.

Also documents one known, **unfixed** limitation: a GitHub Actions expression used as an entire templated image reference (`image: ${{ vars.REGISTRY }}/myimage:latest`) still doesn't match — judged too risky to broaden the character class for a comparatively rare pattern (risks capturing unrelated expression syntax as if it were a plain path).

## Test plan
- [x] `pytest tests/extraction/languages/test_yaml.py` (45 tests) — run via bare `pytest` from an unrelated CWD to reproduce CI's invocation style. `test_args_extraction_strict.py` and `test_class_extraction_strict.py` had **no** prior yaml entry at all — `args` and `class_start` had zero test coverage before this.
- [x] `python -m pytest tests/` — 4093 passed, 1 deselected, 1 xfailed (pre-existing, unrelated)
- [x] `python tests/tools/audit_check.py` — clean (ruff/mypy/dead-key baselines unchanged)
- [x] `python tests/tools/crucible_check.py` — PASS on both venvs, zero diff (see Differential Scan above)
- [x] Migrated yaml's cases out of the four monolithic dict files into `tests/extraction/languages/test_yaml.py`
- [x] Epic #813 and the methodology doc updated with new recurring bug classes 41-43
- [x] ReDoS scaling sweeps (n=2000→32000/100000, linear) for all three regex changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)