### PR TITLE
Document self-scan telemetry usage in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,51 @@ config), `gitgalaxy/tools/` (standalone DevSecOps/legacy-migration CLIs built on
 Each of those directories has its own `README.md` — read the relevant one before working deep
 inside it rather than re-deriving the architecture from source.
 
+## Using GitGalaxy's self-scan output for orientation (token efficiency)
+
+GitGalaxy scans its own repo and produces two artifacts specifically to make an LLM coding
+session cheaper and safer to run — reach for these *before* an Explore subagent, a broad `grep`,
+or reading a large file cold, when the question is really "how big/risky/depended-on is this
+thing" rather than "what does this specific code do."
+
+- **`docs/gitgalaxy_architecture_brief.md`** — auto-committed on every merge to main (a byproduct
+  of the CI scan that also produces SARIF/SBOM), so it's always close to current HEAD. Use it for
+  *repo-wide* framing before a large refactor: Section 7 has the actual blast-radius ranking
+  ("Top 5 Structural Pillars" by import fan-in, "Top 5 Orchestrators" by fan-out), Section 8 has
+  the heaviest functions repo-wide, Section 11 has the top 10 files by cumulative risk. If a file
+  you're about to touch shows up in one of these lists, that's a real signal to be more
+  conservative (smaller diffs, more explicit tests) — not a vague guess.
+- **`docs/self_scan/gitgalaxy_master.db`** (SQLite, via `tests/tools/self_scan.py`) — targeted,
+  near-zero-token ad hoc queries about one specific file/function instead of reading the whole
+  file just to count its functions or gauge its complexity. **It's gitignored and NOT committed
+  on purpose** (a full rescan is ~6-8s, cheaper than storing history) — it may be missing or
+  stale in your checkout. Regenerate with `python tests/tools/self_scan.py` (needs `galaxyscope`
+  on PATH, i.e. an activated venv with `pip install -e .`), or pull the latest
+  `gitgalaxy-self-scan-db` artifact from the most recent push-triggered "Full Report" run of
+  `gitgalaxy.yml` on main if you'd rather not run a local scan.
+  - Always confirm column names with `.schema <table>` first rather than trusting any list here
+    — the recorder schema evolves. Two concrete, verified examples as of this writing:
+    ```bash
+    # Heaviest/most complex functions in a file before editing it -- avoids reading the
+    # whole file just to find what's risky inside it.
+    sqlite3 docs/self_scan/gitgalaxy_master.db \
+      "SELECT f.func_name, f.complexity, f.loc, f.is_recursive, f.calls_out_to
+       FROM function_data f JOIN file_data fd ON f.file_id = fd.id
+       WHERE fd.file_path LIKE '%detector.py%' ORDER BY f.complexity DESC LIMIT 5;"
+
+    # Which directory groups are heaviest, before deciding where new code belongs
+    sqlite3 docs/self_scan/gitgalaxy_master.db \
+      "SELECT directory_group, COUNT(*) files, SUM(total_loc) loc, SUM(function_count) funcs
+       FROM file_data GROUP BY directory_group ORDER BY loc DESC LIMIT 8;"
+    ```
+  - **Known gap:** `pagerank_score` and `normalized_blast_radius` are always NULL in this DB —
+    `self_scan.py` runs galaxyscope in `--db-only` mode, which skips the network/PageRank stage
+    (`network_risk_sensor.py`) for speed. For blast-radius/fan-in questions, use the
+    architecture brief's Section 7 instead, not this DB.
+  - It also doesn't parse inside large dict/list literals (e.g. it can't tell you where the
+    `"scala"` key starts inside `language_standards.py`'s `LANGUAGE_DEFINITIONS`) — it's for
+    orientation and prioritization, not symbol lookup. Read the actual file for that.
+
 ## Adding or hardening a language's structural signatures
 
 Full protocol (LLM generation prompt, the 12 numbered engine rules for ReDoS/boundary


### PR DESCRIPTION
## Summary
`ANTIGRAVITY.md` already documents using the architecture brief + self-scan DB for token-efficient orientation, but `CLAUDE.md` -- the file that actually governs Claude Code sessions in this repo -- had none of that, so it wasn't actually happening for this agent. Adds an equivalent section, but verified against the live DB rather than copied wholesale:

- Confirmed `pagerank_score`/`normalized_blast_radius` are always NULL in the self-scan DB (`self_scan.py` runs `--db-only`, which skips the network/PageRank stage) -- documented as a known gap, pointing at the architecture brief's Section 7 instead for blast-radius questions.
- Both example queries (heaviest functions in a file, heaviest directory groups) run against the live DB and confirmed working before being written down.
- Documents the freshness caveat (gitignored, not committed) and both ways to get a current copy: regenerate locally, or pull the `gitgalaxy-self-scan-db` artifact from the latest "Full Report" run on main (added in #913).

## Test plan
- [x] Both example SQL queries executed against the live `docs/self_scan/gitgalaxy_master.db` and returned real, sensible rows
- [x] Confirmed the NULL-column claim empirically (`SELECT COUNT(*), COUNT(pagerank_score), COUNT(normalized_blast_radius) FROM file_data` -- 182 rows, 0 non-null for both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)