### PR TITLE
Enforce full-precision deps for self-scan; correct CLAUDE.md's wrong root cause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,12 +58,15 @@ or reading a large file cold, when the question is really "how big/risky/depende
 thing" rather than "what does this specific code do."
 
 - **`docs/gitgalaxy_architecture_brief.md`** — auto-committed on every merge to main (a byproduct
-  of the CI scan that also produces SARIF/SBOM), so it's always close to current HEAD. Use it for
-  *repo-wide* framing before a large refactor: Section 7 has the actual blast-radius ranking
-  ("Top 5 Structural Pillars" by import fan-in, "Top 5 Orchestrators" by fan-out), Section 8 has
-  the heaviest functions repo-wide, Section 11 has the top 10 files by cumulative risk. If a file
-  you're about to touch shows up in one of these lists, that's a real signal to be more
-  conservative (smaller diffs, more explicit tests) — not a vague guess.
+  of the CI scan that also produces SARIF/SBOM), so it's always close to current HEAD. This scan
+  always installs `networkx`/`tiktoken`/`xgboost`/`pandas`/`numpy` first (`gitgalaxy.yml`'s
+  "Install GitGalaxy & Full Precision Engines" step) — confirm by checking the brief's own
+  Section 0 traceability table, which reports `Zero-Dependency Mode: Inactive (Full Precision)`.
+  Use it for *repo-wide* framing before a large refactor: Section 7 has the actual blast-radius
+  ranking ("Top 5 Structural Pillars" by import fan-in, "Top 5 Orchestrators" by fan-out),
+  Section 8 has the heaviest functions repo-wide, Section 11 has the top 10 files by cumulative
+  risk. If a file you're about to touch shows up in one of these lists, that's a real signal to
+  be more conservative (smaller diffs, more explicit tests) — not a vague guess.
 - **`docs/self_scan/gitgalaxy_master.db`** (SQLite, via `tests/tools/self_scan.py`) — targeted,
   near-zero-token ad hoc queries about one specific file/function instead of reading the whole
   file just to count its functions or gauge its complexity. **It's gitignored and NOT committed
