### PR TITLE
Fix stale golden-image fixture in test_decoder_forge.py after #939

### DIFF
--- a/tests/tools_recorders/test_decoder_forge.py
+++ b/tests/tools_recorders/test_decoder_forge.py
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 public class EbcdicDecoderUtil {
 
     private static final Logger log = LoggerFactory.getLogger(EbcdicDecoderUtil.class);
-    
+
     // Cp1047 is the standard IBM EBCDIC character set (US/Canada)
     private static final Charset EBCDIC_CHARSET = Charset.forName("Cp1047");
 
@@ -45,7 +45,7 @@ public class EbcdicDecoderUtil {
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < packedBytes.length; i++) {
                 int b = packedBytes[i] & 0xFF;
-                
+
                 // Extract the high and low nibbles (4 bits each)
                 int highNibble = b >>> 4;
                 int lowNibble = b & 0x0F;
@@ -78,7 +78,7 @@ public class EbcdicDecoderUtil {
 
             BigDecimal result = new BigDecimal(sb.toString());
             return result.movePointLeft(scale);
-            
+
         } catch (Exception e) {
             log.error("Critical failure unpacking COMP-3 bytes. Defaulting to ZERO.", e);
             return BigDecimal.ZERO;


### PR DESCRIPTION
## Summary

Discovered while resolving the baseline-conflict merge for PR #938: `main` currently fails `full-suite`'s `test_decoder_forge.py::test_ebcdic_comp3_decoder_golden_image` after PR #939 merged.

PR #939 correctly stripped trailing whitespace from blank lines inside `cobol_to_java_decoder_forge.py`'s Java-code-generating f-string template (the W293 fix it was meant to make), but the hardcoded `GOLDEN_DECODER_UTIL` fixture in this test wasn't updated to match the new output.

Confirmed via diff the drift is **whitespace-only** — three blank lines lost trailing spaces, no bitwise/hex COMP-3 decoding logic changed at all:

```
-    private static final Logger log = LoggerFactory.getLogger(EbcdicDecoderUtil.class);
-    
+    private static final Logger log = LoggerFactory.getLogger(EbcdicDecoderUtil.class);
+
```
(and two more identical blank-line cases)

This slipped through unnoticed because `full-suite` only runs on PRs that get labeled, or on version-tag pushes — not on ordinary pushes to `main` — so #939's merge never triggered it.

## Test plan
- [x] `tests/tools_recorders/test_decoder_forge.py` — now passes
- [x] `tests/tools_recorders/` full directory — 37 passed
- [x] `python tests/tools/audit_check.py` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>