@@ -87,10 +90,16 @@ thing" rather than "what does this specific code do."
       "SELECT directory_group, COUNT(*) files, SUM(total_loc) loc, SUM(function_count) funcs
        FROM file_data GROUP BY directory_group ORDER BY loc DESC LIMIT 8;"
     ```
-  - **Known gap:** `pagerank_score` and `normalized_blast_radius` are always NULL in this DB —
-    `self_scan.py` runs galaxyscope in `--db-only` mode, which skips the network/PageRank stage
-    (`network_risk_sensor.py`) for speed. For blast-radius/fan-in questions, use the
-    architecture brief's Section 7 instead, not this DB.
+  - **Full-precision dependencies required:** `pagerank_score`, `normalized_blast_radius`, and
+    other network/ML-derived columns need `networkx`, `tiktoken`, `numpy`, `pandas`, `xgboost`,
+    and `pyyaml` importable in whatever environment runs the scan — without all of them,
+    galaxyscope silently drops into Zero-Dependency Mode and those columns come back NULL (this
+    is *not* caused by `--db-only` itself, which only selects which recorder writes output; a
+    local dev venv missing one of these packages was the actual cause the one time this bit us).
+    `self_scan.py` now checks for all six before scanning and aborts loudly if any are missing,
+    rather than silently producing a degraded DB — if you hit that, `pip install` whatever it
+    lists. CI's copy (the `gitgalaxy-self-scan-db` artifact) always has these installed first, so
+    it's always full-precision; only a local run can be affected.
   - It also doesn't parse inside large dict/list literals (e.g. it can't tell you where the
     `"scala"` key starts inside `language_standards.py`'s `LANGUAGE_DEFINITIONS`) — it's for
     orientation and prioritization, not symbol lookup. Read the actual file for that.

--- a/tests/tools/self_scan.py
+++ b/tests/tools/self_scan.py
@@ -41,6 +41,7 @@ file_id).
 """
 
 import argparse
+import importlib.util
 import os
 import shutil
 import sqlite3
@@ -52,8 +53,33 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SELF_SCAN_DIR = REPO_ROOT / "docs" / "self_scan"
 DB_PATH = SELF_SCAN_DIR / "gitgalaxy_master.db"
 
+# Mirrors the HAS_NETWORKX / HAS_TIKTOKEN / ML_AVAILABLE / HAS_PYYAML checks in
+# galaxyscope.py / network_risk_sensor.py / security_auditor.py. Without every
+# one of these, galaxyscope silently drops into "Zero-Dependency Mode" --
+# pagerank_score and normalized_blast_radius (and other network/ML-derived
+# columns) get written as NULL instead of erroring, since zero-dependency mode
+# is a legitimate, intentional mode for scanning *other* repos where installing
+# the full ML stack isn't wanted. But for THIS repo's own self-scan, silently
+# degraded output defeats the point -- callers query this DB assuming full
+# precision. Fail loudly before wasting a scan on a DB nobody wanted.
+FULL_PRECISION_PACKAGES = ("networkx", "tiktoken", "numpy", "pandas", "xgboost", "yaml")
+
+
+def _check_full_precision_deps() -> None:
+    missing = [pkg for pkg in FULL_PRECISION_PACKAGES if importlib.util.find_spec(pkg) is None]
+    if missing:
+        sys.exit(
+            "self-scan aborted -- missing full-precision dependencies: "
+            + ", ".join(missing)
+            + "\nWithout these, galaxyscope silently degrades to Zero-Dependency Mode and "
+            "pagerank_score/normalized_blast_radius (and other network/ML-derived columns) "
+            "come back NULL instead of erroring. Install them into this environment first:\n"
+            "    pip install " + " ".join(pkg if pkg != "yaml" else "pyyaml" for pkg in missing)
+        )
+
 
 def regenerate() -> None:
+    _check_full_precision_deps()
     SELF_SCAN_DIR.mkdir(parents=True, exist_ok=True)
     galaxyscope = shutil.which("galaxyscope")
     if not galaxyscope:
@@ -100,6 +126,22 @@ def print_summary() -> None:
         (total_classes,) = conn.execute("SELECT COUNT(*) FROM class_data").fetchone()
         print(f"✅ Regenerated {DB_PATH.relative_to(REPO_ROOT)}")
         print(f"   {total_files} files, {total_funcs} functions, {total_classes} classes indexed.")
+
+        # Belt-and-suspenders: _check_full_precision_deps() confirms the
+        # packages are importABLE, not that galaxyscope actually used them --
+        # an internal exception during graph-building could still leave these
+        # NULL even with every dependency present. Verify the real output.
+        (with_pagerank,) = conn.execute(
+            "SELECT COUNT(*) FROM file_data WHERE pagerank_score IS NOT NULL"
+        ).fetchone()
+        if total_files and with_pagerank == 0:
+            print(
+                "⚠️  pagerank_score/normalized_blast_radius are NULL for every file -- this scan "
+                "ran in Zero-Dependency Mode despite full-precision packages being importable. "
+                "Blast-radius queries against this DB will return nothing; check galaxyscope's "
+                "stderr output above for why.",
+                file=sys.stderr,
+            )
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
Follow-up to #913/#915. The user asked to confirm the self-scan DB and LLM brief are both the "full dependency" product, not degraded. Investigation found:

- The LLM brief (`docs/gitgalaxy_architecture_brief.md`) has **always** been full-precision -- `gitgalaxy.yml` installs `networkx`/`tiktoken`/`xgboost`/`pandas`/`numpy` before scanning, and the brief's own Section 0 confirms `Zero-Dependency Mode: Inactive (Full Precision)`. No change needed there.
- The self-scan DB (`docs/self_scan/gitgalaxy_master.db`) *was* affected -- but by a local dev-venv gap, not `--db-only`. This repo's own `venv/` was missing `networkx`/`tiktoken`/`xgboost`/`pandas`, so a local `python tests/tools/self_scan.py` run silently degraded to Zero-Dependency Mode (`pagerank_score`/`normalized_blast_radius` NULL for every row). CI's copy (the `gitgalaxy-self-scan-db` artifact from #913) was confirmed unaffected -- downloaded the actual artifact and verified 183/183 rows have non-null `pagerank_score`.
- My own CLAUDE.md text from #915 incorrectly blamed this on `--db-only` itself. Corrected: that flag only selects which recorder writes output, it's unrelated to which Python packages are installed.

## Changes
- `tests/tools/self_scan.py`: checks all 6 full-precision packages are importable before scanning, aborts loudly with a `pip install` hint if not (previously silently produced a degraded DB). `print_summary()` also verifies the actual DB output as a second check.
- `CLAUDE.md`: corrected the false "Known gap" claim, added the real caveat (local venvs need the full dependency stack; CI's artifact always has it), and added the brief's Section-0 confirmation as the way to verify full-precision at a glance.

## Test plan
- [x] Reproduced the failure: local `venv/` missing deps -> old code silently produced NULL pagerank data
- [x] New pre-flight check aborts loudly with the missing-package list before that happens
- [x] `pip install networkx tiktoken pandas xgboost` into the local venv, re-ran -- clean success, no warning, `183/183` rows with non-null `pagerank_score`/`normalized_blast_radius`
- [x] Downloaded the real CI artifact from #913's first run and confirmed it was already full-precision (183/183 non-null)
- [x] `ruff check` / `mypy` clean on `tests/tools/self_scan.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)