### PR TITLE
Fix Extraction hardening: zig #838

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -8184,24 +8184,21 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # 1. branch: decisions that split flow. Includes unique 'orelse' and 'catch' patterns.
             "branch": re.compile(r"\b(if|else|switch|while|for|try|catch|orelse|break|continue|return)\b|&&|\|\|"),
             # 2. args: Parameters / Coupling. Captures parameters in function signatures.
-            # BUG FIX (Rule 11): `[^)]*` is a flat negated class -- can't
-            # represent even one level of nesting. Zig function-pointer-type
-            # parameters nest constantly (`fn foo(callback: fn(i32) void)
-            # void`) -- confirmed the old pattern truncated at the inner
-            # `)`. Upgraded to the one-level-nesting bounded form.
-            "args": re.compile(r"\bfn\s*(?:[a-zA-Z_]\w*\s*)?\((?:[^()]|\([^()]*\))*\)"),
+            "args": re.compile(
+                r"\bfn[ \t\n]*(?:@\"[^\"]+\"|[a-zA-Z_]\w*[ \t\n]*)?\(((?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\)"
+            ),
             # 3. linear: Sequential I/O & Network Boundaries. Structural boundaries. EXCLUDES access modifiers and const (freeze_hits).
             "structural_boundaries": re.compile(
                 r"\b(var|return|defer|errdefer|unreachable|resume|suspend|await|nosuspend|usingnamespace)\b"
             ),
             # 4. func_start: Executable Logic Anchors. Anchors logic blocks (fn). EXCLUDES struct/enum/union headers.
             "func_start": re.compile(
-                r"^[ \t]*(?:(?:pub|export|extern|inline|noinline|callconv\([^)]*\))[ \t]+){0,5}fn\s+([a-zA-Z_]\w*)(?=\s*\()",
+                r"^[ \t]*(?:(?:pub|export|extern(?:[ \t]+\"[^\"]+\")?|inline|noinline|callconv\([^)]*\)|linksection\([^)]*\)|align\([^)]*\))[ \t\n]+)*fn[ \t\n]+(@\"[^\"]+\"|[a-zA-Z_]\w*)(?=[ \t\n]*\()",
                 re.M,
             ),
             # 5. class_start: Object / Entity Declarations. Defines structural entities (struct, enum, union, error, opaque).
             "class_start": re.compile(
-                r"^[ \t]*(?:pub[ \t]+)?const[ \t]+([a-zA-Z_]\w*)[ \t]*=[ \t]*(?:packed[ \t]+|extern[ \t]+)?(?:struct|enum|union|error|opaque)(?=[ \t]*[{(])",
+                r"^[ \t]*(?:pub[ \t\n]+)?const[ \t\n]+(@\"[^\"]+\"|[a-zA-Z_]\w*)[ \t\n]*=[ \t\n]*(?:packed[ \t\n]+|extern[ \t\n]+)?(?:struct|enum|union|error|opaque)(?=[ \t\n]*[{(])",
                 re.M,
             ),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
@@ -8279,7 +8276,7 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # bug. None ever matched.
             "import": re.compile(r"@import\b|@cImport\b|@cInclude\b"),
             "_dependency_capture": re.compile(
-                r"^[ \t]*(?:const[ \t]+[a-zA-Z_]\w*[ \t]*=[ \t]*)?(?:@import|@cInclude)[ \t\n]*\([ \t\n]*['\"]([^'\"]+)['\"]",
+                r"(?:^[ \t]*(?:(?:pub[ \t]+)?const[ \t]+(?:@\"[^\"]+\"|[a-zA-Z_]\w*)[ \t]*=[ \t]*|_[ \t]*=[ \t]*)?@import|(?:^[ \t]*(?:const[ \t]+(?:@\"[^\"]+\"|[a-zA-Z_]\w*)[ \t]*=[ \t]*)?@cImport[ \t\n]*\{[ \t\n]*)?@cInclude|[ \t]*@cInclude)[ \t\n]*\([ \t\n]*['\"]([^'\"]+)['\"]",
                 re.M,
             ),
             # 25. ownership: Authorship indicators in comments.

--- a/tests/extraction/languages/test_zig.py
+++ b/tests/extraction/languages/test_zig.py
@@ -1,0 +1,161 @@
+"""
+Zig extraction hardening. See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+ZIG_RULES = LANGUAGE_DEFINITIONS["zig"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start)
+# ==============================================================================
+FUNC_START_VALID = [
+    ("fn foo() void {}", "foo"),
+    ("pub fn foo() void {}", "foo"),
+    ("pub inline fn bar(a: i32) !u8 {}", "bar"),
+    ('extern "c" fn foo() void', "foo"),
+    ('export fn process(data: [*c]u8) callconv(.C) linksection(".text") align(8) void {}', "process"),
+    ("fn generic(comptime T: type, alloc: std.mem.Allocator) ?*T {}", "generic"),
+    ("pub fn\nmultiline\n(\n    a: i32,\n)\nvoid\n{", "multiline"),
+    ('pub fn @"weird function name"() void {}', '@"weird function name"'),
+    ("fn\t\t \nweird_whitespace()\n\t!void {", "weird_whitespace"),
+    ("fn return_type_func() fn(i32) void {", "return_type_func"),
+]
+
+FUNC_START_INVALID = [
+    "// fn commentedOut() void {}",
+    "/// fn docCommentedOut() void {}",
+    'const s = "fn stringFunc() void {}";',
+    "\\\\ fn multilineStringFunc() void {}",
+    "const callback: fn (u32) void = undefined;",
+    "const FuncType = fn (a: i32) bool;",
+]
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNC_START_VALID)
+def test_zig_func_start_valid(payload, expected_name):
+    assert_valid_match(ZIG_RULES["func_start"], payload, expected_name, "zig.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNC_START_INVALID)
+def test_zig_func_start_invalid(payload):
+    assert_invalid_no_match(ZIG_RULES["func_start"], payload, "zig.func_start")
+
+
+def test_zig_func_start_redos_immunity():
+    assert_redos_immune(ZIG_RULES["func_start"], "pub " * 100 + "fn " + "A" * 1000 + "()", timeout_sec=1.0)
+
+
+# ==============================================================================
+# CLASS_START (class_start)
+# ==============================================================================
+CLASS_START_VALID = [
+    ("const Point = struct { x: f32, y: f32 };", "Point"),
+    ("pub const PackedUnion = packed union { a: u8, b: u16 };", "PackedUnion"),
+    ("const State = enum(u8) { on, off };", "State"),
+    ("pub const Handle = opaque {};", "Handle"),
+    ("const ErrorSet = error{ OutOfMemory, InvalidFormat };", "ErrorSet"),
+    ("const   \nMyStruct\n  =\nextern\nstruct\n{", "MyStruct"),
+    ('const @"Class Name" = struct { };', '@"Class Name"'),
+    ("const A = struct { const B = struct { }; };", "A"),
+]
+
+CLASS_START_INVALID = [
+    'const s = "struct { }";',
+    "// const Foo = struct {};",
+    "fn foo(struct_param: i32) void {}",
+    "const instance = .{ .x = 1 };",
+]
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_START_VALID)
+def test_zig_class_start_valid(payload, expected_name):
+    assert_valid_match(ZIG_RULES["class_start"], payload, expected_name, "zig.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_START_INVALID)
+def test_zig_class_start_invalid(payload):
+    assert_invalid_no_match(ZIG_RULES["class_start"], payload, "zig.class_start")
+
+
+# ==============================================================================
+# ARGS (args)
+# ==============================================================================
+ARGS_VALID = [
+    ("fn foo(a: i32, b: f32) void", "a: i32, b: f32"),
+    (
+        "fn generic(comptime T: type, allocator: std.mem.Allocator, args: anytype) void",
+        "comptime T: type, allocator: std.mem.Allocator, args: anytype",
+    ),
+    (
+        "fn process(data: [*c]const u8, optional_ptr: ?*align(4) u32) void",
+        "data: [*c]const u8, optional_ptr: ?*align(4) u32",
+    ),
+    ("fn varargs(fmt: [*c]const u8, ...) void", "fmt: [*c]const u8, ..."),
+    ("fn multiline(\na: i32,\n    b: f32,) void", "\na: i32,\n    b: f32,"),
+    ("fn error_union(err: std.mem.Allocator.Error!u8) void", "err: std.mem.Allocator.Error!u8"),
+    ("fn whitespace ( comptime \n T \n : \ntype \n, )", " comptime \n T \n : \ntype \n, "),
+    ("fn func_ptr(arg: fn(fn(i32) void) bool) void", "arg: fn(fn(i32) void) bool"),
+    ('fn custom_id(@"my weird arg": u8) void', '@"my weird arg": u8'),
+]
+
+ARGS_INVALID = [
+    pytest.param('"fn (a: i32, b: i32)"', marks=pytest.mark.xfail(reason="Known limitation: No block shielding for args inside strings")),
+    pytest.param("// fn (a: i32, b: i32)", marks=pytest.mark.xfail(reason="Known limitation: No block shielding for args inside comments")),
+]
+
+
+@pytest.mark.parametrize("payload,expected_args", ARGS_VALID)
+def test_zig_args_valid(payload, expected_args):
+    assert_valid_match(ZIG_RULES["args"], payload, expected_args, "zig.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_INVALID)
+def test_zig_args_invalid(payload):
+    assert_invalid_no_match(ZIG_RULES["args"], payload, "zig.args")
+
+
+# ==============================================================================
+# DEPENDENCY CAPTURE (_dependency_capture)
+# ==============================================================================
+DEPENDENCY_VALID = [
+    ('const std = @import("std");', "std"),
+    ('const net = @import("std").net;', "std"),
+    ('const parser = @import("parser.zig");', "parser.zig"),
+    ('const c = @cImport({ @cInclude("stdio.h"); });', "stdio.h"),
+    ('_ = @import("std");', "std"),
+    ('const \nstd\n=\n@import\n(\n"std"\n)\n;', "std"),
+    ('pub const @"weird import" = @import("weird-name.zig");', "weird-name.zig"),
+]
+
+DEPENDENCY_INVALID = [
+    '"@import(\\"std\\")"',
+    '// const std = @import("std");',
+]
+
+
+@pytest.mark.parametrize("payload,expected_name", DEPENDENCY_VALID)
+def test_zig_dependency_valid(payload, expected_name):
+    assert_valid_dependency_match(ZIG_RULES["_dependency_capture"], payload, expected_name, "zig.dependency")
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_INVALID)
+def test_zig_dependency_invalid(payload):
+    assert_invalid_no_match(ZIG_RULES["_dependency_capture"], payload, "zig.dependency")

--- a/tests/extraction/test_args_extraction_strict.py
+++ b/tests/extraction/test_args_extraction_strict.py
@@ -69,20 +69,6 @@ ARGS_EXTRACTION_CASES = {
             )
         ],
     },
-    "zig": {
-        "valid": [
-            ("pub fn TargetFunc(a: i32, b: f32) void {", "TargetFunc"),
-            ("fn TargetFunc(comptime T: type, items: []T)", "TargetFunc"),
-        ],
-        "invalid": ["TargetFunc(a, b);", "while (iter.next()) |val| {"],
-        "pathological": [
-            # Vertical sigs with comptime types
-            (
-                "pub \n inline \n fn \n TargetFunc \n (\n  comptime T: type,\n  allocator: std.mem.Allocator,\n) \n !void",
-                "TargetFunc",
-            )
-        ],
-    },
     "apex": {
         "valid": [
             ("public void TargetFunc(String a, Integer b) {", "TargetFunc"),

--- a/tests/extraction/test_dependency_extraction_strict.py
+++ b/tests/extraction/test_dependency_extraction_strict.py
@@ -93,14 +93,6 @@ DEPENDENCY_EXTRACTION_CASES = {
         "invalid": ["import_state = True"],
         "pathological": [("from \n uasyncio \n import \n sleep", "uasyncio")],
     },
-    "zig": {
-        "valid": [
-            ('const std = @import("std");', "std"),
-            ('@cInclude("stdio.h");', "stdio.h"),
-        ],
-        "invalid": ["var import_val = 0;"],
-        "pathological": [('@cInclude \n ( \n "sys/types.h" \n )', "sys/types.h")],
-    },
     "dart": {
         "valid": [
             ("import 'dart:io';", "dart:io"),

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -197,11 +197,6 @@ EXTRACTION_CASES = {
         "invalid": ["class TargetFunc", "type TargetFunc", "interface TargetFunc"],
         "pathological": [("public \n async \n get \n TargetFunc \n (", "TargetFunc")],
     },
-    "zig": {
-        "valid": [("fn TargetFunc()", "TargetFunc"), ("pub fn TargetFunc()", "TargetFunc")],
-        "invalid": ["const TargetFunc = struct", "var TargetFunc"],
-        "pathological": [("pub \n export \n fn \n TargetFunc \n (", "TargetFunc")],
-    },
     "solidity": {
         "valid": [("function TargetFunc()", "TargetFunc"), ("modifier TargetFunc()", "TargetFunc")],
         "invalid": ["contract TargetFunc", "struct TargetFunc"],

--- a/tests/golden_master_audit.json
+++ b/tests/golden_master_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-08-02T02:30:47.267982+00:00",
-            "Total Scan Duration": "26.21 seconds"
+            "Analysis ISO Timestamp": "2026-08-02T02:53:00.088275+00:00",
+            "Total Scan Duration": "27.68 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -199,7 +199,7 @@
             "avg_cognitive_load": 24.052,
             "avg_safety_score": 23.759,
             "avg_tech_debt": 25.519,
-            "avg_documentation": 29.97
+            "avg_documentation": 29.962
         },
         "composition": {
             "xml": {
@@ -465,7 +465,7 @@
             "zig": {
                 "files": 32,
                 "loc": 68347,
-                "impact": 108470.84000000001
+                "impact": 106037.54
             }
         },
         "ecosystem_fingerprint": {
@@ -2662,7 +2662,7 @@
             },
             "zig/tigerbeetle": {
                 "file_count": 11,
-                "total_mass": 12283.34,
+                "total_mass": 11647.14,
                 "avg_exposures": {
                     "cognitive_load": 30.42,
                     "safety_score": 27.36,
@@ -2675,7 +2675,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 65.9,
+                    "documentation": 65.4,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 71.27,
                     "obscured_payload": 0.0,
@@ -4012,7 +4012,7 @@
             },
             "zig/bun": {
                 "file_count": 4,
-                "total_mass": 9697.12,
+                "total_mass": 9527.92,
                 "avg_exposures": {
                     "cognitive_load": 35.05,
                     "safety_score": 7.31,
@@ -4025,7 +4025,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 78.84,
+                    "documentation": 78.83,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 100.0,
                     "obscured_payload": 0.0,
@@ -4037,7 +4037,7 @@
             },
             "zig/zig": {
                 "file_count": 5,
-                "total_mass": 49963.7,
+                "total_mass": 48995.7,
                 "avg_exposures": {
                     "cognitive_load": 26.57,
                     "safety_score": 33.79,
@@ -4050,7 +4050,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 68.85,
+                    "documentation": 68.71,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 100.0,
                     "obscured_payload": 0.0,
@@ -4062,7 +4062,7 @@
             },
             "zig/zls": {
                 "file_count": 6,
-                "total_mass": 28980.36,
+                "total_mass": 28672.86,
                 "avg_exposures": {
                     "cognitive_load": 33.41,
                     "safety_score": 3.24,
@@ -4075,7 +4075,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 76.25,
+                    "documentation": 76.13,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 99.92,
                     "obscured_payload": 0.0,
@@ -4087,7 +4087,7 @@
             },
             "zig/zls/mach": {
                 "file_count": 8,
-                "total_mass": 7692.4,
+                "total_mass": 7340.0,
                 "avg_exposures": {
                     "cognitive_load": 15.45,
                     "safety_score": 21.87,
@@ -4100,7 +4100,7 @@
                     "spec_match": 94.17,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 77.03,
+                    "documentation": 76.98,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 82.01,
                     "obscured_payload": 0.0,
@@ -4112,8 +4112,8 @@
             }
         },
         "network_macro": {
-            "modularity": 0.7118,
-            "assortativity": -0.3445,
+            "modularity": 0.7125,
+            "assortativity": -0.3474,
             "cyclic_density": 0.0128,
             "avg_path_length": 4.0713,
             "articulation_points": 69
@@ -4129,7 +4129,7 @@
             },
             "firewall": {
                 "imports_whitelisted": 0,
-                "imports_unknown": 7626,
+                "imports_unknown": 7639,
                 "imports_blacklisted": 0,
                 "threats_found": 139,
                 "threats_allowed": 0
@@ -6145,33 +6145,33 @@
             "undocumented_critical_path": [
                 {
                     "path": "python/fastapi/fastapi/exceptions.py",
-                    "score": 1522.804,
-                    "pr": 15.288,
+                    "score": 1522.904,
+                    "pr": 15.289,
                     "doc": 99.6078
                 },
                 {
                     "path": "python/fastapi/fastapi/responses.py",
-                    "score": 1203.608,
-                    "pr": 12.465,
+                    "score": 1203.704,
+                    "pr": 12.466,
                     "doc": 96.559
                 },
                 {
                     "path": "zig/zig/Zcu.zig",
-                    "score": 1060.306,
-                    "pr": 14.49,
-                    "doc": 73.175
+                    "score": 1045.798,
+                    "pr": 14.337,
+                    "doc": 72.944
+                },
+                {
+                    "path": "zig/zig/Type.zig",
+                    "score": 834.636,
+                    "pr": 8.602,
+                    "doc": 97.0281
                 },
                 {
                     "path": "zig/zig/InternPool.zig",
-                    "score": 890.029,
-                    "pr": 11.01,
-                    "doc": 80.8382
-                },
-                {
-                    "path": "python/fastapi/fastapi/testclient.py",
-                    "score": 657.103,
-                    "pr": 98.565,
-                    "doc": 6.6667
+                    "score": 789.863,
+                    "pr": 9.799,
+                    "doc": 80.6065
                 }
             ]
         },
@@ -14186,7 +14186,7 @@
             }
         },
         "zig/zig": {
-            "Directory Group Magnitude": 49963.7,
+            "Directory Group Magnitude": 48995.7,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -14203,7 +14203,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "68.85%",
+                "Documentation Exposure": "68.71%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "100.0%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -14231,26 +14231,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.858,
+                        "Repository Drift (Z-Score)": 13.859,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.201,
-                            "file_cluster_1": 14.382,
-                            "file_cluster_2": 14.497,
-                            "file_cluster_3": 15.207,
-                            "file_cluster_4": 14.607,
-                            "file_cluster_5": 14.744,
-                            "file_cluster_6": 14.339,
-                            "file_cluster_7": 14.067,
-                            "file_cluster_8": 13.858,
-                            "file_cluster_9": 14.35,
-                            "file_cluster_10": 15.142,
-                            "file_cluster_11": 14.3,
-                            "file_cluster_12": 14.614,
-                            "file_cluster_13": 14.146,
+                            "file_cluster_0": 14.203,
+                            "file_cluster_1": 14.384,
+                            "file_cluster_2": 14.498,
+                            "file_cluster_3": 15.209,
+                            "file_cluster_4": 14.608,
+                            "file_cluster_5": 14.746,
+                            "file_cluster_6": 14.34,
+                            "file_cluster_7": 14.068,
+                            "file_cluster_8": 13.859,
+                            "file_cluster_9": 14.351,
+                            "file_cluster_10": 15.143,
+                            "file_cluster_11": 14.301,
+                            "file_cluster_12": 14.616,
+                            "file_cluster_13": 14.147,
                             "file_cluster_14": 17.535,
-                            "file_cluster_15": 14.635,
-                            "file_cluster_16": 14.441,
-                            "file_cluster_17": 14.404
+                            "file_cluster_15": 14.636,
+                            "file_cluster_16": 14.443,
+                            "file_cluster_17": 14.406
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -14258,7 +14258,7 @@
                         "Total LOC": 8171,
                         "Coding LOC": 7367,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 13615.94,
+                        "Structural Magnitude": 13373.24,
                         "Control Flow Ratio": "77.5%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -14278,7 +14278,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "72.61%",
+                        "Documentation Exposure": "72.43%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -14329,16 +14329,6 @@
                             "End Line": 6424
                         },
                         {
-                            "Function Name": "startTimer",
-                            "Structural Impact": 765.2,
-                            "Lines of Code (LOC)": 325,
-                            "Control Flow Branches": 106,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "73.6%",
-                            "Start Line": 382,
-                            "End Line": 706
-                        },
-                        {
                             "Function Name": "performAllTheWork",
                             "Structural Impact": 687.9,
                             "Lines of Code (LOC)": 457,
@@ -14347,6 +14337,16 @@
                             "Control Flow Ratio": "79.7%",
                             "Start Line": 4557,
                             "End Line": 5013
+                        },
+                        {
+                            "Function Name": "startTimer",
+                            "Structural Impact": 664.9,
+                            "Lines of Code (LOC)": 325,
+                            "Control Flow Branches": 106,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "73.6%",
+                            "Start Line": 382,
+                            "End Line": 706
                         },
                         {
                             "Function Name": "addModuleErrorMsg",
@@ -14409,26 +14409,6 @@
                             "End Line": 1296
                         },
                         {
-                            "Function Name": "classifyFileExt",
-                            "Structural Impact": 210.2,
-                            "Lines of Code (LOC)": 45,
-                            "Control Flow Branches": 61,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "74.4%",
-                            "Start Line": 7597,
-                            "End Line": 7641
-                        },
-                        {
-                            "Function Name": "destroy",
-                            "Structural Impact": 203.9,
-                            "Lines of Code (LOC)": 78,
-                            "Control Flow Branches": 24,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "96.0%",
-                            "Start Line": 2686,
-                            "End Line": 2763
-                        },
-                        {
                             "Function Name": "spawnZigRc",
                             "Structural Impact": 188.5,
                             "Lines of Code (LOC)": 66,
@@ -14437,6 +14417,26 @@
                             "Control Flow Ratio": "67.5%",
                             "Start Line": 6667,
                             "End Line": 6732
+                        },
+                        {
+                            "Function Name": "classifyFileExt",
+                            "Structural Impact": 188.2,
+                            "Lines of Code (LOC)": 45,
+                            "Control Flow Branches": 61,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "74.4%",
+                            "Start Line": 7597,
+                            "End Line": 7641
+                        },
+                        {
+                            "Function Name": "destroy",
+                            "Structural Impact": 177.1,
+                            "Lines of Code (LOC)": 78,
+                            "Control Flow Branches": 24,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "96.0%",
+                            "Start Line": 2686,
+                            "End Line": 2763
                         },
                         {
                             "Function Name": "toErrorMessage",
@@ -14469,16 +14469,6 @@
                             "End Line": 7901
                         },
                         {
-                            "Function Name": "saveState",
-                            "Structural Impact": 141.6,
-                            "Lines of Code (LOC)": 231,
-                            "Control Flow Branches": 25,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "73.5%",
-                            "Start Line": 3651,
-                            "End Line": 3881
-                        },
-                        {
                             "Function Name": "addNonIncrementalStuffToCacheManifest",
                             "Structural Impact": 136.2,
                             "Lines of Code (LOC)": 152,
@@ -14497,6 +14487,16 @@
                             "Control Flow Ratio": "62.5%",
                             "Start Line": 5280,
                             "End Line": 5328
+                        },
+                        {
+                            "Function Name": "saveState",
+                            "Structural Impact": 124.1,
+                            "Lines of Code (LOC)": 231,
+                            "Control Flow Branches": 25,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "73.5%",
+                            "Start Line": 3651,
+                            "End Line": 3881
                         },
                         {
                             "Function Name": "renameTmpIntoCache",
@@ -14549,16 +14549,6 @@
                             "End Line": 4536
                         },
                         {
-                            "Function Name": "docsCopyFallible",
-                            "Structural Impact": 93.0,
-                            "Lines of Code (LOC)": 60,
-                            "Control Flow Branches": 17,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "54.8%",
-                            "Start Line": 5219,
-                            "End Line": 5278
-                        },
-                        {
                             "Function Name": "lessThan",
                             "Structural Impact": 84.5,
                             "Lines of Code (LOC)": 11,
@@ -14579,6 +14569,16 @@
                             "End Line": 4192
                         },
                         {
+                            "Function Name": "docsCopyFallible",
+                            "Structural Impact": 80.9,
+                            "Lines of Code (LOC)": 60,
+                            "Control Flow Branches": 17,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "54.8%",
+                            "Start Line": 5219,
+                            "End Line": 5278
+                        },
+                        {
                             "Function Name": "eql",
                             "Structural Impact": 79.6,
                             "Lines of Code (LOC)": 25,
@@ -14590,10 +14590,10 @@
                         },
                         {
                             "Function Name": "hasSharedLibraryExt",
-                            "Structural Impact": 75.1,
+                            "Structural Impact": 67.3,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 21,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "65.6%",
                             "Start Line": 7570,
                             "End Line": 7595
@@ -14640,23 +14640,13 @@
                         },
                         {
                             "Function Name": "dump_argv",
-                            "Structural Impact": 44.7,
+                            "Structural Impact": 40.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 8,
-                            "Input Parameters": 5,
+                            "Input Parameters": 4,
                             "Control Flow Ratio": "57.1%",
                             "Start Line": 7721,
                             "End Line": 7732
-                        },
-                        {
-                            "Function Name": "finish",
-                            "Structural Impact": 42.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 360,
-                            "End Line": 375
                         },
                         {
                             "Function Name": "updateSubCompilation",
@@ -14697,6 +14687,16 @@
                             "Control Flow Ratio": "90.9%",
                             "Start Line": 3221,
                             "End Line": 3245
+                        },
+                        {
+                            "Function Name": "finish",
+                            "Structural Impact": 37.2,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 360,
+                            "End Line": 375
                         },
                         {
                             "Function Name": "hashCSource",
@@ -14759,16 +14759,6 @@
                             "End Line": 6044
                         },
                         {
-                            "Function Name": "pause",
-                            "Structural Impact": 30.8,
-                            "Lines of Code (LOC)": 15,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 334,
-                            "End Line": 348
-                        },
-                        {
                             "Function Name": "get_libc_crt_file",
                             "Structural Impact": 30.4,
                             "Lines of Code (LOC)": 8,
@@ -14789,14 +14779,14 @@
                             "End Line": 4555
                         },
                         {
-                            "Function Name": "count",
-                            "Structural Impact": 27.1,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Function Name": "pause",
+                            "Structural Impact": 26.7,
+                            "Lines of Code (LOC)": 15,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 1068,
-                            "End Line": 1072
+                            "Start Line": 334,
+                            "End Line": 348
                         },
                         {
                             "Function Name": "dispatchZcuLinkTask",
@@ -14869,6 +14859,16 @@
                             "End Line": 6014
                         },
                         {
+                            "Function Name": "count",
+                            "Structural Impact": 24.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1068,
+                            "End Line": 1072
+                        },
+                        {
                             "Function Name": "emitFromCObject",
                             "Structural Impact": 22.9,
                             "Lines of Code (LOC)": 34,
@@ -14919,16 +14919,6 @@
                             "End Line": 820
                         },
                         {
-                            "Function Name": "compilerRtOptMode",
-                            "Structural Impact": 21.6,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 8154,
-                            "End Line": 8164
-                        },
-                        {
                             "Function Name": "hash",
                             "Structural Impact": 21.5,
                             "Lines of Code (LOC)": 15,
@@ -14959,16 +14949,6 @@
                             "End Line": 5990
                         },
                         {
-                            "Function Name": "stage",
-                            "Structural Impact": 20.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 1002,
-                            "End Line": 1009
-                        },
-                        {
                             "Function Name": "lessThan",
                             "Structural Impact": 20.3,
                             "Lines of Code (LOC)": 6,
@@ -14979,6 +14959,16 @@
                             "End Line": 3978
                         },
                         {
+                            "Function Name": "compilerRtOptMode",
+                            "Structural Impact": 18.7,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 8154,
+                            "End Line": 8164
+                        },
+                        {
                             "Function Name": "deinit",
                             "Structural Impact": 17.8,
                             "Lines of Code (LOC)": 10,
@@ -14987,6 +14977,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1057,
                             "End Line": 1066
+                        },
+                        {
+                            "Function Name": "stage",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 1002,
+                            "End Line": 1009
                         },
                         {
                             "Function Name": "detectEmbedFileUpdate",
@@ -15029,16 +15029,6 @@
                             "End Line": 6054
                         },
                         {
-                            "Function Name": "toCrtFile",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 8084,
-                            "End Line": 8096
-                        },
-                        {
                             "Function Name": "deinit",
                             "Structural Impact": 14.2,
                             "Lines of Code (LOC)": 7,
@@ -15069,14 +15059,14 @@
                             "End Line": 6071
                         },
                         {
-                            "Function Name": "separateCodegenThreadOk",
-                            "Structural Impact": 13.7,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 5205,
-                            "End Line": 5209
+                            "Function Name": "toCrtFile",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 8084,
+                            "End Line": 8096
                         },
                         {
                             "Function Name": "workerDocsWasm",
@@ -15089,36 +15079,6 @@
                             "End Line": 5338
                         },
                         {
-                            "Function Name": "clangNeedsLanguageOverride",
-                            "Structural Impact": 13.4,
-                            "Lines of Code (LOC)": 28,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 7421,
-                            "End Line": 7448
-                        },
-                        {
-                            "Function Name": "clangSupportsDiagnostics",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 7450,
-                            "End Line": 7467
-                        },
-                        {
-                            "Function Name": "clangSupportsDepFile",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 19,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 7469,
-                            "End Line": 7487
-                        },
-                        {
                             "Function Name": "queuePrelinkTaskMode",
                             "Structural Impact": 12.5,
                             "Lines of Code (LOC)": 10,
@@ -15129,14 +15089,24 @@
                             "End Line": 8053
                         },
                         {
-                            "Function Name": "makeBinFileExecutable",
+                            "Function Name": "separateCodegenThreadOk",
                             "Structural Impact": 12.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 5,
                             "Input Parameters": 3,
                             "Control Flow Ratio": "62.5%",
-                            "Start Line": 3608,
-                            "End Line": 3612
+                            "Start Line": 5205,
+                            "End Line": 5209
+                        },
+                        {
+                            "Function Name": "clangNeedsLanguageOverride",
+                            "Structural Impact": 11.8,
+                            "Lines of Code (LOC)": 28,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 7421,
+                            "End Line": 7448
                         },
                         {
                             "Function Name": "canonicalName",
@@ -15149,6 +15119,26 @@
                             "End Line": 7513
                         },
                         {
+                            "Function Name": "clangSupportsDiagnostics",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 7450,
+                            "End Line": 7467
+                        },
+                        {
+                            "Function Name": "clangSupportsDepFile",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 19,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 7469,
+                            "End Line": 7487
+                        },
+                        {
                             "Function Name": "resolveEmitPath",
                             "Structural Impact": 10.9,
                             "Lines of Code (LOC)": 10,
@@ -15157,16 +15147,6 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 3247,
                             "End Line": 3256
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 10.7,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1619,
-                            "End Line": 1632
                         },
                         {
                             "Function Name": "queuePrelinkTasks",
@@ -15179,14 +15159,14 @@
                             "End Line": 8062
                         },
                         {
-                            "Function Name": "releaseLock",
-                            "Structural Impact": 10.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1605,
-                            "End Line": 1610
+                            "Function Name": "makeBinFileExecutable",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 3608,
+                            "End Line": 3612
                         },
                         {
                             "Function Name": "obtainCObjectCacheManifest",
@@ -15219,74 +15199,54 @@
                             "End Line": 2790
                         },
                         {
-                            "Function Name": "wantBuildLibUnwindFromSource",
+                            "Function Name": "deinit",
                             "Structural Impact": 9.4,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1619,
+                            "End Line": 1632
+                        },
+                        {
+                            "Function Name": "releaseLock",
+                            "Structural Impact": 9.0,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1605,
+                            "End Line": 1610
+                        },
+                        {
+                            "Function Name": "debugIncremental",
+                            "Structural Impact": 8.2,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 851,
+                            "End Line": 854
+                        },
+                        {
+                            "Function Name": "wantBuildLibUnwindFromSource",
+                            "Structural Impact": 8.2,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7675,
                             "End Line": 7683
                         },
                         {
                             "Function Name": "workerDocsCopy",
-                            "Structural Impact": 9.3,
+                            "Structural Impact": 8.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 5211,
                             "End Line": 5217
-                        },
-                        {
-                            "Function Name": "debugIncremental",
-                            "Structural Impact": 9.1,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 851,
-                            "End Line": 854
-                        },
-                        {
-                            "Function Name": "withoutLocalCache",
-                            "Structural Impact": 8.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 736,
-                            "End Line": 743
-                        },
-                        {
-                            "Function Name": "moveLock",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1612,
-                            "End Line": 1616
-                        },
-                        {
-                            "Function Name": "makeBinFileWritable",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 3614,
-                            "End Line": 3617
-                        },
-                        {
-                            "Function Name": "anyErrors",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "42.9%",
-                            "Start Line": 4269,
-                            "End Line": 4273
                         },
                         {
                             "Function Name": "addOptionalDebugFormat",
@@ -15299,6 +15259,16 @@
                             "End Line": 1490
                         },
                         {
+                            "Function Name": "withoutLocalCache",
+                            "Structural Impact": 7.3,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 736,
+                            "End Line": 743
+                        },
+                        {
                             "Function Name": "addDebugFormat",
                             "Structural Impact": 7.3,
                             "Lines of Code (LOC)": 8,
@@ -15309,14 +15279,34 @@
                             "End Line": 1499
                         },
                         {
-                            "Function Name": "hasCppExt",
+                            "Function Name": "moveLock",
                             "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 9,
+                            "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 7537,
-                            "End Line": 7545
+                            "Start Line": 1612,
+                            "End Line": 1616
+                        },
+                        {
+                            "Function Name": "anyErrors",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "42.9%",
+                            "Start Line": 4269,
+                            "End Line": 4273
+                        },
+                        {
+                            "Function Name": "makeBinFileWritable",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 3614,
+                            "End Line": 3617
                         },
                         {
                             "Function Name": "crtFilePath",
@@ -15329,104 +15319,54 @@
                             "End Line": 7673
                         },
                         {
+                            "Function Name": "hasCppExt",
+                            "Structural Impact": 6.5,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 7537,
+                            "End Line": 7545
+                        },
+                        {
                             "Function Name": "hasObjectExt",
-                            "Structural Impact": 7.0,
+                            "Structural Impact": 6.3,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7516,
                             "End Line": 7521
                         },
                         {
                             "Function Name": "hasStaticLibraryExt",
-                            "Structural Impact": 7.0,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7523,
                             "End Line": 7527
                         },
                         {
                             "Function Name": "hasCppHExt",
-                            "Structural Impact": 7.0,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7547,
                             "End Line": 7551
                         },
                         {
                             "Function Name": "hasObjCppExt",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7561,
                             "End Line": 7564
-                        },
-                        {
-                            "Function Name": "clearMiscFailures",
-                            "Structural Impact": 6.5,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 2765,
-                            "End Line": 2773
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 6.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 724,
-                            "End Line": 731
-                        },
-                        {
-                            "Function Name": "keys",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 103,
-                            "End Line": 105
-                        },
-                        {
-                            "Function Name": "count",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 106,
-                            "End Line": 108
-                        },
-                        {
-                            "Function Name": "popFront",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 138,
-                            "End Line": 140
-                        },
-                        {
-                            "Function Name": "values",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 151,
-                            "End Line": 153
                         },
                         {
                             "Function Name": "crtFileAsString",
@@ -15447,6 +15387,26 @@
                             "Control Flow Ratio": "25.0%",
                             "Start Line": 5863,
                             "End Line": 5876
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 5.6,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 724,
+                            "End Line": 731
+                        },
+                        {
+                            "Function Name": "clearMiscFailures",
+                            "Structural Impact": 5.6,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 2765,
+                            "End Line": 2773
                         },
                         {
                             "Function Name": "deinit",
@@ -15509,6 +15469,46 @@
                             "End Line": 7719
                         },
                         {
+                            "Function Name": "keys",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 103,
+                            "End Line": 105
+                        },
+                        {
+                            "Function Name": "count",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 106,
+                            "End Line": 108
+                        },
+                        {
+                            "Function Name": "popFront",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 138,
+                            "End Line": 140
+                        },
+                        {
+                            "Function Name": "values",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 151,
+                            "End Line": 153
+                        },
+                        {
                             "Function Name": "queueJobs",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -15530,93 +15530,73 @@
                         },
                         {
                             "Function Name": "obtainWin32ResourceCacheManifest",
-                            "Structural Impact": 4.8,
+                            "Structural Impact": 4.3,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "33.3%",
                             "Start Line": 5611,
                             "End Line": 5617
                         },
                         {
                             "Function Name": "getTarget",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 2775,
                             "End Line": 2777
                         },
                         {
                             "Function Name": "hasCExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7529,
                             "End Line": 7531
                         },
                         {
                             "Function Name": "hasCHExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7533,
                             "End Line": 7535
                         },
                         {
                             "Function Name": "hasObjCExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7553,
                             "End Line": 7555
                         },
                         {
                             "Function Name": "hasObjCHExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7557,
                             "End Line": 7559
                         },
                         {
                             "Function Name": "hasObjCppHExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7566,
                             "End Line": 7568
-                        },
-                        {
-                            "Function Name": "getZigBackend",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 7734,
-                            "End Line": 7737
-                        },
-                        {
-                            "Function Name": "compilerRtStrip",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 8168,
-                            "End Line": 8170
                         },
                         {
                             "Function Name": "addResolvedTarget",
@@ -15627,6 +15607,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1470,
                             "End Line": 1485
+                        },
+                        {
+                            "Function Name": "getZigBackend",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 7734,
+                            "End Line": 7737
                         },
                         {
                             "Function Name": "addModule",
@@ -15647,6 +15637,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 5017,
                             "End Line": 5019
+                        },
+                        {
+                            "Function Name": "compilerRtStrip",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 8168,
+                            "End Line": 8170
                         },
                         {
                             "Function Name": "addReferenceTraceFrame",
@@ -15749,16 +15749,6 @@
                             "End Line": 7360
                         },
                         {
-                            "Function Name": "setAllocFailure",
-                            "Structural Impact": 2.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 7685,
-                            "End Line": 7689
-                        },
-                        {
                             "Function Name": "getCrtPaths",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 4,
@@ -15779,46 +15769,6 @@
                             "End Line": 137
                         },
                         {
-                            "Function Name": "tryLock",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 252,
-                            "End Line": 252
-                        },
-                        {
-                            "Function Name": "lock",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 253,
-                            "End Line": 253
-                        },
-                        {
-                            "Function Name": "unlock",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 254,
-                            "End Line": 254
-                        },
-                        {
-                            "Function Name": "getAllErrorsAlloc",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 3889,
-                            "End Line": 3889
-                        },
-                        {
                             "Function Name": "reportRetryableCObjectError",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
@@ -15837,6 +15787,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 6734,
                             "End Line": 6734
+                        },
+                        {
+                            "Function Name": "setAllocFailure",
+                            "Structural Impact": 2.0,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 7685,
+                            "End Line": 7689
                         },
                         {
                             "Function Name": "translateC",
@@ -15879,6 +15839,36 @@
                             "End Line": 154
                         },
                         {
+                            "Function Name": "tryLock",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 252,
+                            "End Line": 252
+                        },
+                        {
+                            "Function Name": "lock",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 253,
+                            "End Line": 253
+                        },
+                        {
+                            "Function Name": "unlock",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 254,
+                            "End Line": 254
+                        },
+                        {
                             "Function Name": "fail",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
@@ -15887,6 +15877,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1892,
                             "End Line": 1892
+                        },
+                        {
+                            "Function Name": "getAllErrorsAlloc",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 3889,
+                            "End Line": 3889
                         },
                         {
                             "Function Name": "addModuleTableToCacheHash",
@@ -15923,8 +15923,8 @@
                     "7. Structural Signatures (Net Mitigated Signals)": {
                         "Control Flow Branches": 2282,
                         "Sequential Logic Declarations": 664,
-                        "Function Parameters": 182,
-                        "Function/Method Declarations": 182,
+                        "Function Parameters": 183,
+                        "Function/Method Declarations": 183,
                         "Class/Entity Declarations": 51,
                         "Defensive Programming Constructs": 1138,
                         "Type/Safety Bypasses": 266,
@@ -16017,7 +16017,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 28,
+                        "Direct Upstream (Fragility)": 29,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 4,
                         "Total Downstream (Absolute Dependency Blast Radius)": 7
@@ -16025,6 +16025,7 @@
                     "9. Extracted Dependencies": [
                         "Air.zig",
                         "Builtin.zig",
+                        "Compilation/Config.zig",
                         "InternPool.zig",
                         "Package.zig",
                         "Sema.zig",
@@ -16071,26 +16072,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.025,
+                        "Repository Drift (Z-Score)": 13.022,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.413,
-                            "file_cluster_1": 13.52,
-                            "file_cluster_2": 13.682,
-                            "file_cluster_3": 14.371,
-                            "file_cluster_4": 13.56,
-                            "file_cluster_5": 13.885,
-                            "file_cluster_6": 13.466,
-                            "file_cluster_7": 13.171,
-                            "file_cluster_8": 13.025,
-                            "file_cluster_9": 13.555,
-                            "file_cluster_10": 14.078,
-                            "file_cluster_11": 13.428,
-                            "file_cluster_12": 13.627,
-                            "file_cluster_13": 13.41,
-                            "file_cluster_14": 16.934,
-                            "file_cluster_15": 13.763,
-                            "file_cluster_16": 13.325,
-                            "file_cluster_17": 13.699
+                            "file_cluster_0": 13.411,
+                            "file_cluster_1": 13.518,
+                            "file_cluster_2": 13.68,
+                            "file_cluster_3": 14.369,
+                            "file_cluster_4": 13.557,
+                            "file_cluster_5": 13.883,
+                            "file_cluster_6": 13.463,
+                            "file_cluster_7": 13.169,
+                            "file_cluster_8": 13.022,
+                            "file_cluster_9": 13.552,
+                            "file_cluster_10": 14.075,
+                            "file_cluster_11": 13.425,
+                            "file_cluster_12": 13.624,
+                            "file_cluster_13": 13.407,
+                            "file_cluster_14": 16.932,
+                            "file_cluster_15": 13.76,
+                            "file_cluster_16": 13.322,
+                            "file_cluster_17": 13.696
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -16098,7 +16099,7 @@
                         "Total LOC": 13040,
                         "Coding LOC": 11985,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 7317.1,
+                        "Structural Magnitude": 7154.9,
                         "Control Flow Ratio": "66.7%",
                         "Popularity Rank": 3,
                         "Raw Churn Frequency": 0.0,
@@ -16118,7 +16119,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "80.84%",
+                        "Documentation Exposure": "80.61%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -16140,10 +16141,10 @@
                         },
                         {
                             "Function Name": "List",
-                            "Structural Impact": 348.4,
+                            "Structural Impact": 312.9,
                             "Lines of Code (LOC)": 238,
                             "Control Flow Branches": 42,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "56.8%",
                             "Start Line": 1139,
                             "End Line": 1376
@@ -16199,26 +16200,6 @@
                             "End Line": 403
                         },
                         {
-                            "Function Name": "pack",
-                            "Structural Impact": 86.6,
-                            "Lines of Code (LOC)": 52,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "86.7%",
-                            "Start Line": 12943,
-                            "End Line": 12994
-                        },
-                        {
-                            "Function Name": "next",
-                            "Structural Impact": 85.2,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 11,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "68.8%",
-                            "Start Line": 4146,
-                            "End Line": 4169
-                        },
-                        {
                             "Function Name": "loadEnumType",
                             "Structural Impact": 81.7,
                             "Lines of Code (LOC)": 76,
@@ -16230,13 +16211,23 @@
                         },
                         {
                             "Function Name": "pack",
-                            "Structural Impact": 68.2,
-                            "Lines of Code (LOC)": 43,
-                            "Control Flow Branches": 10,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "90.9%",
-                            "Start Line": 791,
-                            "End Line": 833
+                            "Structural Impact": 75.3,
+                            "Lines of Code (LOC)": 52,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "86.7%",
+                            "Start Line": 12943,
+                            "End Line": 12994
+                        },
+                        {
+                            "Function Name": "next",
+                            "Structural Impact": 73.9,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 11,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "68.8%",
+                            "Start Line": 4146,
+                            "End Line": 4169
                         },
                         {
                             "Function Name": "tagValueIndex",
@@ -16259,6 +16250,16 @@
                             "End Line": 2562
                         },
                         {
+                            "Function Name": "pack",
+                            "Structural Impact": 59.3,
+                            "Lines of Code (LOC)": 43,
+                            "Control Flow Branches": 10,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "90.9%",
+                            "Start Line": 791,
+                            "End Line": 833
+                        },
+                        {
                             "Function Name": "isExternOrFn",
                             "Structural Impact": 57.1,
                             "Lines of Code (LOC)": 17,
@@ -16270,53 +16271,23 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 55.0,
+                            "Structural Impact": 47.8,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 8,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "61.5%",
                             "Start Line": 4107,
                             "End Line": 4126
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 48.4,
+                            "Structural Impact": 42.0,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 5,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "71.4%",
                             "Start Line": 877,
                             "End Line": 884
-                        },
-                        {
-                            "Function Name": "unpack",
-                            "Structural Impact": 44.1,
-                            "Lines of Code (LOC)": 43,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 12996,
-                            "End Line": 13038
-                        },
-                        {
-                            "Function Name": "unpack",
-                            "Structural Impact": 43.6,
-                            "Lines of Code (LOC)": 32,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 757,
-                            "End Line": 788
-                        },
-                        {
-                            "Function Name": "Map",
-                            "Structural Impact": 43.0,
-                            "Lines of Code (LOC)": 56,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1547,
-                            "End Line": 1602
                         },
                         {
                             "Function Name": "nameIndex",
@@ -16327,6 +16298,36 @@
                             "Control Flow Ratio": "64.3%",
                             "Start Line": 3686,
                             "End Line": 3696
+                        },
+                        {
+                            "Function Name": "Map",
+                            "Structural Impact": 38.8,
+                            "Lines of Code (LOC)": 56,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1547,
+                            "End Line": 1602
+                        },
+                        {
+                            "Function Name": "unpack",
+                            "Structural Impact": 38.5,
+                            "Lines of Code (LOC)": 43,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 12996,
+                            "End Line": 13038
+                        },
+                        {
+                            "Function Name": "unpack",
+                            "Structural Impact": 38.0,
+                            "Lines of Code (LOC)": 32,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 757,
+                            "End Line": 788
                         },
                         {
                             "Function Name": "loadUnionType",
@@ -16379,36 +16380,6 @@
                             "End Line": 1810
                         },
                         {
-                            "Function Name": "checkConfig",
-                            "Structural Impact": 23.7,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 4988,
-                            "End Line": 4992
-                        },
-                        {
-                            "Function Name": "getLimbs",
-                            "Structural Impact": 22.7,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 1088,
-                            "End Line": 1094
-                        },
-                        {
-                            "Function Name": "typeOf",
-                            "Structural Impact": 22.6,
-                            "Lines of Code (LOC)": 52,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 3193,
-                            "End Line": 3244
-                        },
-                        {
                             "Function Name": "isFn",
                             "Structural Impact": 22.3,
                             "Lines of Code (LOC)": 13,
@@ -16457,6 +16428,16 @@
                             "Control Flow Ratio": "71.4%",
                             "Start Line": 887,
                             "End Line": 911
+                        },
+                        {
+                            "Function Name": "checkConfig",
+                            "Structural Impact": 21.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 4988,
+                            "End Line": 4992
                         },
                         {
                             "Function Name": "typeOf",
@@ -16509,44 +16490,24 @@
                             "End Line": 2211
                         },
                         {
-                            "Function Name": "values",
-                            "Structural Impact": 20.5,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 2604,
-                            "End Line": 2610
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 20.4,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 436,
-                            "End Line": 444
-                        },
-                        {
-                            "Function Name": "wrap",
-                            "Structural Impact": 20.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 445,
-                            "End Line": 452
-                        },
-                        {
-                            "Function Name": "toInt",
+                            "Function Name": "getLimbs",
                             "Structural Impact": 20.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 3,
                             "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 3676,
-                            "End Line": 3682
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 1088,
+                            "End Line": 1094
+                        },
+                        {
+                            "Function Name": "typeOf",
+                            "Structural Impact": 19.9,
+                            "Lines of Code (LOC)": 52,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3193,
+                            "End Line": 3244
                         },
                         {
                             "Function Name": "toUnsigned",
@@ -16559,44 +16520,14 @@
                             "End Line": 1892
                         },
                         {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
+                            "Function Name": "values",
+                            "Structural Impact": 18.4,
+                            "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
                             "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
-                            "Start Line": 139,
-                            "End Line": 144
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 182,
-                            "End Line": 187
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 697,
-                            "End Line": 702
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1033,
-                            "End Line": 1038
+                            "Start Line": 2604,
+                            "End Line": 2610
                         },
                         {
                             "Function Name": "assumeRuntimeBitsIfFieldTypesWip",
@@ -16629,6 +16560,26 @@
                             "End Line": 165
                         },
                         {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 17.8,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 436,
+                            "End Line": 444
+                        },
+                        {
+                            "Function Name": "wrap",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 445,
+                            "End Line": 452
+                        },
+                        {
                             "Function Name": "format",
                             "Structural Impact": 17.7,
                             "Lines of Code (LOC)": 8,
@@ -16637,6 +16588,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 1899,
                             "End Line": 1906
+                        },
+                        {
+                            "Function Name": "toInt",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 3676,
+                            "End Line": 3682
                         },
                         {
                             "Function Name": "nameIndex",
@@ -16659,6 +16620,46 @@
                             "End Line": 3632
                         },
                         {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 139,
+                            "End Line": 144
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 182,
+                            "End Line": 187
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 697,
+                            "End Line": 702
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1033,
+                            "End Line": 1038
+                        },
+                        {
                             "Function Name": "toBigInt",
                             "Structural Impact": 15.9,
                             "Lines of Code (LOC)": 7,
@@ -16667,56 +16668,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 2415,
                             "End Line": 2421
-                        },
-                        {
-                            "Function Name": "haveFieldTypes",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3301,
-                            "End Line": 3313
-                        },
-                        {
-                            "Function Name": "haveLayout",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3315,
-                            "End Line": 3327
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 460,
-                            "End Line": 465
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1732,
-                            "End Line": 1737
-                        },
-                        {
-                            "Function Name": "hasTag",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3282,
-                            "End Line": 3287
                         },
                         {
                             "Function Name": "getErrorValue",
@@ -16829,6 +16780,56 @@
                             "End Line": 3706
                         },
                         {
+                            "Function Name": "haveFieldTypes",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3301,
+                            "End Line": 3313
+                        },
+                        {
+                            "Function Name": "haveLayout",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3315,
+                            "End Line": 3327
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 460,
+                            "End Line": 465
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1732,
+                            "End Line": 1737
+                        },
+                        {
+                            "Function Name": "hasTag",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3282,
+                            "End Line": 3287
+                        },
+                        {
                             "Function Name": "assumePointerAlignedIfFieldTypesWip",
                             "Structural Impact": 12.7,
                             "Lines of Code (LOC)": 14,
@@ -16849,56 +16850,6 @@
                             "End Line": 3895
                         },
                         {
-                            "Function Name": "wrap",
-                            "Structural Impact": 12.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1947,
-                            "End Line": 1954
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1955,
-                            "End Line": 1962
-                        },
-                        {
-                            "Function Name": "getAddrspace",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 598,
-                            "End Line": 604
-                        },
-                        {
-                            "Function Name": "getAlignment",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 607,
-                            "End Line": 613
-                        },
-                        {
-                            "Function Name": "getLinkSection",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 616,
-                            "End Line": 622
-                        },
-                        {
                             "Function Name": "nameIndex",
                             "Structural Impact": 12.3,
                             "Lines of Code (LOC)": 6,
@@ -16907,56 +16858,6 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 4399,
                             "End Line": 4404
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1620,
-                            "End Line": 1623
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1696,
-                            "End Line": 1698
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1700,
-                            "End Line": 1703
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 1804,
-                            "End Line": 1806
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 1926,
-                            "End Line": 1928
                         },
                         {
                             "Function Name": "fieldAlign",
@@ -17020,6 +16921,26 @@
                         },
                         {
                             "Function Name": "wrap",
+                            "Structural Impact": 10.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1947,
+                            "End Line": 1954
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1955,
+                            "End Line": 1962
+                        },
+                        {
+                            "Function Name": "wrap",
                             "Structural Impact": 10.7,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 1,
@@ -17037,6 +16958,36 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 494,
                             "End Line": 499
+                        },
+                        {
+                            "Function Name": "getAddrspace",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 598,
+                            "End Line": 604
+                        },
+                        {
+                            "Function Name": "getAlignment",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 607,
+                            "End Line": 613
+                        },
+                        {
+                            "Function Name": "getLinkSection",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 616,
+                            "End Line": 622
                         },
                         {
                             "Function Name": "wrap",
@@ -17079,6 +17030,46 @@
                             "End Line": 4083
                         },
                         {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1620,
+                            "End Line": 1623
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1700,
+                            "End Line": 1703
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1696,
+                            "End Line": 1698
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 1804,
+                            "End Line": 1806
+                        },
+                        {
                             "Function Name": "fmt",
                             "Structural Impact": 10.5,
                             "Lines of Code (LOC)": 3,
@@ -17087,6 +17078,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1908,
                             "End Line": 1910
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 1926,
+                            "End Line": 1928
                         },
                         {
                             "Function Name": "hasTag",
@@ -17117,16 +17118,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 3494,
                             "End Line": 3496
-                        },
-                        {
-                            "Function Name": "wrap",
-                            "Structural Impact": 10.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 145,
-                            "End Line": 147
                         },
                         {
                             "Function Name": "clearInitsWip",
@@ -17289,6 +17280,16 @@
                             "End Line": 3673
                         },
                         {
+                            "Function Name": "wrap",
+                            "Structural Impact": 8.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 145,
+                            "End Line": 147
+                        },
+                        {
                             "Function Name": "clearFieldTypesWip",
                             "Structural Impact": 8.4,
                             "Lines of Code (LOC)": 12,
@@ -17327,46 +17328,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1860,
                             "End Line": 1865
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 176,
-                            "End Line": 178
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 706,
-                            "End Line": 708
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1027,
-                            "End Line": 1029
-                        },
-                        {
-                            "Function Name": "lenIncludingSentinel",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 2124,
-                            "End Line": 2126
                         },
                         {
                             "Function Name": "getMutableItems",
@@ -17559,6 +17520,36 @@
                             "End Line": 4786
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 176,
+                            "End Line": 178
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 706,
+                            "End Line": 708
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1027,
+                            "End Line": 1029
+                        },
+                        {
                             "Function Name": "get",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 4,
@@ -17577,6 +17568,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1980,
                             "End Line": 1983
+                        },
+                        {
+                            "Function Name": "lenIncludingSentinel",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 2124,
+                            "End Line": 2126
                         },
                         {
                             "Function Name": "paramIsComptime",
@@ -17739,46 +17740,6 @@
                             "End Line": 3391
                         },
                         {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 454,
-                            "End Line": 456
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1636,
-                            "End Line": 1638
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1687,
-                            "End Line": 1689
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1726,
-                            "End Line": 1728
-                        },
-                        {
                             "Function Name": "toSlice",
                             "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
@@ -17809,26 +17770,6 @@
                             "End Line": 1766
                         },
                         {
-                            "Function Name": "toString",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1837,
-                            "End Line": 1839
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1841,
-                            "End Line": 1843
-                        },
-                        {
                             "Function Name": "indexLessThan",
                             "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 4,
@@ -17857,16 +17798,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 3723,
                             "End Line": 3725
-                        },
-                        {
-                            "Function Name": "hasReorderedFields",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4098,
-                            "End Line": 4100
                         },
                         {
                             "Function Name": "toOverlongSlice",
@@ -18009,6 +17940,66 @@
                             "End Line": 4048
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 454,
+                            "End Line": 456
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1636,
+                            "End Line": 1638
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1687,
+                            "End Line": 1689
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1726,
+                            "End Line": 1728
+                        },
+                        {
+                            "Function Name": "toString",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1837,
+                            "End Line": 1839
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1841,
+                            "End Line": 1843
+                        },
+                        {
                             "Function Name": "fmtId",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -18139,14 +18130,14 @@
                             "End Line": 4028
                         },
                         {
-                            "Function Name": "getTidMask",
-                            "Structural Impact": 4.6,
+                            "Function Name": "hasReorderedFields",
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 1605,
-                            "End Line": 1607
+                            "Start Line": 4098,
+                            "End Line": 4100
                         },
                         {
                             "Function Name": "setBranchHint",
@@ -18197,6 +18188,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 3518,
                             "End Line": 3524
+                        },
+                        {
+                            "Function Name": "getTidMask",
+                            "Structural Impact": 4.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1605,
+                            "End Line": 1607
                         },
                         {
                             "Function Name": "setBit",
@@ -18385,7 +18386,7 @@
                         "Sequential Logic Declarations": 1026,
                         "Function Parameters": 441,
                         "Function/Method Declarations": 437,
-                        "Class/Entity Declarations": 189,
+                        "Class/Entity Declarations": 201,
                         "Defensive Programming Constructs": 675,
                         "Type/Safety Bypasses": 563,
                         "High-Risk Execution Commands": 4,
@@ -18506,26 +18507,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.678,
+                        "Repository Drift (Z-Score)": 12.676,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.11,
-                            "file_cluster_1": 13.272,
-                            "file_cluster_2": 13.426,
-                            "file_cluster_3": 14.168,
-                            "file_cluster_4": 13.581,
-                            "file_cluster_5": 13.671,
-                            "file_cluster_6": 13.309,
-                            "file_cluster_7": 12.93,
-                            "file_cluster_8": 12.678,
-                            "file_cluster_9": 13.297,
-                            "file_cluster_10": 13.911,
-                            "file_cluster_11": 13.202,
-                            "file_cluster_12": 13.551,
-                            "file_cluster_13": 13.108,
-                            "file_cluster_14": 16.74,
-                            "file_cluster_15": 13.561,
-                            "file_cluster_16": 12.989,
-                            "file_cluster_17": 13.411
+                            "file_cluster_0": 13.108,
+                            "file_cluster_1": 13.27,
+                            "file_cluster_2": 13.424,
+                            "file_cluster_3": 14.166,
+                            "file_cluster_4": 13.579,
+                            "file_cluster_5": 13.669,
+                            "file_cluster_6": 13.307,
+                            "file_cluster_7": 12.928,
+                            "file_cluster_8": 12.676,
+                            "file_cluster_9": 13.295,
+                            "file_cluster_10": 13.909,
+                            "file_cluster_11": 13.2,
+                            "file_cluster_12": 13.549,
+                            "file_cluster_13": 13.106,
+                            "file_cluster_14": 16.738,
+                            "file_cluster_15": 13.559,
+                            "file_cluster_16": 12.987,
+                            "file_cluster_17": 13.409
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -18533,9 +18534,9 @@
                         "Total LOC": 4357,
                         "Coding LOC": 3950,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 12924.9,
+                        "Structural Magnitude": 12907.8,
                         "Control Flow Ratio": "66.7%",
-                        "Popularity Rank": 5,
+                        "Popularity Rank": 6,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -18553,7 +18554,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "97.04%",
+                        "Documentation Exposure": "97.03%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -19264,36 +19265,6 @@
                             "End Line": 1281
                         },
                         {
-                            "Function Name": "isNamedInt",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 2357,
-                            "End Line": 2374
-                        },
-                        {
-                            "Function Name": "isRuntimeFloat",
-                            "Structural Impact": 12.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 2377,
-                            "End Line": 2389
-                        },
-                        {
-                            "Function Name": "isAnyFloat",
-                            "Structural Impact": 12.7,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 2392,
-                            "End Line": 2405
-                        },
-                        {
                             "Function Name": "enumTagFieldIndex",
                             "Structural Impact": 12.6,
                             "Lines of Code (LOC)": 11,
@@ -19324,66 +19295,6 @@
                             "End Line": 3347
                         },
                         {
-                            "Function Name": "Tid",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 878,
-                            "End Line": 883
-                        },
-                        {
-                            "Function Name": "ZcuPtr",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 885,
-                            "End Line": 890
-                        },
-                        {
-                            "Function Name": "Tid",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 917,
-                            "End Line": 922
-                        },
-                        {
-                            "Function Name": "ZcuPtr",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 924,
-                            "End Line": 929
-                        },
-                        {
-                            "Function Name": "toLazy",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 941,
-                            "End Line": 946
-                        },
-                        {
-                            "Function Name": "smallestUnsignedBits",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4343,
-                            "End Line": 4348
-                        },
-                        {
                             "Function Name": "structFieldAlignment",
                             "Structural Impact": 11.7,
                             "Lines of Code (LOC)": 14,
@@ -19402,6 +19313,36 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 3222,
                             "End Line": 3235
+                        },
+                        {
+                            "Function Name": "isNamedInt",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 2357,
+                            "End Line": 2374
+                        },
+                        {
+                            "Function Name": "isAnyFloat",
+                            "Structural Impact": 11.1,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 2392,
+                            "End Line": 2405
+                        },
+                        {
+                            "Function Name": "isRuntimeFloat",
+                            "Structural Impact": 11.0,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 2377,
+                            "End Line": 2389
                         },
                         {
                             "Function Name": "floatBits",
@@ -19502,6 +19443,56 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 845,
                             "End Line": 851
+                        },
+                        {
+                            "Function Name": "Tid",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 878,
+                            "End Line": 883
+                        },
+                        {
+                            "Function Name": "ZcuPtr",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 885,
+                            "End Line": 890
+                        },
+                        {
+                            "Function Name": "Tid",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 917,
+                            "End Line": 922
+                        },
+                        {
+                            "Function Name": "ZcuPtr",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 924,
+                            "End Line": 929
+                        },
+                        {
+                            "Function Name": "toLazy",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 941,
+                            "End Line": 946
                         },
                         {
                             "Function Name": "isSinglePointer",
@@ -19672,6 +19663,16 @@
                             "Control Flow Ratio": "62.5%",
                             "Start Line": 4055,
                             "End Line": 4060
+                        },
+                        {
+                            "Function Name": "smallestUnsignedBits",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4343,
+                            "End Line": 4348
                         },
                         {
                             "Function Name": "minInt",
@@ -20005,43 +20006,13 @@
                         },
                         {
                             "Function Name": "ptrAbiAlignment",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1613,
                             "End Line": 1615
-                        },
-                        {
-                            "Function Name": "fromInterned",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 432,
-                            "End Line": 435
-                        },
-                        {
-                            "Function Name": "toIntern",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 437,
-                            "End Line": 440
-                        },
-                        {
-                            "Function Name": "toValue",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 442,
-                            "End Line": 444
                         },
                         {
                             "Function Name": "unionFieldTypeByIndex",
@@ -20074,14 +20045,24 @@
                             "End Line": 3103
                         },
                         {
-                            "Function Name": "isGenericPoison",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
+                            "Function Name": "fromInterned",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 3423,
-                            "End Line": 3425
+                            "Start Line": 432,
+                            "End Line": 435
+                        },
+                        {
+                            "Function Name": "toIntern",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 437,
+                            "End Line": 440
                         },
                         {
                             "Function Name": "unionTagTypeHypothetical",
@@ -20112,6 +20093,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 87,
                             "End Line": 89
+                        },
+                        {
+                            "Function Name": "toValue",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 442,
+                            "End Line": 444
                         },
                         {
                             "Function Name": "bitSizeSema",
@@ -20292,6 +20283,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 3419,
                             "End Line": 3421
+                        },
+                        {
+                            "Function Name": "isGenericPoison",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3423,
+                            "End Line": 3425
                         },
                         {
                             "Function Name": "resolveStructAlignment",
@@ -20503,7 +20504,7 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 7,
-                        "Direct Downstream (Dependency Blast Radius)": 5,
+                        "Direct Downstream (Dependency Blast Radius)": 6,
                         "Total Upstream (Absolute Fragility)": 4,
                         "Total Downstream (Absolute Dependency Blast Radius)": 7
                     },
@@ -20535,26 +20536,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.786,
+                        "Repository Drift (Z-Score)": 13.817,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.989,
-                            "file_cluster_1": 14.207,
-                            "file_cluster_2": 14.333,
-                            "file_cluster_3": 15.016,
-                            "file_cluster_4": 14.4,
-                            "file_cluster_5": 14.521,
-                            "file_cluster_6": 14.179,
-                            "file_cluster_7": 13.857,
-                            "file_cluster_8": 13.786,
-                            "file_cluster_9": 14.16,
-                            "file_cluster_10": 14.842,
-                            "file_cluster_11": 14.075,
-                            "file_cluster_12": 14.422,
-                            "file_cluster_13": 13.93,
-                            "file_cluster_14": 17.414,
-                            "file_cluster_15": 14.377,
-                            "file_cluster_16": 14.063,
-                            "file_cluster_17": 14.236
+                            "file_cluster_0": 14.017,
+                            "file_cluster_1": 14.237,
+                            "file_cluster_2": 14.362,
+                            "file_cluster_3": 15.044,
+                            "file_cluster_4": 14.429,
+                            "file_cluster_5": 14.55,
+                            "file_cluster_6": 14.209,
+                            "file_cluster_7": 13.887,
+                            "file_cluster_8": 13.817,
+                            "file_cluster_9": 14.189,
+                            "file_cluster_10": 14.871,
+                            "file_cluster_11": 14.105,
+                            "file_cluster_12": 14.451,
+                            "file_cluster_13": 13.96,
+                            "file_cluster_14": 17.434,
+                            "file_cluster_15": 14.407,
+                            "file_cluster_16": 14.093,
+                            "file_cluster_17": 14.266
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -20562,7 +20563,7 @@
                         "Total LOC": 4802,
                         "Coding LOC": 4374,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 8634.28,
+                        "Structural Magnitude": 8110.38,
                         "Control Flow Ratio": "71.9%",
                         "Popularity Rank": 4,
                         "Raw Churn Frequency": 0.0,
@@ -20582,7 +20583,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "73.17%",
+                        "Documentation Exposure": "72.94%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -20594,10 +20595,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "findOutdatedToAnalyze",
-                            "Structural Impact": 3656.8,
+                            "Structural Impact": 3172.9,
                             "Lines of Code (LOC)": 897,
                             "Control Flow Branches": 257,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "73.6%",
                             "Start Line": 3197,
                             "End Line": 4093
@@ -20633,16 +20634,6 @@
                             "End Line": 3157
                         },
                         {
-                            "Function Name": "deinit",
-                            "Structural Impact": 116.7,
-                            "Lines of Code (LOC)": 93,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "92.9%",
-                            "Start Line": 2778,
-                            "End Line": 2870
-                        },
-                        {
                             "Function Name": "renderFullyQualifiedDebugName",
                             "Structural Impact": 111.2,
                             "Lines of Code (LOC)": 19,
@@ -20651,6 +20642,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 874,
                             "End Line": 892
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 101.6,
+                            "Lines of Code (LOC)": 93,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "92.9%",
+                            "Start Line": 2778,
+                            "End Line": 2870
                         },
                         {
                             "Function Name": "markTransitiveDependersPotentiallyOutdat",
@@ -20704,20 +20705,20 @@
                         },
                         {
                             "Function Name": "stage",
-                            "Structural Impact": 48.6,
+                            "Structural Impact": 42.2,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "70.0%",
                             "Start Line": 576,
                             "End Line": 588
                         },
                         {
                             "Function Name": "modeFromPath",
-                            "Structural Impact": 36.2,
+                            "Structural Impact": 32.5,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "70.0%",
                             "Start Line": 1013,
                             "End Line": 1021
@@ -20783,26 +20784,6 @@
                             "End Line": 1188
                         },
                         {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 748,
-                            "End Line": 753
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 794,
-                            "End Line": 799
-                        },
-                        {
                             "Function Name": "getAlign",
                             "Structural Impact": 17.8,
                             "Lines of Code (LOC)": 10,
@@ -20831,6 +20812,26 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 894,
                             "End Line": 904
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 748,
+                            "End Line": 753
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 794,
+                            "End Line": 799
                         },
                         {
                             "Function Name": "getTree",
@@ -20944,10 +20945,10 @@
                         },
                         {
                             "Function Name": "toBuiltin",
-                            "Structural Impact": 13.2,
+                            "Structural Impact": 11.6,
                             "Lines of Code (LOC)": 25,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 632,
                             "End Line": 656
@@ -21013,56 +21014,6 @@
                             "End Line": 862
                         },
                         {
-                            "Function Name": "src",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 197,
-                            "End Line": 202
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 742,
-                            "End Line": 744
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 788,
-                            "End Line": 790
-                        },
-                        {
-                            "Function Name": "nodeOffsetDebug",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 2646,
-                            "End Line": 2650
-                        },
-                        {
-                            "Function Name": "nodeOffsetRelease",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 2652,
-                            "End Line": 2654
-                        },
-                        {
                             "Function Name": "deinit",
                             "Structural Impact": 8.0,
                             "Lines of Code (LOC)": 5,
@@ -21071,6 +21022,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 669,
                             "End Line": 673
+                        },
+                        {
+                            "Function Name": "src",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 197,
+                            "End Line": 202
                         },
                         {
                             "Function Name": "unloadTree",
@@ -21103,6 +21064,16 @@
                             "End Line": 1049
                         },
                         {
+                            "Function Name": "nodeOffsetDebug",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 2646,
+                            "End Line": 2650
+                        },
+                        {
                             "Function Name": "ptr",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
@@ -21123,6 +21094,16 @@
                             "End Line": 741
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 742,
+                            "End Line": 744
+                        },
+                        {
                             "Function Name": "ptr",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
@@ -21133,6 +21114,16 @@
                             "End Line": 787
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 788,
+                            "End Line": 790
+                        },
+                        {
                             "Function Name": "get",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
@@ -21141,6 +21132,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1202,
                             "End Line": 1204
+                        },
+                        {
+                            "Function Name": "nodeOffsetRelease",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 2652,
+                            "End Line": 2654
                         },
                         {
                             "Function Name": "init",
@@ -21193,36 +21194,6 @@
                             "End Line": 364
                         },
                         {
-                            "Function Name": "getMode",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1008,
-                            "End Line": 1011
-                        },
-                        {
-                            "Function Name": "fullyQualifiedNameLen",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1119,
-                            "End Line": 1122
-                        },
-                        {
-                            "Function Name": "baseSrcToken",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1269,
-                            "End Line": 1272
-                        },
-                        {
                             "Function Name": "unload",
                             "Structural Impact": 5.5,
                             "Lines of Code (LOC)": 6,
@@ -21233,6 +21204,26 @@
                             "End Line": 1028
                         },
                         {
+                            "Function Name": "getMode",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1008,
+                            "End Line": 1011
+                        },
+                        {
+                            "Function Name": "fullyQualifiedNameLen",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1119,
+                            "End Line": 1122
+                        },
+                        {
                             "Function Name": "destroy",
                             "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
@@ -21241,6 +21232,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1232,
                             "End Line": 1235
+                        },
+                        {
+                            "Function Name": "baseSrcToken",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1269,
+                            "End Line": 1272
                         },
                         {
                             "Function Name": "fileScope",
@@ -21274,10 +21275,10 @@
                         },
                         {
                             "Function Name": "access",
-                            "Structural Impact": 3.2,
+                            "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 592,
                             "End Line": 595
@@ -21294,10 +21295,10 @@
                         },
                         {
                             "Function Name": "kind",
-                            "Structural Impact": 2.0,
+                            "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 478,
                             "End Line": 478
@@ -21411,7 +21412,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 14,
+                        "Direct Upstream (Fragility)": 17,
                         "Direct Downstream (Dependency Blast Radius)": 4,
                         "Total Upstream (Absolute Fragility)": 4,
                         "Total Downstream (Absolute Dependency Blast Radius)": 7
@@ -21422,6 +21423,9 @@
                         "InternPool.zig",
                         "Package.zig",
                         "Sema.zig",
+                        "Type.zig",
+                        "Value.zig",
+                        "Zcu/PerThread.zig",
                         "build_options",
                         "builtin",
                         "codegen/llvm.zig",
@@ -21451,7 +21455,7 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.63,
+                        "Repository Drift (Z-Score)": 13.629,
                         "Repository Fingerprint": {
                             "file_cluster_0": 14.01,
                             "file_cluster_1": 14.296,
@@ -21460,17 +21464,17 @@
                             "file_cluster_4": 14.308,
                             "file_cluster_5": 14.713,
                             "file_cluster_6": 14.224,
-                            "file_cluster_7": 13.992,
-                            "file_cluster_8": 13.63,
+                            "file_cluster_7": 13.991,
+                            "file_cluster_8": 13.629,
                             "file_cluster_9": 14.144,
                             "file_cluster_10": 15.05,
                             "file_cluster_11": 14.094,
                             "file_cluster_12": 14.545,
-                            "file_cluster_13": 13.978,
-                            "file_cluster_14": 17.345,
+                            "file_cluster_13": 13.977,
+                            "file_cluster_14": 17.343,
                             "file_cluster_15": 14.519,
-                            "file_cluster_16": 14.361,
-                            "file_cluster_17": 14.129
+                            "file_cluster_16": 14.36,
+                            "file_cluster_17": 14.128
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -21478,7 +21482,7 @@
                         "Total LOC": 7530,
                         "Coding LOC": 6974,
                         "Documentation LOC": 8,
-                        "Structural Magnitude": 7471.48,
+                        "Structural Magnitude": 7449.38,
                         "Control Flow Ratio": "82.5%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -21498,7 +21502,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "20.59%",
+                        "Documentation Exposure": "20.56%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -21580,20 +21584,20 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 48.4,
+                            "Structural Impact": 42.0,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 5,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "55.6%",
                             "Start Line": 751,
                             "End Line": 758
                         },
                         {
                             "Function Name": "anyObjectLinkInputs",
-                            "Structural Impact": 45.2,
+                            "Structural Impact": 40.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 9,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "81.8%",
                             "Start Line": 7501,
                             "End Line": 7510
@@ -21609,16 +21613,6 @@
                             "End Line": 7407
                         },
                         {
-                            "Function Name": "nextOrFatal",
-                            "Structural Impact": 24.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 759,
-                            "End Line": 766
-                        },
-                        {
                             "Function Name": "addLibDirectoryWarn2",
                             "Structural Impact": 23.1,
                             "Lines of Code (LOC)": 14,
@@ -21629,41 +21623,51 @@
                             "End Line": 7529
                         },
                         {
+                            "Function Name": "nextOrFatal",
+                            "Structural Impact": 21.2,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 759,
+                            "End Line": 766
+                        },
+                        {
                             "Function Name": "parseWasiExecModel",
-                            "Structural Impact": 13.6,
+                            "Structural Impact": 12.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "75.0%",
                             "Start Line": 7414,
                             "End Line": 7417
                         },
                         {
                             "Function Name": "parseOptimizeMode",
-                            "Structural Impact": 10.3,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7409,
                             "End Line": 7412
                         },
                         {
                             "Function Name": "parseStackSize",
-                            "Structural Impact": 10.3,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7419,
                             "End Line": 7422
                         },
                         {
                             "Function Name": "parseImageBase",
-                            "Structural Impact": 10.3,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7424,
                             "End Line": 7427
@@ -21680,33 +21684,23 @@
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 6.3,
+                            "Structural Impact": 5.5,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 7315,
                             "End Line": 7320
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 7172,
                             "End Line": 7175
-                        },
-                        {
-                            "Function Name": "wasi_cwd",
-                            "Structural Impact": 3.8,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 60,
-                            "End Line": 65
                         },
                         {
                             "Function Name": "addLibDirectoryWarn",
@@ -21727,6 +21721,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 7246,
                             "End Line": 7250
+                        },
+                        {
+                            "Function Name": "wasi_cwd",
+                            "Structural Impact": 2.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 60,
+                            "End Line": 65
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -21734,7 +21738,7 @@
                         "Control Flow Branches": 2695,
                         "Sequential Logic Declarations": 571,
                         "Function Parameters": 69,
-                        "Function/Method Declarations": 66,
+                        "Function/Method Declarations": 68,
                         "Class/Entity Declarations": 24,
                         "Defensive Programming Constructs": 953,
                         "Type/Safety Bypasses": 112,
@@ -21827,7 +21831,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 19,
+                        "Direct Upstream (Fragility)": 20,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
@@ -21841,6 +21845,7 @@
                         "build_options",
                         "builtin",
                         "clang_options.zig",
+                        "codegen.zig",
                         "codegen/llvm.zig",
                         "codegen/llvm/bindings.zig",
                         "crash_report.zig",
@@ -30258,7 +30263,7 @@
             }
         },
         "zig/zls": {
-            "Directory Group Magnitude": 28980.36,
+            "Directory Group Magnitude": 28672.86,
             "File Count": 6,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -30275,7 +30280,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "76.25%",
+                "Documentation Exposure": "76.13%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "99.92%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -30297,32 +30302,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4731.79,
+                        "X": -4732.01,
                         "Y": -132.14,
-                        "Z": -1992.06
+                        "Z": -1991.92
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.13,
+                        "Repository Drift (Z-Score)": 12.125,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.684,
-                            "file_cluster_1": 12.822,
-                            "file_cluster_2": 12.968,
-                            "file_cluster_3": 13.797,
-                            "file_cluster_4": 13.076,
-                            "file_cluster_5": 13.276,
-                            "file_cluster_6": 12.969,
-                            "file_cluster_7": 12.489,
-                            "file_cluster_8": 12.13,
-                            "file_cluster_9": 12.839,
-                            "file_cluster_10": 13.72,
-                            "file_cluster_11": 12.957,
-                            "file_cluster_12": 13.216,
-                            "file_cluster_13": 12.638,
-                            "file_cluster_14": 16.356,
-                            "file_cluster_15": 13.205,
-                            "file_cluster_16": 12.934,
-                            "file_cluster_17": 12.894
+                            "file_cluster_0": 12.68,
+                            "file_cluster_1": 12.817,
+                            "file_cluster_2": 12.963,
+                            "file_cluster_3": 13.793,
+                            "file_cluster_4": 13.072,
+                            "file_cluster_5": 13.272,
+                            "file_cluster_6": 12.964,
+                            "file_cluster_7": 12.484,
+                            "file_cluster_8": 12.125,
+                            "file_cluster_9": 12.834,
+                            "file_cluster_10": 13.716,
+                            "file_cluster_11": 12.953,
+                            "file_cluster_12": 13.212,
+                            "file_cluster_13": 12.634,
+                            "file_cluster_14": 16.352,
+                            "file_cluster_15": 13.2,
+                            "file_cluster_16": 12.929,
+                            "file_cluster_17": 12.889
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -30330,9 +30335,9 @@
                         "Total LOC": 1346,
                         "Coding LOC": 1176,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 504.02,
+                        "Structural Magnitude": 493.82,
                         "Control Flow Ratio": "80.1%",
-                        "Popularity Rank": 1,
+                        "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -30350,7 +30355,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "81.24%",
+                        "Documentation Exposure": "80.97%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "99.98%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -30402,33 +30407,23 @@
                         },
                         {
                             "Function Name": "unwrap",
-                            "Structural Impact": 16.2,
+                            "Structural Impact": 14.1,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 162,
                             "End Line": 165
                         },
                         {
                             "Function Name": "unwrap",
-                            "Structural Impact": 16.2,
+                            "Structural Impact": 14.1,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 303,
                             "End Line": 306
-                        },
-                        {
-                            "Function Name": "isContainer",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 236,
-                            "End Line": 241
                         },
                         {
                             "Function Name": "eql",
@@ -30439,6 +30434,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 43,
                             "End Line": 47
+                        },
+                        {
+                            "Function Name": "isContainer",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 236,
+                            "End Line": 241
                         },
                         {
                             "Function Name": "getScopeDeclaration",
@@ -30481,26 +30486,6 @@
                             "End Line": 1291
                         },
                         {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 153,
-                            "End Line": 155
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 293,
-                            "End Line": 295
-                        },
-                        {
                             "Function Name": "getCase",
                             "Structural Impact": 7.2,
                             "Lines of Code (LOC)": 5,
@@ -30531,21 +30516,41 @@
                             "End Line": 134
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 153,
+                            "End Line": 155
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 293,
+                            "End Line": 295
+                        },
+                        {
                             "Function Name": "locToSmallLoc",
-                            "Structural Impact": 6.3,
+                            "Structural Impact": 5.5,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 530,
                             "End Line": 535
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 319,
                             "End Line": 322
@@ -30751,16 +30756,6 @@
                             "End Line": 426
                         },
                         {
-                            "Function Name": "finalize",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 384,
-                            "End Line": 384
-                        },
-                        {
                             "Function Name": "walkUnaryOpNode",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
@@ -30799,6 +30794,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1248,
                             "End Line": 1248
+                        },
+                        {
+                            "Function Name": "finalize",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 384,
+                            "End Line": 384
                         },
                         {
                             "Function Name": "init",
@@ -30910,7 +30915,7 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 4,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 1,
                         "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
@@ -30933,32 +30938,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5214.59,
-                        "Y": -205.03,
-                        "Z": -2205.01
+                        "X": -5214.6,
+                        "Y": -205.02,
+                        "Z": -2204.87
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.714,
+                        "Repository Drift (Z-Score)": 13.724,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.928,
-                            "file_cluster_1": 14.207,
-                            "file_cluster_2": 14.282,
-                            "file_cluster_3": 14.992,
-                            "file_cluster_4": 14.034,
-                            "file_cluster_5": 14.524,
-                            "file_cluster_6": 14.051,
-                            "file_cluster_7": 13.878,
-                            "file_cluster_8": 13.714,
-                            "file_cluster_9": 14.105,
-                            "file_cluster_10": 14.919,
-                            "file_cluster_11": 13.99,
-                            "file_cluster_12": 14.49,
-                            "file_cluster_13": 13.755,
-                            "file_cluster_14": 17.322,
-                            "file_cluster_15": 14.43,
-                            "file_cluster_16": 14.218,
-                            "file_cluster_17": 14.082
+                            "file_cluster_0": 13.937,
+                            "file_cluster_1": 14.217,
+                            "file_cluster_2": 14.292,
+                            "file_cluster_3": 15.002,
+                            "file_cluster_4": 14.044,
+                            "file_cluster_5": 14.534,
+                            "file_cluster_6": 14.061,
+                            "file_cluster_7": 13.888,
+                            "file_cluster_8": 13.724,
+                            "file_cluster_9": 14.114,
+                            "file_cluster_10": 14.928,
+                            "file_cluster_11": 14.0,
+                            "file_cluster_12": 14.499,
+                            "file_cluster_13": 13.765,
+                            "file_cluster_14": 17.328,
+                            "file_cluster_15": 14.439,
+                            "file_cluster_16": 14.227,
+                            "file_cluster_17": 14.091
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -30966,7 +30971,7 @@
                         "Total LOC": 2059,
                         "Coding LOC": 1737,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3040.84,
+                        "Structural Magnitude": 3015.44,
                         "Control Flow Ratio": "66.9%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -30986,7 +30991,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "70.53%",
+                        "Documentation Exposure": "70.35%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -31038,23 +31043,13 @@
                         },
                         {
                             "Function Name": "notifyBuildStart",
-                            "Structural Impact": 77.2,
+                            "Structural Impact": 67.1,
                             "Lines of Code (LOC)": 43,
                             "Control Flow Branches": 14,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 1112,
                             "End Line": 1154
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 65.3,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "87.5%",
-                            "Start Line": 697,
-                            "End Line": 723
                         },
                         {
                             "Function Name": "readFile",
@@ -31065,6 +31060,16 @@
                             "Control Flow Ratio": "72.2%",
                             "Start Line": 740,
                             "End Line": 773
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 56.8,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "87.5%",
+                            "Start Line": 697,
+                            "End Line": 723
                         },
                         {
                             "Function Name": "notifyBuildEnd",
@@ -31078,10 +31083,10 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 35.6,
+                            "Structural Impact": 31.0,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 6,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 676,
                             "End Line": 688
@@ -31228,10 +31233,10 @@
                         },
                         {
                             "Function Name": "isInStd",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 1295,
                             "End Line": 1298
@@ -31245,26 +31250,6 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 482,
                             "End Line": 488
-                        },
-                        {
-                            "Function Name": "isBuildFile",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1287,
-                            "End Line": 1289
-                        },
-                        {
-                            "Function Name": "isBuiltinFile",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1291,
-                            "End Line": 1293
                         },
                         {
                             "Function Name": "refresh",
@@ -31297,6 +31282,26 @@
                             "End Line": 99
                         },
                         {
+                            "Function Name": "isBuildFile",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1287,
+                            "End Line": 1289
+                        },
+                        {
+                            "Function Name": "isBuiltinFile",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1291,
+                            "End Line": 1293
+                        },
+                        {
                             "Function Name": "unlockConfig",
                             "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 3,
@@ -31315,16 +31320,6 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1035,
                             "End Line": 1038
-                        },
-                        {
-                            "Function Name": "getDocumentScope",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 187,
-                            "End Line": 187
                         },
                         {
                             "Function Name": "parseTree",
@@ -31365,6 +31360,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 922,
                             "End Line": 922
+                        },
+                        {
+                            "Function Name": "getDocumentScope",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 187,
+                            "End Line": 187
                         },
                         {
                             "Function Name": "getAssociatedBuildFile",
@@ -31535,7 +31540,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 12,
+                        "Direct Upstream (Fragility)": 13,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 3,
                         "Total Downstream (Absolute Dependency Blast Radius)": 3
@@ -31547,6 +31552,7 @@
                         "TrigramStore.zig",
                         "Uri.zig",
                         "analysis.zig",
+                        "build_runner/shared.zig",
                         "builtin",
                         "lsp",
                         "offsets.zig",
@@ -31567,32 +31573,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5524.24,
+                        "X": -5524.12,
                         "Y": -185.39,
-                        "Z": -1278.29
+                        "Z": -1278.4
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.347,
+                        "Repository Drift (Z-Score)": 13.343,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.726,
-                            "file_cluster_1": 13.946,
-                            "file_cluster_2": 14.021,
-                            "file_cluster_3": 14.775,
-                            "file_cluster_4": 14.104,
-                            "file_cluster_5": 14.338,
-                            "file_cluster_6": 13.864,
-                            "file_cluster_7": 13.64,
-                            "file_cluster_8": 13.347,
-                            "file_cluster_9": 13.904,
-                            "file_cluster_10": 14.75,
-                            "file_cluster_11": 13.726,
-                            "file_cluster_12": 14.132,
-                            "file_cluster_13": 13.509,
-                            "file_cluster_14": 17.138,
-                            "file_cluster_15": 14.208,
-                            "file_cluster_16": 13.897,
-                            "file_cluster_17": 13.875
+                            "file_cluster_0": 13.722,
+                            "file_cluster_1": 13.942,
+                            "file_cluster_2": 14.017,
+                            "file_cluster_3": 14.772,
+                            "file_cluster_4": 14.1,
+                            "file_cluster_5": 14.335,
+                            "file_cluster_6": 13.86,
+                            "file_cluster_7": 13.636,
+                            "file_cluster_8": 13.343,
+                            "file_cluster_9": 13.9,
+                            "file_cluster_10": 14.746,
+                            "file_cluster_11": 13.722,
+                            "file_cluster_12": 14.128,
+                            "file_cluster_13": 13.505,
+                            "file_cluster_14": 17.135,
+                            "file_cluster_15": 14.205,
+                            "file_cluster_16": 13.893,
+                            "file_cluster_17": 13.872
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -31600,7 +31606,7 @@
                         "Total LOC": 2030,
                         "Coding LOC": 1778,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3247.96,
+                        "Structural Magnitude": 3216.56,
                         "Control Flow Ratio": "74.4%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -31620,7 +31626,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "81.66%",
+                        "Documentation Exposure": "81.59%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -31791,16 +31797,6 @@
                             "End Line": 1372
                         },
                         {
-                            "Function Name": "loop",
-                            "Structural Impact": 51.5,
-                            "Lines of Code (LOC)": 29,
-                            "Control Flow Branches": 9,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "56.2%",
-                            "Start Line": 1754,
-                            "End Line": 1782
-                        },
-                        {
                             "Function Name": "willSaveWaitUntilHandler",
                             "Structural Impact": 49.0,
                             "Lines of Code (LOC)": 21,
@@ -31809,16 +31805,6 @@
                             "Control Flow Ratio": "65.2%",
                             "Start Line": 1241,
                             "End Line": 1261
-                        },
-                        {
-                            "Function Name": "sendManualWatchUpdate",
-                            "Structural Impact": 48.5,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "70.0%",
-                            "Start Line": 784,
-                            "End Line": 792
                         },
                         {
                             "Function Name": "initializedHandler",
@@ -31861,6 +31847,16 @@
                             "End Line": 1482
                         },
                         {
+                            "Function Name": "loop",
+                            "Structural Impact": 44.8,
+                            "Lines of Code (LOC)": 29,
+                            "Control Flow Branches": 9,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "56.2%",
+                            "Start Line": 1754,
+                            "End Line": 1782
+                        },
+                        {
                             "Function Name": "semanticTokensRangeHandler",
                             "Structural Impact": 43.5,
                             "Lines of Code (LOC)": 30,
@@ -31901,24 +31897,14 @@
                             "End Line": 1339
                         },
                         {
-                            "Function Name": "isBlockingMessage",
-                            "Structural Impact": 42.3,
-                            "Lines of Code (LOC)": 46,
-                            "Control Flow Branches": 9,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1630,
-                            "End Line": 1675
-                        },
-                        {
-                            "Function Name": "create",
-                            "Structural Impact": 41.6,
-                            "Lines of Code (LOC)": 33,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1687,
-                            "End Line": 1719
+                            "Function Name": "sendManualWatchUpdate",
+                            "Structural Impact": 42.0,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.0%",
+                            "Start Line": 784,
+                            "End Line": 792
                         },
                         {
                             "Function Name": "hoverHandler",
@@ -31941,6 +31927,16 @@
                             "End Line": 1164
                         },
                         {
+                            "Function Name": "isBlockingMessage",
+                            "Structural Impact": 36.9,
+                            "Lines of Code (LOC)": 46,
+                            "Control Flow Branches": 9,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1630,
+                            "End Line": 1675
+                        },
+                        {
                             "Function Name": "documentSymbolsHandler",
                             "Structural Impact": 36.5,
                             "Lines of Code (LOC)": 11,
@@ -31949,6 +31945,16 @@
                             "Control Flow Ratio": "68.8%",
                             "Start Line": 1433,
                             "End Line": 1443
+                        },
+                        {
+                            "Function Name": "create",
+                            "Structural Impact": 36.3,
+                            "Lines of Code (LOC)": 33,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1687,
+                            "End Line": 1719
                         },
                         {
                             "Function Name": "registerCapability",
@@ -32022,20 +32028,20 @@
                         },
                         {
                             "Function Name": "keepRunning",
-                            "Structural Impact": 17.1,
+                            "Structural Impact": 15.3,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 1740,
                             "End Line": 1745
                         },
                         {
                             "Function Name": "requestConfiguration",
-                            "Structural Impact": 16.9,
+                            "Structural Impact": 14.7,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 665,
                             "End Line": 681
@@ -32062,10 +32068,10 @@
                         },
                         {
                             "Function Name": "destroy",
-                            "Structural Impact": 12.6,
+                            "Structural Impact": 11.0,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 1721,
                             "End Line": 1732
@@ -32131,16 +32137,6 @@
                             "End Line": 642
                         },
                         {
-                            "Function Name": "createDocumentStoreConfig",
-                            "Structural Impact": 7.3,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1136,
-                            "End Line": 1146
-                        },
-                        {
                             "Function Name": "initAnalyser",
                             "Structural Impact": 6.5,
                             "Lines of Code (LOC)": 9,
@@ -32149,6 +32145,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 269,
                             "End Line": 277
+                        },
+                        {
+                            "Function Name": "createDocumentStoreConfig",
+                            "Structural Impact": 6.5,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1136,
+                            "End Line": 1146
                         },
                         {
                             "Function Name": "shutdownHandler",
@@ -32192,10 +32198,10 @@
                         },
                         {
                             "Function Name": "fmtMessage",
-                            "Structural Impact": 4.2,
+                            "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 2027,
                             "End Line": 2029
@@ -32209,16 +32215,6 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 794,
                             "End Line": 798
-                        },
-                        {
-                            "Function Name": "autofixWorkaround",
-                            "Structural Impact": 2.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 280,
-                            "End Line": 289
                         },
                         {
                             "Function Name": "sendToClientRequest",
@@ -32239,6 +32235,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 206,
                             "End Line": 206
+                        },
+                        {
+                            "Function Name": "autofixWorkaround",
+                            "Structural Impact": 2.2,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 280,
+                            "End Line": 289
                         },
                         {
                             "Function Name": "sendToClientResponse",
@@ -32281,16 +32287,6 @@
                             "End Line": 297
                         },
                         {
-                            "Function Name": "resolveConfiguration",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 978,
-                            "End Line": 978
-                        },
-                        {
                             "Function Name": "setTransport",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
@@ -32329,6 +32325,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 857,
                             "End Line": 857
+                        },
+                        {
+                            "Function Name": "resolveConfiguration",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 978,
+                            "End Line": 978
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -32482,26 +32488,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 14.517,
+                        "Repository Drift (Z-Score)": 14.526,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.702,
-                            "file_cluster_1": 15.099,
-                            "file_cluster_2": 15.122,
-                            "file_cluster_3": 15.766,
-                            "file_cluster_4": 15.072,
-                            "file_cluster_5": 15.44,
-                            "file_cluster_6": 14.895,
-                            "file_cluster_7": 14.771,
-                            "file_cluster_8": 14.517,
-                            "file_cluster_9": 14.862,
-                            "file_cluster_10": 15.709,
-                            "file_cluster_11": 14.701,
-                            "file_cluster_12": 15.256,
-                            "file_cluster_13": 14.724,
-                            "file_cluster_14": 17.953,
-                            "file_cluster_15": 15.203,
-                            "file_cluster_16": 14.785,
-                            "file_cluster_17": 14.868
+                            "file_cluster_0": 14.71,
+                            "file_cluster_1": 15.108,
+                            "file_cluster_2": 15.131,
+                            "file_cluster_3": 15.775,
+                            "file_cluster_4": 15.081,
+                            "file_cluster_5": 15.449,
+                            "file_cluster_6": 14.904,
+                            "file_cluster_7": 14.78,
+                            "file_cluster_8": 14.526,
+                            "file_cluster_9": 14.87,
+                            "file_cluster_10": 15.718,
+                            "file_cluster_11": 14.71,
+                            "file_cluster_12": 15.265,
+                            "file_cluster_13": 14.733,
+                            "file_cluster_14": 17.959,
+                            "file_cluster_15": 15.212,
+                            "file_cluster_16": 14.794,
+                            "file_cluster_17": 14.877
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -32509,7 +32515,7 @@
                         "Total LOC": 7016,
                         "Coding LOC": 6283,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 18450.86,
+                        "Structural Magnitude": 18254.66,
                         "Control Flow Ratio": "73.5%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -32529,7 +32535,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "92.92%",
+                        "Documentation Exposure": "92.8%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -32621,23 +32627,13 @@
                         },
                         {
                             "Function Name": "isGeneric",
-                            "Structural Impact": 352.8,
+                            "Structural Impact": 305.9,
                             "Lines of Code (LOC)": 55,
                             "Control Flow Branches": 24,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 3578,
                             "End Line": 3632
-                        },
-                        {
-                            "Function Name": "isConditional",
-                            "Structural Impact": 301.9,
-                            "Lines of Code (LOC)": 37,
-                            "Control Flow Branches": 24,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3977,
-                            "End Line": 4013
                         },
                         {
                             "Function Name": "resolveBindingOfNodeUncached",
@@ -32648,6 +32644,16 @@
                             "Control Flow Ratio": "72.7%",
                             "Start Line": 3073,
                             "End Line": 3160
+                        },
+                        {
+                            "Function Name": "isConditional",
+                            "Structural Impact": 261.7,
+                            "Lines of Code (LOC)": 37,
+                            "Control Flow Branches": 24,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3977,
+                            "End Line": 4013
                         },
                         {
                             "Function Name": "resolveVarDeclAlias",
@@ -32710,16 +32716,6 @@
                             "End Line": 1823
                         },
                         {
-                            "Function Name": "typeDefinitionToken",
-                            "Structural Impact": 120.8,
-                            "Lines of Code (LOC)": 37,
-                            "Control Flow Branches": 16,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 4465,
-                            "End Line": 4501
-                        },
-                        {
                             "Function Name": "resolveReturnValueOfFuncNode",
                             "Structural Impact": 118.1,
                             "Lines of Code (LOC)": 36,
@@ -32748,6 +32744,16 @@
                             "Control Flow Ratio": "73.3%",
                             "Start Line": 6949,
                             "End Line": 6980
+                        },
+                        {
+                            "Function Name": "typeDefinitionToken",
+                            "Structural Impact": 104.9,
+                            "Lines of Code (LOC)": 37,
+                            "Control Flow Branches": 16,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 4465,
+                            "End Line": 4501
                         },
                         {
                             "Function Name": "createArray",
@@ -32810,16 +32816,6 @@
                             "End Line": 3332
                         },
                         {
-                            "Function Name": "isConst",
-                            "Structural Impact": 93.4,
-                            "Lines of Code (LOC)": 48,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 5763,
-                            "End Line": 5810
-                        },
-                        {
                             "Function Name": "resolveArrayCat",
                             "Structural Impact": 88.2,
                             "Lines of Code (LOC)": 24,
@@ -32848,6 +32844,16 @@
                             "Control Flow Ratio": "87.5%",
                             "Start Line": 372,
                             "End Line": 385
+                        },
+                        {
+                            "Function Name": "isConst",
+                            "Structural Impact": 81.2,
+                            "Lines of Code (LOC)": 48,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 5763,
+                            "End Line": 5810
                         },
                         {
                             "Function Name": "findReturnStatementInternal",
@@ -32910,26 +32916,6 @@
                             "End Line": 966
                         },
                         {
-                            "Function Name": "isGenericFunc",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "70.0%",
-                            "Start Line": 4381,
-                            "End Line": 4393
-                        },
-                        {
-                            "Function Name": "next",
-                            "Structural Impact": 56.4,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 10,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 6165,
-                            "End Line": 6191
-                        },
-                        {
                             "Function Name": "createTuple",
                             "Structural Impact": 52.9,
                             "Lines of Code (LOC)": 19,
@@ -32940,14 +32926,24 @@
                             "End Line": 3380
                         },
                         {
-                            "Function Name": "isNamespace",
-                            "Structural Impact": 52.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "63.2%",
-                            "Start Line": 4298,
-                            "End Line": 4313
+                            "Function Name": "isGenericFunc",
+                            "Structural Impact": 49.1,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.0%",
+                            "Start Line": 4381,
+                            "End Line": 4393
+                        },
+                        {
+                            "Function Name": "next",
+                            "Structural Impact": 49.0,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 10,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 6165,
+                            "End Line": 6191
                         },
                         {
                             "Function Name": "instanceStdBuiltinType",
@@ -32958,6 +32954,16 @@
                             "Control Flow Ratio": "70.8%",
                             "Start Line": 4939,
                             "End Line": 4960
+                        },
+                        {
+                            "Function Name": "isNamespace",
+                            "Structural Impact": 45.8,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "63.2%",
+                            "Start Line": 4298,
+                            "End Line": 4313
                         },
                         {
                             "Function Name": "getDocCommentTokenIndex",
@@ -33050,16 +33056,6 @@
                             "End Line": 4421
                         },
                         {
-                            "Function Name": "isTaggedUnion",
-                            "Structural Impact": 32.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4327,
-                            "End Line": 4332
-                        },
-                        {
                             "Function Name": "eql",
                             "Structural Impact": 32.2,
                             "Lines of Code (LOC)": 5,
@@ -33110,16 +33106,6 @@
                             "End Line": 5662
                         },
                         {
-                            "Function Name": "isPublic",
-                            "Structural Impact": 31.2,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 5845,
-                            "End Line": 5869
-                        },
-                        {
                             "Function Name": "isInstanceCall",
                             "Structural Impact": 30.4,
                             "Lines of Code (LOC)": 20,
@@ -33130,24 +33116,24 @@
                             "End Line": 437
                         },
                         {
-                            "Function Name": "getContainerKind",
-                            "Structural Impact": 28.6,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4269,
-                            "End Line": 4280
+                            "Function Name": "isTaggedUnion",
+                            "Structural Impact": 28.0,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4327,
+                            "End Line": 4332
                         },
                         {
-                            "Function Name": "isMetaType",
-                            "Structural Impact": 28.4,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4335,
-                            "End Line": 4341
+                            "Function Name": "isPublic",
+                            "Structural Impact": 27.2,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 5845,
+                            "End Line": 5869
                         },
                         {
                             "Function Name": "createOptional",
@@ -33160,44 +33146,24 @@
                             "End Line": 3389
                         },
                         {
-                            "Function Name": "resolveDeclLiteralResultType",
-                            "Structural Impact": 25.6,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
+                            "Function Name": "getContainerKind",
+                            "Structural Impact": 24.8,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
-                            "Start Line": 4361,
-                            "End Line": 4371
+                            "Start Line": 4269,
+                            "End Line": 4280
                         },
                         {
-                            "Function Name": "next",
-                            "Structural Impact": 25.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 4186,
-                            "End Line": 4195
-                        },
-                        {
-                            "Function Name": "isNoreturnType",
-                            "Structural Impact": 24.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 4402,
-                            "End Line": 4409
-                        },
-                        {
-                            "Function Name": "root",
-                            "Structural Impact": 24.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 3263,
-                            "End Line": 3268
+                            "Function Name": "isMetaType",
+                            "Structural Impact": 24.6,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4335,
+                            "End Line": 4341
                         },
                         {
                             "Function Name": "eql",
@@ -33220,6 +33186,26 @@
                             "End Line": 7013
                         },
                         {
+                            "Function Name": "next",
+                            "Structural Impact": 22.2,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 4186,
+                            "End Line": 4195
+                        },
+                        {
+                            "Function Name": "resolveDeclLiteralResultType",
+                            "Structural Impact": 22.2,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4361,
+                            "End Line": 4371
+                        },
+                        {
                             "Function Name": "loc",
                             "Structural Impact": 22.0,
                             "Lines of Code (LOC)": 25,
@@ -33240,6 +33226,26 @@
                             "End Line": 1460
                         },
                         {
+                            "Function Name": "isNoreturnType",
+                            "Structural Impact": 21.2,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 4402,
+                            "End Line": 4409
+                        },
+                        {
+                            "Function Name": "root",
+                            "Structural Impact": 21.1,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3263,
+                            "End Line": 3268
+                        },
+                        {
                             "Function Name": "eql",
                             "Structural Impact": 21.0,
                             "Lines of Code (LOC)": 4,
@@ -33248,26 +33254,6 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 4991,
                             "End Line": 4994
-                        },
-                        {
-                            "Function Name": "isRoot",
-                            "Structural Impact": 20.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4258,
-                            "End Line": 4263
-                        },
-                        {
-                            "Function Name": "isEnumLiteral",
-                            "Structural Impact": 20.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4354,
-                            "End Line": 4359
                         },
                         {
                             "Function Name": "eql",
@@ -33320,6 +33306,26 @@
                             "End Line": 5676
                         },
                         {
+                            "Function Name": "isRoot",
+                            "Structural Impact": 17.6,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4258,
+                            "End Line": 4263
+                        },
+                        {
+                            "Function Name": "isEnumLiteral",
+                            "Structural Impact": 17.6,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4354,
+                            "End Line": 4359
+                        },
+                        {
                             "Function Name": "innermostScopeAtIndexWithTag",
                             "Structural Impact": 17.5,
                             "Lines of Code (LOC)": 14,
@@ -33328,16 +33334,6 @@
                             "Control Flow Ratio": "57.1%",
                             "Start Line": 6221,
                             "End Line": 6234
-                        },
-                        {
-                            "Function Name": "allDigits",
-                            "Structural Impact": 17.1,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1374,
-                            "End Line": 1379
                         },
                         {
                             "Function Name": "createPointerType",
@@ -33350,36 +33346,6 @@
                             "End Line": 3792
                         },
                         {
-                            "Function Name": "ipIndex",
-                            "Structural Impact": 16.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 3871,
-                            "End Line": 3876
-                        },
-                        {
-                            "Function Name": "isTypeFunc",
-                            "Structural Impact": 16.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4373,
-                            "End Line": 4378
-                        },
-                        {
-                            "Function Name": "isFunc",
-                            "Structural Impact": 16.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4395,
-                            "End Line": 4400
-                        },
-                        {
                             "Function Name": "getSymbolEnumLiteral",
                             "Structural Impact": 15.4,
                             "Lines of Code (LOC)": 14,
@@ -33388,6 +33354,16 @@
                             "Control Flow Ratio": "62.5%",
                             "Start Line": 6870,
                             "End Line": 6883
+                        },
+                        {
+                            "Function Name": "allDigits",
+                            "Structural Impact": 15.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1374,
+                            "End Line": 1379
                         },
                         {
                             "Function Name": "createArrayType",
@@ -33410,6 +33386,16 @@
                             "End Line": 7005
                         },
                         {
+                            "Function Name": "ipIndex",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 3871,
+                            "End Line": 3876
+                        },
+                        {
                             "Function Name": "withoutIPIndex",
                             "Structural Impact": 14.2,
                             "Lines of Code (LOC)": 6,
@@ -33418,6 +33404,26 @@
                             "Control Flow Ratio": "75.0%",
                             "Start Line": 3878,
                             "End Line": 3883
+                        },
+                        {
+                            "Function Name": "isTypeFunc",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4373,
+                            "End Line": 4378
+                        },
+                        {
+                            "Function Name": "isFunc",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4395,
+                            "End Line": 4400
                         },
                         {
                             "Function Name": "hash",
@@ -33460,26 +33466,6 @@
                             "End Line": 1426
                         },
                         {
-                            "Function Name": "isCaptureByRef",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 5812,
-                            "End Line": 5829
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 12.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 338,
-                            "End Line": 350
-                        },
-                        {
                             "Function Name": "fromIP",
                             "Structural Impact": 12.4,
                             "Lines of Code (LOC)": 8,
@@ -33490,36 +33476,6 @@
                             "End Line": 3892
                         },
                         {
-                            "Function Name": "peek",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 5325,
-                            "End Line": 5330
-                        },
-                        {
-                            "Function Name": "toNode",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4827,
-                            "End Line": 4831
-                        },
-                        {
-                            "Function Name": "nameToken",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 5690,
-                            "End Line": 5692
-                        },
-                        {
                             "Function Name": "getSymbolFieldAccesses",
                             "Structural Impact": 12.0,
                             "Lines of Code (LOC)": 13,
@@ -33528,6 +33484,26 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 6908,
                             "End Line": 6920
+                        },
+                        {
+                            "Function Name": "isCaptureByRef",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 5812,
+                            "End Line": 5829
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 11.0,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 338,
+                            "End Line": 350
                         },
                         {
                             "Function Name": "isMetaType",
@@ -33560,6 +33536,26 @@
                             "End Line": 3818
                         },
                         {
+                            "Function Name": "peek",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 5325,
+                            "End Line": 5330
+                        },
+                        {
+                            "Function Name": "toNode",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4827,
+                            "End Line": 4831
+                        },
+                        {
                             "Function Name": "eql",
                             "Structural Impact": 10.5,
                             "Lines of Code (LOC)": 3,
@@ -33568,6 +33564,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 5685,
                             "End Line": 5687
+                        },
+                        {
+                            "Function Name": "nameToken",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 5690,
+                            "End Line": 5692
                         },
                         {
                             "Function Name": "resolveFieldAccess",
@@ -33650,16 +33656,6 @@
                             "End Line": 64
                         },
                         {
-                            "Function Name": "isErrSetDef",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 5307,
-                            "End Line": 5309
-                        },
-                        {
                             "Function Name": "getFunctionSignature",
                             "Structural Impact": 7.2,
                             "Lines of Code (LOC)": 5,
@@ -33700,6 +33696,16 @@
                             "End Line": 3862
                         },
                         {
+                            "Function Name": "isErrSetDef",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 5307,
+                            "End Line": 5309
+                        },
+                        {
                             "Function Name": "of",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 7,
@@ -33708,16 +33714,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 6987,
                             "End Line": 6993
-                        },
-                        {
-                            "Function Name": "ArrayMap",
-                            "Structural Impact": 6.9,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 3854,
-                            "End Line": 3856
                         },
                         {
                             "Function Name": "getPositionContext",
@@ -33730,64 +33726,14 @@
                             "End Line": 5361
                         },
                         {
-                            "Function Name": "hash32",
+                            "Function Name": "ArrayMap",
                             "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
                             "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 3831,
-                            "End Line": 3833
-                        },
-                        {
-                            "Function Name": "hash64",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 3835,
-                            "End Line": 3839
-                        },
-                        {
-                            "Function Name": "isGenericType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4265,
-                            "End Line": 4267
-                        },
-                        {
-                            "Function Name": "isEnumType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4315,
-                            "End Line": 4317
-                        },
-                        {
-                            "Function Name": "isUnionType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4319,
-                            "End Line": 4321
-                        },
-                        {
-                            "Function Name": "isOpaqueType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4323,
-                            "End Line": 4325
+                            "Start Line": 3854,
+                            "End Line": 3856
                         },
                         {
                             "Function Name": "tokenLocAppend",
@@ -33810,6 +33756,16 @@
                             "End Line": 6200
                         },
                         {
+                            "Function Name": "hash64",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 3835,
+                            "End Line": 3839
+                        },
+                        {
                             "Function Name": "hashWithHasher",
                             "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
@@ -33820,6 +33776,26 @@
                             "End Line": 3844
                         },
                         {
+                            "Function Name": "hash32",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3831,
+                            "End Line": 3833
+                        },
+                        {
+                            "Function Name": "isGenericType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4265,
+                            "End Line": 4267
+                        },
+                        {
                             "Function Name": "isContainerKind",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -33828,6 +33804,36 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 4282,
                             "End Line": 4284
+                        },
+                        {
+                            "Function Name": "isEnumType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4315,
+                            "End Line": 4317
+                        },
+                        {
+                            "Function Name": "isUnionType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4319,
+                            "End Line": 4321
+                        },
+                        {
+                            "Function Name": "isOpaqueType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4323,
+                            "End Line": 4325
                         },
                         {
                             "Function Name": "writeString",
@@ -33870,16 +33876,6 @@
                             "End Line": 3660
                         },
                         {
-                            "Function Name": "fmtEscapedSnippet",
-                            "Structural Impact": 4.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 388,
-                            "End Line": 390
-                        },
-                        {
                             "Function Name": "innermostScopeAtIndex",
                             "Structural Impact": 4.3,
                             "Lines of Code (LOC)": 6,
@@ -33890,14 +33886,14 @@
                             "End Line": 6219
                         },
                         {
-                            "Function Name": "deinit",
+                            "Function Name": "fmtEscapedSnippet",
                             "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 0,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
                             "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 66,
-                            "End Line": 69
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 388,
+                            "End Line": 390
                         },
                         {
                             "Function Name": "init",
@@ -33928,6 +33924,16 @@
                             "Control Flow Ratio": "33.3%",
                             "Start Line": 1953,
                             "End Line": 1958
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 66,
+                            "End Line": 69
                         },
                         {
                             "Function Name": "findReturnStatement",
@@ -34270,26 +34276,6 @@
                             "End Line": 5321
                         },
                         {
-                            "Function Name": "typeDeclarationNode",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 5710,
-                            "End Line": 5710
-                        },
-                        {
-                            "Function Name": "isStatic",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 5871,
-                            "End Line": 5871
-                        },
-                        {
                             "Function Name": "innermostContainer",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
@@ -34490,6 +34476,16 @@
                             "End Line": 5312
                         },
                         {
+                            "Function Name": "typeDeclarationNode",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 5710,
+                            "End Line": 5710
+                        },
+                        {
                             "Function Name": "docComments",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
@@ -34498,6 +34494,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 5831,
                             "End Line": 5831
+                        },
+                        {
+                            "Function Name": "isStatic",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 5871,
+                            "End Line": 5871
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -34598,12 +34604,13 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 11,
+                        "Direct Upstream (Fragility)": 12,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 3,
                         "Total Downstream (Absolute Dependency Blast Radius)": 3
                     },
                     "9. Extracted Dependencies": [
+                        "DocumentScope.zig",
                         "DocumentStore.zig",
                         "Uri.zig",
                         "analyser/InternPool.zig",
@@ -34629,32 +34636,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4900.27,
+                        "X": -4900.37,
                         "Y": -129.48,
-                        "Z": -1346.3
+                        "Z": -1346.45
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.644,
+                        "Repository Drift (Z-Score)": 11.641,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.104,
-                            "file_cluster_1": 12.342,
-                            "file_cluster_2": 12.455,
-                            "file_cluster_3": 13.278,
-                            "file_cluster_4": 12.445,
-                            "file_cluster_5": 12.801,
-                            "file_cluster_6": 12.328,
-                            "file_cluster_7": 11.971,
-                            "file_cluster_8": 11.644,
-                            "file_cluster_9": 12.251,
-                            "file_cluster_10": 13.147,
-                            "file_cluster_11": 12.292,
-                            "file_cluster_12": 12.621,
-                            "file_cluster_13": 12.119,
-                            "file_cluster_14": 15.893,
-                            "file_cluster_15": 12.643,
-                            "file_cluster_16": 12.416,
-                            "file_cluster_17": 12.308
+                            "file_cluster_0": 12.102,
+                            "file_cluster_1": 12.339,
+                            "file_cluster_2": 12.452,
+                            "file_cluster_3": 13.275,
+                            "file_cluster_4": 12.442,
+                            "file_cluster_5": 12.799,
+                            "file_cluster_6": 12.326,
+                            "file_cluster_7": 11.968,
+                            "file_cluster_8": 11.641,
+                            "file_cluster_9": 12.248,
+                            "file_cluster_10": 13.145,
+                            "file_cluster_11": 12.29,
+                            "file_cluster_12": 12.619,
+                            "file_cluster_13": 12.116,
+                            "file_cluster_14": 15.891,
+                            "file_cluster_15": 12.641,
+                            "file_cluster_16": 12.413,
+                            "file_cluster_17": 12.306
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -34662,7 +34669,7 @@
                         "Total LOC": 1847,
                         "Coding LOC": 1704,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3037.48,
+                        "Structural Magnitude": 3005.18,
                         "Control Flow Ratio": "70.4%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -34682,7 +34689,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "78.12%",
+                        "Documentation Exposure": "78.04%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -34734,10 +34741,10 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 186.7,
+                            "Structural Impact": 162.3,
                             "Lines of Code (LOC)": 94,
                             "Control Flow Branches": 25,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "71.4%",
                             "Start Line": 966,
                             "End Line": 1059
@@ -34764,10 +34771,10 @@
                         },
                         {
                             "Function Name": "initArray",
-                            "Structural Impact": 43.1,
+                            "Structural Impact": 37.5,
                             "Lines of Code (LOC)": 22,
                             "Control Flow Branches": 5,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "55.6%",
                             "Start Line": 1504,
                             "End Line": 1525
@@ -34913,16 +34920,6 @@
                             "End Line": 397
                         },
                         {
-                            "Function Name": "isKeyword",
-                            "Structural Impact": 9.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "40.0%",
-                            "Start Line": 403,
-                            "End Line": 412
-                        },
-                        {
                             "Function Name": "ifFull",
                             "Structural Impact": 8.3,
                             "Lines of Code (LOC)": 11,
@@ -34931,6 +34928,16 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 200,
                             "End Line": 210
+                        },
+                        {
+                            "Function Name": "isKeyword",
+                            "Structural Impact": 8.3,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "40.0%",
+                            "Start Line": 403,
+                            "End Line": 412
                         },
                         {
                             "Function Name": "errorSetFieldCount",
@@ -34994,10 +35001,10 @@
                         },
                         {
                             "Function Name": "parentNode",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1581,
                             "End Line": 1583
@@ -35154,10 +35161,10 @@
                         },
                         {
                             "Function Name": "skip",
-                            "Structural Impact": 3.1,
+                            "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1576,
                             "End Line": 1578
@@ -35373,32 +35380,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5826.19,
+                        "X": -5825.96,
                         "Y": -155.66,
-                        "Z": -1638.65
+                        "Z": -1638.61
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.891,
+                        "Repository Drift (Z-Score)": 11.885,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.484,
-                            "file_cluster_1": 12.737,
-                            "file_cluster_2": 12.818,
-                            "file_cluster_3": 13.679,
-                            "file_cluster_4": 12.789,
-                            "file_cluster_5": 13.248,
-                            "file_cluster_6": 12.785,
-                            "file_cluster_7": 12.43,
-                            "file_cluster_8": 11.891,
-                            "file_cluster_9": 12.618,
-                            "file_cluster_10": 13.691,
-                            "file_cluster_11": 12.733,
-                            "file_cluster_12": 13.111,
-                            "file_cluster_13": 12.489,
-                            "file_cluster_14": 16.148,
-                            "file_cluster_15": 13.126,
-                            "file_cluster_16": 12.814,
-                            "file_cluster_17": 12.599
+                            "file_cluster_0": 12.479,
+                            "file_cluster_1": 12.731,
+                            "file_cluster_2": 12.813,
+                            "file_cluster_3": 13.674,
+                            "file_cluster_4": 12.783,
+                            "file_cluster_5": 13.243,
+                            "file_cluster_6": 12.78,
+                            "file_cluster_7": 12.425,
+                            "file_cluster_8": 11.885,
+                            "file_cluster_9": 12.613,
+                            "file_cluster_10": 13.686,
+                            "file_cluster_11": 12.728,
+                            "file_cluster_12": 13.106,
+                            "file_cluster_13": 12.484,
+                            "file_cluster_14": 16.144,
+                            "file_cluster_15": 13.121,
+                            "file_cluster_16": 12.808,
+                            "file_cluster_17": 12.593
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -35406,7 +35413,7 @@
                         "Total LOC": 950,
                         "Coding LOC": 900,
                         "Documentation LOC": 1,
-                        "Structural Magnitude": 699.2,
+                        "Structural Magnitude": 687.2,
                         "Control Flow Ratio": "81.0%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -35457,16 +35464,6 @@
                             "End Line": 653
                         },
                         {
-                            "Function Name": "nodeTagName",
-                            "Structural Impact": 48.4,
-                            "Lines of Code (LOC)": 188,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "63.2%",
-                            "Start Line": 656,
-                            "End Line": 843
-                        },
-                        {
                             "Function Name": "renderNodeSliceField",
                             "Structural Impact": 45.6,
                             "Lines of Code (LOC)": 18,
@@ -35475,6 +35472,16 @@
                             "Control Flow Ratio": "90.0%",
                             "Start Line": 610,
                             "End Line": 627
+                        },
+                        {
+                            "Function Name": "nodeTagName",
+                            "Structural Impact": 43.2,
+                            "Lines of Code (LOC)": 188,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "63.2%",
+                            "Start Line": 656,
+                            "End Line": 843
                         },
                         {
                             "Function Name": "renderToFile",
@@ -35488,10 +35495,10 @@
                         },
                         {
                             "Function Name": "main",
-                            "Structural Impact": 34.7,
+                            "Structural Impact": 30.3,
                             "Lines of Code (LOC)": 34,
                             "Control Flow Branches": 10,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "58.8%",
                             "Start Line": 845,
                             "End Line": 878
@@ -35548,20 +35555,20 @@
                         },
                         {
                             "Function Name": "renderRoot",
-                            "Structural Impact": 9.2,
+                            "Structural Impact": 8.0,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 66,
                             "End Line": 69
                         },
                         {
                             "Function Name": "newline",
-                            "Structural Impact": 9.2,
+                            "Structural Impact": 8.0,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 524,
                             "End Line": 527
@@ -42409,9 +42416,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1995.15,
+                        "X": -1995.11,
                         "Y": 103.99,
-                        "Z": -3082.11
+                        "Z": -3082.03
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -42571,9 +42578,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2158.42,
+                        "X": -2158.37,
                         "Y": 48.67,
-                        "Z": -3246.91
+                        "Z": -3246.83
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -43522,9 +43529,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1511.11,
+                        "X": -1511.06,
                         "Y": 113.88,
-                        "Z": -3285.17
+                        "Z": -3285.09
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -43829,9 +43836,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1416.74,
+                        "X": -1416.7,
                         "Y": 199.14,
-                        "Z": -3827.65
+                        "Z": -3827.57
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -44044,9 +44051,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1850.11,
+                        "X": -1850.07,
                         "Y": 139.82,
-                        "Z": -3530.75
+                        "Z": -3530.67
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -45168,9 +45175,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1771.59,
+                        "X": -1771.55,
                         "Y": 122.67,
-                        "Z": -4004.25
+                        "Z": -4004.17
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -45398,9 +45405,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2442.21,
+                        "X": -2442.17,
                         "Y": 37.9,
-                        "Z": -3767.74
+                        "Z": -3767.66
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -56940,7 +56947,7 @@
             }
         },
         "zig/tigerbeetle": {
-            "Directory Group Magnitude": 12283.34,
+            "Directory Group Magnitude": 11647.14,
             "File Count": 11,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "90.9%",
@@ -56958,7 +56965,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "65.9%",
+                "Documentation Exposure": "65.4%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "71.27%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -57412,32 +57419,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4321.87,
-                        "Y": 85.66,
-                        "Z": 2802.38
+                        "X": 4323.11,
+                        "Y": 85.81,
+                        "Z": 2801.26
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.627,
+                        "Repository Drift (Z-Score)": 12.608,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.973,
-                            "file_cluster_1": 13.198,
-                            "file_cluster_2": 13.301,
-                            "file_cluster_3": 14.11,
-                            "file_cluster_4": 13.327,
-                            "file_cluster_5": 13.607,
-                            "file_cluster_6": 13.264,
-                            "file_cluster_7": 12.862,
-                            "file_cluster_8": 12.627,
-                            "file_cluster_9": 13.158,
-                            "file_cluster_10": 14.074,
-                            "file_cluster_11": 13.145,
-                            "file_cluster_12": 13.528,
-                            "file_cluster_13": 12.845,
-                            "file_cluster_14": 16.584,
-                            "file_cluster_15": 13.476,
-                            "file_cluster_16": 13.245,
-                            "file_cluster_17": 13.14
+                            "file_cluster_0": 12.957,
+                            "file_cluster_1": 13.181,
+                            "file_cluster_2": 13.284,
+                            "file_cluster_3": 14.094,
+                            "file_cluster_4": 13.309,
+                            "file_cluster_5": 13.591,
+                            "file_cluster_6": 13.248,
+                            "file_cluster_7": 12.844,
+                            "file_cluster_8": 12.608,
+                            "file_cluster_9": 13.141,
+                            "file_cluster_10": 14.058,
+                            "file_cluster_11": 13.129,
+                            "file_cluster_12": 13.511,
+                            "file_cluster_13": 12.828,
+                            "file_cluster_14": 16.57,
+                            "file_cluster_15": 13.459,
+                            "file_cluster_16": 13.228,
+                            "file_cluster_17": 13.123
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -57445,7 +57452,7 @@
                         "Total LOC": 1007,
                         "Coding LOC": 835,
                         "Documentation LOC": 1,
-                        "Structural Magnitude": 2873.8,
+                        "Structural Magnitude": 2596.7,
                         "Control Flow Ratio": "66.8%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -57477,10 +57484,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "AOFType",
-                            "Structural Impact": 2642.7,
+                            "Structural Impact": 2368.3,
                             "Lines of Code (LOC)": 887,
                             "Control Flow Branches": 165,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.8%",
                             "Start Line": 120,
                             "End Line": 1006
@@ -57497,30 +57504,30 @@
                         },
                         {
                             "Function Name": "size_disk",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 48,
                             "End Line": 50
                         },
                         {
                             "Function Name": "size_minimum",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 53,
                             "End Line": 55
                         },
                         {
                             "Function Name": "header",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 57,
                             "End Line": 59
@@ -57659,32 +57666,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4179.07,
-                        "Y": 201.41,
-                        "Z": 2599.88
+                        "X": 4180.46,
+                        "Y": 201.29,
+                        "Z": 2600.11
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.121,
+                        "Repository Drift (Z-Score)": 11.108,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.868,
-                            "file_cluster_1": 11.95,
-                            "file_cluster_2": 12.095,
-                            "file_cluster_3": 13.014,
-                            "file_cluster_4": 12.298,
-                            "file_cluster_5": 12.492,
-                            "file_cluster_6": 12.149,
-                            "file_cluster_7": 11.643,
-                            "file_cluster_8": 11.121,
-                            "file_cluster_9": 11.996,
-                            "file_cluster_10": 13.058,
-                            "file_cluster_11": 12.123,
-                            "file_cluster_12": 12.341,
-                            "file_cluster_13": 11.721,
-                            "file_cluster_14": 15.628,
-                            "file_cluster_15": 12.429,
-                            "file_cluster_16": 12.141,
-                            "file_cluster_17": 12.0
+                            "file_cluster_0": 11.857,
+                            "file_cluster_1": 11.938,
+                            "file_cluster_2": 12.083,
+                            "file_cluster_3": 13.004,
+                            "file_cluster_4": 12.286,
+                            "file_cluster_5": 12.481,
+                            "file_cluster_6": 12.138,
+                            "file_cluster_7": 11.631,
+                            "file_cluster_8": 11.108,
+                            "file_cluster_9": 11.985,
+                            "file_cluster_10": 13.047,
+                            "file_cluster_11": 12.112,
+                            "file_cluster_12": 12.33,
+                            "file_cluster_13": 11.709,
+                            "file_cluster_14": 15.618,
+                            "file_cluster_15": 12.418,
+                            "file_cluster_16": 12.13,
+                            "file_cluster_17": 11.988
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -57692,7 +57699,7 @@
                         "Total LOC": 809,
                         "Coding LOC": 717,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 203.74,
+                        "Structural Magnitude": 179.34,
                         "Control Flow Ratio": "82.7%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -57712,7 +57719,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "33.16%",
+                        "Documentation Exposure": "32.5%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -57724,10 +57731,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "main",
-                            "Structural Impact": 44.5,
+                            "Structural Impact": 26.9,
                             "Lines of Code (LOC)": 58,
                             "Control Flow Branches": 11,
-                            "Input Parameters": 2,
+                            "Input Parameters": 0,
                             "Control Flow Ratio": "61.1%",
                             "Start Line": 52,
                             "End Line": 109
@@ -57744,30 +57751,30 @@
                         },
                         {
                             "Function Name": "parse",
-                            "Structural Impact": 23.0,
+                            "Structural Impact": 20.6,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 22,
                             "End Line": 33
                         },
                         {
                             "Function Name": "self_check_enabled",
-                            "Structural Impact": 20.6,
+                            "Structural Impact": 18.0,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "80.0%",
                             "Start Line": 756,
                             "End Line": 768
                         },
                         {
                             "Function Name": "git_sha_to_binary",
-                            "Structural Impact": 17.7,
+                            "Structural Impact": 15.9,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "57.1%",
                             "Start Line": 791,
                             "End Line": 808
@@ -57967,32 +57974,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4716.99,
-                        "Y": 216.7,
-                        "Z": 2272.47
+                        "X": 4716.86,
+                        "Y": 216.45,
+                        "Z": 2273.81
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.708,
+                        "Repository Drift (Z-Score)": 12.72,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.085,
-                            "file_cluster_1": 13.287,
-                            "file_cluster_2": 13.393,
-                            "file_cluster_3": 14.197,
-                            "file_cluster_4": 13.479,
-                            "file_cluster_5": 13.696,
-                            "file_cluster_6": 13.28,
-                            "file_cluster_7": 12.973,
-                            "file_cluster_8": 12.708,
-                            "file_cluster_9": 13.285,
-                            "file_cluster_10": 14.114,
-                            "file_cluster_11": 13.187,
-                            "file_cluster_12": 13.632,
-                            "file_cluster_13": 12.81,
-                            "file_cluster_14": 16.677,
-                            "file_cluster_15": 13.595,
-                            "file_cluster_16": 13.331,
-                            "file_cluster_17": 13.28
+                            "file_cluster_0": 13.096,
+                            "file_cluster_1": 13.299,
+                            "file_cluster_2": 13.405,
+                            "file_cluster_3": 14.208,
+                            "file_cluster_4": 13.491,
+                            "file_cluster_5": 13.708,
+                            "file_cluster_6": 13.293,
+                            "file_cluster_7": 12.985,
+                            "file_cluster_8": 12.72,
+                            "file_cluster_9": 13.296,
+                            "file_cluster_10": 14.126,
+                            "file_cluster_11": 13.2,
+                            "file_cluster_12": 13.644,
+                            "file_cluster_13": 12.823,
+                            "file_cluster_14": 16.682,
+                            "file_cluster_15": 13.607,
+                            "file_cluster_16": 13.343,
+                            "file_cluster_17": 13.292
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58000,7 +58007,7 @@
                         "Total LOC": 1199,
                         "Coding LOC": 1044,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 1425.08,
+                        "Structural Magnitude": 1297.88,
                         "Control Flow Ratio": "66.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -58020,7 +58027,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "41.85%",
+                        "Documentation Exposure": "41.7%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -58032,10 +58039,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "ClusterType",
-                            "Structural Impact": 1261.2,
+                            "Structural Impact": 1134.0,
                             "Lines of Code (LOC)": 1120,
                             "Control Flow Branches": 153,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.2%",
                             "Start Line": 58,
                             "End Line": 1177
@@ -58139,7 +58146,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 15,
+                        "Direct Upstream (Fragility)": 18,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
@@ -58153,12 +58160,15 @@
                         "cluster/grid_checker.zig",
                         "cluster/journal_checker.zig",
                         "cluster/manifest_checker.zig",
+                        "cluster/message_bus.zig",
+                        "cluster/network.zig",
                         "cluster/state_checker.zig",
                         "cluster/storage_checker.zig",
                         "id.zig",
                         "io.zig",
                         "std",
                         "stdx",
+                        "storage.zig",
                         "time.zig"
                     ]
                 },
@@ -58174,32 +58184,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4009.85,
-                        "Y": 156.41,
-                        "Z": 2741.68
+                        "X": 4010.39,
+                        "Y": 156.42,
+                        "Z": 2741.46
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.63,
+                        "Repository Drift (Z-Score)": 9.603,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.563,
-                            "file_cluster_1": 10.251,
-                            "file_cluster_2": 10.61,
-                            "file_cluster_3": 11.54,
-                            "file_cluster_4": 11.083,
-                            "file_cluster_5": 10.783,
-                            "file_cluster_6": 10.594,
-                            "file_cluster_7": 9.88,
-                            "file_cluster_8": 9.63,
-                            "file_cluster_9": 10.794,
-                            "file_cluster_10": 11.549,
-                            "file_cluster_11": 10.593,
-                            "file_cluster_12": 10.383,
-                            "file_cluster_13": 9.955,
-                            "file_cluster_14": 14.783,
-                            "file_cluster_15": 10.793,
-                            "file_cluster_16": 10.205,
-                            "file_cluster_17": 10.969
+                            "file_cluster_0": 10.54,
+                            "file_cluster_1": 10.227,
+                            "file_cluster_2": 10.586,
+                            "file_cluster_3": 11.519,
+                            "file_cluster_4": 11.06,
+                            "file_cluster_5": 10.76,
+                            "file_cluster_6": 10.571,
+                            "file_cluster_7": 9.854,
+                            "file_cluster_8": 9.603,
+                            "file_cluster_9": 10.771,
+                            "file_cluster_10": 11.527,
+                            "file_cluster_11": 10.571,
+                            "file_cluster_12": 10.359,
+                            "file_cluster_13": 9.93,
+                            "file_cluster_14": 14.766,
+                            "file_cluster_15": 10.77,
+                            "file_cluster_16": 10.18,
+                            "file_cluster_17": 10.946
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58207,7 +58217,7 @@
                         "Total LOC": 296,
                         "Coding LOC": 267,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 86.84,
+                        "Structural Magnitude": 82.04,
                         "Control Flow Ratio": "75.0%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -58239,10 +58249,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "checksum",
-                            "Structural Impact": 27.4,
+                            "Structural Impact": 24.6,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 198,
                             "End Line": 208
@@ -58259,20 +58269,20 @@
                         },
                         {
                             "Function Name": "message_size_max_min",
-                            "Structural Impact": 10.5,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 185,
                             "End Line": 194
                         },
                         {
                             "Function Name": "is_production",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 77,
                             "End Line": 79
@@ -58599,32 +58609,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4950.88,
-                        "Y": 83.75,
-                        "Z": 3082.55
+                        "X": 4949.55,
+                        "Y": 84.14,
+                        "Z": 3080.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.917,
+                        "Repository Drift (Z-Score)": 12.89,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.235,
-                            "file_cluster_1": 13.37,
-                            "file_cluster_2": 13.496,
-                            "file_cluster_3": 14.291,
-                            "file_cluster_4": 13.52,
-                            "file_cluster_5": 13.751,
-                            "file_cluster_6": 13.513,
-                            "file_cluster_7": 13.041,
-                            "file_cluster_8": 12.917,
-                            "file_cluster_9": 13.434,
-                            "file_cluster_10": 14.156,
-                            "file_cluster_11": 13.341,
-                            "file_cluster_12": 13.73,
-                            "file_cluster_13": 12.999,
-                            "file_cluster_14": 16.754,
-                            "file_cluster_15": 13.623,
-                            "file_cluster_16": 13.386,
-                            "file_cluster_17": 13.351
+                            "file_cluster_0": 13.21,
+                            "file_cluster_1": 13.343,
+                            "file_cluster_2": 13.471,
+                            "file_cluster_3": 14.267,
+                            "file_cluster_4": 13.494,
+                            "file_cluster_5": 13.727,
+                            "file_cluster_6": 13.488,
+                            "file_cluster_7": 13.014,
+                            "file_cluster_8": 12.89,
+                            "file_cluster_9": 13.409,
+                            "file_cluster_10": 14.132,
+                            "file_cluster_11": 13.317,
+                            "file_cluster_12": 13.705,
+                            "file_cluster_13": 12.973,
+                            "file_cluster_14": 16.733,
+                            "file_cluster_15": 13.598,
+                            "file_cluster_16": 13.36,
+                            "file_cluster_17": 13.325
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58632,7 +58642,7 @@
                         "Total LOC": 203,
                         "Coding LOC": 175,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 512.5,
+                        "Structural Magnitude": 429.0,
                         "Control Flow Ratio": "68.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -58652,7 +58662,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "58.67%",
+                        "Documentation Exposure": "54.23%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -58664,20 +58674,20 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "extract_memcpy_size",
-                            "Structural Impact": 259.4,
+                            "Structural Impact": 232.2,
                             "Lines of Code (LOC)": 45,
                             "Control Flow Branches": 22,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "73.3%",
                             "Start Line": 141,
                             "End Line": 185
                         },
                         {
                             "Function Name": "main",
-                            "Structural Impact": 136.3,
+                            "Structural Impact": 80.0,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 21,
-                            "Input Parameters": 2,
+                            "Input Parameters": 0,
                             "Control Flow Ratio": "61.8%",
                             "Start Line": 47,
                             "End Line": 105
@@ -58813,32 +58823,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 5340.81,
-                        "Y": 41.64,
-                        "Z": 2690.36
+                        "X": 5340.56,
+                        "Y": 41.67,
+                        "Z": 2690.27
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.613,
+                        "Repository Drift (Z-Score)": 9.595,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.499,
-                            "file_cluster_1": 10.533,
-                            "file_cluster_2": 10.714,
-                            "file_cluster_3": 11.815,
-                            "file_cluster_4": 10.94,
-                            "file_cluster_5": 11.189,
-                            "file_cluster_6": 10.887,
-                            "file_cluster_7": 10.218,
-                            "file_cluster_8": 9.613,
-                            "file_cluster_9": 10.729,
-                            "file_cluster_10": 11.885,
-                            "file_cluster_11": 10.928,
-                            "file_cluster_12": 11.124,
-                            "file_cluster_13": 10.199,
-                            "file_cluster_14": 14.774,
-                            "file_cluster_15": 11.222,
-                            "file_cluster_16": 10.74,
-                            "file_cluster_17": 10.783
+                            "file_cluster_0": 10.484,
+                            "file_cluster_1": 10.518,
+                            "file_cluster_2": 10.699,
+                            "file_cluster_3": 11.802,
+                            "file_cluster_4": 10.925,
+                            "file_cluster_5": 11.174,
+                            "file_cluster_6": 10.873,
+                            "file_cluster_7": 10.202,
+                            "file_cluster_8": 9.595,
+                            "file_cluster_9": 10.714,
+                            "file_cluster_10": 11.871,
+                            "file_cluster_11": 10.914,
+                            "file_cluster_12": 11.11,
+                            "file_cluster_13": 10.184,
+                            "file_cluster_14": 14.763,
+                            "file_cluster_15": 11.208,
+                            "file_cluster_16": 10.725,
+                            "file_cluster_17": 10.768
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58846,7 +58856,7 @@
                         "Total LOC": 73,
                         "Coding LOC": 61,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 99.72,
+                        "Structural Magnitude": 97.22,
                         "Control Flow Ratio": "64.0%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -58898,10 +58908,10 @@
                         },
                         {
                             "Function Name": "allocator",
-                            "Structural Impact": 8.6,
+                            "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 18,
                             "End Line": 28
@@ -58928,30 +58938,30 @@
                         },
                         {
                             "Function Name": "init",
-                            "Structural Impact": 4.2,
+                            "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 10,
                             "End Line": 12
                         },
                         {
                             "Function Name": "live_size",
-                            "Structural Impact": 4.2,
+                            "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 30,
                             "End Line": 32
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 2.1,
+                            "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 14,
                             "End Line": 16
@@ -59076,32 +59086,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 5179.93,
+                        "X": 5179.83,
                         "Y": 175.63,
-                        "Z": 2384.22
+                        "Z": 2384.27
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.258,
+                        "Repository Drift (Z-Score)": 9.253,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.396,
-                            "file_cluster_1": 9.89,
-                            "file_cluster_2": 10.358,
-                            "file_cluster_3": 11.298,
-                            "file_cluster_4": 10.969,
-                            "file_cluster_5": 10.455,
-                            "file_cluster_6": 10.587,
-                            "file_cluster_7": 9.55,
-                            "file_cluster_8": 9.258,
-                            "file_cluster_9": 10.622,
-                            "file_cluster_10": 11.326,
-                            "file_cluster_11": 10.469,
-                            "file_cluster_12": 9.782,
-                            "file_cluster_13": 9.761,
-                            "file_cluster_14": 14.732,
-                            "file_cluster_15": 10.549,
-                            "file_cluster_16": 9.461,
-                            "file_cluster_17": 10.89
+                            "file_cluster_0": 10.391,
+                            "file_cluster_1": 9.885,
+                            "file_cluster_2": 10.354,
+                            "file_cluster_3": 11.294,
+                            "file_cluster_4": 10.964,
+                            "file_cluster_5": 10.45,
+                            "file_cluster_6": 10.583,
+                            "file_cluster_7": 9.545,
+                            "file_cluster_8": 9.253,
+                            "file_cluster_9": 10.618,
+                            "file_cluster_10": 11.322,
+                            "file_cluster_11": 10.465,
+                            "file_cluster_12": 9.777,
+                            "file_cluster_13": 9.756,
+                            "file_cluster_14": 14.729,
+                            "file_cluster_15": 10.544,
+                            "file_cluster_16": 9.456,
+                            "file_cluster_17": 10.886
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -59109,7 +59119,7 @@
                         "Total LOC": 121,
                         "Coding LOC": 109,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 159.58,
+                        "Structural Magnitude": 157.98,
                         "Control Flow Ratio": "77.1%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -59129,7 +59139,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "100.0%",
+                        "Documentation Exposure": "99.99%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -59150,16 +59160,6 @@
                             "End Line": 119
                         },
                         {
-                            "Function Name": "reverse",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 27,
-                            "End Line": 32
-                        },
-                        {
                             "Function Name": "lower",
                             "Structural Impact": 12.2,
                             "Lines of Code (LOC)": 3,
@@ -59178,6 +59178,16 @@
                             "Control Flow Ratio": "75.0%",
                             "Start Line": 56,
                             "End Line": 58
+                        },
+                        {
+                            "Function Name": "reverse",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 27,
+                            "End Line": 32
                         },
                         {
                             "Function Name": "slice_peek",
@@ -59337,26 +59347,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.995,
+                        "Repository Drift (Z-Score)": 10.988,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.819,
-                            "file_cluster_1": 11.711,
-                            "file_cluster_2": 11.949,
-                            "file_cluster_3": 12.854,
-                            "file_cluster_4": 12.296,
-                            "file_cluster_5": 12.247,
-                            "file_cluster_6": 11.921,
-                            "file_cluster_7": 11.401,
-                            "file_cluster_8": 10.995,
-                            "file_cluster_9": 11.937,
-                            "file_cluster_10": 12.792,
-                            "file_cluster_11": 11.985,
-                            "file_cluster_12": 12.147,
-                            "file_cluster_13": 11.698,
-                            "file_cluster_14": 15.625,
-                            "file_cluster_15": 12.233,
-                            "file_cluster_16": 11.86,
-                            "file_cluster_17": 12.085
+                            "file_cluster_0": 11.813,
+                            "file_cluster_1": 11.705,
+                            "file_cluster_2": 11.943,
+                            "file_cluster_3": 12.849,
+                            "file_cluster_4": 12.29,
+                            "file_cluster_5": 12.241,
+                            "file_cluster_6": 11.916,
+                            "file_cluster_7": 11.394,
+                            "file_cluster_8": 10.988,
+                            "file_cluster_9": 11.931,
+                            "file_cluster_10": 12.786,
+                            "file_cluster_11": 11.98,
+                            "file_cluster_12": 12.141,
+                            "file_cluster_13": 11.692,
+                            "file_cluster_14": 15.62,
+                            "file_cluster_15": 12.227,
+                            "file_cluster_16": 11.854,
+                            "file_cluster_17": 12.079
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -59364,7 +59374,7 @@
                         "Total LOC": 5049,
                         "Coding LOC": 4485,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 6657.5,
+                        "Structural Magnitude": 6542.4,
                         "Control Flow Ratio": "71.3%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -59384,7 +59394,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "67.33%",
+                        "Documentation Exposure": "67.11%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -59406,10 +59416,10 @@
                         },
                         {
                             "Function Name": "StateMachineType",
-                            "Structural Impact": 991.4,
+                            "Structural Impact": 893.0,
                             "Lines of Code (LOC)": 1201,
                             "Control Flow Branches": 118,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "71.5%",
                             "Start Line": 221,
                             "End Line": 1421
@@ -59585,36 +59595,6 @@
                             "End Line": 2895
                         },
                         {
-                            "Function Name": "forest_options",
-                            "Structural Impact": 32.0,
-                            "Lines of Code (LOC)": 120,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4508,
-                            "End Line": 4627
-                        },
-                        {
-                            "Function Name": "Type",
-                            "Structural Impact": 31.6,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 3522,
-                            "End Line": 3527
-                        },
-                        {
-                            "Function Name": "Type",
-                            "Structural Impact": 31.6,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 3624,
-                            "End Line": 3629
-                        },
-                        {
                             "Function Name": "execute_get_change_events",
                             "Structural Impact": 30.8,
                             "Lines of Code (LOC)": 28,
@@ -59623,6 +59603,26 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 3311,
                             "End Line": 3338
+                        },
+                        {
+                            "Function Name": "Type",
+                            "Structural Impact": 28.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 3522,
+                            "End Line": 3527
+                        },
+                        {
+                            "Function Name": "Type",
+                            "Structural Impact": 28.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 3624,
+                            "End Line": 3629
                         },
                         {
                             "Function Name": "execute_lookup_accounts",
@@ -59645,11 +59645,21 @@
                             "End Line": 3208
                         },
                         {
+                            "Function Name": "forest_options",
+                            "Structural Impact": 27.7,
+                            "Lines of Code (LOC)": 120,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4508,
+                            "End Line": 4627
+                        },
+                        {
                             "Function Name": "sum_overflows_test",
-                            "Structural Impact": 18.4,
+                            "Structural Impact": 16.6,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 5033,
                             "End Line": 5043
@@ -59725,16 +59735,6 @@
                             "End Line": 3309
                         },
                         {
-                            "Function Name": "prefetch_get_account_balances",
-                            "Structural Impact": 11.2,
-                            "Lines of Code (LOC)": 23,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1492,
-                            "End Line": 1514
-                        },
-                        {
                             "Function Name": "prefetch_get_account_transfers_scan_call",
                             "Structural Impact": 11.0,
                             "Lines of Code (LOC)": 20,
@@ -59743,6 +59743,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1471,
                             "End Line": 1490
+                        },
+                        {
+                            "Function Name": "prefetch_get_account_balances",
+                            "Structural Impact": 9.8,
+                            "Lines of Code (LOC)": 23,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1492,
+                            "End Line": 1514
                         },
                         {
                             "Function Name": "compact",
@@ -59795,16 +59805,6 @@
                             "End Line": 2861
                         },
                         {
-                            "Function Name": "tree_values_count",
-                            "Structural Impact": 7.0,
-                            "Lines of Code (LOC)": 43,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 4640,
-                            "End Line": 4682
-                        },
-                        {
                             "Function Name": "account_event",
                             "Structural Impact": 5.8,
                             "Lines of Code (LOC)": 16,
@@ -59813,6 +59813,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 4264,
                             "End Line": 4279
+                        },
+                        {
+                            "Function Name": "tree_values_count",
+                            "Structural Impact": 5.8,
+                            "Lines of Code (LOC)": 43,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 4640,
+                            "End Line": 4682
                         },
                         {
                             "Function Name": "prefetch_get_account_balances_lookup_acc",
@@ -59826,30 +59836,30 @@
                         },
                         {
                             "Function Name": "checkpoint_finish",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2863,
                             "End Line": 2874
                         },
                         {
                             "Function Name": "compact_finish",
-                            "Structural Impact": 4.5,
+                            "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2842,
                             "End Line": 2851
                         },
                         {
                             "Function Name": "schema",
-                            "Structural Impact": 3.6,
+                            "Structural Impact": 3.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 185,
                             "End Line": 188
@@ -122955,9 +122965,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3177.74,
+                        "X": -3177.69,
                         "Y": -98.39,
-                        "Z": -2619.95
+                        "Z": -2619.89
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -123233,9 +123243,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2816.91,
+                        "X": -2816.86,
                         "Y": -173.53,
-                        "Z": -3614.27
+                        "Z": -3614.21
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -123845,9 +123855,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2846.77,
+                        "X": -2846.72,
                         "Y": -49.48,
-                        "Z": -3122.48
+                        "Z": -3122.43
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -124521,9 +124531,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2560.44,
+                        "X": -2560.39,
                         "Y": 41.58,
-                        "Z": -2778.58
+                        "Z": -2778.52
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -124723,9 +124733,9 @@
                         "Identity Proof": "Single Indicator (Ext: .ts)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3349.81,
+                        "X": -3349.75,
                         "Y": -245.6,
-                        "Z": -3185.65
+                        "Z": -3185.59
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -136587,7 +136597,7 @@
             }
         },
         "zig/bun": {
-            "Directory Group Magnitude": 9697.12,
+            "Directory Group Magnitude": 9527.92,
             "File Count": 4,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -136604,7 +136614,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "78.84%",
+                "Documentation Exposure": "78.83%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "100.0%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -136626,32 +136636,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3427.11,
-                        "Y": 208.68,
-                        "Z": 2335.84
+                        "X": -3428.06,
+                        "Y": 208.42,
+                        "Z": 2334.23
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.439,
+                        "Repository Drift (Z-Score)": 10.405,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.189,
-                            "file_cluster_1": 10.945,
-                            "file_cluster_2": 11.251,
-                            "file_cluster_3": 12.198,
-                            "file_cluster_4": 11.622,
-                            "file_cluster_5": 11.417,
-                            "file_cluster_6": 11.414,
-                            "file_cluster_7": 10.566,
-                            "file_cluster_8": 10.439,
-                            "file_cluster_9": 11.406,
-                            "file_cluster_10": 12.188,
-                            "file_cluster_11": 11.419,
-                            "file_cluster_12": 11.531,
-                            "file_cluster_13": 10.845,
-                            "file_cluster_14": 15.275,
-                            "file_cluster_15": 11.448,
-                            "file_cluster_16": 10.793,
-                            "file_cluster_17": 11.549
+                            "file_cluster_0": 11.16,
+                            "file_cluster_1": 10.913,
+                            "file_cluster_2": 11.221,
+                            "file_cluster_3": 12.17,
+                            "file_cluster_4": 11.592,
+                            "file_cluster_5": 11.388,
+                            "file_cluster_6": 11.385,
+                            "file_cluster_7": 10.534,
+                            "file_cluster_8": 10.405,
+                            "file_cluster_9": 11.377,
+                            "file_cluster_10": 12.16,
+                            "file_cluster_11": 11.39,
+                            "file_cluster_12": 11.501,
+                            "file_cluster_13": 10.815,
+                            "file_cluster_14": 15.252,
+                            "file_cluster_15": 11.419,
+                            "file_cluster_16": 10.761,
+                            "file_cluster_17": 11.519
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -136659,7 +136669,7 @@
                         "Total LOC": 273,
                         "Coding LOC": 227,
                         "Documentation LOC": 2,
-                        "Structural Magnitude": 619.14,
+                        "Structural Magnitude": 542.54,
                         "Control Flow Ratio": "66.7%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -136691,20 +136701,20 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "allocator",
-                            "Structural Impact": 572.4,
+                            "Structural Impact": 497.4,
                             "Lines of Code (LOC)": 248,
                             "Control Flow Branches": 55,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "67.1%",
                             "Start Line": 25,
                             "End Line": 272
                         },
                         {
                             "Function Name": "allocator",
-                            "Structural Impact": 12.2,
+                            "Structural Impact": 10.6,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 11,
                             "End Line": 14
@@ -136830,32 +136840,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4093.58,
-                        "Y": 208.83,
-                        "Z": 2230.67
+                        "X": -4093.1,
+                        "Y": 208.79,
+                        "Z": 2230.32
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.121,
+                        "Repository Drift (Z-Score)": 13.113,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.191,
-                            "file_cluster_1": 13.8,
-                            "file_cluster_2": 13.761,
-                            "file_cluster_3": 14.451,
-                            "file_cluster_4": 13.528,
-                            "file_cluster_5": 14.179,
-                            "file_cluster_6": 13.393,
-                            "file_cluster_7": 13.421,
-                            "file_cluster_8": 13.121,
-                            "file_cluster_9": 13.299,
-                            "file_cluster_10": 14.4,
-                            "file_cluster_11": 13.273,
-                            "file_cluster_12": 13.852,
-                            "file_cluster_13": 13.245,
-                            "file_cluster_14": 16.695,
-                            "file_cluster_15": 13.852,
-                            "file_cluster_16": 13.645,
-                            "file_cluster_17": 13.308
+                            "file_cluster_0": 13.183,
+                            "file_cluster_1": 13.792,
+                            "file_cluster_2": 13.754,
+                            "file_cluster_3": 14.444,
+                            "file_cluster_4": 13.52,
+                            "file_cluster_5": 14.171,
+                            "file_cluster_6": 13.386,
+                            "file_cluster_7": 13.413,
+                            "file_cluster_8": 13.113,
+                            "file_cluster_9": 13.292,
+                            "file_cluster_10": 14.393,
+                            "file_cluster_11": 13.265,
+                            "file_cluster_12": 13.844,
+                            "file_cluster_13": 13.237,
+                            "file_cluster_14": 16.689,
+                            "file_cluster_15": 13.845,
+                            "file_cluster_16": 13.637,
+                            "file_cluster_17": 13.3
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -136863,7 +136873,7 @@
                         "Total LOC": 1628,
                         "Coding LOC": 1436,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3009.72,
+                        "Structural Magnitude": 2985.02,
                         "Control Flow Ratio": "72.2%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -136883,7 +136893,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "78.75%",
+                        "Documentation Exposure": "78.7%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -136925,10 +136935,10 @@
                         },
                         {
                             "Function Name": "parse",
-                            "Structural Impact": 144.8,
+                            "Structural Impact": 125.6,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 17,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "77.3%",
                             "Start Line": 247,
                             "End Line": 263
@@ -136994,16 +137004,6 @@
                             "End Line": 1366
                         },
                         {
-                            "Function Name": "MacroContextType",
-                            "Structural Impact": 10.7,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1565,
-                            "End Line": 1571
-                        },
-                        {
                             "Function Name": "init",
                             "Structural Impact": 9.1,
                             "Lines of Code (LOC)": 8,
@@ -137015,13 +137015,23 @@
                         },
                         {
                             "Function Name": "runtimeMergeAdjacentExpressionStatements",
-                            "Structural Impact": 8.2,
+                            "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 81,
                             "End Line": 83
+                        },
+                        {
+                            "Function Name": "MacroContextType",
+                            "Structural Impact": 6.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1565,
+                            "End Line": 1571
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -137147,32 +137157,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3767.57,
-                        "Y": 50.71,
-                        "Z": 1475.66
+                        "X": -3767.39,
+                        "Y": 50.76,
+                        "Z": 1475.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.482,
+                        "Repository Drift (Z-Score)": 11.47,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.958,
-                            "file_cluster_1": 12.153,
-                            "file_cluster_2": 12.261,
-                            "file_cluster_3": 13.044,
-                            "file_cluster_4": 12.385,
-                            "file_cluster_5": 12.598,
-                            "file_cluster_6": 12.17,
-                            "file_cluster_7": 11.786,
-                            "file_cluster_8": 11.482,
-                            "file_cluster_9": 12.193,
-                            "file_cluster_10": 12.847,
-                            "file_cluster_11": 11.84,
-                            "file_cluster_12": 11.926,
-                            "file_cluster_13": 11.829,
-                            "file_cluster_14": 15.787,
-                            "file_cluster_15": 12.345,
-                            "file_cluster_16": 11.576,
-                            "file_cluster_17": 12.237
+                            "file_cluster_0": 11.947,
+                            "file_cluster_1": 12.141,
+                            "file_cluster_2": 12.25,
+                            "file_cluster_3": 13.034,
+                            "file_cluster_4": 12.374,
+                            "file_cluster_5": 12.588,
+                            "file_cluster_6": 12.159,
+                            "file_cluster_7": 11.774,
+                            "file_cluster_8": 11.47,
+                            "file_cluster_9": 12.182,
+                            "file_cluster_10": 12.836,
+                            "file_cluster_11": 11.83,
+                            "file_cluster_12": 11.915,
+                            "file_cluster_13": 11.818,
+                            "file_cluster_14": 15.778,
+                            "file_cluster_15": 12.334,
+                            "file_cluster_16": 11.564,
+                            "file_cluster_17": 12.226
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -137180,7 +137190,7 @@
                         "Total LOC": 560,
                         "Coding LOC": 484,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 918.08,
+                        "Structural Magnitude": 914.28,
                         "Control Flow Ratio": "69.3%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -137222,20 +137232,20 @@
                         },
                         {
                             "Function Name": "testMap",
-                            "Structural Impact": 18.4,
+                            "Structural Impact": 16.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 377,
                             "End Line": 386
                         },
                         {
                             "Function Name": "testSet",
-                            "Structural Impact": 18.4,
+                            "Structural Impact": 16.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 416,
                             "End Line": 425
@@ -137381,32 +137391,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3752.91,
+                        "X": -3752.7,
                         "Y": 177.39,
-                        "Z": 1724.82
+                        "Z": 1724.71
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.66,
+                        "Repository Drift (Z-Score)": 12.87,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.992,
-                            "file_cluster_1": 13.286,
-                            "file_cluster_2": 13.412,
-                            "file_cluster_3": 14.137,
-                            "file_cluster_4": 13.296,
-                            "file_cluster_5": 13.696,
-                            "file_cluster_6": 13.195,
-                            "file_cluster_7": 12.919,
-                            "file_cluster_8": 12.66,
-                            "file_cluster_9": 13.201,
-                            "file_cluster_10": 14.028,
-                            "file_cluster_11": 13.163,
-                            "file_cluster_12": 13.5,
-                            "file_cluster_13": 13.016,
-                            "file_cluster_14": 16.694,
-                            "file_cluster_15": 13.526,
-                            "file_cluster_16": 13.288,
-                            "file_cluster_17": 13.31
+                            "file_cluster_0": 13.195,
+                            "file_cluster_1": 13.486,
+                            "file_cluster_2": 13.609,
+                            "file_cluster_3": 14.325,
+                            "file_cluster_4": 13.49,
+                            "file_cluster_5": 13.89,
+                            "file_cluster_6": 13.397,
+                            "file_cluster_7": 13.124,
+                            "file_cluster_8": 12.87,
+                            "file_cluster_9": 13.402,
+                            "file_cluster_10": 14.218,
+                            "file_cluster_11": 13.355,
+                            "file_cluster_12": 13.697,
+                            "file_cluster_13": 13.217,
+                            "file_cluster_14": 16.853,
+                            "file_cluster_15": 13.722,
+                            "file_cluster_16": 13.487,
+                            "file_cluster_17": 13.504
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -137414,7 +137424,7 @@
                         "Total LOC": 2556,
                         "Coding LOC": 2339,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 5150.18,
+                        "Structural Magnitude": 5086.08,
                         "Control Flow Ratio": "67.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -137695,16 +137705,6 @@
                             "End Line": 1305
                         },
                         {
-                            "Function Name": "onDispatch",
-                            "Structural Impact": 46.4,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 1507,
-                            "End Line": 1533
-                        },
-                        {
                             "Function Name": "napi_get_uv_event_loop",
                             "Structural Impact": 42.5,
                             "Lines of Code (LOC)": 19,
@@ -137725,14 +137725,14 @@
                             "End Line": 326
                         },
                         {
-                            "Function Name": "deinit",
-                            "Structural Impact": 40.4,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1421,
-                            "End Line": 1427
+                            "Function Name": "onDispatch",
+                            "Structural Impact": 40.3,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 1507,
+                            "End Line": 1533
                         },
                         {
                             "Function Name": "napi_delete_async_work",
@@ -137865,6 +137865,16 @@
                             "End Line": 1012
                         },
                         {
+                            "Function Name": "deinit",
+                            "Structural Impact": 35.0,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1421,
+                            "End Line": 1427
+                        },
+                        {
                             "Function Name": "napi_get_undefined",
                             "Structural Impact": 31.8,
                             "Lines of Code (LOC)": 12,
@@ -137925,16 +137935,6 @@
                             "End Line": 1316
                         },
                         {
-                            "Function Name": "deinit",
-                            "Structural Impact": 30.9,
-                            "Lines of Code (LOC)": 19,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1672,
-                            "End Line": 1690
-                        },
-                        {
                             "Function Name": "napi_async_init",
                             "Structural Impact": 27.2,
                             "Lines of Code (LOC)": 8,
@@ -137943,6 +137943,16 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 655,
                             "End Line": 662
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 26.9,
+                            "Lines of Code (LOC)": 19,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1672,
+                            "End Line": 1690
                         },
                         {
                             "Function Name": "napi_close_handle_scope",
@@ -138016,53 +138026,23 @@
                         },
                         {
                             "Function Name": "schedule",
-                            "Structural Impact": 20.9,
+                            "Structural Impact": 18.2,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "80.0%",
                             "Start Line": 2511,
                             "End Line": 2528
                         },
                         {
                             "Function Name": "maybeQueueFinalizer",
-                            "Structural Impact": 18.8,
+                            "Structural Impact": 16.4,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 1539,
                             "End Line": 1554
-                        },
-                        {
-                            "Function Name": "fromJSType",
-                            "Structural Impact": 16.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 180,
-                            "End Line": 195
-                        },
-                        {
-                            "Function Name": "getAndClearPendingException",
-                            "Structural Impact": 16.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 49,
-                            "End Line": 56
-                        },
-                        {
-                            "Function Name": "acquire",
-                            "Structural Impact": 16.4,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1700,
-                            "End Line": 1708
                         },
                         {
                             "Function Name": "napiSpan",
@@ -138075,21 +138055,41 @@
                             "End Line": 1178
                         },
                         {
-                            "Function Name": "scheduleDispatch",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1658,
-                            "End Line": 1670
+                            "Function Name": "fromJSType",
+                            "Structural Impact": 14.7,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 180,
+                            "End Line": 195
+                        },
+                        {
+                            "Function Name": "getAndClearPendingException",
+                            "Structural Impact": 14.3,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 49,
+                            "End Line": 56
+                        },
+                        {
+                            "Function Name": "acquire",
+                            "Structural Impact": 14.3,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1700,
+                            "End Line": 1708
                         },
                         {
                             "Function Name": "notImplementedYet",
-                            "Structural Impact": 15.3,
+                            "Structural Impact": 14.1,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 5,
+                            "Input Parameters": 4,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 712,
                             "End Line": 724
@@ -138105,51 +138105,51 @@
                             "End Line": 1493
                         },
                         {
-                            "Function Name": "fixDeadCodeElimination",
-                            "Structural Impact": 14.0,
-                            "Lines of Code (LOC)": 21,
-                            "Control Flow Branches": 4,
+                            "Function Name": "scheduleDispatch",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
                             "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
-                            "Start Line": 2476,
-                            "End Line": 2496
+                            "Start Line": 1658,
+                            "End Line": 1670
                         },
                         {
                             "Function Name": "toJSType",
-                            "Structural Impact": 12.8,
+                            "Structural Impact": 11.1,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 197,
                             "End Line": 211
                         },
                         {
                             "Function Name": "invalidArg",
-                            "Structural Impact": 12.3,
+                            "Structural Impact": 10.7,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 25,
                             "End Line": 30
                         },
                         {
                             "Function Name": "genericFailure",
-                            "Structural Impact": 12.3,
+                            "Structural Impact": 10.7,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 32,
                             "End Line": 37
                         },
                         {
                             "Function Name": "toC",
-                            "Structural Impact": 12.2,
+                            "Structural Impact": 10.5,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 213,
                             "End Line": 215
@@ -138165,34 +138165,24 @@
                             "End Line": 772
                         },
                         {
+                            "Function Name": "fixDeadCodeElimination",
+                            "Structural Impact": 8.6,
+                            "Lines of Code (LOC)": 21,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 2476,
+                            "End Line": 2496
+                        },
+                        {
                             "Function Name": "isBlocked",
-                            "Structural Impact": 9.1,
+                            "Structural Impact": 8.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1499,
                             "End Line": 1501
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 2503,
-                            "End Line": 2509
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1495,
-                            "End Line": 1497
                         },
                         {
                             "Function Name": "napi_call_threadsafe_function",
@@ -138205,24 +138195,14 @@
                             "End Line": 1799
                         },
                         {
-                            "Function Name": "napi_acquire_threadsafe_function",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 4,
+                            "Function Name": "init",
+                            "Structural Impact": 7.3,
+                            "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1800,
-                            "End Line": 1803
-                        },
-                        {
-                            "Function Name": "uv_os_getppid",
-                            "Structural Impact": 7.7,
-                            "Lines of Code (LOC)": 85,
-                            "Control Flow Branches": 2,
                             "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1915,
-                            "End Line": 1999
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 2503,
+                            "End Line": 2509
                         },
                         {
                             "Function Name": "napi_get_threadsafe_function_context",
@@ -138245,6 +138225,26 @@
                             "End Line": 776
                         },
                         {
+                            "Function Name": "deinit",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1495,
+                            "End Line": 1497
+                        },
+                        {
+                            "Function Name": "napi_acquire_threadsafe_function",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1800,
+                            "End Line": 1803
+                        },
+                        {
                             "Function Name": "napi_release_threadsafe_function",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 4,
@@ -138256,73 +138256,23 @@
                         },
                         {
                             "Function Name": "get",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 143,
                             "End Line": 145
                         },
                         {
                             "Function Name": "isClosing",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1535,
                             "End Line": 1537
-                        },
-                        {
-                            "Function Name": "toJS",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 7,
-                            "End Line": 9
-                        },
-                        {
-                            "Function Name": "ok",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 20,
-                            "End Line": 22
-                        },
-                        {
-                            "Function Name": "getVersion",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 45,
-                            "End Line": 47
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2530,
-                            "End Line": 2533
-                        },
-                        {
-                            "Function Name": "NapiEnv__ref",
-                            "Structural Impact": 5.5,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 62,
-                            "End Line": 67
                         },
                         {
                             "Function Name": "create",
@@ -138335,14 +138285,24 @@
                             "End Line": 150
                         },
                         {
-                            "Function Name": "napi_internal_suppress_crash_on_abort_if",
+                            "Function Name": "deinit",
                             "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 5,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2530,
+                            "End Line": 2533
+                        },
+                        {
+                            "Function Name": "toJS",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
                             "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1356,
-                            "End Line": 1360
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 7,
+                            "End Line": 9
                         },
                         {
                             "Function Name": "setLastError",
@@ -138355,6 +138315,26 @@
                             "End Line": 17
                         },
                         {
+                            "Function Name": "ok",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 20,
+                            "End Line": 22
+                        },
+                        {
+                            "Function Name": "getVersion",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 45,
+                            "End Line": 47
+                        },
+                        {
                             "Function Name": "open",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -138365,24 +138345,34 @@
                             "End Line": 99
                         },
                         {
+                            "Function Name": "NapiEnv__ref",
+                            "Structural Impact": 4.5,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 1,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 62,
+                            "End Line": 67
+                        },
+                        {
+                            "Function Name": "uv_os_getppid",
+                            "Structural Impact": 4.5,
+                            "Lines of Code (LOC)": 85,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1915,
+                            "End Line": 1999
+                        },
+                        {
                             "Function Name": "napi_internal_register_cleanup_zig",
-                            "Structural Impact": 4.4,
+                            "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1347,
                             "End Line": 1354
-                        },
-                        {
-                            "Function Name": "envIsNull",
-                            "Structural Impact": 3.8,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 72,
-                            "End Line": 77
                         },
                         {
                             "Function Name": "set",
@@ -138395,74 +138385,44 @@
                             "End Line": 141
                         },
                         {
-                            "Function Name": "uv_wtf8_to_utf16",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 2,
+                            "Function Name": "napi_internal_suppress_crash_on_abort_if",
+                            "Structural Impact": 3.2,
+                            "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 2,
+                            "Input Parameters": 0,
                             "Control Flow Ratio": "100.0%",
-                            "Start Line": 2473,
-                            "End Line": 2474
+                            "Start Line": 1356,
+                            "End Line": 1360
                         },
                         {
                             "Function Name": "runOnJSThread",
-                            "Structural Impact": 3.2,
+                            "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2535,
                             "End Line": 2538
                         },
                         {
                             "Function Name": "runAsCleanupHook",
-                            "Structural Impact": 3.2,
+                            "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2540,
                             "End Line": 2543
                         },
                         {
                             "Function Name": "checkGC",
-                            "Structural Impact": 3.1,
+                            "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 40,
-                            "End Line": 42
-                        },
-                        {
-                            "Function Name": "ref",
-                            "Structural Impact": 3.1,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1692,
-                            "End Line": 1694
-                        },
-                        {
-                            "Function Name": "unref",
-                            "Structural Impact": 3.1,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1696,
-                            "End Line": 1698
-                        },
-                        {
-                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
-                            "Structural Impact": 2.8,
-                            "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
                             "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
-                            "Start Line": 2004,
-                            "End Line": 2008
+                            "Start Line": 40,
+                            "End Line": 42
                         },
                         {
                             "Function Name": "close",
@@ -138485,6 +138445,46 @@
                             "End Line": 112
                         },
                         {
+                            "Function Name": "ref",
+                            "Structural Impact": 2.7,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1692,
+                            "End Line": 1694
+                        },
+                        {
+                            "Function Name": "unref",
+                            "Structural Impact": 2.7,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1696,
+                            "End Line": 1698
+                        },
+                        {
+                            "Function Name": "envIsNull",
+                            "Structural Impact": 2.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 72,
+                            "End Line": 77
+                        },
+                        {
+                            "Function Name": "uv_wtf8_to_utf16",
+                            "Structural Impact": 2.1,
+                            "Lines of Code (LOC)": 2,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 2473,
+                            "End Line": 2474
+                        },
+                        {
                             "Function Name": "escape",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
@@ -138493,14 +138493,24 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 117,
                             "End Line": 117
+                        },
+                        {
+                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2004,
+                            "End Line": 2008
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
                     "7. Structural Signatures (Net Mitigated Signals)": {
                         "Control Flow Branches": 513,
                         "Sequential Logic Declarations": 251,
-                        "Function Parameters": 613,
-                        "Function/Method Declarations": 289,
+                        "Function Parameters": 689,
+                        "Function/Method Declarations": 681,
                         "Class/Entity Declarations": 24,
                         "Defensive Programming Constructs": 150,
                         "Type/Safety Bypasses": 21,
@@ -138650,9 +138660,9 @@
                         "Identity Proof": "Metadata Anchor (PATENTS)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3770.89,
+                        "X": -2149.1,
                         "Y": 68.25,
-                        "Z": -3442.13
+                        "Z": -3116.48
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -138811,9 +138821,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4524.79,
+                        "X": -1395.2,
                         "Y": 140.2,
-                        "Z": -3133.95
+                        "Z": -2808.3
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -139068,9 +139078,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3540.23,
+                        "X": -2379.76,
                         "Y": 144.34,
-                        "Z": -2884.17
+                        "Z": -2558.52
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -139471,9 +139481,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3877.94,
+                        "X": -2042.04,
                         "Y": 331.25,
-                        "Z": -2255.55
+                        "Z": -1929.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -139684,9 +139694,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4076.1,
+                        "X": -1843.89,
                         "Y": 203.93,
-                        "Z": -2773.74
+                        "Z": -2448.09
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -140463,9 +140473,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3695.18,
+                        "X": -2224.81,
                         "Y": 262.64,
-                        "Z": -2409.02
+                        "Z": -2083.37
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_15",
@@ -140723,9 +140733,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4348.53,
+                        "X": -1571.45,
                         "Y": 314.15,
-                        "Z": -2343.65
+                        "Z": -2018.01
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -141190,9 +141200,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4116.62,
+                        "X": -1803.36,
                         "Y": 49.43,
-                        "Z": -3395.22
+                        "Z": -3069.57
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_12",
@@ -141454,9 +141464,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2131.68,
+                        "X": -3772.81,
                         "Y": -109.38,
-                        "Z": -3158.54
+                        "Z": 2237.01
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -141615,9 +141625,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2009.45,
+                        "X": -3650.58,
                         "Y": -296.01,
-                        "Z": -2032.35
+                        "Z": 3363.2
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -141795,9 +141805,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2202.29,
+                        "X": -3843.42,
                         "Y": -230.75,
-                        "Z": -2026.91
+                        "Z": 3368.64
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -142092,9 +142102,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1829.62,
+                        "X": -3470.74,
                         "Y": -110.49,
-                        "Z": -3003.54
+                        "Z": 2392.01
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -142412,9 +142422,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1905.98,
+                        "X": -3547.11,
                         "Y": -224.26,
-                        "Z": -2602.97
+                        "Z": 2792.58
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -143371,9 +143381,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2415.23,
+                        "X": -4056.36,
                         "Y": -107.63,
-                        "Z": -2607.91
+                        "Z": 2787.64
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -143735,9 +143745,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1575.16,
+                        "X": -3216.29,
                         "Y": -352.34,
-                        "Z": -2243.12
+                        "Z": 3152.43
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -143941,9 +143951,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1447.25,
+                        "X": -3088.38,
                         "Y": -225.58,
-                        "Z": -2627.9
+                        "Z": 2767.65
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -156898,3093 +156908,6 @@
                 }
             }
         },
-        "zig/zls/mach": {
-            "Directory Group Magnitude": 7692.4,
-            "File Count": 8,
-            "Ecosystem Fingerprint (Archetypes)": {
-                "file_cluster_8": "50.0%",
-                "file_cluster_13": "12.5%",
-                "file_cluster_0": "12.5%",
-                "file_cluster_16": "12.5%",
-                "file_cluster_2": "12.5%"
-            },
-            "Average Risk Exposures": {
-                "Cognitive Load Exposure": "15.45%",
-                "Error & Exception Exposure": "21.87%",
-                "Tech Debt Exposure": "52.89%",
-                "Testing Exposure": "70.15%",
-                "API Exposure": "6.39%",
-                "Concurrency Exposure": "2.3%",
-                "State Flux Exposure": "16.63%",
-                "Commented Logic Exposure": "3.69%",
-                "Specification Exposure": "94.17%",
-                "Instability Exposure": "50.0%",
-                "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "77.03%",
-                "Civil War Exposure": "100.0%",
-                "Algorithmic DoS Exposure": "82.01%",
-                "Obfuscation & Evasion Surface": "0.0%",
-                "Exploit Generation Surface": "17.39%",
-                "Weaponizable Injection Vectors": "0.0%",
-                "Raw Memory Manipulation": "1.25%",
-                "Hardcoded Payload Artifacts": "0.0%"
-            },
-            "Files": {
-                "zig/zls/mach/Core.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "Core.zig",
-                        "Path": "zig/zls/mach/Core.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Alert": "TYPOSQUATTING THREAT: 'build-options' mimics 'build_options'",
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -4030.82,
-                        "Y": 207.01,
-                        "Z": 2870.48
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 10.862,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 11.372,
-                            "file_cluster_1": 11.507,
-                            "file_cluster_2": 11.067,
-                            "file_cluster_3": 12.54,
-                            "file_cluster_4": 11.81,
-                            "file_cluster_5": 11.955,
-                            "file_cluster_6": 11.372,
-                            "file_cluster_7": 11.147,
-                            "file_cluster_8": 10.929,
-                            "file_cluster_9": 11.577,
-                            "file_cluster_10": 12.293,
-                            "file_cluster_11": 11.39,
-                            "file_cluster_12": 11.789,
-                            "file_cluster_13": 10.862,
-                            "file_cluster_14": 15.143,
-                            "file_cluster_15": 11.827,
-                            "file_cluster_16": 11.565,
-                            "file_cluster_17": 11.402
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 798,
-                        "Coding LOC": 683,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 432.56,
-                        "Control Flow Ratio": "69.8%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.28
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "6.61%",
-                        "Error & Exception Exposure": "9.74%",
-                        "Tech Debt Exposure": "76.47%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "6.95%",
-                        "Concurrency Exposure": "18.44%",
-                        "State Flux Exposure": "12.1%",
-                        "Commented Logic Exposure": "5.87%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "72.34%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "98.92%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "detectBackendType",
-                            "Structural Impact": 97.2,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 23,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "65.7%",
-                            "Start Line": 398,
-                            "End Line": 421
-                        },
-                        {
-                            "Function Name": "initWindow",
-                            "Structural Impact": 51.9,
-                            "Lines of Code (LOC)": 69,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "76.5%",
-                            "Start Line": 147,
-                            "End Line": 215
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 37.2,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 122,
-                            "End Line": 145
-                        },
-                        {
-                            "Function Name": "main",
-                            "Structural Impact": 21.5,
-                            "Lines of Code (LOC)": 15,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 254,
-                            "End Line": 268
-                        },
-                        {
-                            "Function Name": "pushEvent",
-                            "Structural Impact": 18.4,
-                            "Lines of Code (LOC)": 22,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 313,
-                            "End Line": 334
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 12.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 287,
-                            "End Line": 302
-                        },
-                        {
-                            "Function Name": "presentFrame",
-                            "Structural Impact": 11.6,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "40.0%",
-                            "Start Line": 228,
-                            "End Line": 252
-                        },
-                        {
-                            "Function Name": "tick",
-                            "Structural Impact": 10.9,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 217,
-                            "End Line": 226
-                        },
-                        {
-                            "Function Name": "printUnhandledErrorCallback",
-                            "Structural Impact": 9.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 387,
-                            "End Line": 396
-                        },
-                        {
-                            "Function Name": "outOfMemory",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 339,
-                            "End Line": 343
-                        },
-                        {
-                            "Function Name": "platform_update_callback",
-                            "Structural Impact": 7.5,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 270,
-                            "End Line": 281
-                        },
-                        {
-                            "Function Name": "isKeyPressed",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 444,
-                            "End Line": 446
-                        },
-                        {
-                            "Function Name": "isKeyReleased",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 448,
-                            "End Line": 450
-                        },
-                        {
-                            "Function Name": "isMouseButtonPressed",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 452,
-                            "End Line": 454
-                        },
-                        {
-                            "Function Name": "isMouseButtonReleased",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 456,
-                            "End Line": 458
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 733,
-                            "End Line": 735
-                        },
-                        {
-                            "Function Name": "requestAdapterCallback",
-                            "Structural Impact": 4.3,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 365,
-                            "End Line": 376
-                        },
-                        {
-                            "Function Name": "nextEvent",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 306,
-                            "End Line": 308
-                        },
-                        {
-                            "Function Name": "mousePosition",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 361,
-                            "End Line": 363
-                        },
-                        {
-                            "Function Name": "keyPressed",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 345,
-                            "End Line": 347
-                        },
-                        {
-                            "Function Name": "keyReleased",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 349,
-                            "End Line": 351
-                        },
-                        {
-                            "Function Name": "mousePressed",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 353,
-                            "End Line": 355
-                        },
-                        {
-                            "Function Name": "mouseReleased",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 357,
-                            "End Line": 359
-                        },
-                        {
-                            "Function Name": "assertHasDecl",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 775,
-                            "End Line": 777
-                        },
-                        {
-                            "Function Name": "assertHasField",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 779,
-                            "End Line": 781
-                        },
-                        {
-                            "Function Name": "deviceLostCallback",
-                            "Structural Impact": 2.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 380,
-                            "End Line": 385
-                        },
-                        {
-                            "Function Name": "exit",
-                            "Structural Impact": 2.1,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 283,
-                            "End Line": 285
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 90,
-                        "Sequential Logic Declarations": 39,
-                        "Function Parameters": 27,
-                        "Function/Method Declarations": 27,
-                        "Class/Entity Declarations": 17,
-                        "Defensive Programming Constructs": 23,
-                        "Type/Safety Bypasses": 12,
-                        "High-Risk Execution Commands": 7,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 42,
-                        "State Mutations / Variable Reassignments": 24,
-                        "Commented-out Code (Dead Logic)": 2,
-                        "Structured Documentation Blocks": 65,
-                        "Unit Test Assertions": 0,
-                        "Asynchronous/Concurrent Execution": 1,
-                        "UI / View Layer Components": 31,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 42,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 3,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 6,
-                        "Metaprogramming & Reflection": 2,
-                        "Module Dependencies (Imports)": 19,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 9,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 18,
-                        "Manual Memory Allocation": 2,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 5,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 6,
-                        "Fatal Aborts & Exceptions": 36,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 30,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 44,
-                        "Resource Deallocation & Cleanup": 6,
-                        "Private / Encapsulated Scopes": 26,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 562,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 11,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 4,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 1,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 4,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
-                    },
-                    "9. Extracted Dependencies": [
-                        "build-options",
-                        "builtin",
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/StringTable.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "StringTable.zig",
-                        "Path": "zig/zls/mach/StringTable.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3707.19,
-                        "Y": 317.63,
-                        "Z": 3316.77
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.036,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 13.346,
-                            "file_cluster_1": 13.522,
-                            "file_cluster_2": 13.65,
-                            "file_cluster_3": 14.423,
-                            "file_cluster_4": 13.685,
-                            "file_cluster_5": 13.88,
-                            "file_cluster_6": 13.643,
-                            "file_cluster_7": 13.17,
-                            "file_cluster_8": 13.036,
-                            "file_cluster_9": 13.542,
-                            "file_cluster_10": 14.431,
-                            "file_cluster_11": 13.622,
-                            "file_cluster_12": 13.909,
-                            "file_cluster_13": 13.145,
-                            "file_cluster_14": 16.931,
-                            "file_cluster_15": 13.818,
-                            "file_cluster_16": 13.611,
-                            "file_cluster_17": 13.529
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 109,
-                        "Coding LOC": 85,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 79.0,
-                        "Control Flow Ratio": "73.7%",
-                        "Popularity Rank": 1,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.529
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "14.63%",
-                        "Error & Exception Exposure": "53.53%",
-                        "Tech Debt Exposure": "100.0%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "3.67%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "91.86%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "58.69%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "19.1%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "indexOrPut",
-                            "Structural Impact": 18.6,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 31,
-                            "End Line": 41
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 71,
-                            "End Line": 74
-                        },
-                        {
-                            "Function Name": "index",
-                            "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 22,
-                            "End Line": 27
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 57,
-                            "End Line": 60
-                        },
-                        {
-                            "Function Name": "hash",
-                            "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 62,
-                            "End Line": 65
-                        },
-                        {
-                            "Function Name": "hash",
-                            "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 76,
-                            "End Line": 79
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 3.7,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 49,
-                            "End Line": 52
-                        },
-                        {
-                            "Function Name": "string",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 45,
-                            "End Line": 47
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 28,
-                        "Sequential Logic Declarations": 10,
-                        "Function Parameters": 8,
-                        "Function/Method Declarations": 8,
-                        "Class/Entity Declarations": 2,
-                        "Defensive Programming Constructs": 17,
-                        "Type/Safety Bypasses": 4,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 9,
-                        "State Mutations / Variable Reassignments": 6,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 14,
-                        "Unit Test Assertions": 7,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 16,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 0,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 1,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 0,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 9,
-                        "Manual Memory Allocation": 1,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 13,
-                        "Fatal Aborts & Exceptions": 8,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 6,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 23,
-                        "Resource Deallocation & Cleanup": 4,
-                        "Private / Encapsulated Scopes": 15,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 52,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 4,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 1,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 1,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 4
-                    },
-                    "9. Extracted Dependencies": [
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/collision.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "collision.zig",
-                        "Path": "zig/zls/mach/collision.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3215.45,
-                        "Y": 283.8,
-                        "Z": 3276.3
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 13.746,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 13.746,
-                            "file_cluster_1": 14.321,
-                            "file_cluster_2": 14.354,
-                            "file_cluster_3": 14.927,
-                            "file_cluster_4": 14.146,
-                            "file_cluster_5": 14.642,
-                            "file_cluster_6": 13.768,
-                            "file_cluster_7": 13.942,
-                            "file_cluster_8": 13.767,
-                            "file_cluster_9": 13.834,
-                            "file_cluster_10": 14.473,
-                            "file_cluster_11": 13.797,
-                            "file_cluster_12": 14.457,
-                            "file_cluster_13": 13.826,
-                            "file_cluster_14": 17.166,
-                            "file_cluster_15": 14.364,
-                            "file_cluster_16": 14.318,
-                            "file_cluster_17": 13.9
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 825,
-                        "Coding LOC": 715,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 602.6,
-                        "Control Flow Ratio": "80.8%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.524
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "18.69%",
-                        "Error & Exception Exposure": "3.21%",
-                        "Tech Debt Exposure": "88.72%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "1.23%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "11.75%",
-                        "Commented Logic Exposure": "12.91%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "33.3%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "polygonPolygonContact",
-                            "Structural Impact": 130.6,
-                            "Lines of Code (LOC)": 66,
-                            "Control Flow Branches": 20,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "69.0%",
-                            "Start Line": 558,
-                            "End Line": 623
-                        },
-                        {
-                            "Function Name": "collidesLine",
-                            "Structural Impact": 68.8,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "70.6%",
-                            "Start Line": 284,
-                            "End Line": 308
-                        },
-                        {
-                            "Function Name": "collisionRect",
-                            "Structural Impact": 52.9,
-                            "Lines of Code (LOC)": 19,
-                            "Control Flow Branches": 11,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "84.6%",
-                            "Start Line": 40,
-                            "End Line": 58
-                        },
-                        {
-                            "Function Name": "circlePolygonContact",
-                            "Structural Impact": 38.2,
-                            "Lines of Code (LOC)": 71,
-                            "Control Flow Branches": 9,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 698,
-                            "End Line": 768
-                        },
-                        {
-                            "Function Name": "collidesRect",
-                            "Structural Impact": 32.4,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "72.7%",
-                            "Start Line": 102,
-                            "End Line": 125
-                        },
-                        {
-                            "Function Name": "findMinSeparation",
-                            "Structural Impact": 29.0,
-                            "Lines of Code (LOC)": 26,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "63.6%",
-                            "Start Line": 501,
-                            "End Line": 526
-                        },
-                        {
-                            "Function Name": "collidesPoly",
-                            "Structural Impact": 27.0,
-                            "Lines of Code (LOC)": 21,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 204,
-                            "End Line": 224
-                        },
-                        {
-                            "Function Name": "findDeepestVertex",
-                            "Structural Impact": 24.8,
-                            "Lines of Code (LOC)": 15,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 420,
-                            "End Line": 434
-                        },
-                        {
-                            "Function Name": "minmaxProjectionDistance",
-                            "Structural Impact": 24.6,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 379,
-                            "End Line": 391
-                        },
-                        {
-                            "Function Name": "circleCircleContact",
-                            "Structural Impact": 19.0,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 786,
-                            "End Line": 802
-                        },
-                        {
-                            "Function Name": "vertices",
-                            "Structural Impact": 8.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 78,
-                            "End Line": 85
-                        },
-                        {
-                            "Function Name": "collidesCircle",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 136,
-                            "End Line": 146
-                        },
-                        {
-                            "Function Name": "collidesTriangle",
-                            "Structural Impact": 7.7,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 244,
-                            "End Line": 259
-                        },
-                        {
-                            "Function Name": "collidesRect",
-                            "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 23,
-                            "End Line": 28
-                        },
-                        {
-                            "Function Name": "collidesRect",
-                            "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 162,
-                            "End Line": 167
-                        },
-                        {
-                            "Function Name": "collidesLine",
-                            "Structural Impact": 5.7,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 332,
-                            "End Line": 342
-                        },
-                        {
-                            "Function Name": "collidesCircle",
-                            "Structural Impact": 5.5,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 185,
-                            "End Line": 190
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 232,
-                        "Sequential Logic Declarations": 55,
-                        "Function Parameters": 17,
-                        "Function/Method Declarations": 17,
-                        "Class/Entity Declarations": 7,
-                        "Defensive Programming Constructs": 117,
-                        "Type/Safety Bypasses": 9,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 22,
-                        "State Mutations / Variable Reassignments": 69,
-                        "Commented-out Code (Dead Logic)": 10,
-                        "Structured Documentation Blocks": 42,
-                        "Unit Test Assertions": 17,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 150,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 38,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 3,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 6,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 2,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 0,
-                        "Fatal Aborts & Exceptions": 29,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 103,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 135,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 145,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 645,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 7,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 2,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 3,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
-                    },
-                    "9. Extracted Dependencies": [
-                        "../testing.zig",
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/graph.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "graph.zig",
-                        "Path": "zig/zls/mach/graph.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3480.33,
-                        "Y": 205.67,
-                        "Z": 2483.83
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.858,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 14.077,
-                            "file_cluster_1": 14.36,
-                            "file_cluster_2": 14.401,
-                            "file_cluster_3": 15.157,
-                            "file_cluster_4": 13.966,
-                            "file_cluster_5": 14.708,
-                            "file_cluster_6": 14.347,
-                            "file_cluster_7": 14.028,
-                            "file_cluster_8": 13.858,
-                            "file_cluster_9": 14.234,
-                            "file_cluster_10": 15.116,
-                            "file_cluster_11": 14.274,
-                            "file_cluster_12": 14.657,
-                            "file_cluster_13": 13.982,
-                            "file_cluster_14": 17.403,
-                            "file_cluster_15": 14.585,
-                            "file_cluster_16": 14.42,
-                            "file_cluster_17": 14.149
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 653,
-                        "Coding LOC": 546,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 676.02,
-                        "Control Flow Ratio": "72.2%",
-                        "Popularity Rank": 1,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.835
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "34.03%",
-                        "Error & Exception Exposure": "2.66%",
-                        "Tech Debt Exposure": "61.68%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "1.1%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "95.38%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "81.21%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "processOp",
-                            "Structural Impact": 220.3,
-                            "Lines of Code (LOC)": 66,
-                            "Control Flow Branches": 30,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 227,
-                            "End Line": 292
-                        },
-                        {
-                            "Function Name": "removeChild",
-                            "Structural Impact": 55.9,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "72.7%",
-                            "Start Line": 36,
-                            "End Line": 62
-                        },
-                        {
-                            "Function Name": "acquireResultList",
-                            "Structural Impact": 41.1,
-                            "Lines of Code (LOC)": 23,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "53.8%",
-                            "Start Line": 388,
-                            "End Line": 410
-                        },
-                        {
-                            "Function Name": "getChildren",
-                            "Structural Impact": 33.2,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "58.3%",
-                            "Start Line": 362,
-                            "End Line": 386
-                        },
-                        {
-                            "Function Name": "preallocateNodes2",
-                            "Structural Impact": 32.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "85.7%",
-                            "Start Line": 295,
-                            "End Line": 314
-                        },
-                        {
-                            "Function Name": "getParent",
-                            "Structural Impact": 20.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 420,
-                            "End Line": 435
-                        },
-                        {
-                            "Function Name": "hasChild",
-                            "Structural Impact": 17.7,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 15,
-                            "End Line": 21
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 14.5,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 188,
-                            "End Line": 199
-                        },
-                        {
-                            "Function Name": "addChild",
-                            "Structural Impact": 14.4,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 24,
-                            "End Line": 33
-                        },
-                        {
-                            "Function Name": "processThread",
-                            "Structural Impact": 14.2,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 209,
-                            "End Line": 215
-                        },
-                        {
-                            "Function Name": "addChild",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 316,
-                            "End Line": 323
-                        },
-                        {
-                            "Function Name": "removeChild",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 325,
-                            "End Line": 331
-                        },
-                        {
-                            "Function Name": "setParent",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 333,
-                            "End Line": 340
-                        },
-                        {
-                            "Function Name": "removeParent",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 342,
-                            "End Line": 346
-                        },
-                        {
-                            "Function Name": "cleanupIsolatedNode",
-                            "Structural Impact": 8.1,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 218,
-                            "End Line": 224
-                        },
-                        {
-                            "Function Name": "getNode",
-                            "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 202,
-                            "End Line": 206
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 357,
-                            "End Line": 359
-                        },
-                        {
-                            "Function Name": "releaseResultList",
-                            "Structural Impact": 2.9,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 412,
-                            "End Line": 418
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 2.5,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 0,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 142,
-                            "End Line": 150
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 197,
-                        "Sequential Logic Declarations": 76,
-                        "Function Parameters": 19,
-                        "Function/Method Declarations": 19,
-                        "Class/Entity Declarations": 5,
-                        "Defensive Programming Constructs": 155,
-                        "Type/Safety Bypasses": 12,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 12,
-                        "State Mutations / Variable Reassignments": 94,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 38,
-                        "Unit Test Assertions": 10,
-                        "Asynchronous/Concurrent Execution": 22,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 69,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 0,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 3,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 0,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 38,
-                        "Manual Memory Allocation": 10,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 0,
-                        "Fatal Aborts & Exceptions": 21,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 48,
-                        "Thread Synchronization Locks": 30,
-                        "Immutable Data Declarations": 48,
-                        "Resource Deallocation & Cleanup": 39,
-                        "Private / Encapsulated Scopes": 74,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 499,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 1,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 6,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 2,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 4
-                    },
-                    "9. Extracted Dependencies": [
-                        "mpsc.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/main.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "main.zig",
-                        "Path": "zig/zls/mach/main.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3826.65,
-                        "Y": 147.68,
-                        "Z": 2201.41
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 6.731,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 8.524,
-                            "file_cluster_1": 8.034,
-                            "file_cluster_2": 8.611,
-                            "file_cluster_3": 9.792,
-                            "file_cluster_4": 9.002,
-                            "file_cluster_5": 8.923,
-                            "file_cluster_6": 8.93,
-                            "file_cluster_7": 7.683,
-                            "file_cluster_8": 6.731,
-                            "file_cluster_9": 8.766,
-                            "file_cluster_10": 10.094,
-                            "file_cluster_11": 9.288,
-                            "file_cluster_12": 9.098,
-                            "file_cluster_13": 6.787,
-                            "file_cluster_14": 13.521,
-                            "file_cluster_15": 9.514,
-                            "file_cluster_16": 8.381,
-                            "file_cluster_17": 9.088
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 12,
-                        "Coding LOC": 8,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 18.16,
-                        "Control Flow Ratio": "0.0%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.625
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "5.0%",
-                        "Error & Exception Exposure": "0.0%",
-                        "Tech Debt Exposure": "0.0%",
-                        "Testing Exposure": "1.23%",
-                        "API Exposure": "12.55%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "53.33%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "53.33%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "0.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "0.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 0,
-                        "Sequential Logic Declarations": 0,
-                        "Function Parameters": 0,
-                        "Function/Method Declarations": 0,
-                        "Class/Entity Declarations": 0,
-                        "Defensive Programming Constructs": 0,
-                        "Type/Safety Bypasses": 0,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 4,
-                        "State Mutations / Variable Reassignments": 0,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 0,
-                        "Unit Test Assertions": 0,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 4,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 0,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 3,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 0,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 0,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 0,
-                        "Fatal Aborts & Exceptions": 0,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 0,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 4,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 0,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 2,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 0,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 16
-                    },
-                    "9. Extracted Dependencies": []
-                },
-                "zig/zls/mach/module.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "module.zig",
-                        "Path": "zig/zls/mach/module.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3854.74,
-                        "Y": 237.51,
-                        "Z": 3166.74
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 12.473,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 12.838,
-                            "file_cluster_1": 13.099,
-                            "file_cluster_2": 12.951,
-                            "file_cluster_3": 13.822,
-                            "file_cluster_4": 13.189,
-                            "file_cluster_5": 13.413,
-                            "file_cluster_6": 12.695,
-                            "file_cluster_7": 12.722,
-                            "file_cluster_8": 12.675,
-                            "file_cluster_9": 13.072,
-                            "file_cluster_10": 13.667,
-                            "file_cluster_11": 12.521,
-                            "file_cluster_12": 12.588,
-                            "file_cluster_13": 12.686,
-                            "file_cluster_14": 16.386,
-                            "file_cluster_15": 13.141,
-                            "file_cluster_16": 12.473,
-                            "file_cluster_17": 13.076
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 1021,
-                        "Coding LOC": 894,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 2526.58,
-                        "Control Flow Ratio": "69.6%",
-                        "Popularity Rank": 4,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.868
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "30.79%",
-                        "Error & Exception Exposure": "52.93%",
-                        "Tech Debt Exposure": "24.42%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "4.24%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "13.81%",
-                        "Commented Logic Exposure": "5.61%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "84.26%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "Objects",
-                            "Structural Impact": 1186.1,
-                            "Lines of Code (LOC)": 444,
-                            "Control Flow Branches": 95,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "70.4%",
-                            "Start Line": 29,
-                            "End Line": 472
-                        },
-                        {
-                            "Function Name": "Modules",
-                            "Structural Impact": 612.2,
-                            "Lines of Code (LOC)": 205,
-                            "Control Flow Branches": 42,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "77.8%",
-                            "Start Line": 587,
-                            "End Line": 791
-                        },
-                        {
-                            "Function Name": "validate",
-                            "Structural Impact": 467.5,
-                            "Lines of Code (LOC)": 227,
-                            "Control Flow Branches": 33,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 794,
-                            "End Line": 1020
-                        },
-                        {
-                            "Function Name": "ModuleTagEnum",
-                            "Structural Impact": 52.2,
-                            "Lines of Code (LOC)": 38,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "72.7%",
-                            "Start Line": 548,
-                            "End Line": 585
-                        },
-                        {
-                            "Function Name": "ModuleFunctionName2",
-                            "Structural Impact": 23.3,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 528,
-                            "End Line": 545
-                        },
-                        {
-                            "Function Name": "ModFunctionIDs",
-                            "Structural Impact": 14.4,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 505,
-                            "End Line": 524
-                        },
-                        {
-                            "Function Name": "Mod",
-                            "Structural Impact": 10.0,
-                            "Lines of Code (LOC)": 21,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 483,
-                            "End Line": 503
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 190,
-                        "Sequential Logic Declarations": 83,
-                        "Function Parameters": 56,
-                        "Function/Method Declarations": 55,
-                        "Class/Entity Declarations": 10,
-                        "Defensive Programming Constructs": 48,
-                        "Type/Safety Bypasses": 38,
-                        "High-Risk Execution Commands": 3,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 66,
-                        "State Mutations / Variable Reassignments": 70,
-                        "Commented-out Code (Dead Logic)": 2,
-                        "Structured Documentation Blocks": 136,
-                        "Unit Test Assertions": 3,
-                        "Asynchronous/Concurrent Execution": 7,
-                        "UI / View Layer Components": 11,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 130,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 73,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 4,
-                        "Metaprogramming & Reflection": 81,
-                        "Module Dependencies (Imports)": 4,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 22,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 21,
-                        "Manual Memory Allocation": 4,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 19,
-                        "Fatal Aborts & Exceptions": 58,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 103,
-                        "Thread Synchronization Locks": 12,
-                        "Immutable Data Declarations": 128,
-                        "Resource Deallocation & Cleanup": 16,
-                        "Private / Encapsulated Scopes": 123,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 811,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 4,
-                        "Direct Downstream (Dependency Blast Radius)": 4,
-                        "Total Upstream (Absolute Fragility)": 3,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 3
-                    },
-                    "9. Extracted Dependencies": [
-                        "StringTable.zig",
-                        "graph.zig",
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/testing.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "testing.zig",
-                        "Path": "zig/zls/mach/testing.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3027.54,
-                        "Y": 256.77,
-                        "Z": 2744.93
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_2",
-                        "Repository Drift (Z-Score)": 11.627,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 12.331,
-                            "file_cluster_1": 12.198,
-                            "file_cluster_2": 11.627,
-                            "file_cluster_3": 13.222,
-                            "file_cluster_4": 12.806,
-                            "file_cluster_5": 12.598,
-                            "file_cluster_6": 12.343,
-                            "file_cluster_7": 11.882,
-                            "file_cluster_8": 11.748,
-                            "file_cluster_9": 12.556,
-                            "file_cluster_10": 12.49,
-                            "file_cluster_11": 12.198,
-                            "file_cluster_12": 12.422,
-                            "file_cluster_13": 11.887,
-                            "file_cluster_14": 15.734,
-                            "file_cluster_15": 12.511,
-                            "file_cluster_16": 11.737,
-                            "file_cluster_17": 12.312
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 224,
-                        "Coding LOC": 199,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 253.58,
-                        "Control Flow Ratio": "67.9%",
-                        "Popularity Rank": 2,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.317
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "7.51%",
-                        "Error & Exception Exposure": "4.2%",
-                        "Tech Debt Exposure": "20.27%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "5.07%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "99.92%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "Expect",
-                            "Structural Impact": 60.2,
-                            "Lines of Code (LOC)": 41,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 114,
-                            "End Line": 154
-                        },
-                        {
-                            "Function Name": "ExpectVector",
-                            "Structural Impact": 48.4,
-                            "Lines of Code (LOC)": 29,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 33,
-                            "End Line": 61
-                        },
-                        {
-                            "Function Name": "ExpectVecMat",
-                            "Structural Impact": 48.3,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 63,
-                            "End Line": 89
-                        },
-                        {
-                            "Function Name": "ExpectFloat",
-                            "Structural Impact": 34.8,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 7,
-                            "End Line": 31
-                        },
-                        {
-                            "Function Name": "ExpectBytes",
-                            "Structural Impact": 18.5,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 100,
-                            "End Line": 112
-                        },
-                        {
-                            "Function Name": "ExpectComptime",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 91,
-                            "End Line": 98
-                        },
-                        {
-                            "Function Name": "expect",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 204,
-                            "End Line": 206
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 36,
-                        "Sequential Logic Declarations": 17,
-                        "Function Parameters": 20,
-                        "Function/Method Declarations": 20,
-                        "Class/Entity Declarations": 0,
-                        "Defensive Programming Constructs": 10,
-                        "Type/Safety Bypasses": 0,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 16,
-                        "State Mutations / Variable Reassignments": 6,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 57,
-                        "Unit Test Assertions": 3,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 19,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 13,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 14,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 23,
-                        "Metaprogramming & Reflection": 2,
-                        "Module Dependencies (Imports)": 2,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 2,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 13,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 5,
-                        "Explicit Type Casts": 5,
-                        "Fatal Aborts & Exceptions": 15,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 0,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 29,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 17,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 129,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 2,
-                        "Direct Downstream (Dependency Blast Radius)": 2,
-                        "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 1
-                    },
-                    "9. Extracted Dependencies": [
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/win32.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "win32.zig",
-                        "Path": "zig/zls/mach/win32.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3545.36,
-                        "Y": 281.46,
-                        "Z": 3057.12
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.973,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 11.825,
-                            "file_cluster_1": 11.8,
-                            "file_cluster_2": 12.054,
-                            "file_cluster_3": 12.858,
-                            "file_cluster_4": 12.338,
-                            "file_cluster_5": 12.344,
-                            "file_cluster_6": 11.937,
-                            "file_cluster_7": 11.463,
-                            "file_cluster_8": 10.973,
-                            "file_cluster_9": 12.037,
-                            "file_cluster_10": 12.779,
-                            "file_cluster_11": 11.954,
-                            "file_cluster_12": 12.124,
-                            "file_cluster_13": 11.416,
-                            "file_cluster_14": 15.848,
-                            "file_cluster_15": 12.331,
-                            "file_cluster_16": 11.646,
-                            "file_cluster_17": 12.316
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 4254,
-                        "Coding LOC": 4140,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 3103.9,
-                        "Control Flow Ratio": "58.8%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.078
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "6.37%",
-                        "Error & Exception Exposure": "48.72%",
-                        "Tech Debt Exposure": "51.58%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "16.3%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "5.14%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "99.99%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "98.45%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "9.99%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 248.2,
-                            "Lines of Code (LOC)": 45,
-                            "Control Flow Branches": 21,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "63.6%",
-                            "Start Line": 1080,
-                            "End Line": 1124
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 203.1,
-                            "Lines of Code (LOC)": 37,
-                            "Control Flow Branches": 17,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "63.0%",
-                            "Start Line": 634,
-                            "End Line": 670
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 158.6,
-                            "Lines of Code (LOC)": 41,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "48.1%",
-                            "Start Line": 3591,
-                            "End Line": 3631
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 79.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "46.2%",
-                            "Start Line": 3880,
-                            "End Line": 3899
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 79.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "46.2%",
-                            "Start Line": 3977,
-                            "End Line": 3996
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 79.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "46.2%",
-                            "Start Line": 4058,
-                            "End Line": 4077
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 67.9,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "45.5%",
-                            "Start Line": 3834,
-                            "End Line": 3850
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 67.9,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "45.5%",
-                            "Start Line": 3928,
-                            "End Line": 3944
-                        },
-                        {
-                            "Function Name": "loword",
-                            "Structural Impact": 64.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "77.8%",
-                            "Start Line": 4224,
-                            "End Line": 4233
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "44.4%",
-                            "Start Line": 3684,
-                            "End Line": 3697
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "44.4%",
-                            "Start Line": 3726,
-                            "End Line": 3739
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "44.4%",
-                            "Start Line": 3794,
-                            "End Line": 3807
-                        },
-                        {
-                            "Function Name": "hiword",
-                            "Structural Impact": 48.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 4234,
-                            "End Line": 4243
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 45.5,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "63.6%",
-                            "Start Line": 496,
-                            "End Line": 511
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 45.3,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "42.9%",
-                            "Start Line": 4014,
-                            "End Line": 4024
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 33.9,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "40.0%",
-                            "Start Line": 4090,
-                            "End Line": 4097
-                        },
-                        {
-                            "Function Name": "CoTaskMemFree",
-                            "Structural Impact": 21.5,
-                            "Lines of Code (LOC)": 30,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "37.5%",
-                            "Start Line": 3742,
-                            "End Line": 3771
-                        },
-                        {
-                            "Function Name": "hexVal",
-                            "Structural Impact": 18.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 387,
-                            "End Line": 391
-                        },
-                        {
-                            "Function Name": "SetCursorPos",
-                            "Structural Impact": 16.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 249,
-                            "End Line": 266
-                        },
-                        {
-                            "Function Name": "pxFromPt",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4193,
-                            "End Line": 4199
-                        },
-                        {
-                            "Function Name": "ptFromPx",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4201,
-                            "End Line": 4207
-                        },
-                        {
-                            "Function Name": "GetDeviceData",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 730,
-                            "End Line": 732
-                        },
-                        {
-                            "Function Name": "CreateEffect",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 754,
-                            "End Line": 756
-                        },
-                        {
-                            "Function Name": "SendDeviceData",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 778,
-                            "End Line": 780
-                        },
-                        {
-                            "Function Name": "EnumEffectsInFile",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 781,
-                            "End Line": 783
-                        },
-                        {
-                            "Function Name": "WriteEffectToFile",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 784,
-                            "End Line": 786
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 14.2,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 393,
-                            "End Line": 399
-                        },
-                        {
-                            "Function Name": "initString",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 379,
-                            "End Line": 385
-                        },
-                        {
-                            "Function Name": "EnumObjects",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 712,
-                            "End Line": 714
-                        },
-                        {
-                            "Function Name": "Acquire",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 721,
-                            "End Line": 723
-                        },
-                        {
-                            "Function Name": "Unacquire",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 724,
-                            "End Line": 726
-                        },
-                        {
-                            "Function Name": "GetObjectInfo",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 742,
-                            "End Line": 744
-                        },
-                        {
-                            "Function Name": "Initialize",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 751,
-                            "End Line": 753
-                        },
-                        {
-                            "Function Name": "EnumEffects",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 757,
-                            "End Line": 759
-                        },
-                        {
-                            "Function Name": "EnumCreatedEffectObjects",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 769,
-                            "End Line": 771
-                        },
-                        {
-                            "Function Name": "Poll",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 775,
-                            "End Line": 777
-                        },
-                        {
-                            "Function Name": "BuildActionMap",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 787,
-                            "End Line": 789
-                        },
-                        {
-                            "Function Name": "SetActionMap",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 790,
-                            "End Line": 792
-                        },
-                        {
-                            "Function Name": "hexVal",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 351,
-                            "End Line": 355
-                        },
-                        {
-                            "Function Name": "GetProperty",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 715,
-                            "End Line": 717
-                        },
-                        {
-                            "Function Name": "SetProperty",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 718,
-                            "End Line": 720
-                        },
-                        {
-                            "Function Name": "GetDeviceState",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 727,
-                            "End Line": 729
-                        },
-                        {
-                            "Function Name": "SetCooperativeLevel",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 739,
-                            "End Line": 741
-                        },
-                        {
-                            "Function Name": "RunControlPanel",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 748,
-                            "End Line": 750
-                        },
-                        {
-                            "Function Name": "GetEffectInfo",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 760,
-                            "End Line": 762
-                        },
-                        {
-                            "Function Name": "QueryInterface",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 796,
-                            "End Line": 798
-                        },
-                        {
-                            "Function Name": "GetCapabilities",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 709,
-                            "End Line": 711
-                        },
-                        {
-                            "Function Name": "SetDataFormat",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 733,
-                            "End Line": 735
-                        },
-                        {
-                            "Function Name": "SetEventNotification",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 736,
-                            "End Line": 738
-                        },
-                        {
-                            "Function Name": "GetDeviceInfo",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 745,
-                            "End Line": 747
-                        },
-                        {
-                            "Function Name": "GetForceFeedbackState",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 763,
-                            "End Line": 765
-                        },
-                        {
-                            "Function Name": "SendForceFeedbackCommand",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 766,
-                            "End Line": 768
-                        },
-                        {
-                            "Function Name": "Escape",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 772,
-                            "End Line": 774
-                        },
-                        {
-                            "Function Name": "GetImageInfo",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 793,
-                            "End Line": 795
-                        },
-                        {
-                            "Function Name": "dpiFromHwnd",
-                            "Structural Impact": 9.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4179,
-                            "End Line": 4186
-                        },
-                        {
-                            "Function Name": "GetWindowLongPtrW",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 231,
-                            "End Line": 236
-                        },
-                        {
-                            "Function Name": "AddRef",
-                            "Structural Impact": 6.9,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 799,
-                            "End Line": 801
-                        },
-                        {
-                            "Function Name": "Release",
-                            "Structural Impact": 6.9,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 802,
-                            "End Line": 804
-                        },
-                        {
-                            "Function Name": "SetWindowPos",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 46,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 8,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 283,
-                            "End Line": 328
-                        },
-                        {
-                            "Function Name": "DirectInput8Create",
-                            "Structural Impact": 4.7,
-                            "Lines of Code (LOC)": 42,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 6,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 55,
-                            "End Line": 96
-                        },
-                        {
-                            "Function Name": "PeekMessageW",
-                            "Structural Impact": 4.7,
-                            "Lines of Code (LOC)": 41,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 6,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 123,
-                            "End Line": 163
-                        },
-                        {
-                            "Function Name": "decodeHexByte",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 357,
-                            "End Line": 359
-                        },
-                        {
-                            "Function Name": "getDpiFactor",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4188,
-                            "End Line": 4191
-                        },
-                        {
-                            "Function Name": "xFromLparam",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4245,
-                            "End Line": 4247
-                        },
-                        {
-                            "Function Name": "yFromLparam",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4248,
-                            "End Line": 4250
-                        },
-                        {
-                            "Function Name": "pointFromLparam",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4251,
-                            "End Line": 4253
-                        },
-                        {
-                            "Function Name": "ShowWindow",
-                            "Structural Impact": 4.0,
-                            "Lines of Code (LOC)": 44,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1416,
-                            "End Line": 1459
-                        },
-                        {
-                            "Function Name": "RegisterClassW",
-                            "Structural Impact": 3.2,
-                            "Lines of Code (LOC)": 38,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1322,
-                            "End Line": 1359
-                        },
-                        {
-                            "Function Name": "DefWindowProcW",
-                            "Structural Impact": 3.1,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1609,
-                            "End Line": 1622
-                        },
-                        {
-                            "Function Name": "EnumDisplayMonitors",
-                            "Structural Impact": 3.0,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2417,
-                            "End Line": 2427
-                        },
-                        {
-                            "Function Name": "LoadCursorW",
-                            "Structural Impact": 2.9,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1237,
-                            "End Line": 1253
-                        },
-                        {
-                            "Function Name": "ReleaseCapture",
-                            "Structural Impact": 2.6,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2358,
-                            "End Line": 2375
-                        },
-                        {
-                            "Function Name": "ExitProcess",
-                            "Structural Impact": 2.2,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2617,
-                            "End Line": 2626
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 247,
-                        "Sequential Logic Declarations": 173,
-                        "Function Parameters": 404,
-                        "Function/Method Declarations": 131,
-                        "Class/Entity Declarations": 158,
-                        "Defensive Programming Constructs": 4,
-                        "Type/Safety Bypasses": 154,
-                        "High-Risk Execution Commands": 1,
-                        "I/O and Network Boundaries": 2,
-                        "Exposed API / Public Exports": 1032,
-                        "State Mutations / Variable Reassignments": 3,
-                        "Commented-out Code (Dead Logic)": 4,
-                        "Structured Documentation Blocks": 0,
-                        "Unit Test Assertions": 0,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 836,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 65,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 23,
-                        "Metaprogramming & Reflection": 12,
-                        "Module Dependencies (Imports)": 137,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 27,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 728,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 416,
-                        "Fatal Aborts & Exceptions": 139,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 32,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 1625,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 20,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 3016,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 16,
-                        "Orphaned Logic": 16,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 2,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 2,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
-                    },
-                    "9. Extracted Dependencies": [
-                        "builtin",
-                        "std"
-                    ]
-                }
-            }
-        },
         "python/airflow": {
             "Directory Group Magnitude": 7540.6,
             "File Count": 3,
@@ -166893,6 +163816,3097 @@
                         "Tappable",
                         "clause",
                         "stdClass"
+                    ]
+                }
+            }
+        },
+        "zig/zls/mach": {
+            "Directory Group Magnitude": 7340.0,
+            "File Count": 8,
+            "Ecosystem Fingerprint (Archetypes)": {
+                "file_cluster_8": "50.0%",
+                "file_cluster_13": "12.5%",
+                "file_cluster_0": "12.5%",
+                "file_cluster_16": "12.5%",
+                "file_cluster_2": "12.5%"
+            },
+            "Average Risk Exposures": {
+                "Cognitive Load Exposure": "15.45%",
+                "Error & Exception Exposure": "21.87%",
+                "Tech Debt Exposure": "52.89%",
+                "Testing Exposure": "70.15%",
+                "API Exposure": "6.39%",
+                "Concurrency Exposure": "2.3%",
+                "State Flux Exposure": "16.63%",
+                "Commented Logic Exposure": "3.69%",
+                "Specification Exposure": "94.17%",
+                "Instability Exposure": "50.0%",
+                "Volatility Exposure": "0.0%",
+                "Documentation Exposure": "76.98%",
+                "Civil War Exposure": "100.0%",
+                "Algorithmic DoS Exposure": "82.01%",
+                "Obfuscation & Evasion Surface": "0.0%",
+                "Exploit Generation Surface": "17.39%",
+                "Weaponizable Injection Vectors": "0.0%",
+                "Raw Memory Manipulation": "1.25%",
+                "Hardcoded Payload Artifacts": "0.0%"
+            },
+            "Files": {
+                "zig/zls/mach/Core.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "Core.zig",
+                        "Path": "zig/zls/mach/Core.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Alert": "TYPOSQUATTING THREAT: 'build-options' mimics 'build_options'",
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3531.27,
+                        "Y": 207.21,
+                        "Z": -2850.04
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_13",
+                        "Repository Drift (Z-Score)": 10.854,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 11.364,
+                            "file_cluster_1": 11.499,
+                            "file_cluster_2": 11.059,
+                            "file_cluster_3": 12.533,
+                            "file_cluster_4": 11.802,
+                            "file_cluster_5": 11.948,
+                            "file_cluster_6": 11.364,
+                            "file_cluster_7": 11.138,
+                            "file_cluster_8": 10.921,
+                            "file_cluster_9": 11.569,
+                            "file_cluster_10": 12.286,
+                            "file_cluster_11": 11.383,
+                            "file_cluster_12": 11.781,
+                            "file_cluster_13": 10.854,
+                            "file_cluster_14": 15.137,
+                            "file_cluster_15": 11.82,
+                            "file_cluster_16": 11.557,
+                            "file_cluster_17": 11.394
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 798,
+                        "Coding LOC": 683,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 410.86,
+                        "Control Flow Ratio": "69.8%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.28
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "6.61%",
+                        "Error & Exception Exposure": "9.74%",
+                        "Tech Debt Exposure": "76.47%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "6.95%",
+                        "Concurrency Exposure": "18.44%",
+                        "State Flux Exposure": "12.1%",
+                        "Commented Logic Exposure": "5.87%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "72.22%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "98.92%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "detectBackendType",
+                            "Structural Impact": 84.3,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 23,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "65.7%",
+                            "Start Line": 398,
+                            "End Line": 421
+                        },
+                        {
+                            "Function Name": "initWindow",
+                            "Structural Impact": 51.9,
+                            "Lines of Code (LOC)": 69,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "76.5%",
+                            "Start Line": 147,
+                            "End Line": 215
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 32.4,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 122,
+                            "End Line": 145
+                        },
+                        {
+                            "Function Name": "main",
+                            "Structural Impact": 21.5,
+                            "Lines of Code (LOC)": 15,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 254,
+                            "End Line": 268
+                        },
+                        {
+                            "Function Name": "pushEvent",
+                            "Structural Impact": 18.4,
+                            "Lines of Code (LOC)": 22,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 313,
+                            "End Line": 334
+                        },
+                        {
+                            "Function Name": "presentFrame",
+                            "Structural Impact": 11.6,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "40.0%",
+                            "Start Line": 228,
+                            "End Line": 252
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 11.2,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 287,
+                            "End Line": 302
+                        },
+                        {
+                            "Function Name": "tick",
+                            "Structural Impact": 10.9,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 217,
+                            "End Line": 226
+                        },
+                        {
+                            "Function Name": "printUnhandledErrorCallback",
+                            "Structural Impact": 9.5,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 387,
+                            "End Line": 396
+                        },
+                        {
+                            "Function Name": "platform_update_callback",
+                            "Structural Impact": 7.5,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 270,
+                            "End Line": 281
+                        },
+                        {
+                            "Function Name": "outOfMemory",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 339,
+                            "End Line": 343
+                        },
+                        {
+                            "Function Name": "isKeyPressed",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 444,
+                            "End Line": 446
+                        },
+                        {
+                            "Function Name": "isKeyReleased",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 448,
+                            "End Line": 450
+                        },
+                        {
+                            "Function Name": "isMouseButtonPressed",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 452,
+                            "End Line": 454
+                        },
+                        {
+                            "Function Name": "isMouseButtonReleased",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 456,
+                            "End Line": 458
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 733,
+                            "End Line": 735
+                        },
+                        {
+                            "Function Name": "requestAdapterCallback",
+                            "Structural Impact": 4.3,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 365,
+                            "End Line": 376
+                        },
+                        {
+                            "Function Name": "nextEvent",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 306,
+                            "End Line": 308
+                        },
+                        {
+                            "Function Name": "keyPressed",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 345,
+                            "End Line": 347
+                        },
+                        {
+                            "Function Name": "keyReleased",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 349,
+                            "End Line": 351
+                        },
+                        {
+                            "Function Name": "mousePressed",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 353,
+                            "End Line": 355
+                        },
+                        {
+                            "Function Name": "mouseReleased",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 357,
+                            "End Line": 359
+                        },
+                        {
+                            "Function Name": "mousePosition",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 361,
+                            "End Line": 363
+                        },
+                        {
+                            "Function Name": "assertHasDecl",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 775,
+                            "End Line": 777
+                        },
+                        {
+                            "Function Name": "assertHasField",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 779,
+                            "End Line": 781
+                        },
+                        {
+                            "Function Name": "deviceLostCallback",
+                            "Structural Impact": 2.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 380,
+                            "End Line": 385
+                        },
+                        {
+                            "Function Name": "exit",
+                            "Structural Impact": 1.9,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 283,
+                            "End Line": 285
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 90,
+                        "Sequential Logic Declarations": 39,
+                        "Function Parameters": 27,
+                        "Function/Method Declarations": 27,
+                        "Class/Entity Declarations": 17,
+                        "Defensive Programming Constructs": 23,
+                        "Type/Safety Bypasses": 12,
+                        "High-Risk Execution Commands": 7,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 42,
+                        "State Mutations / Variable Reassignments": 24,
+                        "Commented-out Code (Dead Logic)": 2,
+                        "Structured Documentation Blocks": 65,
+                        "Unit Test Assertions": 0,
+                        "Asynchronous/Concurrent Execution": 1,
+                        "UI / View Layer Components": 31,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 42,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 3,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 6,
+                        "Metaprogramming & Reflection": 2,
+                        "Module Dependencies (Imports)": 19,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 9,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 18,
+                        "Manual Memory Allocation": 2,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 5,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 6,
+                        "Fatal Aborts & Exceptions": 36,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 30,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 44,
+                        "Resource Deallocation & Cleanup": 6,
+                        "Private / Encapsulated Scopes": 26,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 562,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 11,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 4,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 1,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 4,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                    },
+                    "9. Extracted Dependencies": [
+                        "build-options",
+                        "builtin",
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/StringTable.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "StringTable.zig",
+                        "Path": "zig/zls/mach/StringTable.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3853.62,
+                        "Y": 317.57,
+                        "Z": -2404.92
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 13.036,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 13.346,
+                            "file_cluster_1": 13.522,
+                            "file_cluster_2": 13.65,
+                            "file_cluster_3": 14.423,
+                            "file_cluster_4": 13.685,
+                            "file_cluster_5": 13.88,
+                            "file_cluster_6": 13.643,
+                            "file_cluster_7": 13.17,
+                            "file_cluster_8": 13.036,
+                            "file_cluster_9": 13.542,
+                            "file_cluster_10": 14.431,
+                            "file_cluster_11": 13.622,
+                            "file_cluster_12": 13.909,
+                            "file_cluster_13": 13.145,
+                            "file_cluster_14": 16.931,
+                            "file_cluster_15": 13.818,
+                            "file_cluster_16": 13.611,
+                            "file_cluster_17": 13.529
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 109,
+                        "Coding LOC": 85,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 79.0,
+                        "Control Flow Ratio": "73.7%",
+                        "Popularity Rank": 1,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.529
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "14.63%",
+                        "Error & Exception Exposure": "53.53%",
+                        "Tech Debt Exposure": "100.0%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "3.67%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "91.86%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "58.69%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "19.1%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "indexOrPut",
+                            "Structural Impact": 18.6,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 31,
+                            "End Line": 41
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 71,
+                            "End Line": 74
+                        },
+                        {
+                            "Function Name": "index",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 22,
+                            "End Line": 27
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 6.2,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 57,
+                            "End Line": 60
+                        },
+                        {
+                            "Function Name": "hash",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 62,
+                            "End Line": 65
+                        },
+                        {
+                            "Function Name": "hash",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 76,
+                            "End Line": 79
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 49,
+                            "End Line": 52
+                        },
+                        {
+                            "Function Name": "string",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 45,
+                            "End Line": 47
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 28,
+                        "Sequential Logic Declarations": 10,
+                        "Function Parameters": 8,
+                        "Function/Method Declarations": 8,
+                        "Class/Entity Declarations": 2,
+                        "Defensive Programming Constructs": 17,
+                        "Type/Safety Bypasses": 4,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 9,
+                        "State Mutations / Variable Reassignments": 6,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 14,
+                        "Unit Test Assertions": 7,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 16,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 0,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 1,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 0,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 9,
+                        "Manual Memory Allocation": 1,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 13,
+                        "Fatal Aborts & Exceptions": 8,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 6,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 23,
+                        "Resource Deallocation & Cleanup": 4,
+                        "Private / Encapsulated Scopes": 15,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 52,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 4,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 1,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 1,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
+                    },
+                    "9. Extracted Dependencies": [
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/collision.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "collision.zig",
+                        "Path": "zig/zls/mach/collision.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4344.54,
+                        "Y": 283.66,
+                        "Z": -2445.23
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_0",
+                        "Repository Drift (Z-Score)": 13.744,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 13.744,
+                            "file_cluster_1": 14.319,
+                            "file_cluster_2": 14.353,
+                            "file_cluster_3": 14.926,
+                            "file_cluster_4": 14.144,
+                            "file_cluster_5": 14.641,
+                            "file_cluster_6": 13.767,
+                            "file_cluster_7": 13.94,
+                            "file_cluster_8": 13.765,
+                            "file_cluster_9": 13.833,
+                            "file_cluster_10": 14.472,
+                            "file_cluster_11": 13.796,
+                            "file_cluster_12": 14.456,
+                            "file_cluster_13": 13.824,
+                            "file_cluster_14": 17.165,
+                            "file_cluster_15": 14.362,
+                            "file_cluster_16": 14.317,
+                            "file_cluster_17": 13.899
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 825,
+                        "Coding LOC": 715,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 601.5,
+                        "Control Flow Ratio": "80.8%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.524
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "18.69%",
+                        "Error & Exception Exposure": "3.21%",
+                        "Tech Debt Exposure": "88.72%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "1.23%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "11.75%",
+                        "Commented Logic Exposure": "12.91%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "33.3%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "polygonPolygonContact",
+                            "Structural Impact": 130.6,
+                            "Lines of Code (LOC)": 66,
+                            "Control Flow Branches": 20,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "69.0%",
+                            "Start Line": 558,
+                            "End Line": 623
+                        },
+                        {
+                            "Function Name": "collidesLine",
+                            "Structural Impact": 68.8,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.6%",
+                            "Start Line": 284,
+                            "End Line": 308
+                        },
+                        {
+                            "Function Name": "collisionRect",
+                            "Structural Impact": 52.9,
+                            "Lines of Code (LOC)": 19,
+                            "Control Flow Branches": 11,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "84.6%",
+                            "Start Line": 40,
+                            "End Line": 58
+                        },
+                        {
+                            "Function Name": "circlePolygonContact",
+                            "Structural Impact": 38.2,
+                            "Lines of Code (LOC)": 71,
+                            "Control Flow Branches": 9,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 698,
+                            "End Line": 768
+                        },
+                        {
+                            "Function Name": "collidesRect",
+                            "Structural Impact": 32.4,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "72.7%",
+                            "Start Line": 102,
+                            "End Line": 125
+                        },
+                        {
+                            "Function Name": "findMinSeparation",
+                            "Structural Impact": 29.0,
+                            "Lines of Code (LOC)": 26,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "63.6%",
+                            "Start Line": 501,
+                            "End Line": 526
+                        },
+                        {
+                            "Function Name": "collidesPoly",
+                            "Structural Impact": 27.0,
+                            "Lines of Code (LOC)": 21,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 204,
+                            "End Line": 224
+                        },
+                        {
+                            "Function Name": "findDeepestVertex",
+                            "Structural Impact": 24.8,
+                            "Lines of Code (LOC)": 15,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 420,
+                            "End Line": 434
+                        },
+                        {
+                            "Function Name": "minmaxProjectionDistance",
+                            "Structural Impact": 24.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 379,
+                            "End Line": 391
+                        },
+                        {
+                            "Function Name": "circleCircleContact",
+                            "Structural Impact": 19.0,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 786,
+                            "End Line": 802
+                        },
+                        {
+                            "Function Name": "collidesCircle",
+                            "Structural Impact": 8.3,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 136,
+                            "End Line": 146
+                        },
+                        {
+                            "Function Name": "collidesTriangle",
+                            "Structural Impact": 7.7,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 244,
+                            "End Line": 259
+                        },
+                        {
+                            "Function Name": "vertices",
+                            "Structural Impact": 7.3,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 78,
+                            "End Line": 85
+                        },
+                        {
+                            "Function Name": "collidesRect",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 23,
+                            "End Line": 28
+                        },
+                        {
+                            "Function Name": "collidesRect",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 162,
+                            "End Line": 167
+                        },
+                        {
+                            "Function Name": "collidesLine",
+                            "Structural Impact": 5.7,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 332,
+                            "End Line": 342
+                        },
+                        {
+                            "Function Name": "collidesCircle",
+                            "Structural Impact": 5.5,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 185,
+                            "End Line": 190
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 232,
+                        "Sequential Logic Declarations": 55,
+                        "Function Parameters": 17,
+                        "Function/Method Declarations": 17,
+                        "Class/Entity Declarations": 7,
+                        "Defensive Programming Constructs": 117,
+                        "Type/Safety Bypasses": 9,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 22,
+                        "State Mutations / Variable Reassignments": 69,
+                        "Commented-out Code (Dead Logic)": 10,
+                        "Structured Documentation Blocks": 42,
+                        "Unit Test Assertions": 17,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 150,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 38,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 3,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 6,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 2,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 0,
+                        "Fatal Aborts & Exceptions": 29,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 103,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 135,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 145,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 645,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 7,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 2,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 3,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                    },
+                    "9. Extracted Dependencies": [
+                        "../testing.zig",
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/graph.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "graph.zig",
+                        "Path": "zig/zls/mach/graph.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4080.15,
+                        "Y": 205.76,
+                        "Z": -3236.02
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 13.857,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 14.076,
+                            "file_cluster_1": 14.358,
+                            "file_cluster_2": 14.4,
+                            "file_cluster_3": 15.156,
+                            "file_cluster_4": 13.965,
+                            "file_cluster_5": 14.707,
+                            "file_cluster_6": 14.346,
+                            "file_cluster_7": 14.027,
+                            "file_cluster_8": 13.857,
+                            "file_cluster_9": 14.233,
+                            "file_cluster_10": 15.115,
+                            "file_cluster_11": 14.273,
+                            "file_cluster_12": 14.656,
+                            "file_cluster_13": 13.981,
+                            "file_cluster_14": 17.402,
+                            "file_cluster_15": 14.584,
+                            "file_cluster_16": 14.418,
+                            "file_cluster_17": 14.148
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 653,
+                        "Coding LOC": 546,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 675.42,
+                        "Control Flow Ratio": "72.2%",
+                        "Popularity Rank": 1,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.835
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "34.03%",
+                        "Error & Exception Exposure": "2.66%",
+                        "Tech Debt Exposure": "61.68%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "1.1%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "95.38%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "81.21%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "processOp",
+                            "Structural Impact": 220.3,
+                            "Lines of Code (LOC)": 66,
+                            "Control Flow Branches": 30,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 227,
+                            "End Line": 292
+                        },
+                        {
+                            "Function Name": "removeChild",
+                            "Structural Impact": 55.9,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "72.7%",
+                            "Start Line": 36,
+                            "End Line": 62
+                        },
+                        {
+                            "Function Name": "acquireResultList",
+                            "Structural Impact": 41.1,
+                            "Lines of Code (LOC)": 23,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "53.8%",
+                            "Start Line": 388,
+                            "End Line": 410
+                        },
+                        {
+                            "Function Name": "getChildren",
+                            "Structural Impact": 33.2,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "58.3%",
+                            "Start Line": 362,
+                            "End Line": 386
+                        },
+                        {
+                            "Function Name": "preallocateNodes2",
+                            "Structural Impact": 32.3,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "85.7%",
+                            "Start Line": 295,
+                            "End Line": 314
+                        },
+                        {
+                            "Function Name": "getParent",
+                            "Structural Impact": 20.8,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 420,
+                            "End Line": 435
+                        },
+                        {
+                            "Function Name": "hasChild",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 15,
+                            "End Line": 21
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 14.5,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 188,
+                            "End Line": 199
+                        },
+                        {
+                            "Function Name": "addChild",
+                            "Structural Impact": 14.4,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 24,
+                            "End Line": 33
+                        },
+                        {
+                            "Function Name": "processThread",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 209,
+                            "End Line": 215
+                        },
+                        {
+                            "Function Name": "addChild",
+                            "Structural Impact": 13.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 316,
+                            "End Line": 323
+                        },
+                        {
+                            "Function Name": "removeChild",
+                            "Structural Impact": 13.8,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 325,
+                            "End Line": 331
+                        },
+                        {
+                            "Function Name": "setParent",
+                            "Structural Impact": 13.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 333,
+                            "End Line": 340
+                        },
+                        {
+                            "Function Name": "removeParent",
+                            "Structural Impact": 8.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 342,
+                            "End Line": 346
+                        },
+                        {
+                            "Function Name": "cleanupIsolatedNode",
+                            "Structural Impact": 8.1,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 218,
+                            "End Line": 224
+                        },
+                        {
+                            "Function Name": "getNode",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 202,
+                            "End Line": 206
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 357,
+                            "End Line": 359
+                        },
+                        {
+                            "Function Name": "releaseResultList",
+                            "Structural Impact": 2.9,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 412,
+                            "End Line": 418
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 2.5,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 142,
+                            "End Line": 150
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 197,
+                        "Sequential Logic Declarations": 76,
+                        "Function Parameters": 19,
+                        "Function/Method Declarations": 19,
+                        "Class/Entity Declarations": 5,
+                        "Defensive Programming Constructs": 155,
+                        "Type/Safety Bypasses": 12,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 12,
+                        "State Mutations / Variable Reassignments": 94,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 38,
+                        "Unit Test Assertions": 10,
+                        "Asynchronous/Concurrent Execution": 22,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 69,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 0,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 3,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 0,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 38,
+                        "Manual Memory Allocation": 10,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 0,
+                        "Fatal Aborts & Exceptions": 21,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 48,
+                        "Thread Synchronization Locks": 30,
+                        "Immutable Data Declarations": 48,
+                        "Resource Deallocation & Cleanup": 39,
+                        "Private / Encapsulated Scopes": 74,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 499,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 1,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 6,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 2,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
+                    },
+                    "9. Extracted Dependencies": [
+                        "mpsc.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/main.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "main.zig",
+                        "Path": "zig/zls/mach/main.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3734.34,
+                        "Y": 147.81,
+                        "Z": -3518.55
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 6.864,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 8.605,
+                            "file_cluster_1": 8.147,
+                            "file_cluster_2": 8.712,
+                            "file_cluster_3": 9.883,
+                            "file_cluster_4": 9.102,
+                            "file_cluster_5": 9.021,
+                            "file_cluster_6": 9.026,
+                            "file_cluster_7": 7.794,
+                            "file_cluster_8": 6.864,
+                            "file_cluster_9": 8.856,
+                            "file_cluster_10": 10.185,
+                            "file_cluster_11": 9.372,
+                            "file_cluster_12": 9.197,
+                            "file_cluster_13": 6.91,
+                            "file_cluster_14": 13.547,
+                            "file_cluster_15": 9.608,
+                            "file_cluster_16": 8.485,
+                            "file_cluster_17": 9.182
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 12,
+                        "Coding LOC": 8,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 18.16,
+                        "Control Flow Ratio": "0.0%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.625
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "5.0%",
+                        "Error & Exception Exposure": "0.0%",
+                        "Tech Debt Exposure": "0.0%",
+                        "Testing Exposure": "1.23%",
+                        "API Exposure": "12.55%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "53.33%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "53.33%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "0.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "0.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 0,
+                        "Sequential Logic Declarations": 0,
+                        "Function Parameters": 0,
+                        "Function/Method Declarations": 0,
+                        "Class/Entity Declarations": 0,
+                        "Defensive Programming Constructs": 0,
+                        "Type/Safety Bypasses": 0,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 4,
+                        "State Mutations / Variable Reassignments": 0,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 0,
+                        "Unit Test Assertions": 0,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 4,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 0,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 3,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 0,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 0,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 0,
+                        "Fatal Aborts & Exceptions": 0,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 0,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 4,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 0,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 2,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 3,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 16
+                    },
+                    "9. Extracted Dependencies": [
+                        "Frequency.zig",
+                        "Timer.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/module.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "module.zig",
+                        "Path": "zig/zls/mach/module.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3707.19,
+                        "Y": 237.53,
+                        "Z": -2555.29
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_16",
+                        "Repository Drift (Z-Score)": 12.45,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 12.817,
+                            "file_cluster_1": 13.077,
+                            "file_cluster_2": 12.929,
+                            "file_cluster_3": 13.801,
+                            "file_cluster_4": 13.167,
+                            "file_cluster_5": 13.392,
+                            "file_cluster_6": 12.674,
+                            "file_cluster_7": 12.7,
+                            "file_cluster_8": 12.652,
+                            "file_cluster_9": 13.05,
+                            "file_cluster_10": 13.647,
+                            "file_cluster_11": 12.499,
+                            "file_cluster_12": 12.566,
+                            "file_cluster_13": 12.665,
+                            "file_cluster_14": 16.368,
+                            "file_cluster_15": 13.12,
+                            "file_cluster_16": 12.45,
+                            "file_cluster_17": 13.055
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 1021,
+                        "Coding LOC": 894,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 2387.88,
+                        "Control Flow Ratio": "69.6%",
+                        "Popularity Rank": 4,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.868
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "30.79%",
+                        "Error & Exception Exposure": "52.93%",
+                        "Tech Debt Exposure": "24.42%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "4.24%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "13.81%",
+                        "Commented Logic Exposure": "5.61%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "84.05%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "Objects",
+                            "Structural Impact": 1186.1,
+                            "Lines of Code (LOC)": 444,
+                            "Control Flow Branches": 95,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.4%",
+                            "Start Line": 29,
+                            "End Line": 472
+                        },
+                        {
+                            "Function Name": "Modules",
+                            "Structural Impact": 531.6,
+                            "Lines of Code (LOC)": 205,
+                            "Control Flow Branches": 42,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "77.8%",
+                            "Start Line": 587,
+                            "End Line": 791
+                        },
+                        {
+                            "Function Name": "validate",
+                            "Structural Impact": 419.4,
+                            "Lines of Code (LOC)": 227,
+                            "Control Flow Branches": 33,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 794,
+                            "End Line": 1020
+                        },
+                        {
+                            "Function Name": "ModuleTagEnum",
+                            "Structural Impact": 46.9,
+                            "Lines of Code (LOC)": 38,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "72.7%",
+                            "Start Line": 548,
+                            "End Line": 585
+                        },
+                        {
+                            "Function Name": "ModuleFunctionName2",
+                            "Structural Impact": 20.9,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 528,
+                            "End Line": 545
+                        },
+                        {
+                            "Function Name": "ModFunctionIDs",
+                            "Structural Impact": 13.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 505,
+                            "End Line": 524
+                        },
+                        {
+                            "Function Name": "Mod",
+                            "Structural Impact": 9.1,
+                            "Lines of Code (LOC)": 21,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 483,
+                            "End Line": 503
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 190,
+                        "Sequential Logic Declarations": 83,
+                        "Function Parameters": 56,
+                        "Function/Method Declarations": 55,
+                        "Class/Entity Declarations": 10,
+                        "Defensive Programming Constructs": 48,
+                        "Type/Safety Bypasses": 38,
+                        "High-Risk Execution Commands": 3,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 66,
+                        "State Mutations / Variable Reassignments": 70,
+                        "Commented-out Code (Dead Logic)": 2,
+                        "Structured Documentation Blocks": 136,
+                        "Unit Test Assertions": 3,
+                        "Asynchronous/Concurrent Execution": 7,
+                        "UI / View Layer Components": 11,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 130,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 73,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 4,
+                        "Metaprogramming & Reflection": 81,
+                        "Module Dependencies (Imports)": 4,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 22,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 21,
+                        "Manual Memory Allocation": 4,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 19,
+                        "Fatal Aborts & Exceptions": 58,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 103,
+                        "Thread Synchronization Locks": 12,
+                        "Immutable Data Declarations": 128,
+                        "Resource Deallocation & Cleanup": 16,
+                        "Private / Encapsulated Scopes": 123,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 811,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 4,
+                        "Direct Downstream (Dependency Blast Radius)": 4,
+                        "Total Upstream (Absolute Fragility)": 3,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 3
+                    },
+                    "9. Extracted Dependencies": [
+                        "StringTable.zig",
+                        "graph.zig",
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/testing.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "testing.zig",
+                        "Path": "zig/zls/mach/testing.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4531.33,
+                        "Y": 256.69,
+                        "Z": -2974.77
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_2",
+                        "Repository Drift (Z-Score)": 11.603,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 12.309,
+                            "file_cluster_1": 12.174,
+                            "file_cluster_2": 11.603,
+                            "file_cluster_3": 13.201,
+                            "file_cluster_4": 12.784,
+                            "file_cluster_5": 12.576,
+                            "file_cluster_6": 12.321,
+                            "file_cluster_7": 11.858,
+                            "file_cluster_8": 11.723,
+                            "file_cluster_9": 12.534,
+                            "file_cluster_10": 12.468,
+                            "file_cluster_11": 12.177,
+                            "file_cluster_12": 12.399,
+                            "file_cluster_13": 11.864,
+                            "file_cluster_14": 15.716,
+                            "file_cluster_15": 12.489,
+                            "file_cluster_16": 11.713,
+                            "file_cluster_17": 12.289
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 224,
+                        "Coding LOC": 199,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 230.68,
+                        "Control Flow Ratio": "67.9%",
+                        "Popularity Rank": 2,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.317
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "7.51%",
+                        "Error & Exception Exposure": "4.2%",
+                        "Tech Debt Exposure": "20.27%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "5.07%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "99.91%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "Expect",
+                            "Structural Impact": 54.0,
+                            "Lines of Code (LOC)": 41,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 114,
+                            "End Line": 154
+                        },
+                        {
+                            "Function Name": "ExpectVector",
+                            "Structural Impact": 43.5,
+                            "Lines of Code (LOC)": 29,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 33,
+                            "End Line": 61
+                        },
+                        {
+                            "Function Name": "ExpectVecMat",
+                            "Structural Impact": 43.4,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 63,
+                            "End Line": 89
+                        },
+                        {
+                            "Function Name": "ExpectFloat",
+                            "Structural Impact": 31.2,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 7,
+                            "End Line": 31
+                        },
+                        {
+                            "Function Name": "ExpectBytes",
+                            "Structural Impact": 16.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 100,
+                            "End Line": 112
+                        },
+                        {
+                            "Function Name": "ExpectComptime",
+                            "Structural Impact": 12.4,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 91,
+                            "End Line": 98
+                        },
+                        {
+                            "Function Name": "expect",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 204,
+                            "End Line": 206
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 36,
+                        "Sequential Logic Declarations": 17,
+                        "Function Parameters": 20,
+                        "Function/Method Declarations": 20,
+                        "Class/Entity Declarations": 0,
+                        "Defensive Programming Constructs": 10,
+                        "Type/Safety Bypasses": 0,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 16,
+                        "State Mutations / Variable Reassignments": 6,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 57,
+                        "Unit Test Assertions": 3,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 19,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 13,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 14,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 23,
+                        "Metaprogramming & Reflection": 2,
+                        "Module Dependencies (Imports)": 2,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 2,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 13,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 5,
+                        "Explicit Type Casts": 5,
+                        "Fatal Aborts & Exceptions": 15,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 0,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 29,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 17,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 129,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 2,
+                        "Direct Downstream (Dependency Blast Radius)": 2,
+                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 1
+                    },
+                    "9. Extracted Dependencies": [
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/win32.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "win32.zig",
+                        "Path": "zig/zls/mach/win32.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4015.2,
+                        "Y": 281.46,
+                        "Z": -2663.67
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 10.995,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 11.845,
+                            "file_cluster_1": 11.821,
+                            "file_cluster_2": 12.074,
+                            "file_cluster_3": 12.877,
+                            "file_cluster_4": 12.356,
+                            "file_cluster_5": 12.364,
+                            "file_cluster_6": 11.958,
+                            "file_cluster_7": 11.485,
+                            "file_cluster_8": 10.995,
+                            "file_cluster_9": 12.058,
+                            "file_cluster_10": 12.799,
+                            "file_cluster_11": 11.972,
+                            "file_cluster_12": 12.144,
+                            "file_cluster_13": 11.437,
+                            "file_cluster_14": 15.863,
+                            "file_cluster_15": 12.351,
+                            "file_cluster_16": 11.667,
+                            "file_cluster_17": 12.334
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 4254,
+                        "Coding LOC": 4140,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 2936.5,
+                        "Control Flow Ratio": "58.8%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.078
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "6.37%",
+                        "Error & Exception Exposure": "48.72%",
+                        "Tech Debt Exposure": "51.58%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "16.3%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "5.14%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "99.99%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "98.45%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "9.99%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 222.2,
+                            "Lines of Code (LOC)": 45,
+                            "Control Flow Branches": 21,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "63.6%",
+                            "Start Line": 1080,
+                            "End Line": 1124
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 181.8,
+                            "Lines of Code (LOC)": 37,
+                            "Control Flow Branches": 17,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "63.0%",
+                            "Start Line": 634,
+                            "End Line": 670
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 142.1,
+                            "Lines of Code (LOC)": 41,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "48.1%",
+                            "Start Line": 3591,
+                            "End Line": 3631
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 71.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "46.2%",
+                            "Start Line": 3880,
+                            "End Line": 3899
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 71.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "46.2%",
+                            "Start Line": 3977,
+                            "End Line": 3996
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 71.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "46.2%",
+                            "Start Line": 4058,
+                            "End Line": 4077
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 60.9,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "45.5%",
+                            "Start Line": 3834,
+                            "End Line": 3850
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 60.9,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "45.5%",
+                            "Start Line": 3928,
+                            "End Line": 3944
+                        },
+                        {
+                            "Function Name": "loword",
+                            "Structural Impact": 55.9,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "77.8%",
+                            "Start Line": 4224,
+                            "End Line": 4233
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 50.7,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "44.4%",
+                            "Start Line": 3684,
+                            "End Line": 3697
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 50.7,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "44.4%",
+                            "Start Line": 3726,
+                            "End Line": 3739
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 50.7,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "44.4%",
+                            "Start Line": 3794,
+                            "End Line": 3807
+                        },
+                        {
+                            "Function Name": "hiword",
+                            "Structural Impact": 42.1,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 4234,
+                            "End Line": 4243
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 40.8,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "63.6%",
+                            "Start Line": 496,
+                            "End Line": 511
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 40.5,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "42.9%",
+                            "Start Line": 4014,
+                            "End Line": 4024
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 30.4,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "40.0%",
+                            "Start Line": 4090,
+                            "End Line": 4097
+                        },
+                        {
+                            "Function Name": "CoTaskMemFree",
+                            "Structural Impact": 18.8,
+                            "Lines of Code (LOC)": 30,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "37.5%",
+                            "Start Line": 3742,
+                            "End Line": 3771
+                        },
+                        {
+                            "Function Name": "SetCursorPos",
+                            "Structural Impact": 16.9,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 249,
+                            "End Line": 266
+                        },
+                        {
+                            "Function Name": "hexVal",
+                            "Structural Impact": 15.8,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 387,
+                            "End Line": 391
+                        },
+                        {
+                            "Function Name": "pxFromPt",
+                            "Structural Impact": 15.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4193,
+                            "End Line": 4199
+                        },
+                        {
+                            "Function Name": "ptFromPx",
+                            "Structural Impact": 15.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4201,
+                            "End Line": 4207
+                        },
+                        {
+                            "Function Name": "GetDeviceData",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 730,
+                            "End Line": 732
+                        },
+                        {
+                            "Function Name": "CreateEffect",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 754,
+                            "End Line": 756
+                        },
+                        {
+                            "Function Name": "SendDeviceData",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 778,
+                            "End Line": 780
+                        },
+                        {
+                            "Function Name": "EnumEffectsInFile",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 781,
+                            "End Line": 783
+                        },
+                        {
+                            "Function Name": "WriteEffectToFile",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 784,
+                            "End Line": 786
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 393,
+                            "End Line": 399
+                        },
+                        {
+                            "Function Name": "EnumObjects",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 712,
+                            "End Line": 714
+                        },
+                        {
+                            "Function Name": "GetObjectInfo",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 742,
+                            "End Line": 744
+                        },
+                        {
+                            "Function Name": "Initialize",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 751,
+                            "End Line": 753
+                        },
+                        {
+                            "Function Name": "EnumEffects",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 757,
+                            "End Line": 759
+                        },
+                        {
+                            "Function Name": "EnumCreatedEffectObjects",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 769,
+                            "End Line": 771
+                        },
+                        {
+                            "Function Name": "BuildActionMap",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 787,
+                            "End Line": 789
+                        },
+                        {
+                            "Function Name": "SetActionMap",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 790,
+                            "End Line": 792
+                        },
+                        {
+                            "Function Name": "initString",
+                            "Structural Impact": 12.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 379,
+                            "End Line": 385
+                        },
+                        {
+                            "Function Name": "GetProperty",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 715,
+                            "End Line": 717
+                        },
+                        {
+                            "Function Name": "SetProperty",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 718,
+                            "End Line": 720
+                        },
+                        {
+                            "Function Name": "Acquire",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 721,
+                            "End Line": 723
+                        },
+                        {
+                            "Function Name": "Unacquire",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 724,
+                            "End Line": 726
+                        },
+                        {
+                            "Function Name": "GetDeviceState",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 727,
+                            "End Line": 729
+                        },
+                        {
+                            "Function Name": "SetCooperativeLevel",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 739,
+                            "End Line": 741
+                        },
+                        {
+                            "Function Name": "RunControlPanel",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 748,
+                            "End Line": 750
+                        },
+                        {
+                            "Function Name": "GetEffectInfo",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 760,
+                            "End Line": 762
+                        },
+                        {
+                            "Function Name": "Poll",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 775,
+                            "End Line": 777
+                        },
+                        {
+                            "Function Name": "QueryInterface",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 796,
+                            "End Line": 798
+                        },
+                        {
+                            "Function Name": "hexVal",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 351,
+                            "End Line": 355
+                        },
+                        {
+                            "Function Name": "GetCapabilities",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 709,
+                            "End Line": 711
+                        },
+                        {
+                            "Function Name": "SetDataFormat",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 733,
+                            "End Line": 735
+                        },
+                        {
+                            "Function Name": "SetEventNotification",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 736,
+                            "End Line": 738
+                        },
+                        {
+                            "Function Name": "GetDeviceInfo",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 745,
+                            "End Line": 747
+                        },
+                        {
+                            "Function Name": "GetForceFeedbackState",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 763,
+                            "End Line": 765
+                        },
+                        {
+                            "Function Name": "SendForceFeedbackCommand",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 766,
+                            "End Line": 768
+                        },
+                        {
+                            "Function Name": "Escape",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 772,
+                            "End Line": 774
+                        },
+                        {
+                            "Function Name": "GetImageInfo",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 793,
+                            "End Line": 795
+                        },
+                        {
+                            "Function Name": "GetWindowLongPtrW",
+                            "Structural Impact": 8.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 231,
+                            "End Line": 236
+                        },
+                        {
+                            "Function Name": "dpiFromHwnd",
+                            "Structural Impact": 8.2,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4179,
+                            "End Line": 4186
+                        },
+                        {
+                            "Function Name": "AddRef",
+                            "Structural Impact": 6.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 799,
+                            "End Line": 801
+                        },
+                        {
+                            "Function Name": "Release",
+                            "Structural Impact": 6.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 802,
+                            "End Line": 804
+                        },
+                        {
+                            "Function Name": "SetWindowPos",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 46,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 8,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 283,
+                            "End Line": 328
+                        },
+                        {
+                            "Function Name": "DirectInput8Create",
+                            "Structural Impact": 4.7,
+                            "Lines of Code (LOC)": 42,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 6,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 55,
+                            "End Line": 96
+                        },
+                        {
+                            "Function Name": "PeekMessageW",
+                            "Structural Impact": 4.7,
+                            "Lines of Code (LOC)": 41,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 6,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 123,
+                            "End Line": 163
+                        },
+                        {
+                            "Function Name": "ShowWindow",
+                            "Structural Impact": 4.0,
+                            "Lines of Code (LOC)": 44,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1416,
+                            "End Line": 1459
+                        },
+                        {
+                            "Function Name": "getDpiFactor",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4188,
+                            "End Line": 4191
+                        },
+                        {
+                            "Function Name": "decodeHexByte",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 357,
+                            "End Line": 359
+                        },
+                        {
+                            "Function Name": "xFromLparam",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4245,
+                            "End Line": 4247
+                        },
+                        {
+                            "Function Name": "yFromLparam",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4248,
+                            "End Line": 4250
+                        },
+                        {
+                            "Function Name": "pointFromLparam",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4251,
+                            "End Line": 4253
+                        },
+                        {
+                            "Function Name": "RegisterClassW",
+                            "Structural Impact": 3.2,
+                            "Lines of Code (LOC)": 38,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1322,
+                            "End Line": 1359
+                        },
+                        {
+                            "Function Name": "DefWindowProcW",
+                            "Structural Impact": 3.1,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1609,
+                            "End Line": 1622
+                        },
+                        {
+                            "Function Name": "EnumDisplayMonitors",
+                            "Structural Impact": 3.0,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2417,
+                            "End Line": 2427
+                        },
+                        {
+                            "Function Name": "LoadCursorW",
+                            "Structural Impact": 2.9,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1237,
+                            "End Line": 1253
+                        },
+                        {
+                            "Function Name": "ExitProcess",
+                            "Structural Impact": 2.2,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2617,
+                            "End Line": 2626
+                        },
+                        {
+                            "Function Name": "ReleaseCapture",
+                            "Structural Impact": 1.5,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2358,
+                            "End Line": 2375
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 247,
+                        "Sequential Logic Declarations": 173,
+                        "Function Parameters": 404,
+                        "Function/Method Declarations": 181,
+                        "Class/Entity Declarations": 158,
+                        "Defensive Programming Constructs": 4,
+                        "Type/Safety Bypasses": 154,
+                        "High-Risk Execution Commands": 1,
+                        "I/O and Network Boundaries": 2,
+                        "Exposed API / Public Exports": 1032,
+                        "State Mutations / Variable Reassignments": 3,
+                        "Commented-out Code (Dead Logic)": 4,
+                        "Structured Documentation Blocks": 0,
+                        "Unit Test Assertions": 0,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 836,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 65,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 23,
+                        "Metaprogramming & Reflection": 12,
+                        "Module Dependencies (Imports)": 137,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 27,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 728,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 416,
+                        "Fatal Aborts & Exceptions": 139,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 32,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 1625,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 20,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 3016,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 16,
+                        "Orphaned Logic": 16,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 2,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 2,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                    },
+                    "9. Extracted Dependencies": [
+                        "builtin",
+                        "std"
                     ]
                 }
             }
@@ -192659,9 +192673,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4554.93,
+                        "X": -4554.73,
                         "Y": -213.15,
-                        "Z": 3307.89
+                        "Z": 3307.75
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_4",
@@ -192873,9 +192887,9 @@
                         "Identity Proof": "Metadata Anchor (Makefile.PL)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5048.09,
+                        "X": -5047.89,
                         "Y": -176.96,
-                        "Z": 3266.82
+                        "Z": 3266.68
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
@@ -193057,9 +193071,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4846.61,
+                        "X": -4846.42,
                         "Y": -219.45,
-                        "Z": 3402.92
+                        "Z": 3402.78
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_4",
@@ -193297,9 +193311,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4472.92,
+                        "X": -4472.72,
                         "Y": -141.29,
-                        "Z": 2949.21
+                        "Z": 2949.07
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -193512,9 +193526,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4191.0,
+                        "X": -4190.8,
                         "Y": -215.6,
-                        "Z": 3794.05
+                        "Z": 3793.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
@@ -248705,9 +248719,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (100% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3778.16,
+                        "X": -3777.96,
                         "Y": -67.5,
-                        "Z": 3903.15
+                        "Z": 3902.95
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -248978,9 +248992,9 @@
                         "Identity Proof": "Single Indicator (Shebang)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3744.02,
+                        "X": -3743.83,
                         "Y": 72.52,
-                        "Z": 3376.07
+                        "Z": 3375.87
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -249429,9 +249443,9 @@
                         "Identity Proof": "Single Indicator (Shebang)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3526.73,
+                        "X": -3526.54,
                         "Y": -42.48,
-                        "Z": 4453.41
+                        "Z": 4453.21
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -249697,9 +249711,9 @@
                         "Identity Proof": "Sibling Anchor (.m)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3437.4,
+                        "X": -3437.2,
                         "Y": 109.91,
-                        "Z": 3590.0
+                        "Z": 3589.8
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -249893,9 +249907,9 @@
                         "Identity Proof": "Sibling Anchor (.h)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4117.1,
+                        "X": -4116.9,
                         "Y": -83.53,
-                        "Z": 4025.38
+                        "Z": 4025.18
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -250206,9 +250220,9 @@
                         "Identity Proof": "Single Indicator (Shebang)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4307.01,
+                        "X": -4306.81,
                         "Y": -87.83,
-                        "Z": 3983.89
+                        "Z": 3983.69
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -267405,9 +267419,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1750.39,
+                        "X": -1750.35,
                         "Y": -221.18,
-                        "Z": -4306.51
+                        "Z": -4306.42
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -267596,9 +267610,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2000.08,
+                        "X": -2000.04,
                         "Y": -198.6,
-                        "Z": -5145.5
+                        "Z": -5145.42
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_15",
@@ -267921,9 +267935,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2038.92,
+                        "X": -2038.88,
                         "Y": -210.0,
-                        "Z": -4404.36
+                        "Z": -4404.28
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -268247,9 +268261,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2255.63,
+                        "X": -2255.6,
                         "Y": -121.61,
-                        "Z": -4478.99
+                        "Z": -4478.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -268528,9 +268542,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2477.08,
+                        "X": -2477.04,
                         "Y": -76.62,
-                        "Z": -4780.82
+                        "Z": -4780.74
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -276689,9 +276703,9 @@
                         "Identity Proof": "Prose Extension (.md)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4144.48,
+                        "X": 4142.82,
                         "Y": 98.22,
-                        "Z": -3540.29
+                        "Z": -3538.86
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -276850,9 +276864,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4413.16,
+                        "X": 4411.5,
                         "Y": 192.22,
-                        "Z": -4033.4
+                        "Z": -4031.97
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -277037,9 +277051,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4661.74,
+                        "X": 4660.08,
                         "Y": 187.55,
-                        "Z": -3387.26
+                        "Z": -3385.83
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -277237,9 +277251,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3908.02,
+                        "X": 3906.36,
                         "Y": 106.83,
-                        "Z": -3920.58
+                        "Z": -3919.15
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -277435,9 +277449,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4336.1,
+                        "X": 4334.44,
                         "Y": 179.55,
-                        "Z": -3758.76
+                        "Z": -3757.33
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -277708,9 +277722,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4756.61,
+                        "X": 4754.95,
                         "Y": 254.32,
-                        "Z": -4134.84
+                        "Z": -4133.41
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -285389,9 +285403,9 @@
                         "Identity Proof": "Metadata Anchor (COPYING)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4865.26,
+                        "X": -4865.06,
                         "Y": 211.06,
-                        "Z": 4423.64
+                        "Z": 4423.46
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -285550,9 +285564,9 @@
                         "Identity Proof": "Metadata Anchor (configure.ac)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4623.85,
+                        "X": -4623.65,
                         "Y": 251.14,
-                        "Z": 4005.29
+                        "Z": 4005.11
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -285997,9 +286011,9 @@
                         "Identity Proof": "Single Indicator (Ext: .xml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2430.95,
+                        "X": -2430.91,
                         "Y": 119.54,
-                        "Z": -3825.55
+                        "Z": -3825.48
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -286177,9 +286191,9 @@
                         "Identity Proof": "Single Indicator (Ext: .xml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3134.26,
+                        "X": -3134.21,
                         "Y": 255.82,
-                        "Z": -4276.45
+                        "Z": -4276.38
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -286357,9 +286371,9 @@
                         "Identity Proof": "Single Indicator (Ext: .xml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2286.39,
+                        "X": -2286.34,
                         "Y": 90.51,
-                        "Z": -4368.4
+                        "Z": -4368.33
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -286537,9 +286551,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cls)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2735.24,
+                        "X": -2735.2,
                         "Y": 135.41,
-                        "Z": -4188.91
+                        "Z": -4188.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -286868,9 +286882,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cls)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2726.06,
+                        "X": -2726.02,
                         "Y": 152.26,
-                        "Z": -4536.57
+                        "Z": -4536.5
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -287079,9 +287093,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cls)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2987.85,
+                        "X": -2987.81,
                         "Y": 234.28,
-                        "Z": -4020.05
+                        "Z": -4019.98
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -293689,9 +293703,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3627.49,
+                        "X": -3627.46,
                         "Y": 14.83,
-                        "Z": -3971.9
+                        "Z": -3971.86
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -293878,9 +293892,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3412.16,
+                        "X": -3412.13,
                         "Y": -7.95,
-                        "Z": -3980.53
+                        "Z": -3980.5
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -296977,9 +296991,9 @@
                         "Identity Proof": "Single Indicator (Ext: .td)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4877.82,
+                        "X": 4876.18,
                         "Y": -130.72,
-                        "Z": -3807.62
+                        "Z": -3806.38
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -297157,9 +297171,9 @@
                         "Identity Proof": "Single Indicator (Ext: .td)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 5144.65,
+                        "X": 5143.01,
                         "Y": -71.47,
-                        "Z": -4000.79
+                        "Z": -3999.54
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -297757,9 +297771,9 @@
                         "Identity Proof": "Single Indicator (Ext: .nix)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5337.22,
+                        "X": -5337.03,
                         "Y": 96.0,
-                        "Z": 3207.7
+                        "Z": 3207.58
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -297937,9 +297951,9 @@
                         "Identity Proof": "Single Indicator (Ext: .nix)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5554.35,
+                        "X": -5554.16,
                         "Y": 86.12,
-                        "Z": 3444.61
+                        "Z": 3444.49
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299107,9 +299121,9 @@
                         "Identity Proof": "Single Indicator (Ext: .mlir)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2166.23,
+                        "X": -2166.2,
                         "Y": -161.46,
-                        "Z": -5240.67
+                        "Z": -5240.59
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299287,9 +299301,9 @@
                         "Identity Proof": "Single Indicator (Ext: .mlir)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1976.87,
+                        "X": -1976.84,
                         "Y": -190.21,
-                        "Z": -5209.37
+                        "Z": -5209.29
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299497,9 +299511,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4734.33,
+                        "X": -4733.83,
                         "Y": 92.28,
-                        "Z": 2083.73
+                        "Z": 2083.52
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299677,9 +299691,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4515.15,
+                        "X": -4514.66,
                         "Y": 141.88,
-                        "Z": 1735.24
+                        "Z": 1735.03
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -302177,9 +302191,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2843.71,
+                        "X": -2843.67,
                         "Y": 112.5,
-                        "Z": -4925.21
+                        "Z": -4925.14
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -302338,9 +302352,9 @@
                         "Identity Proof": "Single Indicator (Ext: .html)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3031.39,
+                        "X": -3031.35,
                         "Y": 183.94,
-                        "Z": -4556.54
+                        "Z": -4556.48
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
@@ -307404,9 +307418,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4174.28,
+                        "X": -4174.1,
                         "Y": 12.49,
-                        "Z": 4525.88
+                        "Z": 4525.67
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -308525,9 +308539,9 @@
                         "Identity Proof": "Single Indicator (Ext: .sql)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3515.99,
+                        "X": -3515.94,
                         "Y": 104.77,
-                        "Z": -3451.56
+                        "Z": -3451.51
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -308766,9 +308780,9 @@
                         "Identity Proof": "Prose Extension (.md)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4682.63,
+                        "X": 4681.07,
                         "Y": 161.35,
-                        "Z": -4327.28
+                        "Z": -4325.81
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -309148,9 +309162,9 @@
                         "Identity Proof": "Single Indicator (Ext: .sql)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4891.99,
+                        "X": -4891.8,
                         "Y": -179.88,
-                        "Z": 3960.5
+                        "Z": 3960.36
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -309379,9 +309393,9 @@
                         "Identity Proof": "Metadata Anchor (COPYRIGHT)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3318.33,
+                        "X": -3318.28,
                         "Y": 181.11,
-                        "Z": -4654.53
+                        "Z": -4654.47
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -311154,9 +311168,9 @@
                         "Identity Proof": "Single Indicator (Exact Match)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4310.22,
+                        "X": -4309.76,
                         "Y": 29.45,
-                        "Z": 2380.88
+                        "Z": 2380.63
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -312929,9 +312943,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2500.75,
+                        "X": -2500.71,
                         "Y": -114.88,
-                        "Z": -4945.57
+                        "Z": -4945.49
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",

--- a/tests/golden_master_zero_dep_audit.json
+++ b/tests/golden_master_zero_dep_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-08-02T02:31:20.066890+00:00",
-            "Total Scan Duration": "24.37 seconds"
+            "Analysis ISO Timestamp": "2026-08-02T02:53:33.014182+00:00",
+            "Total Scan Duration": "24.2 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "main",
@@ -199,7 +199,7 @@
             "avg_cognitive_load": 24.052,
             "avg_safety_score": 23.759,
             "avg_tech_debt": 25.519,
-            "avg_documentation": 29.97
+            "avg_documentation": 29.962
         },
         "composition": {
             "xml": {
@@ -465,7 +465,7 @@
             "zig": {
                 "files": 32,
                 "loc": 68347,
-                "impact": 108470.84000000001
+                "impact": 106037.54
             }
         },
         "ecosystem_fingerprint": {
@@ -2662,7 +2662,7 @@
             },
             "zig/tigerbeetle": {
                 "file_count": 11,
-                "total_mass": 12283.34,
+                "total_mass": 11647.14,
                 "avg_exposures": {
                     "cognitive_load": 30.42,
                     "safety_score": 27.36,
@@ -2675,7 +2675,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 65.9,
+                    "documentation": 65.4,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 71.27,
                     "obscured_payload": 0.0,
@@ -4012,7 +4012,7 @@
             },
             "zig/bun": {
                 "file_count": 4,
-                "total_mass": 9697.12,
+                "total_mass": 9527.92,
                 "avg_exposures": {
                     "cognitive_load": 35.05,
                     "safety_score": 7.31,
@@ -4025,7 +4025,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 78.84,
+                    "documentation": 78.83,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 100.0,
                     "obscured_payload": 0.0,
@@ -4037,7 +4037,7 @@
             },
             "zig/zig": {
                 "file_count": 5,
-                "total_mass": 49963.7,
+                "total_mass": 48995.7,
                 "avg_exposures": {
                     "cognitive_load": 26.57,
                     "safety_score": 33.79,
@@ -4050,7 +4050,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 68.85,
+                    "documentation": 68.71,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 100.0,
                     "obscured_payload": 0.0,
@@ -4062,7 +4062,7 @@
             },
             "zig/zls": {
                 "file_count": 6,
-                "total_mass": 28980.36,
+                "total_mass": 28672.86,
                 "avg_exposures": {
                     "cognitive_load": 33.41,
                     "safety_score": 3.24,
@@ -4075,7 +4075,7 @@
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 76.25,
+                    "documentation": 76.13,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 99.92,
                     "obscured_payload": 0.0,
@@ -4087,7 +4087,7 @@
             },
             "zig/zls/mach": {
                 "file_count": 8,
-                "total_mass": 7692.4,
+                "total_mass": 7340.0,
                 "avg_exposures": {
                     "cognitive_load": 15.45,
                     "safety_score": 21.87,
@@ -4100,7 +4100,7 @@
                     "spec_match": 94.17,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 77.03,
+                    "documentation": 76.98,
                     "tabs_vs_spaces": 100.0,
                     "algorithmic_dos": 82.01,
                     "obscured_payload": 0.0,
@@ -4129,7 +4129,7 @@
             },
             "firewall": {
                 "imports_whitelisted": 0,
-                "imports_unknown": 7626,
+                "imports_unknown": 7639,
                 "imports_blacklisted": 0,
                 "threats_found": 139,
                 "threats_allowed": 0
@@ -14186,7 +14186,7 @@
             }
         },
         "zig/zig": {
-            "Directory Group Magnitude": 49963.7,
+            "Directory Group Magnitude": 48995.7,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -14203,7 +14203,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "68.85%",
+                "Documentation Exposure": "68.71%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "100.0%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -14231,26 +14231,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.858,
+                        "Repository Drift (Z-Score)": 13.859,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.201,
-                            "file_cluster_1": 14.382,
-                            "file_cluster_2": 14.497,
-                            "file_cluster_3": 15.207,
-                            "file_cluster_4": 14.607,
-                            "file_cluster_5": 14.744,
-                            "file_cluster_6": 14.339,
-                            "file_cluster_7": 14.067,
-                            "file_cluster_8": 13.858,
-                            "file_cluster_9": 14.35,
-                            "file_cluster_10": 15.142,
-                            "file_cluster_11": 14.3,
-                            "file_cluster_12": 14.614,
-                            "file_cluster_13": 14.146,
+                            "file_cluster_0": 14.203,
+                            "file_cluster_1": 14.384,
+                            "file_cluster_2": 14.498,
+                            "file_cluster_3": 15.209,
+                            "file_cluster_4": 14.608,
+                            "file_cluster_5": 14.746,
+                            "file_cluster_6": 14.34,
+                            "file_cluster_7": 14.068,
+                            "file_cluster_8": 13.859,
+                            "file_cluster_9": 14.351,
+                            "file_cluster_10": 15.143,
+                            "file_cluster_11": 14.301,
+                            "file_cluster_12": 14.616,
+                            "file_cluster_13": 14.147,
                             "file_cluster_14": 17.535,
-                            "file_cluster_15": 14.635,
-                            "file_cluster_16": 14.441,
-                            "file_cluster_17": 14.404
+                            "file_cluster_15": 14.636,
+                            "file_cluster_16": 14.443,
+                            "file_cluster_17": 14.406
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -14258,7 +14258,7 @@
                         "Total LOC": 8171,
                         "Coding LOC": 7367,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 13615.94,
+                        "Structural Magnitude": 13373.24,
                         "Control Flow Ratio": "77.5%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -14278,7 +14278,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "72.61%",
+                        "Documentation Exposure": "72.43%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -14329,16 +14329,6 @@
                             "End Line": 6424
                         },
                         {
-                            "Function Name": "startTimer",
-                            "Structural Impact": 765.2,
-                            "Lines of Code (LOC)": 325,
-                            "Control Flow Branches": 106,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "73.6%",
-                            "Start Line": 382,
-                            "End Line": 706
-                        },
-                        {
                             "Function Name": "performAllTheWork",
                             "Structural Impact": 687.9,
                             "Lines of Code (LOC)": 457,
@@ -14347,6 +14337,16 @@
                             "Control Flow Ratio": "79.7%",
                             "Start Line": 4557,
                             "End Line": 5013
+                        },
+                        {
+                            "Function Name": "startTimer",
+                            "Structural Impact": 664.9,
+                            "Lines of Code (LOC)": 325,
+                            "Control Flow Branches": 106,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "73.6%",
+                            "Start Line": 382,
+                            "End Line": 706
                         },
                         {
                             "Function Name": "addModuleErrorMsg",
@@ -14409,26 +14409,6 @@
                             "End Line": 1296
                         },
                         {
-                            "Function Name": "classifyFileExt",
-                            "Structural Impact": 210.2,
-                            "Lines of Code (LOC)": 45,
-                            "Control Flow Branches": 61,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "74.4%",
-                            "Start Line": 7597,
-                            "End Line": 7641
-                        },
-                        {
-                            "Function Name": "destroy",
-                            "Structural Impact": 203.9,
-                            "Lines of Code (LOC)": 78,
-                            "Control Flow Branches": 24,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "96.0%",
-                            "Start Line": 2686,
-                            "End Line": 2763
-                        },
-                        {
                             "Function Name": "spawnZigRc",
                             "Structural Impact": 188.5,
                             "Lines of Code (LOC)": 66,
@@ -14437,6 +14417,26 @@
                             "Control Flow Ratio": "67.5%",
                             "Start Line": 6667,
                             "End Line": 6732
+                        },
+                        {
+                            "Function Name": "classifyFileExt",
+                            "Structural Impact": 188.2,
+                            "Lines of Code (LOC)": 45,
+                            "Control Flow Branches": 61,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "74.4%",
+                            "Start Line": 7597,
+                            "End Line": 7641
+                        },
+                        {
+                            "Function Name": "destroy",
+                            "Structural Impact": 177.1,
+                            "Lines of Code (LOC)": 78,
+                            "Control Flow Branches": 24,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "96.0%",
+                            "Start Line": 2686,
+                            "End Line": 2763
                         },
                         {
                             "Function Name": "toErrorMessage",
@@ -14469,16 +14469,6 @@
                             "End Line": 7901
                         },
                         {
-                            "Function Name": "saveState",
-                            "Structural Impact": 141.6,
-                            "Lines of Code (LOC)": 231,
-                            "Control Flow Branches": 25,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "73.5%",
-                            "Start Line": 3651,
-                            "End Line": 3881
-                        },
-                        {
                             "Function Name": "addNonIncrementalStuffToCacheManifest",
                             "Structural Impact": 136.2,
                             "Lines of Code (LOC)": 152,
@@ -14497,6 +14487,16 @@
                             "Control Flow Ratio": "62.5%",
                             "Start Line": 5280,
                             "End Line": 5328
+                        },
+                        {
+                            "Function Name": "saveState",
+                            "Structural Impact": 124.1,
+                            "Lines of Code (LOC)": 231,
+                            "Control Flow Branches": 25,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "73.5%",
+                            "Start Line": 3651,
+                            "End Line": 3881
                         },
                         {
                             "Function Name": "renameTmpIntoCache",
@@ -14549,16 +14549,6 @@
                             "End Line": 4536
                         },
                         {
-                            "Function Name": "docsCopyFallible",
-                            "Structural Impact": 93.0,
-                            "Lines of Code (LOC)": 60,
-                            "Control Flow Branches": 17,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "54.8%",
-                            "Start Line": 5219,
-                            "End Line": 5278
-                        },
-                        {
                             "Function Name": "lessThan",
                             "Structural Impact": 84.5,
                             "Lines of Code (LOC)": 11,
@@ -14579,6 +14569,16 @@
                             "End Line": 4192
                         },
                         {
+                            "Function Name": "docsCopyFallible",
+                            "Structural Impact": 80.9,
+                            "Lines of Code (LOC)": 60,
+                            "Control Flow Branches": 17,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "54.8%",
+                            "Start Line": 5219,
+                            "End Line": 5278
+                        },
+                        {
                             "Function Name": "eql",
                             "Structural Impact": 79.6,
                             "Lines of Code (LOC)": 25,
@@ -14590,10 +14590,10 @@
                         },
                         {
                             "Function Name": "hasSharedLibraryExt",
-                            "Structural Impact": 75.1,
+                            "Structural Impact": 67.3,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 21,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "65.6%",
                             "Start Line": 7570,
                             "End Line": 7595
@@ -14640,23 +14640,13 @@
                         },
                         {
                             "Function Name": "dump_argv",
-                            "Structural Impact": 44.7,
+                            "Structural Impact": 40.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 8,
-                            "Input Parameters": 5,
+                            "Input Parameters": 4,
                             "Control Flow Ratio": "57.1%",
                             "Start Line": 7721,
                             "End Line": 7732
-                        },
-                        {
-                            "Function Name": "finish",
-                            "Structural Impact": 42.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 360,
-                            "End Line": 375
                         },
                         {
                             "Function Name": "updateSubCompilation",
@@ -14697,6 +14687,16 @@
                             "Control Flow Ratio": "90.9%",
                             "Start Line": 3221,
                             "End Line": 3245
+                        },
+                        {
+                            "Function Name": "finish",
+                            "Structural Impact": 37.2,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 360,
+                            "End Line": 375
                         },
                         {
                             "Function Name": "hashCSource",
@@ -14759,16 +14759,6 @@
                             "End Line": 6044
                         },
                         {
-                            "Function Name": "pause",
-                            "Structural Impact": 30.8,
-                            "Lines of Code (LOC)": 15,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 334,
-                            "End Line": 348
-                        },
-                        {
                             "Function Name": "get_libc_crt_file",
                             "Structural Impact": 30.4,
                             "Lines of Code (LOC)": 8,
@@ -14789,14 +14779,14 @@
                             "End Line": 4555
                         },
                         {
-                            "Function Name": "count",
-                            "Structural Impact": 27.1,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Function Name": "pause",
+                            "Structural Impact": 26.7,
+                            "Lines of Code (LOC)": 15,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 1068,
-                            "End Line": 1072
+                            "Start Line": 334,
+                            "End Line": 348
                         },
                         {
                             "Function Name": "dispatchZcuLinkTask",
@@ -14869,6 +14859,16 @@
                             "End Line": 6014
                         },
                         {
+                            "Function Name": "count",
+                            "Structural Impact": 24.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1068,
+                            "End Line": 1072
+                        },
+                        {
                             "Function Name": "emitFromCObject",
                             "Structural Impact": 22.9,
                             "Lines of Code (LOC)": 34,
@@ -14919,16 +14919,6 @@
                             "End Line": 820
                         },
                         {
-                            "Function Name": "compilerRtOptMode",
-                            "Structural Impact": 21.6,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 8154,
-                            "End Line": 8164
-                        },
-                        {
                             "Function Name": "hash",
                             "Structural Impact": 21.5,
                             "Lines of Code (LOC)": 15,
@@ -14959,16 +14949,6 @@
                             "End Line": 5990
                         },
                         {
-                            "Function Name": "stage",
-                            "Structural Impact": 20.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 1002,
-                            "End Line": 1009
-                        },
-                        {
                             "Function Name": "lessThan",
                             "Structural Impact": 20.3,
                             "Lines of Code (LOC)": 6,
@@ -14979,6 +14959,16 @@
                             "End Line": 3978
                         },
                         {
+                            "Function Name": "compilerRtOptMode",
+                            "Structural Impact": 18.7,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 8154,
+                            "End Line": 8164
+                        },
+                        {
                             "Function Name": "deinit",
                             "Structural Impact": 17.8,
                             "Lines of Code (LOC)": 10,
@@ -14987,6 +14977,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1057,
                             "End Line": 1066
+                        },
+                        {
+                            "Function Name": "stage",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 1002,
+                            "End Line": 1009
                         },
                         {
                             "Function Name": "detectEmbedFileUpdate",
@@ -15029,16 +15029,6 @@
                             "End Line": 6054
                         },
                         {
-                            "Function Name": "toCrtFile",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 8084,
-                            "End Line": 8096
-                        },
-                        {
                             "Function Name": "deinit",
                             "Structural Impact": 14.2,
                             "Lines of Code (LOC)": 7,
@@ -15069,14 +15059,14 @@
                             "End Line": 6071
                         },
                         {
-                            "Function Name": "separateCodegenThreadOk",
-                            "Structural Impact": 13.7,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 5205,
-                            "End Line": 5209
+                            "Function Name": "toCrtFile",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 8084,
+                            "End Line": 8096
                         },
                         {
                             "Function Name": "workerDocsWasm",
@@ -15089,36 +15079,6 @@
                             "End Line": 5338
                         },
                         {
-                            "Function Name": "clangNeedsLanguageOverride",
-                            "Structural Impact": 13.4,
-                            "Lines of Code (LOC)": 28,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 7421,
-                            "End Line": 7448
-                        },
-                        {
-                            "Function Name": "clangSupportsDiagnostics",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 7450,
-                            "End Line": 7467
-                        },
-                        {
-                            "Function Name": "clangSupportsDepFile",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 19,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 7469,
-                            "End Line": 7487
-                        },
-                        {
                             "Function Name": "queuePrelinkTaskMode",
                             "Structural Impact": 12.5,
                             "Lines of Code (LOC)": 10,
@@ -15129,14 +15089,24 @@
                             "End Line": 8053
                         },
                         {
-                            "Function Name": "makeBinFileExecutable",
+                            "Function Name": "separateCodegenThreadOk",
                             "Structural Impact": 12.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 5,
                             "Input Parameters": 3,
                             "Control Flow Ratio": "62.5%",
-                            "Start Line": 3608,
-                            "End Line": 3612
+                            "Start Line": 5205,
+                            "End Line": 5209
+                        },
+                        {
+                            "Function Name": "clangNeedsLanguageOverride",
+                            "Structural Impact": 11.8,
+                            "Lines of Code (LOC)": 28,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 7421,
+                            "End Line": 7448
                         },
                         {
                             "Function Name": "canonicalName",
@@ -15149,6 +15119,26 @@
                             "End Line": 7513
                         },
                         {
+                            "Function Name": "clangSupportsDiagnostics",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 7450,
+                            "End Line": 7467
+                        },
+                        {
+                            "Function Name": "clangSupportsDepFile",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 19,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 7469,
+                            "End Line": 7487
+                        },
+                        {
                             "Function Name": "resolveEmitPath",
                             "Structural Impact": 10.9,
                             "Lines of Code (LOC)": 10,
@@ -15157,16 +15147,6 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 3247,
                             "End Line": 3256
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 10.7,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1619,
-                            "End Line": 1632
                         },
                         {
                             "Function Name": "queuePrelinkTasks",
@@ -15179,14 +15159,14 @@
                             "End Line": 8062
                         },
                         {
-                            "Function Name": "releaseLock",
-                            "Structural Impact": 10.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1605,
-                            "End Line": 1610
+                            "Function Name": "makeBinFileExecutable",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 3608,
+                            "End Line": 3612
                         },
                         {
                             "Function Name": "obtainCObjectCacheManifest",
@@ -15219,74 +15199,54 @@
                             "End Line": 2790
                         },
                         {
-                            "Function Name": "wantBuildLibUnwindFromSource",
+                            "Function Name": "deinit",
                             "Structural Impact": 9.4,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1619,
+                            "End Line": 1632
+                        },
+                        {
+                            "Function Name": "releaseLock",
+                            "Structural Impact": 9.0,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1605,
+                            "End Line": 1610
+                        },
+                        {
+                            "Function Name": "debugIncremental",
+                            "Structural Impact": 8.2,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 851,
+                            "End Line": 854
+                        },
+                        {
+                            "Function Name": "wantBuildLibUnwindFromSource",
+                            "Structural Impact": 8.2,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7675,
                             "End Line": 7683
                         },
                         {
                             "Function Name": "workerDocsCopy",
-                            "Structural Impact": 9.3,
+                            "Structural Impact": 8.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 5211,
                             "End Line": 5217
-                        },
-                        {
-                            "Function Name": "debugIncremental",
-                            "Structural Impact": 9.1,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 851,
-                            "End Line": 854
-                        },
-                        {
-                            "Function Name": "withoutLocalCache",
-                            "Structural Impact": 8.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 736,
-                            "End Line": 743
-                        },
-                        {
-                            "Function Name": "moveLock",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1612,
-                            "End Line": 1616
-                        },
-                        {
-                            "Function Name": "makeBinFileWritable",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 3614,
-                            "End Line": 3617
-                        },
-                        {
-                            "Function Name": "anyErrors",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "42.9%",
-                            "Start Line": 4269,
-                            "End Line": 4273
                         },
                         {
                             "Function Name": "addOptionalDebugFormat",
@@ -15299,6 +15259,16 @@
                             "End Line": 1490
                         },
                         {
+                            "Function Name": "withoutLocalCache",
+                            "Structural Impact": 7.3,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 736,
+                            "End Line": 743
+                        },
+                        {
                             "Function Name": "addDebugFormat",
                             "Structural Impact": 7.3,
                             "Lines of Code (LOC)": 8,
@@ -15309,14 +15279,34 @@
                             "End Line": 1499
                         },
                         {
-                            "Function Name": "hasCppExt",
+                            "Function Name": "moveLock",
                             "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 9,
+                            "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 7537,
-                            "End Line": 7545
+                            "Start Line": 1612,
+                            "End Line": 1616
+                        },
+                        {
+                            "Function Name": "anyErrors",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "42.9%",
+                            "Start Line": 4269,
+                            "End Line": 4273
+                        },
+                        {
+                            "Function Name": "makeBinFileWritable",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 3614,
+                            "End Line": 3617
                         },
                         {
                             "Function Name": "crtFilePath",
@@ -15329,104 +15319,54 @@
                             "End Line": 7673
                         },
                         {
+                            "Function Name": "hasCppExt",
+                            "Structural Impact": 6.5,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 7537,
+                            "End Line": 7545
+                        },
+                        {
                             "Function Name": "hasObjectExt",
-                            "Structural Impact": 7.0,
+                            "Structural Impact": 6.3,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7516,
                             "End Line": 7521
                         },
                         {
                             "Function Name": "hasStaticLibraryExt",
-                            "Structural Impact": 7.0,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7523,
                             "End Line": 7527
                         },
                         {
                             "Function Name": "hasCppHExt",
-                            "Structural Impact": 7.0,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7547,
                             "End Line": 7551
                         },
                         {
                             "Function Name": "hasObjCppExt",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7561,
                             "End Line": 7564
-                        },
-                        {
-                            "Function Name": "clearMiscFailures",
-                            "Structural Impact": 6.5,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 2765,
-                            "End Line": 2773
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 6.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 724,
-                            "End Line": 731
-                        },
-                        {
-                            "Function Name": "keys",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 103,
-                            "End Line": 105
-                        },
-                        {
-                            "Function Name": "count",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 106,
-                            "End Line": 108
-                        },
-                        {
-                            "Function Name": "popFront",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 138,
-                            "End Line": 140
-                        },
-                        {
-                            "Function Name": "values",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 151,
-                            "End Line": 153
                         },
                         {
                             "Function Name": "crtFileAsString",
@@ -15447,6 +15387,26 @@
                             "Control Flow Ratio": "25.0%",
                             "Start Line": 5863,
                             "End Line": 5876
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 5.6,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 724,
+                            "End Line": 731
+                        },
+                        {
+                            "Function Name": "clearMiscFailures",
+                            "Structural Impact": 5.6,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 2765,
+                            "End Line": 2773
                         },
                         {
                             "Function Name": "deinit",
@@ -15509,6 +15469,46 @@
                             "End Line": 7719
                         },
                         {
+                            "Function Name": "keys",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 103,
+                            "End Line": 105
+                        },
+                        {
+                            "Function Name": "count",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 106,
+                            "End Line": 108
+                        },
+                        {
+                            "Function Name": "popFront",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 138,
+                            "End Line": 140
+                        },
+                        {
+                            "Function Name": "values",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 151,
+                            "End Line": 153
+                        },
+                        {
                             "Function Name": "queueJobs",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -15530,93 +15530,73 @@
                         },
                         {
                             "Function Name": "obtainWin32ResourceCacheManifest",
-                            "Structural Impact": 4.8,
+                            "Structural Impact": 4.3,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "33.3%",
                             "Start Line": 5611,
                             "End Line": 5617
                         },
                         {
                             "Function Name": "getTarget",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 2775,
                             "End Line": 2777
                         },
                         {
                             "Function Name": "hasCExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7529,
                             "End Line": 7531
                         },
                         {
                             "Function Name": "hasCHExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7533,
                             "End Line": 7535
                         },
                         {
                             "Function Name": "hasObjCExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7553,
                             "End Line": 7555
                         },
                         {
                             "Function Name": "hasObjCHExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7557,
                             "End Line": 7559
                         },
                         {
                             "Function Name": "hasObjCppHExt",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 7566,
                             "End Line": 7568
-                        },
-                        {
-                            "Function Name": "getZigBackend",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 7734,
-                            "End Line": 7737
-                        },
-                        {
-                            "Function Name": "compilerRtStrip",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 8168,
-                            "End Line": 8170
                         },
                         {
                             "Function Name": "addResolvedTarget",
@@ -15627,6 +15607,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1470,
                             "End Line": 1485
+                        },
+                        {
+                            "Function Name": "getZigBackend",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 7734,
+                            "End Line": 7737
                         },
                         {
                             "Function Name": "addModule",
@@ -15647,6 +15637,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 5017,
                             "End Line": 5019
+                        },
+                        {
+                            "Function Name": "compilerRtStrip",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 8168,
+                            "End Line": 8170
                         },
                         {
                             "Function Name": "addReferenceTraceFrame",
@@ -15749,16 +15749,6 @@
                             "End Line": 7360
                         },
                         {
-                            "Function Name": "setAllocFailure",
-                            "Structural Impact": 2.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 7685,
-                            "End Line": 7689
-                        },
-                        {
                             "Function Name": "getCrtPaths",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 4,
@@ -15779,46 +15769,6 @@
                             "End Line": 137
                         },
                         {
-                            "Function Name": "tryLock",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 252,
-                            "End Line": 252
-                        },
-                        {
-                            "Function Name": "lock",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 253,
-                            "End Line": 253
-                        },
-                        {
-                            "Function Name": "unlock",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 254,
-                            "End Line": 254
-                        },
-                        {
-                            "Function Name": "getAllErrorsAlloc",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 3889,
-                            "End Line": 3889
-                        },
-                        {
                             "Function Name": "reportRetryableCObjectError",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
@@ -15837,6 +15787,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 6734,
                             "End Line": 6734
+                        },
+                        {
+                            "Function Name": "setAllocFailure",
+                            "Structural Impact": 2.0,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 7685,
+                            "End Line": 7689
                         },
                         {
                             "Function Name": "translateC",
@@ -15879,6 +15839,36 @@
                             "End Line": 154
                         },
                         {
+                            "Function Name": "tryLock",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 252,
+                            "End Line": 252
+                        },
+                        {
+                            "Function Name": "lock",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 253,
+                            "End Line": 253
+                        },
+                        {
+                            "Function Name": "unlock",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 254,
+                            "End Line": 254
+                        },
+                        {
                             "Function Name": "fail",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
@@ -15887,6 +15877,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1892,
                             "End Line": 1892
+                        },
+                        {
+                            "Function Name": "getAllErrorsAlloc",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 3889,
+                            "End Line": 3889
                         },
                         {
                             "Function Name": "addModuleTableToCacheHash",
@@ -15923,8 +15923,8 @@
                     "7. Structural Signatures (Net Mitigated Signals)": {
                         "Control Flow Branches": 2282,
                         "Sequential Logic Declarations": 664,
-                        "Function Parameters": 182,
-                        "Function/Method Declarations": 182,
+                        "Function Parameters": 183,
+                        "Function/Method Declarations": 183,
                         "Class/Entity Declarations": 51,
                         "Defensive Programming Constructs": 1138,
                         "Type/Safety Bypasses": 266,
@@ -16017,7 +16017,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 28,
+                        "Direct Upstream (Fragility)": 29,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 8
@@ -16025,6 +16025,7 @@
                     "9. Extracted Dependencies": [
                         "Air.zig",
                         "Builtin.zig",
+                        "Compilation/Config.zig",
                         "InternPool.zig",
                         "Package.zig",
                         "Sema.zig",
@@ -16071,26 +16072,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.025,
+                        "Repository Drift (Z-Score)": 13.022,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.413,
-                            "file_cluster_1": 13.52,
-                            "file_cluster_2": 13.682,
-                            "file_cluster_3": 14.371,
-                            "file_cluster_4": 13.56,
-                            "file_cluster_5": 13.885,
-                            "file_cluster_6": 13.466,
-                            "file_cluster_7": 13.171,
-                            "file_cluster_8": 13.025,
-                            "file_cluster_9": 13.555,
-                            "file_cluster_10": 14.078,
-                            "file_cluster_11": 13.428,
-                            "file_cluster_12": 13.627,
-                            "file_cluster_13": 13.41,
-                            "file_cluster_14": 16.934,
-                            "file_cluster_15": 13.763,
-                            "file_cluster_16": 13.325,
-                            "file_cluster_17": 13.699
+                            "file_cluster_0": 13.411,
+                            "file_cluster_1": 13.518,
+                            "file_cluster_2": 13.68,
+                            "file_cluster_3": 14.369,
+                            "file_cluster_4": 13.557,
+                            "file_cluster_5": 13.883,
+                            "file_cluster_6": 13.463,
+                            "file_cluster_7": 13.169,
+                            "file_cluster_8": 13.022,
+                            "file_cluster_9": 13.552,
+                            "file_cluster_10": 14.075,
+                            "file_cluster_11": 13.425,
+                            "file_cluster_12": 13.624,
+                            "file_cluster_13": 13.407,
+                            "file_cluster_14": 16.932,
+                            "file_cluster_15": 13.76,
+                            "file_cluster_16": 13.322,
+                            "file_cluster_17": 13.696
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -16098,7 +16099,7 @@
                         "Total LOC": 13040,
                         "Coding LOC": 11985,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 7317.1,
+                        "Structural Magnitude": 7154.9,
                         "Control Flow Ratio": "66.7%",
                         "Popularity Rank": 3,
                         "Raw Churn Frequency": 0.0,
@@ -16118,7 +16119,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "80.84%",
+                        "Documentation Exposure": "80.61%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -16140,10 +16141,10 @@
                         },
                         {
                             "Function Name": "List",
-                            "Structural Impact": 348.4,
+                            "Structural Impact": 312.9,
                             "Lines of Code (LOC)": 238,
                             "Control Flow Branches": 42,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "56.8%",
                             "Start Line": 1139,
                             "End Line": 1376
@@ -16199,26 +16200,6 @@
                             "End Line": 403
                         },
                         {
-                            "Function Name": "pack",
-                            "Structural Impact": 86.6,
-                            "Lines of Code (LOC)": 52,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "86.7%",
-                            "Start Line": 12943,
-                            "End Line": 12994
-                        },
-                        {
-                            "Function Name": "next",
-                            "Structural Impact": 85.2,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 11,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "68.8%",
-                            "Start Line": 4146,
-                            "End Line": 4169
-                        },
-                        {
                             "Function Name": "loadEnumType",
                             "Structural Impact": 81.7,
                             "Lines of Code (LOC)": 76,
@@ -16230,13 +16211,23 @@
                         },
                         {
                             "Function Name": "pack",
-                            "Structural Impact": 68.2,
-                            "Lines of Code (LOC)": 43,
-                            "Control Flow Branches": 10,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "90.9%",
-                            "Start Line": 791,
-                            "End Line": 833
+                            "Structural Impact": 75.3,
+                            "Lines of Code (LOC)": 52,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "86.7%",
+                            "Start Line": 12943,
+                            "End Line": 12994
+                        },
+                        {
+                            "Function Name": "next",
+                            "Structural Impact": 73.9,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 11,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "68.8%",
+                            "Start Line": 4146,
+                            "End Line": 4169
                         },
                         {
                             "Function Name": "tagValueIndex",
@@ -16259,6 +16250,16 @@
                             "End Line": 2562
                         },
                         {
+                            "Function Name": "pack",
+                            "Structural Impact": 59.3,
+                            "Lines of Code (LOC)": 43,
+                            "Control Flow Branches": 10,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "90.9%",
+                            "Start Line": 791,
+                            "End Line": 833
+                        },
+                        {
                             "Function Name": "isExternOrFn",
                             "Structural Impact": 57.1,
                             "Lines of Code (LOC)": 17,
@@ -16270,53 +16271,23 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 55.0,
+                            "Structural Impact": 47.8,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 8,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "61.5%",
                             "Start Line": 4107,
                             "End Line": 4126
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 48.4,
+                            "Structural Impact": 42.0,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 5,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "71.4%",
                             "Start Line": 877,
                             "End Line": 884
-                        },
-                        {
-                            "Function Name": "unpack",
-                            "Structural Impact": 44.1,
-                            "Lines of Code (LOC)": 43,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 12996,
-                            "End Line": 13038
-                        },
-                        {
-                            "Function Name": "unpack",
-                            "Structural Impact": 43.6,
-                            "Lines of Code (LOC)": 32,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 757,
-                            "End Line": 788
-                        },
-                        {
-                            "Function Name": "Map",
-                            "Structural Impact": 43.0,
-                            "Lines of Code (LOC)": 56,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1547,
-                            "End Line": 1602
                         },
                         {
                             "Function Name": "nameIndex",
@@ -16327,6 +16298,36 @@
                             "Control Flow Ratio": "64.3%",
                             "Start Line": 3686,
                             "End Line": 3696
+                        },
+                        {
+                            "Function Name": "Map",
+                            "Structural Impact": 38.8,
+                            "Lines of Code (LOC)": 56,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1547,
+                            "End Line": 1602
+                        },
+                        {
+                            "Function Name": "unpack",
+                            "Structural Impact": 38.5,
+                            "Lines of Code (LOC)": 43,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 12996,
+                            "End Line": 13038
+                        },
+                        {
+                            "Function Name": "unpack",
+                            "Structural Impact": 38.0,
+                            "Lines of Code (LOC)": 32,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 757,
+                            "End Line": 788
                         },
                         {
                             "Function Name": "loadUnionType",
@@ -16379,36 +16380,6 @@
                             "End Line": 1810
                         },
                         {
-                            "Function Name": "checkConfig",
-                            "Structural Impact": 23.7,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 4988,
-                            "End Line": 4992
-                        },
-                        {
-                            "Function Name": "getLimbs",
-                            "Structural Impact": 22.7,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 1088,
-                            "End Line": 1094
-                        },
-                        {
-                            "Function Name": "typeOf",
-                            "Structural Impact": 22.6,
-                            "Lines of Code (LOC)": 52,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 3193,
-                            "End Line": 3244
-                        },
-                        {
                             "Function Name": "isFn",
                             "Structural Impact": 22.3,
                             "Lines of Code (LOC)": 13,
@@ -16457,6 +16428,16 @@
                             "Control Flow Ratio": "71.4%",
                             "Start Line": 887,
                             "End Line": 911
+                        },
+                        {
+                            "Function Name": "checkConfig",
+                            "Structural Impact": 21.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 4988,
+                            "End Line": 4992
                         },
                         {
                             "Function Name": "typeOf",
@@ -16509,44 +16490,24 @@
                             "End Line": 2211
                         },
                         {
-                            "Function Name": "values",
-                            "Structural Impact": 20.5,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 2604,
-                            "End Line": 2610
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 20.4,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 436,
-                            "End Line": 444
-                        },
-                        {
-                            "Function Name": "wrap",
-                            "Structural Impact": 20.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 445,
-                            "End Line": 452
-                        },
-                        {
-                            "Function Name": "toInt",
+                            "Function Name": "getLimbs",
                             "Structural Impact": 20.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 3,
                             "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 3676,
-                            "End Line": 3682
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 1088,
+                            "End Line": 1094
+                        },
+                        {
+                            "Function Name": "typeOf",
+                            "Structural Impact": 19.9,
+                            "Lines of Code (LOC)": 52,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3193,
+                            "End Line": 3244
                         },
                         {
                             "Function Name": "toUnsigned",
@@ -16559,44 +16520,14 @@
                             "End Line": 1892
                         },
                         {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
+                            "Function Name": "values",
+                            "Structural Impact": 18.4,
+                            "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
                             "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
-                            "Start Line": 139,
-                            "End Line": 144
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 182,
-                            "End Line": 187
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 697,
-                            "End Line": 702
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1033,
-                            "End Line": 1038
+                            "Start Line": 2604,
+                            "End Line": 2610
                         },
                         {
                             "Function Name": "assumeRuntimeBitsIfFieldTypesWip",
@@ -16629,6 +16560,26 @@
                             "End Line": 165
                         },
                         {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 17.8,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 436,
+                            "End Line": 444
+                        },
+                        {
+                            "Function Name": "wrap",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 445,
+                            "End Line": 452
+                        },
+                        {
                             "Function Name": "format",
                             "Structural Impact": 17.7,
                             "Lines of Code (LOC)": 8,
@@ -16637,6 +16588,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 1899,
                             "End Line": 1906
+                        },
+                        {
+                            "Function Name": "toInt",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 3676,
+                            "End Line": 3682
                         },
                         {
                             "Function Name": "nameIndex",
@@ -16659,6 +16620,46 @@
                             "End Line": 3632
                         },
                         {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 139,
+                            "End Line": 144
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 182,
+                            "End Line": 187
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 697,
+                            "End Line": 702
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1033,
+                            "End Line": 1038
+                        },
+                        {
                             "Function Name": "toBigInt",
                             "Structural Impact": 15.9,
                             "Lines of Code (LOC)": 7,
@@ -16667,56 +16668,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 2415,
                             "End Line": 2421
-                        },
-                        {
-                            "Function Name": "haveFieldTypes",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3301,
-                            "End Line": 3313
-                        },
-                        {
-                            "Function Name": "haveLayout",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3315,
-                            "End Line": 3327
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 460,
-                            "End Line": 465
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1732,
-                            "End Line": 1737
-                        },
-                        {
-                            "Function Name": "hasTag",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3282,
-                            "End Line": 3287
                         },
                         {
                             "Function Name": "getErrorValue",
@@ -16829,6 +16780,56 @@
                             "End Line": 3706
                         },
                         {
+                            "Function Name": "haveFieldTypes",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3301,
+                            "End Line": 3313
+                        },
+                        {
+                            "Function Name": "haveLayout",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3315,
+                            "End Line": 3327
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 460,
+                            "End Line": 465
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1732,
+                            "End Line": 1737
+                        },
+                        {
+                            "Function Name": "hasTag",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3282,
+                            "End Line": 3287
+                        },
+                        {
                             "Function Name": "assumePointerAlignedIfFieldTypesWip",
                             "Structural Impact": 12.7,
                             "Lines of Code (LOC)": 14,
@@ -16849,56 +16850,6 @@
                             "End Line": 3895
                         },
                         {
-                            "Function Name": "wrap",
-                            "Structural Impact": 12.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1947,
-                            "End Line": 1954
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1955,
-                            "End Line": 1962
-                        },
-                        {
-                            "Function Name": "getAddrspace",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 598,
-                            "End Line": 604
-                        },
-                        {
-                            "Function Name": "getAlignment",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 607,
-                            "End Line": 613
-                        },
-                        {
-                            "Function Name": "getLinkSection",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 616,
-                            "End Line": 622
-                        },
-                        {
                             "Function Name": "nameIndex",
                             "Structural Impact": 12.3,
                             "Lines of Code (LOC)": 6,
@@ -16907,56 +16858,6 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 4399,
                             "End Line": 4404
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1620,
-                            "End Line": 1623
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1696,
-                            "End Line": 1698
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1700,
-                            "End Line": 1703
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 1804,
-                            "End Line": 1806
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 1926,
-                            "End Line": 1928
                         },
                         {
                             "Function Name": "fieldAlign",
@@ -17020,6 +16921,26 @@
                         },
                         {
                             "Function Name": "wrap",
+                            "Structural Impact": 10.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1947,
+                            "End Line": 1954
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1955,
+                            "End Line": 1962
+                        },
+                        {
+                            "Function Name": "wrap",
                             "Structural Impact": 10.7,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 1,
@@ -17037,6 +16958,36 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 494,
                             "End Line": 499
+                        },
+                        {
+                            "Function Name": "getAddrspace",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 598,
+                            "End Line": 604
+                        },
+                        {
+                            "Function Name": "getAlignment",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 607,
+                            "End Line": 613
+                        },
+                        {
+                            "Function Name": "getLinkSection",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 616,
+                            "End Line": 622
                         },
                         {
                             "Function Name": "wrap",
@@ -17079,6 +17030,46 @@
                             "End Line": 4083
                         },
                         {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1620,
+                            "End Line": 1623
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1700,
+                            "End Line": 1703
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1696,
+                            "End Line": 1698
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 1804,
+                            "End Line": 1806
+                        },
+                        {
                             "Function Name": "fmt",
                             "Structural Impact": 10.5,
                             "Lines of Code (LOC)": 3,
@@ -17087,6 +17078,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1908,
                             "End Line": 1910
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 1926,
+                            "End Line": 1928
                         },
                         {
                             "Function Name": "hasTag",
@@ -17117,16 +17118,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 3494,
                             "End Line": 3496
-                        },
-                        {
-                            "Function Name": "wrap",
-                            "Structural Impact": 10.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 145,
-                            "End Line": 147
                         },
                         {
                             "Function Name": "clearInitsWip",
@@ -17289,6 +17280,16 @@
                             "End Line": 3673
                         },
                         {
+                            "Function Name": "wrap",
+                            "Structural Impact": 8.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 145,
+                            "End Line": 147
+                        },
+                        {
                             "Function Name": "clearFieldTypesWip",
                             "Structural Impact": 8.4,
                             "Lines of Code (LOC)": 12,
@@ -17327,46 +17328,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1860,
                             "End Line": 1865
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 176,
-                            "End Line": 178
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 706,
-                            "End Line": 708
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1027,
-                            "End Line": 1029
-                        },
-                        {
-                            "Function Name": "lenIncludingSentinel",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 2124,
-                            "End Line": 2126
                         },
                         {
                             "Function Name": "getMutableItems",
@@ -17559,6 +17520,36 @@
                             "End Line": 4786
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 176,
+                            "End Line": 178
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 706,
+                            "End Line": 708
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1027,
+                            "End Line": 1029
+                        },
+                        {
                             "Function Name": "get",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 4,
@@ -17577,6 +17568,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1980,
                             "End Line": 1983
+                        },
+                        {
+                            "Function Name": "lenIncludingSentinel",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 2124,
+                            "End Line": 2126
                         },
                         {
                             "Function Name": "paramIsComptime",
@@ -17739,46 +17740,6 @@
                             "End Line": 3391
                         },
                         {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 454,
-                            "End Line": 456
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1636,
-                            "End Line": 1638
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1687,
-                            "End Line": 1689
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1726,
-                            "End Line": 1728
-                        },
-                        {
                             "Function Name": "toSlice",
                             "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
@@ -17809,26 +17770,6 @@
                             "End Line": 1766
                         },
                         {
-                            "Function Name": "toString",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1837,
-                            "End Line": 1839
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1841,
-                            "End Line": 1843
-                        },
-                        {
                             "Function Name": "indexLessThan",
                             "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 4,
@@ -17857,16 +17798,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 3723,
                             "End Line": 3725
-                        },
-                        {
-                            "Function Name": "hasReorderedFields",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4098,
-                            "End Line": 4100
                         },
                         {
                             "Function Name": "toOverlongSlice",
@@ -18009,6 +17940,66 @@
                             "End Line": 4048
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 454,
+                            "End Line": 456
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1636,
+                            "End Line": 1638
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1687,
+                            "End Line": 1689
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1726,
+                            "End Line": 1728
+                        },
+                        {
+                            "Function Name": "toString",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1837,
+                            "End Line": 1839
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1841,
+                            "End Line": 1843
+                        },
+                        {
                             "Function Name": "fmtId",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -18139,14 +18130,14 @@
                             "End Line": 4028
                         },
                         {
-                            "Function Name": "getTidMask",
-                            "Structural Impact": 4.6,
+                            "Function Name": "hasReorderedFields",
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 1605,
-                            "End Line": 1607
+                            "Start Line": 4098,
+                            "End Line": 4100
                         },
                         {
                             "Function Name": "setBranchHint",
@@ -18197,6 +18188,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 3518,
                             "End Line": 3524
+                        },
+                        {
+                            "Function Name": "getTidMask",
+                            "Structural Impact": 4.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1605,
+                            "End Line": 1607
                         },
                         {
                             "Function Name": "setBit",
@@ -18385,7 +18386,7 @@
                         "Sequential Logic Declarations": 1026,
                         "Function Parameters": 441,
                         "Function/Method Declarations": 437,
-                        "Class/Entity Declarations": 189,
+                        "Class/Entity Declarations": 201,
                         "Defensive Programming Constructs": 675,
                         "Type/Safety Bypasses": 563,
                         "High-Risk Execution Commands": 4,
@@ -18506,26 +18507,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.678,
+                        "Repository Drift (Z-Score)": 12.676,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.11,
-                            "file_cluster_1": 13.272,
-                            "file_cluster_2": 13.426,
-                            "file_cluster_3": 14.168,
-                            "file_cluster_4": 13.581,
-                            "file_cluster_5": 13.671,
-                            "file_cluster_6": 13.309,
-                            "file_cluster_7": 12.93,
-                            "file_cluster_8": 12.678,
-                            "file_cluster_9": 13.297,
-                            "file_cluster_10": 13.911,
-                            "file_cluster_11": 13.202,
-                            "file_cluster_12": 13.551,
-                            "file_cluster_13": 13.108,
-                            "file_cluster_14": 16.74,
-                            "file_cluster_15": 13.561,
-                            "file_cluster_16": 12.989,
-                            "file_cluster_17": 13.411
+                            "file_cluster_0": 13.108,
+                            "file_cluster_1": 13.27,
+                            "file_cluster_2": 13.424,
+                            "file_cluster_3": 14.166,
+                            "file_cluster_4": 13.579,
+                            "file_cluster_5": 13.669,
+                            "file_cluster_6": 13.307,
+                            "file_cluster_7": 12.928,
+                            "file_cluster_8": 12.676,
+                            "file_cluster_9": 13.295,
+                            "file_cluster_10": 13.909,
+                            "file_cluster_11": 13.2,
+                            "file_cluster_12": 13.549,
+                            "file_cluster_13": 13.106,
+                            "file_cluster_14": 16.738,
+                            "file_cluster_15": 13.559,
+                            "file_cluster_16": 12.987,
+                            "file_cluster_17": 13.409
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -18533,9 +18534,9 @@
                         "Total LOC": 4357,
                         "Coding LOC": 3950,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 12924.9,
+                        "Structural Magnitude": 12907.8,
                         "Control Flow Ratio": "66.7%",
-                        "Popularity Rank": 5,
+                        "Popularity Rank": 6,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -18553,7 +18554,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "97.04%",
+                        "Documentation Exposure": "97.03%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -19264,36 +19265,6 @@
                             "End Line": 1281
                         },
                         {
-                            "Function Name": "isNamedInt",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 2357,
-                            "End Line": 2374
-                        },
-                        {
-                            "Function Name": "isRuntimeFloat",
-                            "Structural Impact": 12.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 2377,
-                            "End Line": 2389
-                        },
-                        {
-                            "Function Name": "isAnyFloat",
-                            "Structural Impact": 12.7,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 2392,
-                            "End Line": 2405
-                        },
-                        {
                             "Function Name": "enumTagFieldIndex",
                             "Structural Impact": 12.6,
                             "Lines of Code (LOC)": 11,
@@ -19324,66 +19295,6 @@
                             "End Line": 3347
                         },
                         {
-                            "Function Name": "Tid",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 878,
-                            "End Line": 883
-                        },
-                        {
-                            "Function Name": "ZcuPtr",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 885,
-                            "End Line": 890
-                        },
-                        {
-                            "Function Name": "Tid",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 917,
-                            "End Line": 922
-                        },
-                        {
-                            "Function Name": "ZcuPtr",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 924,
-                            "End Line": 929
-                        },
-                        {
-                            "Function Name": "toLazy",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 941,
-                            "End Line": 946
-                        },
-                        {
-                            "Function Name": "smallestUnsignedBits",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4343,
-                            "End Line": 4348
-                        },
-                        {
                             "Function Name": "structFieldAlignment",
                             "Structural Impact": 11.7,
                             "Lines of Code (LOC)": 14,
@@ -19402,6 +19313,36 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 3222,
                             "End Line": 3235
+                        },
+                        {
+                            "Function Name": "isNamedInt",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 2357,
+                            "End Line": 2374
+                        },
+                        {
+                            "Function Name": "isAnyFloat",
+                            "Structural Impact": 11.1,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 2392,
+                            "End Line": 2405
+                        },
+                        {
+                            "Function Name": "isRuntimeFloat",
+                            "Structural Impact": 11.0,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 2377,
+                            "End Line": 2389
                         },
                         {
                             "Function Name": "floatBits",
@@ -19502,6 +19443,56 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 845,
                             "End Line": 851
+                        },
+                        {
+                            "Function Name": "Tid",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 878,
+                            "End Line": 883
+                        },
+                        {
+                            "Function Name": "ZcuPtr",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 885,
+                            "End Line": 890
+                        },
+                        {
+                            "Function Name": "Tid",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 917,
+                            "End Line": 922
+                        },
+                        {
+                            "Function Name": "ZcuPtr",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 924,
+                            "End Line": 929
+                        },
+                        {
+                            "Function Name": "toLazy",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 941,
+                            "End Line": 946
                         },
                         {
                             "Function Name": "isSinglePointer",
@@ -19672,6 +19663,16 @@
                             "Control Flow Ratio": "62.5%",
                             "Start Line": 4055,
                             "End Line": 4060
+                        },
+                        {
+                            "Function Name": "smallestUnsignedBits",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4343,
+                            "End Line": 4348
                         },
                         {
                             "Function Name": "minInt",
@@ -20005,43 +20006,13 @@
                         },
                         {
                             "Function Name": "ptrAbiAlignment",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1613,
                             "End Line": 1615
-                        },
-                        {
-                            "Function Name": "fromInterned",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 432,
-                            "End Line": 435
-                        },
-                        {
-                            "Function Name": "toIntern",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 437,
-                            "End Line": 440
-                        },
-                        {
-                            "Function Name": "toValue",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 442,
-                            "End Line": 444
                         },
                         {
                             "Function Name": "unionFieldTypeByIndex",
@@ -20074,14 +20045,24 @@
                             "End Line": 3103
                         },
                         {
-                            "Function Name": "isGenericPoison",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
+                            "Function Name": "fromInterned",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 3423,
-                            "End Line": 3425
+                            "Start Line": 432,
+                            "End Line": 435
+                        },
+                        {
+                            "Function Name": "toIntern",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 437,
+                            "End Line": 440
                         },
                         {
                             "Function Name": "unionTagTypeHypothetical",
@@ -20112,6 +20093,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 87,
                             "End Line": 89
+                        },
+                        {
+                            "Function Name": "toValue",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 442,
+                            "End Line": 444
                         },
                         {
                             "Function Name": "bitSizeSema",
@@ -20292,6 +20283,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 3419,
                             "End Line": 3421
+                        },
+                        {
+                            "Function Name": "isGenericPoison",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3423,
+                            "End Line": 3425
                         },
                         {
                             "Function Name": "resolveStructAlignment",
@@ -20503,7 +20504,7 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 7,
-                        "Direct Downstream (Dependency Blast Radius)": 5,
+                        "Direct Downstream (Dependency Blast Radius)": 6,
                         "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 8
                     },
@@ -20535,26 +20536,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.786,
+                        "Repository Drift (Z-Score)": 13.817,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.989,
-                            "file_cluster_1": 14.207,
-                            "file_cluster_2": 14.333,
-                            "file_cluster_3": 15.016,
-                            "file_cluster_4": 14.4,
-                            "file_cluster_5": 14.521,
-                            "file_cluster_6": 14.179,
-                            "file_cluster_7": 13.857,
-                            "file_cluster_8": 13.786,
-                            "file_cluster_9": 14.16,
-                            "file_cluster_10": 14.842,
-                            "file_cluster_11": 14.075,
-                            "file_cluster_12": 14.422,
-                            "file_cluster_13": 13.93,
-                            "file_cluster_14": 17.414,
-                            "file_cluster_15": 14.377,
-                            "file_cluster_16": 14.063,
-                            "file_cluster_17": 14.236
+                            "file_cluster_0": 14.017,
+                            "file_cluster_1": 14.237,
+                            "file_cluster_2": 14.362,
+                            "file_cluster_3": 15.044,
+                            "file_cluster_4": 14.429,
+                            "file_cluster_5": 14.55,
+                            "file_cluster_6": 14.209,
+                            "file_cluster_7": 13.887,
+                            "file_cluster_8": 13.817,
+                            "file_cluster_9": 14.189,
+                            "file_cluster_10": 14.871,
+                            "file_cluster_11": 14.105,
+                            "file_cluster_12": 14.451,
+                            "file_cluster_13": 13.96,
+                            "file_cluster_14": 17.434,
+                            "file_cluster_15": 14.407,
+                            "file_cluster_16": 14.093,
+                            "file_cluster_17": 14.266
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -20562,7 +20563,7 @@
                         "Total LOC": 4802,
                         "Coding LOC": 4374,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 8634.28,
+                        "Structural Magnitude": 8110.38,
                         "Control Flow Ratio": "71.9%",
                         "Popularity Rank": 4,
                         "Raw Churn Frequency": 0.0,
@@ -20582,7 +20583,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "73.17%",
+                        "Documentation Exposure": "72.94%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -20594,10 +20595,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "findOutdatedToAnalyze",
-                            "Structural Impact": 3656.8,
+                            "Structural Impact": 3172.9,
                             "Lines of Code (LOC)": 897,
                             "Control Flow Branches": 257,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "73.6%",
                             "Start Line": 3197,
                             "End Line": 4093
@@ -20633,16 +20634,6 @@
                             "End Line": 3157
                         },
                         {
-                            "Function Name": "deinit",
-                            "Structural Impact": 116.7,
-                            "Lines of Code (LOC)": 93,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "92.9%",
-                            "Start Line": 2778,
-                            "End Line": 2870
-                        },
-                        {
                             "Function Name": "renderFullyQualifiedDebugName",
                             "Structural Impact": 111.2,
                             "Lines of Code (LOC)": 19,
@@ -20651,6 +20642,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 874,
                             "End Line": 892
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 101.6,
+                            "Lines of Code (LOC)": 93,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "92.9%",
+                            "Start Line": 2778,
+                            "End Line": 2870
                         },
                         {
                             "Function Name": "markTransitiveDependersPotentiallyOutdat",
@@ -20704,20 +20705,20 @@
                         },
                         {
                             "Function Name": "stage",
-                            "Structural Impact": 48.6,
+                            "Structural Impact": 42.2,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "70.0%",
                             "Start Line": 576,
                             "End Line": 588
                         },
                         {
                             "Function Name": "modeFromPath",
-                            "Structural Impact": 36.2,
+                            "Structural Impact": 32.5,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "70.0%",
                             "Start Line": 1013,
                             "End Line": 1021
@@ -20783,26 +20784,6 @@
                             "End Line": 1188
                         },
                         {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 748,
-                            "End Line": 753
-                        },
-                        {
-                            "Function Name": "unwrap",
-                            "Structural Impact": 18.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 794,
-                            "End Line": 799
-                        },
-                        {
                             "Function Name": "getAlign",
                             "Structural Impact": 17.8,
                             "Lines of Code (LOC)": 10,
@@ -20831,6 +20812,26 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 894,
                             "End Line": 904
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 748,
+                            "End Line": 753
+                        },
+                        {
+                            "Function Name": "unwrap",
+                            "Structural Impact": 15.9,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 794,
+                            "End Line": 799
                         },
                         {
                             "Function Name": "getTree",
@@ -20944,10 +20945,10 @@
                         },
                         {
                             "Function Name": "toBuiltin",
-                            "Structural Impact": 13.2,
+                            "Structural Impact": 11.6,
                             "Lines of Code (LOC)": 25,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 632,
                             "End Line": 656
@@ -21013,56 +21014,6 @@
                             "End Line": 862
                         },
                         {
-                            "Function Name": "src",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 197,
-                            "End Line": 202
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 742,
-                            "End Line": 744
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 788,
-                            "End Line": 790
-                        },
-                        {
-                            "Function Name": "nodeOffsetDebug",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 2646,
-                            "End Line": 2650
-                        },
-                        {
-                            "Function Name": "nodeOffsetRelease",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 2652,
-                            "End Line": 2654
-                        },
-                        {
                             "Function Name": "deinit",
                             "Structural Impact": 8.0,
                             "Lines of Code (LOC)": 5,
@@ -21071,6 +21022,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 669,
                             "End Line": 673
+                        },
+                        {
+                            "Function Name": "src",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 197,
+                            "End Line": 202
                         },
                         {
                             "Function Name": "unloadTree",
@@ -21103,6 +21064,16 @@
                             "End Line": 1049
                         },
                         {
+                            "Function Name": "nodeOffsetDebug",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 2646,
+                            "End Line": 2650
+                        },
+                        {
                             "Function Name": "ptr",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
@@ -21123,6 +21094,16 @@
                             "End Line": 741
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 742,
+                            "End Line": 744
+                        },
+                        {
                             "Function Name": "ptr",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
@@ -21133,6 +21114,16 @@
                             "End Line": 787
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 788,
+                            "End Line": 790
+                        },
+                        {
                             "Function Name": "get",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
@@ -21141,6 +21132,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1202,
                             "End Line": 1204
+                        },
+                        {
+                            "Function Name": "nodeOffsetRelease",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 2652,
+                            "End Line": 2654
                         },
                         {
                             "Function Name": "init",
@@ -21193,36 +21194,6 @@
                             "End Line": 364
                         },
                         {
-                            "Function Name": "getMode",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1008,
-                            "End Line": 1011
-                        },
-                        {
-                            "Function Name": "fullyQualifiedNameLen",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1119,
-                            "End Line": 1122
-                        },
-                        {
-                            "Function Name": "baseSrcToken",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1269,
-                            "End Line": 1272
-                        },
-                        {
                             "Function Name": "unload",
                             "Structural Impact": 5.5,
                             "Lines of Code (LOC)": 6,
@@ -21233,6 +21204,26 @@
                             "End Line": 1028
                         },
                         {
+                            "Function Name": "getMode",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1008,
+                            "End Line": 1011
+                        },
+                        {
+                            "Function Name": "fullyQualifiedNameLen",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1119,
+                            "End Line": 1122
+                        },
+                        {
                             "Function Name": "destroy",
                             "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
@@ -21241,6 +21232,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1232,
                             "End Line": 1235
+                        },
+                        {
+                            "Function Name": "baseSrcToken",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1269,
+                            "End Line": 1272
                         },
                         {
                             "Function Name": "fileScope",
@@ -21274,10 +21275,10 @@
                         },
                         {
                             "Function Name": "access",
-                            "Structural Impact": 3.2,
+                            "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 592,
                             "End Line": 595
@@ -21294,10 +21295,10 @@
                         },
                         {
                             "Function Name": "kind",
-                            "Structural Impact": 2.0,
+                            "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 478,
                             "End Line": 478
@@ -21411,7 +21412,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 14,
+                        "Direct Upstream (Fragility)": 17,
                         "Direct Downstream (Dependency Blast Radius)": 4,
                         "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 8
@@ -21422,6 +21423,9 @@
                         "InternPool.zig",
                         "Package.zig",
                         "Sema.zig",
+                        "Type.zig",
+                        "Value.zig",
+                        "Zcu/PerThread.zig",
                         "build_options",
                         "builtin",
                         "codegen/llvm.zig",
@@ -21451,7 +21455,7 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.63,
+                        "Repository Drift (Z-Score)": 13.629,
                         "Repository Fingerprint": {
                             "file_cluster_0": 14.01,
                             "file_cluster_1": 14.296,
@@ -21460,17 +21464,17 @@
                             "file_cluster_4": 14.308,
                             "file_cluster_5": 14.713,
                             "file_cluster_6": 14.224,
-                            "file_cluster_7": 13.992,
-                            "file_cluster_8": 13.63,
+                            "file_cluster_7": 13.991,
+                            "file_cluster_8": 13.629,
                             "file_cluster_9": 14.144,
                             "file_cluster_10": 15.05,
                             "file_cluster_11": 14.094,
                             "file_cluster_12": 14.545,
-                            "file_cluster_13": 13.978,
-                            "file_cluster_14": 17.345,
+                            "file_cluster_13": 13.977,
+                            "file_cluster_14": 17.343,
                             "file_cluster_15": 14.519,
-                            "file_cluster_16": 14.361,
-                            "file_cluster_17": 14.129
+                            "file_cluster_16": 14.36,
+                            "file_cluster_17": 14.128
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -21478,7 +21482,7 @@
                         "Total LOC": 7530,
                         "Coding LOC": 6974,
                         "Documentation LOC": 8,
-                        "Structural Magnitude": 7471.48,
+                        "Structural Magnitude": 7449.38,
                         "Control Flow Ratio": "82.5%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -21498,7 +21502,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "20.59%",
+                        "Documentation Exposure": "20.56%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -21580,20 +21584,20 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 48.4,
+                            "Structural Impact": 42.0,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 5,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "55.6%",
                             "Start Line": 751,
                             "End Line": 758
                         },
                         {
                             "Function Name": "anyObjectLinkInputs",
-                            "Structural Impact": 45.2,
+                            "Structural Impact": 40.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 9,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "81.8%",
                             "Start Line": 7501,
                             "End Line": 7510
@@ -21609,16 +21613,6 @@
                             "End Line": 7407
                         },
                         {
-                            "Function Name": "nextOrFatal",
-                            "Structural Impact": 24.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 759,
-                            "End Line": 766
-                        },
-                        {
                             "Function Name": "addLibDirectoryWarn2",
                             "Structural Impact": 23.1,
                             "Lines of Code (LOC)": 14,
@@ -21629,41 +21623,51 @@
                             "End Line": 7529
                         },
                         {
+                            "Function Name": "nextOrFatal",
+                            "Structural Impact": 21.2,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 759,
+                            "End Line": 766
+                        },
+                        {
                             "Function Name": "parseWasiExecModel",
-                            "Structural Impact": 13.6,
+                            "Structural Impact": 12.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "75.0%",
                             "Start Line": 7414,
                             "End Line": 7417
                         },
                         {
                             "Function Name": "parseOptimizeMode",
-                            "Structural Impact": 10.3,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7409,
                             "End Line": 7412
                         },
                         {
                             "Function Name": "parseStackSize",
-                            "Structural Impact": 10.3,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7419,
                             "End Line": 7422
                         },
                         {
                             "Function Name": "parseImageBase",
-                            "Structural Impact": 10.3,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 7424,
                             "End Line": 7427
@@ -21680,33 +21684,23 @@
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 6.3,
+                            "Structural Impact": 5.5,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 7315,
                             "End Line": 7320
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 7172,
                             "End Line": 7175
-                        },
-                        {
-                            "Function Name": "wasi_cwd",
-                            "Structural Impact": 3.8,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 60,
-                            "End Line": 65
                         },
                         {
                             "Function Name": "addLibDirectoryWarn",
@@ -21727,6 +21721,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 7246,
                             "End Line": 7250
+                        },
+                        {
+                            "Function Name": "wasi_cwd",
+                            "Structural Impact": 2.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 60,
+                            "End Line": 65
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -21734,7 +21738,7 @@
                         "Control Flow Branches": 2695,
                         "Sequential Logic Declarations": 571,
                         "Function Parameters": 69,
-                        "Function/Method Declarations": 66,
+                        "Function/Method Declarations": 68,
                         "Class/Entity Declarations": 24,
                         "Defensive Programming Constructs": 953,
                         "Type/Safety Bypasses": 112,
@@ -21827,7 +21831,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 19,
+                        "Direct Upstream (Fragility)": 20,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 5,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
@@ -21841,6 +21845,7 @@
                         "build_options",
                         "builtin",
                         "clang_options.zig",
+                        "codegen.zig",
                         "codegen/llvm.zig",
                         "codegen/llvm/bindings.zig",
                         "crash_report.zig",
@@ -30258,7 +30263,7 @@
             }
         },
         "zig/zls": {
-            "Directory Group Magnitude": 28980.36,
+            "Directory Group Magnitude": 28672.86,
             "File Count": 6,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -30275,7 +30280,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "76.25%",
+                "Documentation Exposure": "76.13%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "99.92%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -30297,32 +30302,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4731.79,
+                        "X": -4732.01,
                         "Y": -132.14,
-                        "Z": -1992.06
+                        "Z": -1991.92
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.13,
+                        "Repository Drift (Z-Score)": 12.125,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.684,
-                            "file_cluster_1": 12.822,
-                            "file_cluster_2": 12.968,
-                            "file_cluster_3": 13.797,
-                            "file_cluster_4": 13.076,
-                            "file_cluster_5": 13.276,
-                            "file_cluster_6": 12.969,
-                            "file_cluster_7": 12.489,
-                            "file_cluster_8": 12.13,
-                            "file_cluster_9": 12.839,
-                            "file_cluster_10": 13.72,
-                            "file_cluster_11": 12.957,
-                            "file_cluster_12": 13.216,
-                            "file_cluster_13": 12.638,
-                            "file_cluster_14": 16.356,
-                            "file_cluster_15": 13.205,
-                            "file_cluster_16": 12.934,
-                            "file_cluster_17": 12.894
+                            "file_cluster_0": 12.68,
+                            "file_cluster_1": 12.817,
+                            "file_cluster_2": 12.963,
+                            "file_cluster_3": 13.793,
+                            "file_cluster_4": 13.072,
+                            "file_cluster_5": 13.272,
+                            "file_cluster_6": 12.964,
+                            "file_cluster_7": 12.484,
+                            "file_cluster_8": 12.125,
+                            "file_cluster_9": 12.834,
+                            "file_cluster_10": 13.716,
+                            "file_cluster_11": 12.953,
+                            "file_cluster_12": 13.212,
+                            "file_cluster_13": 12.634,
+                            "file_cluster_14": 16.352,
+                            "file_cluster_15": 13.2,
+                            "file_cluster_16": 12.929,
+                            "file_cluster_17": 12.889
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -30330,9 +30335,9 @@
                         "Total LOC": 1346,
                         "Coding LOC": 1176,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 504.02,
+                        "Structural Magnitude": 493.82,
                         "Control Flow Ratio": "80.1%",
-                        "Popularity Rank": 1,
+                        "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
                         "Authorship Centralization": 0.0,
                         "Ownership Entropy": 0.0,
@@ -30350,7 +30355,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "81.24%",
+                        "Documentation Exposure": "80.97%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "99.98%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -30402,33 +30407,23 @@
                         },
                         {
                             "Function Name": "unwrap",
-                            "Structural Impact": 16.2,
+                            "Structural Impact": 14.1,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 162,
                             "End Line": 165
                         },
                         {
                             "Function Name": "unwrap",
-                            "Structural Impact": 16.2,
+                            "Structural Impact": 14.1,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 303,
                             "End Line": 306
-                        },
-                        {
-                            "Function Name": "isContainer",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 236,
-                            "End Line": 241
                         },
                         {
                             "Function Name": "eql",
@@ -30439,6 +30434,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 43,
                             "End Line": 47
+                        },
+                        {
+                            "Function Name": "isContainer",
+                            "Structural Impact": 13.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 236,
+                            "End Line": 241
                         },
                         {
                             "Function Name": "getScopeDeclaration",
@@ -30481,26 +30486,6 @@
                             "End Line": 1291
                         },
                         {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 153,
-                            "End Line": 155
-                        },
-                        {
-                            "Function Name": "toOptional",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 293,
-                            "End Line": 295
-                        },
-                        {
                             "Function Name": "getCase",
                             "Structural Impact": 7.2,
                             "Lines of Code (LOC)": 5,
@@ -30531,21 +30516,41 @@
                             "End Line": 134
                         },
                         {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 153,
+                            "End Line": 155
+                        },
+                        {
+                            "Function Name": "toOptional",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 293,
+                            "End Line": 295
+                        },
+                        {
                             "Function Name": "locToSmallLoc",
-                            "Structural Impact": 6.3,
+                            "Structural Impact": 5.5,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 530,
                             "End Line": 535
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 319,
                             "End Line": 322
@@ -30751,16 +30756,6 @@
                             "End Line": 426
                         },
                         {
-                            "Function Name": "finalize",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 384,
-                            "End Line": 384
-                        },
-                        {
                             "Function Name": "walkUnaryOpNode",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
@@ -30799,6 +30794,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1248,
                             "End Line": 1248
+                        },
+                        {
+                            "Function Name": "finalize",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 384,
+                            "End Line": 384
                         },
                         {
                             "Function Name": "init",
@@ -30910,7 +30915,7 @@
                     },
                     "8. Dependency Network": {
                         "Direct Upstream (Fragility)": 4,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 1,
                         "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
@@ -30933,32 +30938,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5214.59,
-                        "Y": -205.03,
-                        "Z": -2205.01
+                        "X": -5214.6,
+                        "Y": -205.02,
+                        "Z": -2204.87
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.714,
+                        "Repository Drift (Z-Score)": 13.724,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.928,
-                            "file_cluster_1": 14.207,
-                            "file_cluster_2": 14.282,
-                            "file_cluster_3": 14.992,
-                            "file_cluster_4": 14.034,
-                            "file_cluster_5": 14.524,
-                            "file_cluster_6": 14.051,
-                            "file_cluster_7": 13.878,
-                            "file_cluster_8": 13.714,
-                            "file_cluster_9": 14.105,
-                            "file_cluster_10": 14.919,
-                            "file_cluster_11": 13.99,
-                            "file_cluster_12": 14.49,
-                            "file_cluster_13": 13.755,
-                            "file_cluster_14": 17.322,
-                            "file_cluster_15": 14.43,
-                            "file_cluster_16": 14.218,
-                            "file_cluster_17": 14.082
+                            "file_cluster_0": 13.937,
+                            "file_cluster_1": 14.217,
+                            "file_cluster_2": 14.292,
+                            "file_cluster_3": 15.002,
+                            "file_cluster_4": 14.044,
+                            "file_cluster_5": 14.534,
+                            "file_cluster_6": 14.061,
+                            "file_cluster_7": 13.888,
+                            "file_cluster_8": 13.724,
+                            "file_cluster_9": 14.114,
+                            "file_cluster_10": 14.928,
+                            "file_cluster_11": 14.0,
+                            "file_cluster_12": 14.499,
+                            "file_cluster_13": 13.765,
+                            "file_cluster_14": 17.328,
+                            "file_cluster_15": 14.439,
+                            "file_cluster_16": 14.227,
+                            "file_cluster_17": 14.091
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -30966,7 +30971,7 @@
                         "Total LOC": 2059,
                         "Coding LOC": 1737,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3040.84,
+                        "Structural Magnitude": 3015.44,
                         "Control Flow Ratio": "66.9%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -30986,7 +30991,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "70.53%",
+                        "Documentation Exposure": "70.35%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -31038,23 +31043,13 @@
                         },
                         {
                             "Function Name": "notifyBuildStart",
-                            "Structural Impact": 77.2,
+                            "Structural Impact": 67.1,
                             "Lines of Code (LOC)": 43,
                             "Control Flow Branches": 14,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 1112,
                             "End Line": 1154
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 65.3,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "87.5%",
-                            "Start Line": 697,
-                            "End Line": 723
                         },
                         {
                             "Function Name": "readFile",
@@ -31065,6 +31060,16 @@
                             "Control Flow Ratio": "72.2%",
                             "Start Line": 740,
                             "End Line": 773
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 56.8,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "87.5%",
+                            "Start Line": 697,
+                            "End Line": 723
                         },
                         {
                             "Function Name": "notifyBuildEnd",
@@ -31078,10 +31083,10 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 35.6,
+                            "Structural Impact": 31.0,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 6,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 676,
                             "End Line": 688
@@ -31228,10 +31233,10 @@
                         },
                         {
                             "Function Name": "isInStd",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 1295,
                             "End Line": 1298
@@ -31245,26 +31250,6 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 482,
                             "End Line": 488
-                        },
-                        {
-                            "Function Name": "isBuildFile",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1287,
-                            "End Line": 1289
-                        },
-                        {
-                            "Function Name": "isBuiltinFile",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1291,
-                            "End Line": 1293
                         },
                         {
                             "Function Name": "refresh",
@@ -31297,6 +31282,26 @@
                             "End Line": 99
                         },
                         {
+                            "Function Name": "isBuildFile",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1287,
+                            "End Line": 1289
+                        },
+                        {
+                            "Function Name": "isBuiltinFile",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1291,
+                            "End Line": 1293
+                        },
+                        {
                             "Function Name": "unlockConfig",
                             "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 3,
@@ -31315,16 +31320,6 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1035,
                             "End Line": 1038
-                        },
-                        {
-                            "Function Name": "getDocumentScope",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 187,
-                            "End Line": 187
                         },
                         {
                             "Function Name": "parseTree",
@@ -31365,6 +31360,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 922,
                             "End Line": 922
+                        },
+                        {
+                            "Function Name": "getDocumentScope",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 187,
+                            "End Line": 187
                         },
                         {
                             "Function Name": "getAssociatedBuildFile",
@@ -31535,7 +31540,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 12,
+                        "Direct Upstream (Fragility)": 13,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 4,
                         "Total Downstream (Absolute Dependency Blast Radius)": 4
@@ -31547,6 +31552,7 @@
                         "TrigramStore.zig",
                         "Uri.zig",
                         "analysis.zig",
+                        "build_runner/shared.zig",
                         "builtin",
                         "lsp",
                         "offsets.zig",
@@ -31567,32 +31573,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5524.24,
+                        "X": -5524.12,
                         "Y": -185.39,
-                        "Z": -1278.29
+                        "Z": -1278.4
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.347,
+                        "Repository Drift (Z-Score)": 13.343,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.726,
-                            "file_cluster_1": 13.946,
-                            "file_cluster_2": 14.021,
-                            "file_cluster_3": 14.775,
-                            "file_cluster_4": 14.104,
-                            "file_cluster_5": 14.338,
-                            "file_cluster_6": 13.864,
-                            "file_cluster_7": 13.64,
-                            "file_cluster_8": 13.347,
-                            "file_cluster_9": 13.904,
-                            "file_cluster_10": 14.75,
-                            "file_cluster_11": 13.726,
-                            "file_cluster_12": 14.132,
-                            "file_cluster_13": 13.509,
-                            "file_cluster_14": 17.138,
-                            "file_cluster_15": 14.208,
-                            "file_cluster_16": 13.897,
-                            "file_cluster_17": 13.875
+                            "file_cluster_0": 13.722,
+                            "file_cluster_1": 13.942,
+                            "file_cluster_2": 14.017,
+                            "file_cluster_3": 14.772,
+                            "file_cluster_4": 14.1,
+                            "file_cluster_5": 14.335,
+                            "file_cluster_6": 13.86,
+                            "file_cluster_7": 13.636,
+                            "file_cluster_8": 13.343,
+                            "file_cluster_9": 13.9,
+                            "file_cluster_10": 14.746,
+                            "file_cluster_11": 13.722,
+                            "file_cluster_12": 14.128,
+                            "file_cluster_13": 13.505,
+                            "file_cluster_14": 17.135,
+                            "file_cluster_15": 14.205,
+                            "file_cluster_16": 13.893,
+                            "file_cluster_17": 13.872
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -31600,7 +31606,7 @@
                         "Total LOC": 2030,
                         "Coding LOC": 1778,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3247.96,
+                        "Structural Magnitude": 3216.56,
                         "Control Flow Ratio": "74.4%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -31620,7 +31626,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "81.66%",
+                        "Documentation Exposure": "81.59%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -31791,16 +31797,6 @@
                             "End Line": 1372
                         },
                         {
-                            "Function Name": "loop",
-                            "Structural Impact": 51.5,
-                            "Lines of Code (LOC)": 29,
-                            "Control Flow Branches": 9,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "56.2%",
-                            "Start Line": 1754,
-                            "End Line": 1782
-                        },
-                        {
                             "Function Name": "willSaveWaitUntilHandler",
                             "Structural Impact": 49.0,
                             "Lines of Code (LOC)": 21,
@@ -31809,16 +31805,6 @@
                             "Control Flow Ratio": "65.2%",
                             "Start Line": 1241,
                             "End Line": 1261
-                        },
-                        {
-                            "Function Name": "sendManualWatchUpdate",
-                            "Structural Impact": 48.5,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "70.0%",
-                            "Start Line": 784,
-                            "End Line": 792
                         },
                         {
                             "Function Name": "initializedHandler",
@@ -31861,6 +31847,16 @@
                             "End Line": 1482
                         },
                         {
+                            "Function Name": "loop",
+                            "Structural Impact": 44.8,
+                            "Lines of Code (LOC)": 29,
+                            "Control Flow Branches": 9,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "56.2%",
+                            "Start Line": 1754,
+                            "End Line": 1782
+                        },
+                        {
                             "Function Name": "semanticTokensRangeHandler",
                             "Structural Impact": 43.5,
                             "Lines of Code (LOC)": 30,
@@ -31901,24 +31897,14 @@
                             "End Line": 1339
                         },
                         {
-                            "Function Name": "isBlockingMessage",
-                            "Structural Impact": 42.3,
-                            "Lines of Code (LOC)": 46,
-                            "Control Flow Branches": 9,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1630,
-                            "End Line": 1675
-                        },
-                        {
-                            "Function Name": "create",
-                            "Structural Impact": 41.6,
-                            "Lines of Code (LOC)": 33,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1687,
-                            "End Line": 1719
+                            "Function Name": "sendManualWatchUpdate",
+                            "Structural Impact": 42.0,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.0%",
+                            "Start Line": 784,
+                            "End Line": 792
                         },
                         {
                             "Function Name": "hoverHandler",
@@ -31941,6 +31927,16 @@
                             "End Line": 1164
                         },
                         {
+                            "Function Name": "isBlockingMessage",
+                            "Structural Impact": 36.9,
+                            "Lines of Code (LOC)": 46,
+                            "Control Flow Branches": 9,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1630,
+                            "End Line": 1675
+                        },
+                        {
                             "Function Name": "documentSymbolsHandler",
                             "Structural Impact": 36.5,
                             "Lines of Code (LOC)": 11,
@@ -31949,6 +31945,16 @@
                             "Control Flow Ratio": "68.8%",
                             "Start Line": 1433,
                             "End Line": 1443
+                        },
+                        {
+                            "Function Name": "create",
+                            "Structural Impact": 36.3,
+                            "Lines of Code (LOC)": 33,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1687,
+                            "End Line": 1719
                         },
                         {
                             "Function Name": "registerCapability",
@@ -32022,20 +32028,20 @@
                         },
                         {
                             "Function Name": "keepRunning",
-                            "Structural Impact": 17.1,
+                            "Structural Impact": 15.3,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 1740,
                             "End Line": 1745
                         },
                         {
                             "Function Name": "requestConfiguration",
-                            "Structural Impact": 16.9,
+                            "Structural Impact": 14.7,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 3,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 665,
                             "End Line": 681
@@ -32062,10 +32068,10 @@
                         },
                         {
                             "Function Name": "destroy",
-                            "Structural Impact": 12.6,
+                            "Structural Impact": 11.0,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 1721,
                             "End Line": 1732
@@ -32131,16 +32137,6 @@
                             "End Line": 642
                         },
                         {
-                            "Function Name": "createDocumentStoreConfig",
-                            "Structural Impact": 7.3,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1136,
-                            "End Line": 1146
-                        },
-                        {
                             "Function Name": "initAnalyser",
                             "Structural Impact": 6.5,
                             "Lines of Code (LOC)": 9,
@@ -32149,6 +32145,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 269,
                             "End Line": 277
+                        },
+                        {
+                            "Function Name": "createDocumentStoreConfig",
+                            "Structural Impact": 6.5,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1136,
+                            "End Line": 1146
                         },
                         {
                             "Function Name": "shutdownHandler",
@@ -32192,10 +32198,10 @@
                         },
                         {
                             "Function Name": "fmtMessage",
-                            "Structural Impact": 4.2,
+                            "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 2027,
                             "End Line": 2029
@@ -32209,16 +32215,6 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 794,
                             "End Line": 798
-                        },
-                        {
-                            "Function Name": "autofixWorkaround",
-                            "Structural Impact": 2.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 280,
-                            "End Line": 289
                         },
                         {
                             "Function Name": "sendToClientRequest",
@@ -32239,6 +32235,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 206,
                             "End Line": 206
+                        },
+                        {
+                            "Function Name": "autofixWorkaround",
+                            "Structural Impact": 2.2,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 280,
+                            "End Line": 289
                         },
                         {
                             "Function Name": "sendToClientResponse",
@@ -32281,16 +32287,6 @@
                             "End Line": 297
                         },
                         {
-                            "Function Name": "resolveConfiguration",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 978,
-                            "End Line": 978
-                        },
-                        {
                             "Function Name": "setTransport",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
@@ -32329,6 +32325,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 857,
                             "End Line": 857
+                        },
+                        {
+                            "Function Name": "resolveConfiguration",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 978,
+                            "End Line": 978
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -32482,26 +32488,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 14.517,
+                        "Repository Drift (Z-Score)": 14.526,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.702,
-                            "file_cluster_1": 15.099,
-                            "file_cluster_2": 15.122,
-                            "file_cluster_3": 15.766,
-                            "file_cluster_4": 15.072,
-                            "file_cluster_5": 15.44,
-                            "file_cluster_6": 14.895,
-                            "file_cluster_7": 14.771,
-                            "file_cluster_8": 14.517,
-                            "file_cluster_9": 14.862,
-                            "file_cluster_10": 15.709,
-                            "file_cluster_11": 14.701,
-                            "file_cluster_12": 15.256,
-                            "file_cluster_13": 14.724,
-                            "file_cluster_14": 17.953,
-                            "file_cluster_15": 15.203,
-                            "file_cluster_16": 14.785,
-                            "file_cluster_17": 14.868
+                            "file_cluster_0": 14.71,
+                            "file_cluster_1": 15.108,
+                            "file_cluster_2": 15.131,
+                            "file_cluster_3": 15.775,
+                            "file_cluster_4": 15.081,
+                            "file_cluster_5": 15.449,
+                            "file_cluster_6": 14.904,
+                            "file_cluster_7": 14.78,
+                            "file_cluster_8": 14.526,
+                            "file_cluster_9": 14.87,
+                            "file_cluster_10": 15.718,
+                            "file_cluster_11": 14.71,
+                            "file_cluster_12": 15.265,
+                            "file_cluster_13": 14.733,
+                            "file_cluster_14": 17.959,
+                            "file_cluster_15": 15.212,
+                            "file_cluster_16": 14.794,
+                            "file_cluster_17": 14.877
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -32509,7 +32515,7 @@
                         "Total LOC": 7016,
                         "Coding LOC": 6283,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 18450.86,
+                        "Structural Magnitude": 18254.66,
                         "Control Flow Ratio": "73.5%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -32529,7 +32535,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "92.92%",
+                        "Documentation Exposure": "92.8%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -32621,23 +32627,13 @@
                         },
                         {
                             "Function Name": "isGeneric",
-                            "Structural Impact": 352.8,
+                            "Structural Impact": 305.9,
                             "Lines of Code (LOC)": 55,
                             "Control Flow Branches": 24,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 3578,
                             "End Line": 3632
-                        },
-                        {
-                            "Function Name": "isConditional",
-                            "Structural Impact": 301.9,
-                            "Lines of Code (LOC)": 37,
-                            "Control Flow Branches": 24,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 3977,
-                            "End Line": 4013
                         },
                         {
                             "Function Name": "resolveBindingOfNodeUncached",
@@ -32648,6 +32644,16 @@
                             "Control Flow Ratio": "72.7%",
                             "Start Line": 3073,
                             "End Line": 3160
+                        },
+                        {
+                            "Function Name": "isConditional",
+                            "Structural Impact": 261.7,
+                            "Lines of Code (LOC)": 37,
+                            "Control Flow Branches": 24,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 3977,
+                            "End Line": 4013
                         },
                         {
                             "Function Name": "resolveVarDeclAlias",
@@ -32710,16 +32716,6 @@
                             "End Line": 1823
                         },
                         {
-                            "Function Name": "typeDefinitionToken",
-                            "Structural Impact": 120.8,
-                            "Lines of Code (LOC)": 37,
-                            "Control Flow Branches": 16,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 4465,
-                            "End Line": 4501
-                        },
-                        {
                             "Function Name": "resolveReturnValueOfFuncNode",
                             "Structural Impact": 118.1,
                             "Lines of Code (LOC)": 36,
@@ -32748,6 +32744,16 @@
                             "Control Flow Ratio": "73.3%",
                             "Start Line": 6949,
                             "End Line": 6980
+                        },
+                        {
+                            "Function Name": "typeDefinitionToken",
+                            "Structural Impact": 104.9,
+                            "Lines of Code (LOC)": 37,
+                            "Control Flow Branches": 16,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 4465,
+                            "End Line": 4501
                         },
                         {
                             "Function Name": "createArray",
@@ -32810,16 +32816,6 @@
                             "End Line": 3332
                         },
                         {
-                            "Function Name": "isConst",
-                            "Structural Impact": 93.4,
-                            "Lines of Code (LOC)": 48,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 5763,
-                            "End Line": 5810
-                        },
-                        {
                             "Function Name": "resolveArrayCat",
                             "Structural Impact": 88.2,
                             "Lines of Code (LOC)": 24,
@@ -32848,6 +32844,16 @@
                             "Control Flow Ratio": "87.5%",
                             "Start Line": 372,
                             "End Line": 385
+                        },
+                        {
+                            "Function Name": "isConst",
+                            "Structural Impact": 81.2,
+                            "Lines of Code (LOC)": 48,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 5763,
+                            "End Line": 5810
                         },
                         {
                             "Function Name": "findReturnStatementInternal",
@@ -32910,26 +32916,6 @@
                             "End Line": 966
                         },
                         {
-                            "Function Name": "isGenericFunc",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "70.0%",
-                            "Start Line": 4381,
-                            "End Line": 4393
-                        },
-                        {
-                            "Function Name": "next",
-                            "Structural Impact": 56.4,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 10,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 6165,
-                            "End Line": 6191
-                        },
-                        {
                             "Function Name": "createTuple",
                             "Structural Impact": 52.9,
                             "Lines of Code (LOC)": 19,
@@ -32940,14 +32926,24 @@
                             "End Line": 3380
                         },
                         {
-                            "Function Name": "isNamespace",
-                            "Structural Impact": 52.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "63.2%",
-                            "Start Line": 4298,
-                            "End Line": 4313
+                            "Function Name": "isGenericFunc",
+                            "Structural Impact": 49.1,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.0%",
+                            "Start Line": 4381,
+                            "End Line": 4393
+                        },
+                        {
+                            "Function Name": "next",
+                            "Structural Impact": 49.0,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 10,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 6165,
+                            "End Line": 6191
                         },
                         {
                             "Function Name": "instanceStdBuiltinType",
@@ -32958,6 +32954,16 @@
                             "Control Flow Ratio": "70.8%",
                             "Start Line": 4939,
                             "End Line": 4960
+                        },
+                        {
+                            "Function Name": "isNamespace",
+                            "Structural Impact": 45.8,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "63.2%",
+                            "Start Line": 4298,
+                            "End Line": 4313
                         },
                         {
                             "Function Name": "getDocCommentTokenIndex",
@@ -33050,16 +33056,6 @@
                             "End Line": 4421
                         },
                         {
-                            "Function Name": "isTaggedUnion",
-                            "Structural Impact": 32.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4327,
-                            "End Line": 4332
-                        },
-                        {
                             "Function Name": "eql",
                             "Structural Impact": 32.2,
                             "Lines of Code (LOC)": 5,
@@ -33110,16 +33106,6 @@
                             "End Line": 5662
                         },
                         {
-                            "Function Name": "isPublic",
-                            "Structural Impact": 31.2,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 5845,
-                            "End Line": 5869
-                        },
-                        {
                             "Function Name": "isInstanceCall",
                             "Structural Impact": 30.4,
                             "Lines of Code (LOC)": 20,
@@ -33130,24 +33116,24 @@
                             "End Line": 437
                         },
                         {
-                            "Function Name": "getContainerKind",
-                            "Structural Impact": 28.6,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4269,
-                            "End Line": 4280
+                            "Function Name": "isTaggedUnion",
+                            "Structural Impact": 28.0,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4327,
+                            "End Line": 4332
                         },
                         {
-                            "Function Name": "isMetaType",
-                            "Structural Impact": 28.4,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4335,
-                            "End Line": 4341
+                            "Function Name": "isPublic",
+                            "Structural Impact": 27.2,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 5845,
+                            "End Line": 5869
                         },
                         {
                             "Function Name": "createOptional",
@@ -33160,44 +33146,24 @@
                             "End Line": 3389
                         },
                         {
-                            "Function Name": "resolveDeclLiteralResultType",
-                            "Structural Impact": 25.6,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
+                            "Function Name": "getContainerKind",
+                            "Structural Impact": 24.8,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
-                            "Start Line": 4361,
-                            "End Line": 4371
+                            "Start Line": 4269,
+                            "End Line": 4280
                         },
                         {
-                            "Function Name": "next",
-                            "Structural Impact": 25.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 4186,
-                            "End Line": 4195
-                        },
-                        {
-                            "Function Name": "isNoreturnType",
-                            "Structural Impact": 24.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 4402,
-                            "End Line": 4409
-                        },
-                        {
-                            "Function Name": "root",
-                            "Structural Impact": 24.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 3263,
-                            "End Line": 3268
+                            "Function Name": "isMetaType",
+                            "Structural Impact": 24.6,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4335,
+                            "End Line": 4341
                         },
                         {
                             "Function Name": "eql",
@@ -33220,6 +33186,26 @@
                             "End Line": 7013
                         },
                         {
+                            "Function Name": "next",
+                            "Structural Impact": 22.2,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 4186,
+                            "End Line": 4195
+                        },
+                        {
+                            "Function Name": "resolveDeclLiteralResultType",
+                            "Structural Impact": 22.2,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4361,
+                            "End Line": 4371
+                        },
+                        {
                             "Function Name": "loc",
                             "Structural Impact": 22.0,
                             "Lines of Code (LOC)": 25,
@@ -33240,6 +33226,26 @@
                             "End Line": 1460
                         },
                         {
+                            "Function Name": "isNoreturnType",
+                            "Structural Impact": 21.2,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 4402,
+                            "End Line": 4409
+                        },
+                        {
+                            "Function Name": "root",
+                            "Structural Impact": 21.1,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3263,
+                            "End Line": 3268
+                        },
+                        {
                             "Function Name": "eql",
                             "Structural Impact": 21.0,
                             "Lines of Code (LOC)": 4,
@@ -33248,26 +33254,6 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 4991,
                             "End Line": 4994
-                        },
-                        {
-                            "Function Name": "isRoot",
-                            "Structural Impact": 20.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4258,
-                            "End Line": 4263
-                        },
-                        {
-                            "Function Name": "isEnumLiteral",
-                            "Structural Impact": 20.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4354,
-                            "End Line": 4359
                         },
                         {
                             "Function Name": "eql",
@@ -33320,6 +33306,26 @@
                             "End Line": 5676
                         },
                         {
+                            "Function Name": "isRoot",
+                            "Structural Impact": 17.6,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4258,
+                            "End Line": 4263
+                        },
+                        {
+                            "Function Name": "isEnumLiteral",
+                            "Structural Impact": 17.6,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4354,
+                            "End Line": 4359
+                        },
+                        {
                             "Function Name": "innermostScopeAtIndexWithTag",
                             "Structural Impact": 17.5,
                             "Lines of Code (LOC)": 14,
@@ -33328,16 +33334,6 @@
                             "Control Flow Ratio": "57.1%",
                             "Start Line": 6221,
                             "End Line": 6234
-                        },
-                        {
-                            "Function Name": "allDigits",
-                            "Structural Impact": 17.1,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1374,
-                            "End Line": 1379
                         },
                         {
                             "Function Name": "createPointerType",
@@ -33350,36 +33346,6 @@
                             "End Line": 3792
                         },
                         {
-                            "Function Name": "ipIndex",
-                            "Structural Impact": 16.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 3871,
-                            "End Line": 3876
-                        },
-                        {
-                            "Function Name": "isTypeFunc",
-                            "Structural Impact": 16.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4373,
-                            "End Line": 4378
-                        },
-                        {
-                            "Function Name": "isFunc",
-                            "Structural Impact": 16.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4395,
-                            "End Line": 4400
-                        },
-                        {
                             "Function Name": "getSymbolEnumLiteral",
                             "Structural Impact": 15.4,
                             "Lines of Code (LOC)": 14,
@@ -33388,6 +33354,16 @@
                             "Control Flow Ratio": "62.5%",
                             "Start Line": 6870,
                             "End Line": 6883
+                        },
+                        {
+                            "Function Name": "allDigits",
+                            "Structural Impact": 15.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1374,
+                            "End Line": 1379
                         },
                         {
                             "Function Name": "createArrayType",
@@ -33410,6 +33386,16 @@
                             "End Line": 7005
                         },
                         {
+                            "Function Name": "ipIndex",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 3871,
+                            "End Line": 3876
+                        },
+                        {
                             "Function Name": "withoutIPIndex",
                             "Structural Impact": 14.2,
                             "Lines of Code (LOC)": 6,
@@ -33418,6 +33404,26 @@
                             "Control Flow Ratio": "75.0%",
                             "Start Line": 3878,
                             "End Line": 3883
+                        },
+                        {
+                            "Function Name": "isTypeFunc",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4373,
+                            "End Line": 4378
+                        },
+                        {
+                            "Function Name": "isFunc",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4395,
+                            "End Line": 4400
                         },
                         {
                             "Function Name": "hash",
@@ -33460,26 +33466,6 @@
                             "End Line": 1426
                         },
                         {
-                            "Function Name": "isCaptureByRef",
-                            "Structural Impact": 12.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 5812,
-                            "End Line": 5829
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 12.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 338,
-                            "End Line": 350
-                        },
-                        {
                             "Function Name": "fromIP",
                             "Structural Impact": 12.4,
                             "Lines of Code (LOC)": 8,
@@ -33490,36 +33476,6 @@
                             "End Line": 3892
                         },
                         {
-                            "Function Name": "peek",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 5325,
-                            "End Line": 5330
-                        },
-                        {
-                            "Function Name": "toNode",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4827,
-                            "End Line": 4831
-                        },
-                        {
-                            "Function Name": "nameToken",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 5690,
-                            "End Line": 5692
-                        },
-                        {
                             "Function Name": "getSymbolFieldAccesses",
                             "Structural Impact": 12.0,
                             "Lines of Code (LOC)": 13,
@@ -33528,6 +33484,26 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 6908,
                             "End Line": 6920
+                        },
+                        {
+                            "Function Name": "isCaptureByRef",
+                            "Structural Impact": 11.3,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 5812,
+                            "End Line": 5829
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 11.0,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 338,
+                            "End Line": 350
                         },
                         {
                             "Function Name": "isMetaType",
@@ -33560,6 +33536,26 @@
                             "End Line": 3818
                         },
                         {
+                            "Function Name": "peek",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 5325,
+                            "End Line": 5330
+                        },
+                        {
+                            "Function Name": "toNode",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4827,
+                            "End Line": 4831
+                        },
+                        {
                             "Function Name": "eql",
                             "Structural Impact": 10.5,
                             "Lines of Code (LOC)": 3,
@@ -33568,6 +33564,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 5685,
                             "End Line": 5687
+                        },
+                        {
+                            "Function Name": "nameToken",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 5690,
+                            "End Line": 5692
                         },
                         {
                             "Function Name": "resolveFieldAccess",
@@ -33650,16 +33656,6 @@
                             "End Line": 64
                         },
                         {
-                            "Function Name": "isErrSetDef",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 5307,
-                            "End Line": 5309
-                        },
-                        {
                             "Function Name": "getFunctionSignature",
                             "Structural Impact": 7.2,
                             "Lines of Code (LOC)": 5,
@@ -33700,6 +33696,16 @@
                             "End Line": 3862
                         },
                         {
+                            "Function Name": "isErrSetDef",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 5307,
+                            "End Line": 5309
+                        },
+                        {
                             "Function Name": "of",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 7,
@@ -33708,16 +33714,6 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 6987,
                             "End Line": 6993
-                        },
-                        {
-                            "Function Name": "ArrayMap",
-                            "Structural Impact": 6.9,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 3854,
-                            "End Line": 3856
                         },
                         {
                             "Function Name": "getPositionContext",
@@ -33730,64 +33726,14 @@
                             "End Line": 5361
                         },
                         {
-                            "Function Name": "hash32",
+                            "Function Name": "ArrayMap",
                             "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
                             "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
-                            "Start Line": 3831,
-                            "End Line": 3833
-                        },
-                        {
-                            "Function Name": "hash64",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 3835,
-                            "End Line": 3839
-                        },
-                        {
-                            "Function Name": "isGenericType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4265,
-                            "End Line": 4267
-                        },
-                        {
-                            "Function Name": "isEnumType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4315,
-                            "End Line": 4317
-                        },
-                        {
-                            "Function Name": "isUnionType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4319,
-                            "End Line": 4321
-                        },
-                        {
-                            "Function Name": "isOpaqueType",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4323,
-                            "End Line": 4325
+                            "Start Line": 3854,
+                            "End Line": 3856
                         },
                         {
                             "Function Name": "tokenLocAppend",
@@ -33810,6 +33756,16 @@
                             "End Line": 6200
                         },
                         {
+                            "Function Name": "hash64",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 3835,
+                            "End Line": 3839
+                        },
+                        {
                             "Function Name": "hashWithHasher",
                             "Structural Impact": 5.4,
                             "Lines of Code (LOC)": 4,
@@ -33820,6 +33776,26 @@
                             "End Line": 3844
                         },
                         {
+                            "Function Name": "hash32",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 3831,
+                            "End Line": 3833
+                        },
+                        {
+                            "Function Name": "isGenericType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4265,
+                            "End Line": 4267
+                        },
+                        {
                             "Function Name": "isContainerKind",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -33828,6 +33804,36 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 4282,
                             "End Line": 4284
+                        },
+                        {
+                            "Function Name": "isEnumType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4315,
+                            "End Line": 4317
+                        },
+                        {
+                            "Function Name": "isUnionType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4319,
+                            "End Line": 4321
+                        },
+                        {
+                            "Function Name": "isOpaqueType",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4323,
+                            "End Line": 4325
                         },
                         {
                             "Function Name": "writeString",
@@ -33870,16 +33876,6 @@
                             "End Line": 3660
                         },
                         {
-                            "Function Name": "fmtEscapedSnippet",
-                            "Structural Impact": 4.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 388,
-                            "End Line": 390
-                        },
-                        {
                             "Function Name": "innermostScopeAtIndex",
                             "Structural Impact": 4.3,
                             "Lines of Code (LOC)": 6,
@@ -33890,14 +33886,14 @@
                             "End Line": 6219
                         },
                         {
-                            "Function Name": "deinit",
+                            "Function Name": "fmtEscapedSnippet",
                             "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 0,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
                             "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 66,
-                            "End Line": 69
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 388,
+                            "End Line": 390
                         },
                         {
                             "Function Name": "init",
@@ -33928,6 +33924,16 @@
                             "Control Flow Ratio": "33.3%",
                             "Start Line": 1953,
                             "End Line": 1958
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 66,
+                            "End Line": 69
                         },
                         {
                             "Function Name": "findReturnStatement",
@@ -34270,26 +34276,6 @@
                             "End Line": 5321
                         },
                         {
-                            "Function Name": "typeDeclarationNode",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 5710,
-                            "End Line": 5710
-                        },
-                        {
-                            "Function Name": "isStatic",
-                            "Structural Impact": 2.0,
-                            "Lines of Code (LOC)": 1,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 5871,
-                            "End Line": 5871
-                        },
-                        {
                             "Function Name": "innermostContainer",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
@@ -34490,6 +34476,16 @@
                             "End Line": 5312
                         },
                         {
+                            "Function Name": "typeDeclarationNode",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 5710,
+                            "End Line": 5710
+                        },
+                        {
                             "Function Name": "docComments",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
@@ -34498,6 +34494,16 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 5831,
                             "End Line": 5831
+                        },
+                        {
+                            "Function Name": "isStatic",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 1,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 5871,
+                            "End Line": 5871
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -34598,12 +34604,13 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 11,
+                        "Direct Upstream (Fragility)": 12,
                         "Direct Downstream (Dependency Blast Radius)": 2,
                         "Total Upstream (Absolute Fragility)": 4,
                         "Total Downstream (Absolute Dependency Blast Radius)": 4
                     },
                     "9. Extracted Dependencies": [
+                        "DocumentScope.zig",
                         "DocumentStore.zig",
                         "Uri.zig",
                         "analyser/InternPool.zig",
@@ -34629,32 +34636,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4900.27,
+                        "X": -4900.37,
                         "Y": -129.48,
-                        "Z": -1346.3
+                        "Z": -1346.45
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.644,
+                        "Repository Drift (Z-Score)": 11.641,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.104,
-                            "file_cluster_1": 12.342,
-                            "file_cluster_2": 12.455,
-                            "file_cluster_3": 13.278,
-                            "file_cluster_4": 12.445,
-                            "file_cluster_5": 12.801,
-                            "file_cluster_6": 12.328,
-                            "file_cluster_7": 11.971,
-                            "file_cluster_8": 11.644,
-                            "file_cluster_9": 12.251,
-                            "file_cluster_10": 13.147,
-                            "file_cluster_11": 12.292,
-                            "file_cluster_12": 12.621,
-                            "file_cluster_13": 12.119,
-                            "file_cluster_14": 15.893,
-                            "file_cluster_15": 12.643,
-                            "file_cluster_16": 12.416,
-                            "file_cluster_17": 12.308
+                            "file_cluster_0": 12.102,
+                            "file_cluster_1": 12.339,
+                            "file_cluster_2": 12.452,
+                            "file_cluster_3": 13.275,
+                            "file_cluster_4": 12.442,
+                            "file_cluster_5": 12.799,
+                            "file_cluster_6": 12.326,
+                            "file_cluster_7": 11.968,
+                            "file_cluster_8": 11.641,
+                            "file_cluster_9": 12.248,
+                            "file_cluster_10": 13.145,
+                            "file_cluster_11": 12.29,
+                            "file_cluster_12": 12.619,
+                            "file_cluster_13": 12.116,
+                            "file_cluster_14": 15.891,
+                            "file_cluster_15": 12.641,
+                            "file_cluster_16": 12.413,
+                            "file_cluster_17": 12.306
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -34662,7 +34669,7 @@
                         "Total LOC": 1847,
                         "Coding LOC": 1704,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3037.48,
+                        "Structural Magnitude": 3005.18,
                         "Control Flow Ratio": "70.4%",
                         "Popularity Rank": 2,
                         "Raw Churn Frequency": 0.0,
@@ -34682,7 +34689,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "78.12%",
+                        "Documentation Exposure": "78.04%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -34734,10 +34741,10 @@
                         },
                         {
                             "Function Name": "next",
-                            "Structural Impact": 186.7,
+                            "Structural Impact": 162.3,
                             "Lines of Code (LOC)": 94,
                             "Control Flow Branches": 25,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "71.4%",
                             "Start Line": 966,
                             "End Line": 1059
@@ -34764,10 +34771,10 @@
                         },
                         {
                             "Function Name": "initArray",
-                            "Structural Impact": 43.1,
+                            "Structural Impact": 37.5,
                             "Lines of Code (LOC)": 22,
                             "Control Flow Branches": 5,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "55.6%",
                             "Start Line": 1504,
                             "End Line": 1525
@@ -34913,16 +34920,6 @@
                             "End Line": 397
                         },
                         {
-                            "Function Name": "isKeyword",
-                            "Structural Impact": 9.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "40.0%",
-                            "Start Line": 403,
-                            "End Line": 412
-                        },
-                        {
                             "Function Name": "ifFull",
                             "Structural Impact": 8.3,
                             "Lines of Code (LOC)": 11,
@@ -34931,6 +34928,16 @@
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 200,
                             "End Line": 210
+                        },
+                        {
+                            "Function Name": "isKeyword",
+                            "Structural Impact": 8.3,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "40.0%",
+                            "Start Line": 403,
+                            "End Line": 412
                         },
                         {
                             "Function Name": "errorSetFieldCount",
@@ -34994,10 +35001,10 @@
                         },
                         {
                             "Function Name": "parentNode",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1581,
                             "End Line": 1583
@@ -35154,10 +35161,10 @@
                         },
                         {
                             "Function Name": "skip",
-                            "Structural Impact": 3.1,
+                            "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1576,
                             "End Line": 1578
@@ -35373,32 +35380,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5826.19,
+                        "X": -5825.96,
                         "Y": -155.66,
-                        "Z": -1638.65
+                        "Z": -1638.61
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.891,
+                        "Repository Drift (Z-Score)": 11.885,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.484,
-                            "file_cluster_1": 12.737,
-                            "file_cluster_2": 12.818,
-                            "file_cluster_3": 13.679,
-                            "file_cluster_4": 12.789,
-                            "file_cluster_5": 13.248,
-                            "file_cluster_6": 12.785,
-                            "file_cluster_7": 12.43,
-                            "file_cluster_8": 11.891,
-                            "file_cluster_9": 12.618,
-                            "file_cluster_10": 13.691,
-                            "file_cluster_11": 12.733,
-                            "file_cluster_12": 13.111,
-                            "file_cluster_13": 12.489,
-                            "file_cluster_14": 16.148,
-                            "file_cluster_15": 13.126,
-                            "file_cluster_16": 12.814,
-                            "file_cluster_17": 12.599
+                            "file_cluster_0": 12.479,
+                            "file_cluster_1": 12.731,
+                            "file_cluster_2": 12.813,
+                            "file_cluster_3": 13.674,
+                            "file_cluster_4": 12.783,
+                            "file_cluster_5": 13.243,
+                            "file_cluster_6": 12.78,
+                            "file_cluster_7": 12.425,
+                            "file_cluster_8": 11.885,
+                            "file_cluster_9": 12.613,
+                            "file_cluster_10": 13.686,
+                            "file_cluster_11": 12.728,
+                            "file_cluster_12": 13.106,
+                            "file_cluster_13": 12.484,
+                            "file_cluster_14": 16.144,
+                            "file_cluster_15": 13.121,
+                            "file_cluster_16": 12.808,
+                            "file_cluster_17": 12.593
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -35406,7 +35413,7 @@
                         "Total LOC": 950,
                         "Coding LOC": 900,
                         "Documentation LOC": 1,
-                        "Structural Magnitude": 699.2,
+                        "Structural Magnitude": 687.2,
                         "Control Flow Ratio": "81.0%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -35457,16 +35464,6 @@
                             "End Line": 653
                         },
                         {
-                            "Function Name": "nodeTagName",
-                            "Structural Impact": 48.4,
-                            "Lines of Code (LOC)": 188,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "63.2%",
-                            "Start Line": 656,
-                            "End Line": 843
-                        },
-                        {
                             "Function Name": "renderNodeSliceField",
                             "Structural Impact": 45.6,
                             "Lines of Code (LOC)": 18,
@@ -35475,6 +35472,16 @@
                             "Control Flow Ratio": "90.0%",
                             "Start Line": 610,
                             "End Line": 627
+                        },
+                        {
+                            "Function Name": "nodeTagName",
+                            "Structural Impact": 43.2,
+                            "Lines of Code (LOC)": 188,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "63.2%",
+                            "Start Line": 656,
+                            "End Line": 843
                         },
                         {
                             "Function Name": "renderToFile",
@@ -35488,10 +35495,10 @@
                         },
                         {
                             "Function Name": "main",
-                            "Structural Impact": 34.7,
+                            "Structural Impact": 30.3,
                             "Lines of Code (LOC)": 34,
                             "Control Flow Branches": 10,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "58.8%",
                             "Start Line": 845,
                             "End Line": 878
@@ -35548,20 +35555,20 @@
                         },
                         {
                             "Function Name": "renderRoot",
-                            "Structural Impact": 9.2,
+                            "Structural Impact": 8.0,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 66,
                             "End Line": 69
                         },
                         {
                             "Function Name": "newline",
-                            "Structural Impact": 9.2,
+                            "Structural Impact": 8.0,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 524,
                             "End Line": 527
@@ -42409,9 +42416,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1995.15,
+                        "X": -1995.11,
                         "Y": 103.99,
-                        "Z": -3082.11
+                        "Z": -3082.03
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -42571,9 +42578,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2158.42,
+                        "X": -2158.37,
                         "Y": 48.67,
-                        "Z": -3246.91
+                        "Z": -3246.83
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -43522,9 +43529,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1511.11,
+                        "X": -1511.06,
                         "Y": 113.88,
-                        "Z": -3285.17
+                        "Z": -3285.09
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -43829,9 +43836,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1416.74,
+                        "X": -1416.7,
                         "Y": 199.14,
-                        "Z": -3827.65
+                        "Z": -3827.57
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -44044,9 +44051,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1850.11,
+                        "X": -1850.07,
                         "Y": 139.82,
-                        "Z": -3530.75
+                        "Z": -3530.67
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -45168,9 +45175,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1771.59,
+                        "X": -1771.55,
                         "Y": 122.67,
-                        "Z": -4004.25
+                        "Z": -4004.17
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -45398,9 +45405,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2442.21,
+                        "X": -2442.17,
                         "Y": 37.9,
-                        "Z": -3767.74
+                        "Z": -3767.66
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -56940,7 +56947,7 @@
             }
         },
         "zig/tigerbeetle": {
-            "Directory Group Magnitude": 12283.34,
+            "Directory Group Magnitude": 11647.14,
             "File Count": 11,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "90.9%",
@@ -56958,7 +56965,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "65.9%",
+                "Documentation Exposure": "65.4%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "71.27%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -57412,32 +57419,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4321.87,
-                        "Y": 85.66,
-                        "Z": 2802.38
+                        "X": 4323.11,
+                        "Y": 85.81,
+                        "Z": 2801.26
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.627,
+                        "Repository Drift (Z-Score)": 12.608,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.973,
-                            "file_cluster_1": 13.198,
-                            "file_cluster_2": 13.301,
-                            "file_cluster_3": 14.11,
-                            "file_cluster_4": 13.327,
-                            "file_cluster_5": 13.607,
-                            "file_cluster_6": 13.264,
-                            "file_cluster_7": 12.862,
-                            "file_cluster_8": 12.627,
-                            "file_cluster_9": 13.158,
-                            "file_cluster_10": 14.074,
-                            "file_cluster_11": 13.145,
-                            "file_cluster_12": 13.528,
-                            "file_cluster_13": 12.845,
-                            "file_cluster_14": 16.584,
-                            "file_cluster_15": 13.476,
-                            "file_cluster_16": 13.245,
-                            "file_cluster_17": 13.14
+                            "file_cluster_0": 12.957,
+                            "file_cluster_1": 13.181,
+                            "file_cluster_2": 13.284,
+                            "file_cluster_3": 14.094,
+                            "file_cluster_4": 13.309,
+                            "file_cluster_5": 13.591,
+                            "file_cluster_6": 13.248,
+                            "file_cluster_7": 12.844,
+                            "file_cluster_8": 12.608,
+                            "file_cluster_9": 13.141,
+                            "file_cluster_10": 14.058,
+                            "file_cluster_11": 13.129,
+                            "file_cluster_12": 13.511,
+                            "file_cluster_13": 12.828,
+                            "file_cluster_14": 16.57,
+                            "file_cluster_15": 13.459,
+                            "file_cluster_16": 13.228,
+                            "file_cluster_17": 13.123
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -57445,7 +57452,7 @@
                         "Total LOC": 1007,
                         "Coding LOC": 835,
                         "Documentation LOC": 1,
-                        "Structural Magnitude": 2873.8,
+                        "Structural Magnitude": 2596.7,
                         "Control Flow Ratio": "66.8%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -57477,10 +57484,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "AOFType",
-                            "Structural Impact": 2642.7,
+                            "Structural Impact": 2368.3,
                             "Lines of Code (LOC)": 887,
                             "Control Flow Branches": 165,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.8%",
                             "Start Line": 120,
                             "End Line": 1006
@@ -57497,30 +57504,30 @@
                         },
                         {
                             "Function Name": "size_disk",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 48,
                             "End Line": 50
                         },
                         {
                             "Function Name": "size_minimum",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 53,
                             "End Line": 55
                         },
                         {
                             "Function Name": "header",
-                            "Structural Impact": 6.2,
+                            "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 57,
                             "End Line": 59
@@ -57659,32 +57666,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4179.07,
-                        "Y": 201.41,
-                        "Z": 2599.88
+                        "X": 4180.46,
+                        "Y": 201.29,
+                        "Z": 2600.11
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.121,
+                        "Repository Drift (Z-Score)": 11.108,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.868,
-                            "file_cluster_1": 11.95,
-                            "file_cluster_2": 12.095,
-                            "file_cluster_3": 13.014,
-                            "file_cluster_4": 12.298,
-                            "file_cluster_5": 12.492,
-                            "file_cluster_6": 12.149,
-                            "file_cluster_7": 11.643,
-                            "file_cluster_8": 11.121,
-                            "file_cluster_9": 11.996,
-                            "file_cluster_10": 13.058,
-                            "file_cluster_11": 12.123,
-                            "file_cluster_12": 12.341,
-                            "file_cluster_13": 11.721,
-                            "file_cluster_14": 15.628,
-                            "file_cluster_15": 12.429,
-                            "file_cluster_16": 12.141,
-                            "file_cluster_17": 12.0
+                            "file_cluster_0": 11.857,
+                            "file_cluster_1": 11.938,
+                            "file_cluster_2": 12.083,
+                            "file_cluster_3": 13.004,
+                            "file_cluster_4": 12.286,
+                            "file_cluster_5": 12.481,
+                            "file_cluster_6": 12.138,
+                            "file_cluster_7": 11.631,
+                            "file_cluster_8": 11.108,
+                            "file_cluster_9": 11.985,
+                            "file_cluster_10": 13.047,
+                            "file_cluster_11": 12.112,
+                            "file_cluster_12": 12.33,
+                            "file_cluster_13": 11.709,
+                            "file_cluster_14": 15.618,
+                            "file_cluster_15": 12.418,
+                            "file_cluster_16": 12.13,
+                            "file_cluster_17": 11.988
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -57692,7 +57699,7 @@
                         "Total LOC": 809,
                         "Coding LOC": 717,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 203.74,
+                        "Structural Magnitude": 179.34,
                         "Control Flow Ratio": "82.7%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -57712,7 +57719,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "33.16%",
+                        "Documentation Exposure": "32.5%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -57724,10 +57731,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "main",
-                            "Structural Impact": 44.5,
+                            "Structural Impact": 26.9,
                             "Lines of Code (LOC)": 58,
                             "Control Flow Branches": 11,
-                            "Input Parameters": 2,
+                            "Input Parameters": 0,
                             "Control Flow Ratio": "61.1%",
                             "Start Line": 52,
                             "End Line": 109
@@ -57744,30 +57751,30 @@
                         },
                         {
                             "Function Name": "parse",
-                            "Structural Impact": 23.0,
+                            "Structural Impact": 20.6,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 22,
                             "End Line": 33
                         },
                         {
                             "Function Name": "self_check_enabled",
-                            "Structural Impact": 20.6,
+                            "Structural Impact": 18.0,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "80.0%",
                             "Start Line": 756,
                             "End Line": 768
                         },
                         {
                             "Function Name": "git_sha_to_binary",
-                            "Structural Impact": 17.7,
+                            "Structural Impact": 15.9,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "57.1%",
                             "Start Line": 791,
                             "End Line": 808
@@ -57967,32 +57974,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4716.99,
-                        "Y": 216.7,
-                        "Z": 2272.47
+                        "X": 4716.86,
+                        "Y": 216.45,
+                        "Z": 2273.81
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.708,
+                        "Repository Drift (Z-Score)": 12.72,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.085,
-                            "file_cluster_1": 13.287,
-                            "file_cluster_2": 13.393,
-                            "file_cluster_3": 14.197,
-                            "file_cluster_4": 13.479,
-                            "file_cluster_5": 13.696,
-                            "file_cluster_6": 13.28,
-                            "file_cluster_7": 12.973,
-                            "file_cluster_8": 12.708,
-                            "file_cluster_9": 13.285,
-                            "file_cluster_10": 14.114,
-                            "file_cluster_11": 13.187,
-                            "file_cluster_12": 13.632,
-                            "file_cluster_13": 12.81,
-                            "file_cluster_14": 16.677,
-                            "file_cluster_15": 13.595,
-                            "file_cluster_16": 13.331,
-                            "file_cluster_17": 13.28
+                            "file_cluster_0": 13.096,
+                            "file_cluster_1": 13.299,
+                            "file_cluster_2": 13.405,
+                            "file_cluster_3": 14.208,
+                            "file_cluster_4": 13.491,
+                            "file_cluster_5": 13.708,
+                            "file_cluster_6": 13.293,
+                            "file_cluster_7": 12.985,
+                            "file_cluster_8": 12.72,
+                            "file_cluster_9": 13.296,
+                            "file_cluster_10": 14.126,
+                            "file_cluster_11": 13.2,
+                            "file_cluster_12": 13.644,
+                            "file_cluster_13": 12.823,
+                            "file_cluster_14": 16.682,
+                            "file_cluster_15": 13.607,
+                            "file_cluster_16": 13.343,
+                            "file_cluster_17": 13.292
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58000,7 +58007,7 @@
                         "Total LOC": 1199,
                         "Coding LOC": 1044,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 1425.08,
+                        "Structural Magnitude": 1297.88,
                         "Control Flow Ratio": "66.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -58020,7 +58027,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "41.85%",
+                        "Documentation Exposure": "41.7%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -58032,10 +58039,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "ClusterType",
-                            "Structural Impact": 1261.2,
+                            "Structural Impact": 1134.0,
                             "Lines of Code (LOC)": 1120,
                             "Control Flow Branches": 153,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "66.2%",
                             "Start Line": 58,
                             "End Line": 1177
@@ -58139,7 +58146,7 @@
                         "Agentic Rce": 0
                     },
                     "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 15,
+                        "Direct Upstream (Fragility)": 18,
                         "Direct Downstream (Dependency Blast Radius)": 0,
                         "Total Upstream (Absolute Fragility)": 0,
                         "Total Downstream (Absolute Dependency Blast Radius)": 0
@@ -58153,12 +58160,15 @@
                         "cluster/grid_checker.zig",
                         "cluster/journal_checker.zig",
                         "cluster/manifest_checker.zig",
+                        "cluster/message_bus.zig",
+                        "cluster/network.zig",
                         "cluster/state_checker.zig",
                         "cluster/storage_checker.zig",
                         "id.zig",
                         "io.zig",
                         "std",
                         "stdx",
+                        "storage.zig",
                         "time.zig"
                     ]
                 },
@@ -58174,32 +58184,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4009.85,
-                        "Y": 156.41,
-                        "Z": 2741.68
+                        "X": 4010.39,
+                        "Y": 156.42,
+                        "Z": 2741.46
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.63,
+                        "Repository Drift (Z-Score)": 9.603,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.563,
-                            "file_cluster_1": 10.251,
-                            "file_cluster_2": 10.61,
-                            "file_cluster_3": 11.54,
-                            "file_cluster_4": 11.083,
-                            "file_cluster_5": 10.783,
-                            "file_cluster_6": 10.594,
-                            "file_cluster_7": 9.88,
-                            "file_cluster_8": 9.63,
-                            "file_cluster_9": 10.794,
-                            "file_cluster_10": 11.549,
-                            "file_cluster_11": 10.593,
-                            "file_cluster_12": 10.383,
-                            "file_cluster_13": 9.955,
-                            "file_cluster_14": 14.783,
-                            "file_cluster_15": 10.793,
-                            "file_cluster_16": 10.205,
-                            "file_cluster_17": 10.969
+                            "file_cluster_0": 10.54,
+                            "file_cluster_1": 10.227,
+                            "file_cluster_2": 10.586,
+                            "file_cluster_3": 11.519,
+                            "file_cluster_4": 11.06,
+                            "file_cluster_5": 10.76,
+                            "file_cluster_6": 10.571,
+                            "file_cluster_7": 9.854,
+                            "file_cluster_8": 9.603,
+                            "file_cluster_9": 10.771,
+                            "file_cluster_10": 11.527,
+                            "file_cluster_11": 10.571,
+                            "file_cluster_12": 10.359,
+                            "file_cluster_13": 9.93,
+                            "file_cluster_14": 14.766,
+                            "file_cluster_15": 10.77,
+                            "file_cluster_16": 10.18,
+                            "file_cluster_17": 10.946
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58207,7 +58217,7 @@
                         "Total LOC": 296,
                         "Coding LOC": 267,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 86.84,
+                        "Structural Magnitude": 82.04,
                         "Control Flow Ratio": "75.0%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -58239,10 +58249,10 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "checksum",
-                            "Structural Impact": 27.4,
+                            "Structural Impact": 24.6,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 198,
                             "End Line": 208
@@ -58259,20 +58269,20 @@
                         },
                         {
                             "Function Name": "message_size_max_min",
-                            "Structural Impact": 10.5,
+                            "Structural Impact": 9.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 185,
                             "End Line": 194
                         },
                         {
                             "Function Name": "is_production",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 77,
                             "End Line": 79
@@ -58599,32 +58609,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4950.88,
-                        "Y": 83.75,
-                        "Z": 3082.55
+                        "X": 4949.55,
+                        "Y": 84.14,
+                        "Z": 3080.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.917,
+                        "Repository Drift (Z-Score)": 12.89,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.235,
-                            "file_cluster_1": 13.37,
-                            "file_cluster_2": 13.496,
-                            "file_cluster_3": 14.291,
-                            "file_cluster_4": 13.52,
-                            "file_cluster_5": 13.751,
-                            "file_cluster_6": 13.513,
-                            "file_cluster_7": 13.041,
-                            "file_cluster_8": 12.917,
-                            "file_cluster_9": 13.434,
-                            "file_cluster_10": 14.156,
-                            "file_cluster_11": 13.341,
-                            "file_cluster_12": 13.73,
-                            "file_cluster_13": 12.999,
-                            "file_cluster_14": 16.754,
-                            "file_cluster_15": 13.623,
-                            "file_cluster_16": 13.386,
-                            "file_cluster_17": 13.351
+                            "file_cluster_0": 13.21,
+                            "file_cluster_1": 13.343,
+                            "file_cluster_2": 13.471,
+                            "file_cluster_3": 14.267,
+                            "file_cluster_4": 13.494,
+                            "file_cluster_5": 13.727,
+                            "file_cluster_6": 13.488,
+                            "file_cluster_7": 13.014,
+                            "file_cluster_8": 12.89,
+                            "file_cluster_9": 13.409,
+                            "file_cluster_10": 14.132,
+                            "file_cluster_11": 13.317,
+                            "file_cluster_12": 13.705,
+                            "file_cluster_13": 12.973,
+                            "file_cluster_14": 16.733,
+                            "file_cluster_15": 13.598,
+                            "file_cluster_16": 13.36,
+                            "file_cluster_17": 13.325
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58632,7 +58642,7 @@
                         "Total LOC": 203,
                         "Coding LOC": 175,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 512.5,
+                        "Structural Magnitude": 429.0,
                         "Control Flow Ratio": "68.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -58652,7 +58662,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "58.67%",
+                        "Documentation Exposure": "54.23%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -58664,20 +58674,20 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "extract_memcpy_size",
-                            "Structural Impact": 259.4,
+                            "Structural Impact": 232.2,
                             "Lines of Code (LOC)": 45,
                             "Control Flow Branches": 22,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "73.3%",
                             "Start Line": 141,
                             "End Line": 185
                         },
                         {
                             "Function Name": "main",
-                            "Structural Impact": 136.3,
+                            "Structural Impact": 80.0,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 21,
-                            "Input Parameters": 2,
+                            "Input Parameters": 0,
                             "Control Flow Ratio": "61.8%",
                             "Start Line": 47,
                             "End Line": 105
@@ -58813,32 +58823,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 5340.81,
-                        "Y": 41.64,
-                        "Z": 2690.36
+                        "X": 5340.56,
+                        "Y": 41.67,
+                        "Z": 2690.27
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.613,
+                        "Repository Drift (Z-Score)": 9.595,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.499,
-                            "file_cluster_1": 10.533,
-                            "file_cluster_2": 10.714,
-                            "file_cluster_3": 11.815,
-                            "file_cluster_4": 10.94,
-                            "file_cluster_5": 11.189,
-                            "file_cluster_6": 10.887,
-                            "file_cluster_7": 10.218,
-                            "file_cluster_8": 9.613,
-                            "file_cluster_9": 10.729,
-                            "file_cluster_10": 11.885,
-                            "file_cluster_11": 10.928,
-                            "file_cluster_12": 11.124,
-                            "file_cluster_13": 10.199,
-                            "file_cluster_14": 14.774,
-                            "file_cluster_15": 11.222,
-                            "file_cluster_16": 10.74,
-                            "file_cluster_17": 10.783
+                            "file_cluster_0": 10.484,
+                            "file_cluster_1": 10.518,
+                            "file_cluster_2": 10.699,
+                            "file_cluster_3": 11.802,
+                            "file_cluster_4": 10.925,
+                            "file_cluster_5": 11.174,
+                            "file_cluster_6": 10.873,
+                            "file_cluster_7": 10.202,
+                            "file_cluster_8": 9.595,
+                            "file_cluster_9": 10.714,
+                            "file_cluster_10": 11.871,
+                            "file_cluster_11": 10.914,
+                            "file_cluster_12": 11.11,
+                            "file_cluster_13": 10.184,
+                            "file_cluster_14": 14.763,
+                            "file_cluster_15": 11.208,
+                            "file_cluster_16": 10.725,
+                            "file_cluster_17": 10.768
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -58846,7 +58856,7 @@
                         "Total LOC": 73,
                         "Coding LOC": 61,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 99.72,
+                        "Structural Magnitude": 97.22,
                         "Control Flow Ratio": "64.0%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -58898,10 +58908,10 @@
                         },
                         {
                             "Function Name": "allocator",
-                            "Structural Impact": 8.6,
+                            "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 18,
                             "End Line": 28
@@ -58928,30 +58938,30 @@
                         },
                         {
                             "Function Name": "init",
-                            "Structural Impact": 4.2,
+                            "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 10,
                             "End Line": 12
                         },
                         {
                             "Function Name": "live_size",
-                            "Structural Impact": 4.2,
+                            "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 30,
                             "End Line": 32
                         },
                         {
                             "Function Name": "deinit",
-                            "Structural Impact": 2.1,
+                            "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 14,
                             "End Line": 16
@@ -59076,32 +59086,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 5179.93,
+                        "X": 5179.83,
                         "Y": 175.63,
-                        "Z": 2384.22
+                        "Z": 2384.27
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.258,
+                        "Repository Drift (Z-Score)": 9.253,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.396,
-                            "file_cluster_1": 9.89,
-                            "file_cluster_2": 10.358,
-                            "file_cluster_3": 11.298,
-                            "file_cluster_4": 10.969,
-                            "file_cluster_5": 10.455,
-                            "file_cluster_6": 10.587,
-                            "file_cluster_7": 9.55,
-                            "file_cluster_8": 9.258,
-                            "file_cluster_9": 10.622,
-                            "file_cluster_10": 11.326,
-                            "file_cluster_11": 10.469,
-                            "file_cluster_12": 9.782,
-                            "file_cluster_13": 9.761,
-                            "file_cluster_14": 14.732,
-                            "file_cluster_15": 10.549,
-                            "file_cluster_16": 9.461,
-                            "file_cluster_17": 10.89
+                            "file_cluster_0": 10.391,
+                            "file_cluster_1": 9.885,
+                            "file_cluster_2": 10.354,
+                            "file_cluster_3": 11.294,
+                            "file_cluster_4": 10.964,
+                            "file_cluster_5": 10.45,
+                            "file_cluster_6": 10.583,
+                            "file_cluster_7": 9.545,
+                            "file_cluster_8": 9.253,
+                            "file_cluster_9": 10.618,
+                            "file_cluster_10": 11.322,
+                            "file_cluster_11": 10.465,
+                            "file_cluster_12": 9.777,
+                            "file_cluster_13": 9.756,
+                            "file_cluster_14": 14.729,
+                            "file_cluster_15": 10.544,
+                            "file_cluster_16": 9.456,
+                            "file_cluster_17": 10.886
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -59109,7 +59119,7 @@
                         "Total LOC": 121,
                         "Coding LOC": 109,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 159.58,
+                        "Structural Magnitude": 157.98,
                         "Control Flow Ratio": "77.1%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -59129,7 +59139,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "100.0%",
+                        "Documentation Exposure": "99.99%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -59150,16 +59160,6 @@
                             "End Line": 119
                         },
                         {
-                            "Function Name": "reverse",
-                            "Structural Impact": 12.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 27,
-                            "End Line": 32
-                        },
-                        {
                             "Function Name": "lower",
                             "Structural Impact": 12.2,
                             "Lines of Code (LOC)": 3,
@@ -59178,6 +59178,16 @@
                             "Control Flow Ratio": "75.0%",
                             "Start Line": 56,
                             "End Line": 58
+                        },
+                        {
+                            "Function Name": "reverse",
+                            "Structural Impact": 10.7,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 27,
+                            "End Line": 32
                         },
                         {
                             "Function Name": "slice_peek",
@@ -59337,26 +59347,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.995,
+                        "Repository Drift (Z-Score)": 10.988,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.819,
-                            "file_cluster_1": 11.711,
-                            "file_cluster_2": 11.949,
-                            "file_cluster_3": 12.854,
-                            "file_cluster_4": 12.296,
-                            "file_cluster_5": 12.247,
-                            "file_cluster_6": 11.921,
-                            "file_cluster_7": 11.401,
-                            "file_cluster_8": 10.995,
-                            "file_cluster_9": 11.937,
-                            "file_cluster_10": 12.792,
-                            "file_cluster_11": 11.985,
-                            "file_cluster_12": 12.147,
-                            "file_cluster_13": 11.698,
-                            "file_cluster_14": 15.625,
-                            "file_cluster_15": 12.233,
-                            "file_cluster_16": 11.86,
-                            "file_cluster_17": 12.085
+                            "file_cluster_0": 11.813,
+                            "file_cluster_1": 11.705,
+                            "file_cluster_2": 11.943,
+                            "file_cluster_3": 12.849,
+                            "file_cluster_4": 12.29,
+                            "file_cluster_5": 12.241,
+                            "file_cluster_6": 11.916,
+                            "file_cluster_7": 11.394,
+                            "file_cluster_8": 10.988,
+                            "file_cluster_9": 11.931,
+                            "file_cluster_10": 12.786,
+                            "file_cluster_11": 11.98,
+                            "file_cluster_12": 12.141,
+                            "file_cluster_13": 11.692,
+                            "file_cluster_14": 15.62,
+                            "file_cluster_15": 12.227,
+                            "file_cluster_16": 11.854,
+                            "file_cluster_17": 12.079
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -59364,7 +59374,7 @@
                         "Total LOC": 5049,
                         "Coding LOC": 4485,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 6657.5,
+                        "Structural Magnitude": 6542.4,
                         "Control Flow Ratio": "71.3%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -59384,7 +59394,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "67.33%",
+                        "Documentation Exposure": "67.11%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -59406,10 +59416,10 @@
                         },
                         {
                             "Function Name": "StateMachineType",
-                            "Structural Impact": 991.4,
+                            "Structural Impact": 893.0,
                             "Lines of Code (LOC)": 1201,
                             "Control Flow Branches": 118,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "71.5%",
                             "Start Line": 221,
                             "End Line": 1421
@@ -59585,36 +59595,6 @@
                             "End Line": 2895
                         },
                         {
-                            "Function Name": "forest_options",
-                            "Structural Impact": 32.0,
-                            "Lines of Code (LOC)": 120,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 4508,
-                            "End Line": 4627
-                        },
-                        {
-                            "Function Name": "Type",
-                            "Structural Impact": 31.6,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 3522,
-                            "End Line": 3527
-                        },
-                        {
-                            "Function Name": "Type",
-                            "Structural Impact": 31.6,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 3624,
-                            "End Line": 3629
-                        },
-                        {
                             "Function Name": "execute_get_change_events",
                             "Structural Impact": 30.8,
                             "Lines of Code (LOC)": 28,
@@ -59623,6 +59603,26 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 3311,
                             "End Line": 3338
+                        },
+                        {
+                            "Function Name": "Type",
+                            "Structural Impact": 28.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 3522,
+                            "End Line": 3527
+                        },
+                        {
+                            "Function Name": "Type",
+                            "Structural Impact": 28.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 3624,
+                            "End Line": 3629
                         },
                         {
                             "Function Name": "execute_lookup_accounts",
@@ -59645,11 +59645,21 @@
                             "End Line": 3208
                         },
                         {
+                            "Function Name": "forest_options",
+                            "Structural Impact": 27.7,
+                            "Lines of Code (LOC)": 120,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 4508,
+                            "End Line": 4627
+                        },
+                        {
                             "Function Name": "sum_overflows_test",
-                            "Structural Impact": 18.4,
+                            "Structural Impact": 16.6,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 5033,
                             "End Line": 5043
@@ -59725,16 +59735,6 @@
                             "End Line": 3309
                         },
                         {
-                            "Function Name": "prefetch_get_account_balances",
-                            "Structural Impact": 11.2,
-                            "Lines of Code (LOC)": 23,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1492,
-                            "End Line": 1514
-                        },
-                        {
                             "Function Name": "prefetch_get_account_transfers_scan_call",
                             "Structural Impact": 11.0,
                             "Lines of Code (LOC)": 20,
@@ -59743,6 +59743,16 @@
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1471,
                             "End Line": 1490
+                        },
+                        {
+                            "Function Name": "prefetch_get_account_balances",
+                            "Structural Impact": 9.8,
+                            "Lines of Code (LOC)": 23,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1492,
+                            "End Line": 1514
                         },
                         {
                             "Function Name": "compact",
@@ -59795,16 +59805,6 @@
                             "End Line": 2861
                         },
                         {
-                            "Function Name": "tree_values_count",
-                            "Structural Impact": 7.0,
-                            "Lines of Code (LOC)": 43,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 4640,
-                            "End Line": 4682
-                        },
-                        {
                             "Function Name": "account_event",
                             "Structural Impact": 5.8,
                             "Lines of Code (LOC)": 16,
@@ -59813,6 +59813,16 @@
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 4264,
                             "End Line": 4279
+                        },
+                        {
+                            "Function Name": "tree_values_count",
+                            "Structural Impact": 5.8,
+                            "Lines of Code (LOC)": 43,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 4640,
+                            "End Line": 4682
                         },
                         {
                             "Function Name": "prefetch_get_account_balances_lookup_acc",
@@ -59826,30 +59836,30 @@
                         },
                         {
                             "Function Name": "checkpoint_finish",
-                            "Structural Impact": 4.6,
+                            "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2863,
                             "End Line": 2874
                         },
                         {
                             "Function Name": "compact_finish",
-                            "Structural Impact": 4.5,
+                            "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2842,
                             "End Line": 2851
                         },
                         {
                             "Function Name": "schema",
-                            "Structural Impact": 3.6,
+                            "Structural Impact": 3.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 185,
                             "End Line": 188
@@ -122955,9 +122965,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3177.74,
+                        "X": -3177.69,
                         "Y": -98.39,
-                        "Z": -2619.95
+                        "Z": -2619.89
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -123233,9 +123243,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2816.91,
+                        "X": -2816.86,
                         "Y": -173.53,
-                        "Z": -3614.27
+                        "Z": -3614.21
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -123845,9 +123855,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2846.77,
+                        "X": -2846.72,
                         "Y": -49.48,
-                        "Z": -3122.48
+                        "Z": -3122.43
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -124521,9 +124531,9 @@
                         "Identity Proof": "Single Indicator (Ext: .js)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2560.44,
+                        "X": -2560.39,
                         "Y": 41.58,
-                        "Z": -2778.58
+                        "Z": -2778.52
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -124723,9 +124733,9 @@
                         "Identity Proof": "Single Indicator (Ext: .ts)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3349.81,
+                        "X": -3349.75,
                         "Y": -245.6,
-                        "Z": -3185.65
+                        "Z": -3185.59
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -136587,7 +136597,7 @@
             }
         },
         "zig/bun": {
-            "Directory Group Magnitude": 9697.12,
+            "Directory Group Magnitude": 9527.92,
             "File Count": 4,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_8": "100.0%"
@@ -136604,7 +136614,7 @@
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "78.84%",
+                "Documentation Exposure": "78.83%",
                 "Civil War Exposure": "100.0%",
                 "Algorithmic DoS Exposure": "100.0%",
                 "Obfuscation & Evasion Surface": "0.0%",
@@ -136626,32 +136636,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3427.11,
-                        "Y": 208.68,
-                        "Z": 2335.84
+                        "X": -3428.06,
+                        "Y": 208.42,
+                        "Z": 2334.23
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.439,
+                        "Repository Drift (Z-Score)": 10.405,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.189,
-                            "file_cluster_1": 10.945,
-                            "file_cluster_2": 11.251,
-                            "file_cluster_3": 12.198,
-                            "file_cluster_4": 11.622,
-                            "file_cluster_5": 11.417,
-                            "file_cluster_6": 11.414,
-                            "file_cluster_7": 10.566,
-                            "file_cluster_8": 10.439,
-                            "file_cluster_9": 11.406,
-                            "file_cluster_10": 12.188,
-                            "file_cluster_11": 11.419,
-                            "file_cluster_12": 11.531,
-                            "file_cluster_13": 10.845,
-                            "file_cluster_14": 15.275,
-                            "file_cluster_15": 11.448,
-                            "file_cluster_16": 10.793,
-                            "file_cluster_17": 11.549
+                            "file_cluster_0": 11.16,
+                            "file_cluster_1": 10.913,
+                            "file_cluster_2": 11.221,
+                            "file_cluster_3": 12.17,
+                            "file_cluster_4": 11.592,
+                            "file_cluster_5": 11.388,
+                            "file_cluster_6": 11.385,
+                            "file_cluster_7": 10.534,
+                            "file_cluster_8": 10.405,
+                            "file_cluster_9": 11.377,
+                            "file_cluster_10": 12.16,
+                            "file_cluster_11": 11.39,
+                            "file_cluster_12": 11.501,
+                            "file_cluster_13": 10.815,
+                            "file_cluster_14": 15.252,
+                            "file_cluster_15": 11.419,
+                            "file_cluster_16": 10.761,
+                            "file_cluster_17": 11.519
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -136659,7 +136669,7 @@
                         "Total LOC": 273,
                         "Coding LOC": 227,
                         "Documentation LOC": 2,
-                        "Structural Magnitude": 619.14,
+                        "Structural Magnitude": 542.54,
                         "Control Flow Ratio": "66.7%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -136691,20 +136701,20 @@
                     "5. Function Analysis": [
                         {
                             "Function Name": "allocator",
-                            "Structural Impact": 572.4,
+                            "Structural Impact": 497.4,
                             "Lines of Code (LOC)": 248,
                             "Control Flow Branches": 55,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "67.1%",
                             "Start Line": 25,
                             "End Line": 272
                         },
                         {
                             "Function Name": "allocator",
-                            "Structural Impact": 12.2,
+                            "Structural Impact": 10.6,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 11,
                             "End Line": 14
@@ -136830,32 +136840,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4093.58,
-                        "Y": 208.83,
-                        "Z": 2230.67
+                        "X": -4093.1,
+                        "Y": 208.79,
+                        "Z": 2230.32
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.121,
+                        "Repository Drift (Z-Score)": 13.113,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.191,
-                            "file_cluster_1": 13.8,
-                            "file_cluster_2": 13.761,
-                            "file_cluster_3": 14.451,
-                            "file_cluster_4": 13.528,
-                            "file_cluster_5": 14.179,
-                            "file_cluster_6": 13.393,
-                            "file_cluster_7": 13.421,
-                            "file_cluster_8": 13.121,
-                            "file_cluster_9": 13.299,
-                            "file_cluster_10": 14.4,
-                            "file_cluster_11": 13.273,
-                            "file_cluster_12": 13.852,
-                            "file_cluster_13": 13.245,
-                            "file_cluster_14": 16.695,
-                            "file_cluster_15": 13.852,
-                            "file_cluster_16": 13.645,
-                            "file_cluster_17": 13.308
+                            "file_cluster_0": 13.183,
+                            "file_cluster_1": 13.792,
+                            "file_cluster_2": 13.754,
+                            "file_cluster_3": 14.444,
+                            "file_cluster_4": 13.52,
+                            "file_cluster_5": 14.171,
+                            "file_cluster_6": 13.386,
+                            "file_cluster_7": 13.413,
+                            "file_cluster_8": 13.113,
+                            "file_cluster_9": 13.292,
+                            "file_cluster_10": 14.393,
+                            "file_cluster_11": 13.265,
+                            "file_cluster_12": 13.844,
+                            "file_cluster_13": 13.237,
+                            "file_cluster_14": 16.689,
+                            "file_cluster_15": 13.845,
+                            "file_cluster_16": 13.637,
+                            "file_cluster_17": 13.3
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -136863,7 +136873,7 @@
                         "Total LOC": 1628,
                         "Coding LOC": 1436,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 3009.72,
+                        "Structural Magnitude": 2985.02,
                         "Control Flow Ratio": "72.2%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -136883,7 +136893,7 @@
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "78.75%",
+                        "Documentation Exposure": "78.7%",
                         "Indentation Consistency": "Spaces",
                         "Algorithmic DoS Exposure": "100.0%",
                         "Obfuscation & Evasion Surface": "0.0%",
@@ -136925,10 +136935,10 @@
                         },
                         {
                             "Function Name": "parse",
-                            "Structural Impact": 144.8,
+                            "Structural Impact": 125.6,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 17,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "77.3%",
                             "Start Line": 247,
                             "End Line": 263
@@ -136994,16 +137004,6 @@
                             "End Line": 1366
                         },
                         {
-                            "Function Name": "MacroContextType",
-                            "Structural Impact": 10.7,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 1565,
-                            "End Line": 1571
-                        },
-                        {
                             "Function Name": "init",
                             "Structural Impact": 9.1,
                             "Lines of Code (LOC)": 8,
@@ -137015,13 +137015,23 @@
                         },
                         {
                             "Function Name": "runtimeMergeAdjacentExpressionStatements",
-                            "Structural Impact": 8.2,
+                            "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 81,
                             "End Line": 83
+                        },
+                        {
+                            "Function Name": "MacroContextType",
+                            "Structural Impact": 6.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 1565,
+                            "End Line": 1571
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
@@ -137147,32 +137157,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3767.57,
-                        "Y": 50.71,
-                        "Z": 1475.66
+                        "X": -3767.39,
+                        "Y": 50.76,
+                        "Z": 1475.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 11.482,
+                        "Repository Drift (Z-Score)": 11.47,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.958,
-                            "file_cluster_1": 12.153,
-                            "file_cluster_2": 12.261,
-                            "file_cluster_3": 13.044,
-                            "file_cluster_4": 12.385,
-                            "file_cluster_5": 12.598,
-                            "file_cluster_6": 12.17,
-                            "file_cluster_7": 11.786,
-                            "file_cluster_8": 11.482,
-                            "file_cluster_9": 12.193,
-                            "file_cluster_10": 12.847,
-                            "file_cluster_11": 11.84,
-                            "file_cluster_12": 11.926,
-                            "file_cluster_13": 11.829,
-                            "file_cluster_14": 15.787,
-                            "file_cluster_15": 12.345,
-                            "file_cluster_16": 11.576,
-                            "file_cluster_17": 12.237
+                            "file_cluster_0": 11.947,
+                            "file_cluster_1": 12.141,
+                            "file_cluster_2": 12.25,
+                            "file_cluster_3": 13.034,
+                            "file_cluster_4": 12.374,
+                            "file_cluster_5": 12.588,
+                            "file_cluster_6": 12.159,
+                            "file_cluster_7": 11.774,
+                            "file_cluster_8": 11.47,
+                            "file_cluster_9": 12.182,
+                            "file_cluster_10": 12.836,
+                            "file_cluster_11": 11.83,
+                            "file_cluster_12": 11.915,
+                            "file_cluster_13": 11.818,
+                            "file_cluster_14": 15.778,
+                            "file_cluster_15": 12.334,
+                            "file_cluster_16": 11.564,
+                            "file_cluster_17": 12.226
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -137180,7 +137190,7 @@
                         "Total LOC": 560,
                         "Coding LOC": 484,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 918.08,
+                        "Structural Magnitude": 914.28,
                         "Control Flow Ratio": "69.3%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -137222,20 +137232,20 @@
                         },
                         {
                             "Function Name": "testMap",
-                            "Structural Impact": 18.4,
+                            "Structural Impact": 16.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 377,
                             "End Line": 386
                         },
                         {
                             "Function Name": "testSet",
-                            "Structural Impact": 18.4,
+                            "Structural Impact": 16.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 7,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 416,
                             "End Line": 425
@@ -137381,32 +137391,32 @@
                         "Identity Proof": "Single Indicator (Ext: .zig)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3752.91,
+                        "X": -3752.7,
                         "Y": 177.39,
-                        "Z": 1724.82
+                        "Z": 1724.71
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 12.66,
+                        "Repository Drift (Z-Score)": 12.87,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.992,
-                            "file_cluster_1": 13.286,
-                            "file_cluster_2": 13.412,
-                            "file_cluster_3": 14.137,
-                            "file_cluster_4": 13.296,
-                            "file_cluster_5": 13.696,
-                            "file_cluster_6": 13.195,
-                            "file_cluster_7": 12.919,
-                            "file_cluster_8": 12.66,
-                            "file_cluster_9": 13.201,
-                            "file_cluster_10": 14.028,
-                            "file_cluster_11": 13.163,
-                            "file_cluster_12": 13.5,
-                            "file_cluster_13": 13.016,
-                            "file_cluster_14": 16.694,
-                            "file_cluster_15": 13.526,
-                            "file_cluster_16": 13.288,
-                            "file_cluster_17": 13.31
+                            "file_cluster_0": 13.195,
+                            "file_cluster_1": 13.486,
+                            "file_cluster_2": 13.609,
+                            "file_cluster_3": 14.325,
+                            "file_cluster_4": 13.49,
+                            "file_cluster_5": 13.89,
+                            "file_cluster_6": 13.397,
+                            "file_cluster_7": 13.124,
+                            "file_cluster_8": 12.87,
+                            "file_cluster_9": 13.402,
+                            "file_cluster_10": 14.218,
+                            "file_cluster_11": 13.355,
+                            "file_cluster_12": 13.697,
+                            "file_cluster_13": 13.217,
+                            "file_cluster_14": 16.853,
+                            "file_cluster_15": 13.722,
+                            "file_cluster_16": 13.487,
+                            "file_cluster_17": 13.504
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -137414,7 +137424,7 @@
                         "Total LOC": 2556,
                         "Coding LOC": 2339,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 5150.18,
+                        "Structural Magnitude": 5086.08,
                         "Control Flow Ratio": "67.1%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -137695,16 +137705,6 @@
                             "End Line": 1305
                         },
                         {
-                            "Function Name": "onDispatch",
-                            "Structural Impact": 46.4,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 1507,
-                            "End Line": 1533
-                        },
-                        {
                             "Function Name": "napi_get_uv_event_loop",
                             "Structural Impact": 42.5,
                             "Lines of Code (LOC)": 19,
@@ -137725,14 +137725,14 @@
                             "End Line": 326
                         },
                         {
-                            "Function Name": "deinit",
-                            "Structural Impact": 40.4,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1421,
-                            "End Line": 1427
+                            "Function Name": "onDispatch",
+                            "Structural Impact": 40.3,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 1507,
+                            "End Line": 1533
                         },
                         {
                             "Function Name": "napi_delete_async_work",
@@ -137865,6 +137865,16 @@
                             "End Line": 1012
                         },
                         {
+                            "Function Name": "deinit",
+                            "Structural Impact": 35.0,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1421,
+                            "End Line": 1427
+                        },
+                        {
                             "Function Name": "napi_get_undefined",
                             "Structural Impact": 31.8,
                             "Lines of Code (LOC)": 12,
@@ -137925,16 +137935,6 @@
                             "End Line": 1316
                         },
                         {
-                            "Function Name": "deinit",
-                            "Structural Impact": 30.9,
-                            "Lines of Code (LOC)": 19,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 1672,
-                            "End Line": 1690
-                        },
-                        {
                             "Function Name": "napi_async_init",
                             "Structural Impact": 27.2,
                             "Lines of Code (LOC)": 8,
@@ -137943,6 +137943,16 @@
                             "Control Flow Ratio": "60.0%",
                             "Start Line": 655,
                             "End Line": 662
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 26.9,
+                            "Lines of Code (LOC)": 19,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 1672,
+                            "End Line": 1690
                         },
                         {
                             "Function Name": "napi_close_handle_scope",
@@ -138016,53 +138026,23 @@
                         },
                         {
                             "Function Name": "schedule",
-                            "Structural Impact": 20.9,
+                            "Structural Impact": 18.2,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 4,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "80.0%",
                             "Start Line": 2511,
                             "End Line": 2528
                         },
                         {
                             "Function Name": "maybeQueueFinalizer",
-                            "Structural Impact": 18.8,
+                            "Structural Impact": 16.4,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 1539,
                             "End Line": 1554
-                        },
-                        {
-                            "Function Name": "fromJSType",
-                            "Structural Impact": 16.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 180,
-                            "End Line": 195
-                        },
-                        {
-                            "Function Name": "getAndClearPendingException",
-                            "Structural Impact": 16.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 49,
-                            "End Line": 56
-                        },
-                        {
-                            "Function Name": "acquire",
-                            "Structural Impact": 16.4,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1700,
-                            "End Line": 1708
                         },
                         {
                             "Function Name": "napiSpan",
@@ -138075,21 +138055,41 @@
                             "End Line": 1178
                         },
                         {
-                            "Function Name": "scheduleDispatch",
-                            "Structural Impact": 15.7,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1658,
-                            "End Line": 1670
+                            "Function Name": "fromJSType",
+                            "Structural Impact": 14.7,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 180,
+                            "End Line": 195
+                        },
+                        {
+                            "Function Name": "getAndClearPendingException",
+                            "Structural Impact": 14.3,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 49,
+                            "End Line": 56
+                        },
+                        {
+                            "Function Name": "acquire",
+                            "Structural Impact": 14.3,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1700,
+                            "End Line": 1708
                         },
                         {
                             "Function Name": "notImplementedYet",
-                            "Structural Impact": 15.3,
+                            "Structural Impact": 14.1,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 5,
+                            "Input Parameters": 4,
                             "Control Flow Ratio": "100.0%",
                             "Start Line": 712,
                             "End Line": 724
@@ -138105,51 +138105,51 @@
                             "End Line": 1493
                         },
                         {
-                            "Function Name": "fixDeadCodeElimination",
-                            "Structural Impact": 14.0,
-                            "Lines of Code (LOC)": 21,
-                            "Control Flow Branches": 4,
+                            "Function Name": "scheduleDispatch",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 2,
                             "Input Parameters": 2,
                             "Control Flow Ratio": "100.0%",
-                            "Start Line": 2476,
-                            "End Line": 2496
+                            "Start Line": 1658,
+                            "End Line": 1670
                         },
                         {
                             "Function Name": "toJSType",
-                            "Structural Impact": 12.8,
+                            "Structural Impact": 11.1,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 197,
                             "End Line": 211
                         },
                         {
                             "Function Name": "invalidArg",
-                            "Structural Impact": 12.3,
+                            "Structural Impact": 10.7,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 25,
                             "End Line": 30
                         },
                         {
                             "Function Name": "genericFailure",
-                            "Structural Impact": 12.3,
+                            "Structural Impact": 10.7,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 2,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "66.7%",
                             "Start Line": 32,
                             "End Line": 37
                         },
                         {
                             "Function Name": "toC",
-                            "Structural Impact": 12.2,
+                            "Structural Impact": 10.5,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 213,
                             "End Line": 215
@@ -138165,34 +138165,24 @@
                             "End Line": 772
                         },
                         {
+                            "Function Name": "fixDeadCodeElimination",
+                            "Structural Impact": 8.6,
+                            "Lines of Code (LOC)": 21,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 2476,
+                            "End Line": 2496
+                        },
+                        {
                             "Function Name": "isBlocked",
-                            "Structural Impact": 9.1,
+                            "Structural Impact": 8.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1499,
                             "End Line": 1501
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 2503,
-                            "End Line": 2509
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1495,
-                            "End Line": 1497
                         },
                         {
                             "Function Name": "napi_call_threadsafe_function",
@@ -138205,24 +138195,14 @@
                             "End Line": 1799
                         },
                         {
-                            "Function Name": "napi_acquire_threadsafe_function",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 4,
+                            "Function Name": "init",
+                            "Structural Impact": 7.3,
+                            "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 1800,
-                            "End Line": 1803
-                        },
-                        {
-                            "Function Name": "uv_os_getppid",
-                            "Structural Impact": 7.7,
-                            "Lines of Code (LOC)": 85,
-                            "Control Flow Branches": 2,
                             "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1915,
-                            "End Line": 1999
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 2503,
+                            "End Line": 2509
                         },
                         {
                             "Function Name": "napi_get_threadsafe_function_context",
@@ -138245,6 +138225,26 @@
                             "End Line": 776
                         },
                         {
+                            "Function Name": "deinit",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1495,
+                            "End Line": 1497
+                        },
+                        {
+                            "Function Name": "napi_acquire_threadsafe_function",
+                            "Structural Impact": 7.1,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 1800,
+                            "End Line": 1803
+                        },
+                        {
                             "Function Name": "napi_release_threadsafe_function",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 4,
@@ -138256,73 +138256,23 @@
                         },
                         {
                             "Function Name": "get",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 143,
                             "End Line": 145
                         },
                         {
                             "Function Name": "isClosing",
-                            "Structural Impact": 6.9,
+                            "Structural Impact": 6.2,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 4,
+                            "Input Parameters": 3,
                             "Control Flow Ratio": "50.0%",
                             "Start Line": 1535,
                             "End Line": 1537
-                        },
-                        {
-                            "Function Name": "toJS",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 7,
-                            "End Line": 9
-                        },
-                        {
-                            "Function Name": "ok",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 20,
-                            "End Line": 22
-                        },
-                        {
-                            "Function Name": "getVersion",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 45,
-                            "End Line": 47
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2530,
-                            "End Line": 2533
-                        },
-                        {
-                            "Function Name": "NapiEnv__ref",
-                            "Structural Impact": 5.5,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 62,
-                            "End Line": 67
                         },
                         {
                             "Function Name": "create",
@@ -138335,14 +138285,24 @@
                             "End Line": 150
                         },
                         {
-                            "Function Name": "napi_internal_suppress_crash_on_abort_if",
+                            "Function Name": "deinit",
                             "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 5,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2530,
+                            "End Line": 2533
+                        },
+                        {
+                            "Function Name": "toJS",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
                             "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 1356,
-                            "End Line": 1360
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 7,
+                            "End Line": 9
                         },
                         {
                             "Function Name": "setLastError",
@@ -138355,6 +138315,26 @@
                             "End Line": 17
                         },
                         {
+                            "Function Name": "ok",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 20,
+                            "End Line": 22
+                        },
+                        {
+                            "Function Name": "getVersion",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 45,
+                            "End Line": 47
+                        },
+                        {
                             "Function Name": "open",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
@@ -138365,24 +138345,34 @@
                             "End Line": 99
                         },
                         {
+                            "Function Name": "NapiEnv__ref",
+                            "Structural Impact": 4.5,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 1,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 62,
+                            "End Line": 67
+                        },
+                        {
+                            "Function Name": "uv_os_getppid",
+                            "Structural Impact": 4.5,
+                            "Lines of Code (LOC)": 85,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 1915,
+                            "End Line": 1999
+                        },
+                        {
                             "Function Name": "napi_internal_register_cleanup_zig",
-                            "Structural Impact": 4.4,
+                            "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 1347,
                             "End Line": 1354
-                        },
-                        {
-                            "Function Name": "envIsNull",
-                            "Structural Impact": 3.8,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 72,
-                            "End Line": 77
                         },
                         {
                             "Function Name": "set",
@@ -138395,74 +138385,44 @@
                             "End Line": 141
                         },
                         {
-                            "Function Name": "uv_wtf8_to_utf16",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 2,
+                            "Function Name": "napi_internal_suppress_crash_on_abort_if",
+                            "Structural Impact": 3.2,
+                            "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
-                            "Input Parameters": 2,
+                            "Input Parameters": 0,
                             "Control Flow Ratio": "100.0%",
-                            "Start Line": 2473,
-                            "End Line": 2474
+                            "Start Line": 1356,
+                            "End Line": 1360
                         },
                         {
                             "Function Name": "runOnJSThread",
-                            "Structural Impact": 3.2,
+                            "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2535,
                             "End Line": 2538
                         },
                         {
                             "Function Name": "runAsCleanupHook",
-                            "Structural Impact": 3.2,
+                            "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
-                            "Input Parameters": 3,
+                            "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 2540,
                             "End Line": 2543
                         },
                         {
                             "Function Name": "checkGC",
-                            "Structural Impact": 3.1,
+                            "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 40,
-                            "End Line": 42
-                        },
-                        {
-                            "Function Name": "ref",
-                            "Structural Impact": 3.1,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1692,
-                            "End Line": 1694
-                        },
-                        {
-                            "Function Name": "unref",
-                            "Structural Impact": 3.1,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1696,
-                            "End Line": 1698
-                        },
-                        {
-                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
-                            "Structural Impact": 2.8,
-                            "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
                             "Input Parameters": 2,
                             "Control Flow Ratio": "0.0%",
-                            "Start Line": 2004,
-                            "End Line": 2008
+                            "Start Line": 40,
+                            "End Line": 42
                         },
                         {
                             "Function Name": "close",
@@ -138485,6 +138445,46 @@
                             "End Line": 112
                         },
                         {
+                            "Function Name": "ref",
+                            "Structural Impact": 2.7,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1692,
+                            "End Line": 1694
+                        },
+                        {
+                            "Function Name": "unref",
+                            "Structural Impact": 2.7,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1696,
+                            "End Line": 1698
+                        },
+                        {
+                            "Function Name": "envIsNull",
+                            "Structural Impact": 2.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 72,
+                            "End Line": 77
+                        },
+                        {
+                            "Function Name": "uv_wtf8_to_utf16",
+                            "Structural Impact": 2.1,
+                            "Lines of Code (LOC)": 2,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 2473,
+                            "End Line": 2474
+                        },
+                        {
                             "Function Name": "escape",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
@@ -138493,14 +138493,24 @@
                             "Control Flow Ratio": "0.0%",
                             "Start Line": 117,
                             "End Line": 117
+                        },
+                        {
+                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
+                            "Structural Impact": 1.8,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2004,
+                            "End Line": 2008
                         }
                     ],
                     "6. Contextual Mitigations & Amplifications": "None Detected",
                     "7. Structural Signatures (Net Mitigated Signals)": {
                         "Control Flow Branches": 513,
                         "Sequential Logic Declarations": 251,
-                        "Function Parameters": 613,
-                        "Function/Method Declarations": 289,
+                        "Function Parameters": 689,
+                        "Function/Method Declarations": 681,
                         "Class/Entity Declarations": 24,
                         "Defensive Programming Constructs": 150,
                         "Type/Safety Bypasses": 21,
@@ -138650,9 +138660,9 @@
                         "Identity Proof": "Metadata Anchor (PATENTS)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3770.89,
+                        "X": -2149.1,
                         "Y": 68.25,
-                        "Z": -3442.13
+                        "Z": -3116.48
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -138811,9 +138821,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4524.79,
+                        "X": -1395.2,
                         "Y": 140.2,
-                        "Z": -3133.95
+                        "Z": -2808.3
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -139068,9 +139078,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3540.23,
+                        "X": -2379.76,
                         "Y": 144.34,
-                        "Z": -2884.17
+                        "Z": -2558.52
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -139471,9 +139481,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3877.94,
+                        "X": -2042.04,
                         "Y": 331.25,
-                        "Z": -2255.55
+                        "Z": -1929.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -139684,9 +139694,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4076.1,
+                        "X": -1843.89,
                         "Y": 203.93,
-                        "Z": -2773.74
+                        "Z": -2448.09
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -140463,9 +140473,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3695.18,
+                        "X": -2224.81,
                         "Y": 262.64,
-                        "Z": -2409.02
+                        "Z": -2083.37
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_15",
@@ -140723,9 +140733,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4348.53,
+                        "X": -1571.45,
                         "Y": 314.15,
-                        "Z": -2343.65
+                        "Z": -2018.01
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -141190,9 +141200,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4116.62,
+                        "X": -1803.36,
                         "Y": 49.43,
-                        "Z": -3395.22
+                        "Z": -3069.57
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_12",
@@ -141454,9 +141464,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2131.68,
+                        "X": -3772.81,
                         "Y": -109.38,
-                        "Z": -3158.54
+                        "Z": 2237.01
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -141615,9 +141625,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2009.45,
+                        "X": -3650.58,
                         "Y": -296.01,
-                        "Z": -2032.35
+                        "Z": 3363.2
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -141795,9 +141805,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2202.29,
+                        "X": -3843.42,
                         "Y": -230.75,
-                        "Z": -2026.91
+                        "Z": 3368.64
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -142092,9 +142102,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1829.62,
+                        "X": -3470.74,
                         "Y": -110.49,
-                        "Z": -3003.54
+                        "Z": 2392.01
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -142412,9 +142422,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1905.98,
+                        "X": -3547.11,
                         "Y": -224.26,
-                        "Z": -2602.97
+                        "Z": 2792.58
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -143371,9 +143381,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2415.23,
+                        "X": -4056.36,
                         "Y": -107.63,
-                        "Z": -2607.91
+                        "Z": 2787.64
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -143735,9 +143745,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1575.16,
+                        "X": -3216.29,
                         "Y": -352.34,
-                        "Z": -2243.12
+                        "Z": 3152.43
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -143941,9 +143951,9 @@
                         "Identity Proof": "Single Indicator (Ext: .php)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1447.25,
+                        "X": -3088.38,
                         "Y": -225.58,
-                        "Z": -2627.9
+                        "Z": 2767.65
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -156898,3093 +156908,6 @@
                 }
             }
         },
-        "zig/zls/mach": {
-            "Directory Group Magnitude": 7692.4,
-            "File Count": 8,
-            "Ecosystem Fingerprint (Archetypes)": {
-                "file_cluster_8": "50.0%",
-                "file_cluster_13": "12.5%",
-                "file_cluster_0": "12.5%",
-                "file_cluster_16": "12.5%",
-                "file_cluster_2": "12.5%"
-            },
-            "Average Risk Exposures": {
-                "Cognitive Load Exposure": "15.45%",
-                "Error & Exception Exposure": "21.87%",
-                "Tech Debt Exposure": "52.89%",
-                "Testing Exposure": "70.15%",
-                "API Exposure": "6.39%",
-                "Concurrency Exposure": "2.3%",
-                "State Flux Exposure": "16.63%",
-                "Commented Logic Exposure": "3.69%",
-                "Specification Exposure": "94.17%",
-                "Instability Exposure": "50.0%",
-                "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "77.03%",
-                "Civil War Exposure": "100.0%",
-                "Algorithmic DoS Exposure": "82.01%",
-                "Obfuscation & Evasion Surface": "0.0%",
-                "Exploit Generation Surface": "17.39%",
-                "Weaponizable Injection Vectors": "0.0%",
-                "Raw Memory Manipulation": "1.25%",
-                "Hardcoded Payload Artifacts": "0.0%"
-            },
-            "Files": {
-                "zig/zls/mach/Core.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "Core.zig",
-                        "Path": "zig/zls/mach/Core.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Alert": "TYPOSQUATTING THREAT: 'build-options' mimics 'build_options'",
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -4030.82,
-                        "Y": 207.01,
-                        "Z": 2870.48
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 10.862,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 11.372,
-                            "file_cluster_1": 11.507,
-                            "file_cluster_2": 11.067,
-                            "file_cluster_3": 12.54,
-                            "file_cluster_4": 11.81,
-                            "file_cluster_5": 11.955,
-                            "file_cluster_6": 11.372,
-                            "file_cluster_7": 11.147,
-                            "file_cluster_8": 10.929,
-                            "file_cluster_9": 11.577,
-                            "file_cluster_10": 12.293,
-                            "file_cluster_11": 11.39,
-                            "file_cluster_12": 11.789,
-                            "file_cluster_13": 10.862,
-                            "file_cluster_14": 15.143,
-                            "file_cluster_15": 11.827,
-                            "file_cluster_16": 11.565,
-                            "file_cluster_17": 11.402
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 798,
-                        "Coding LOC": 683,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 432.56,
-                        "Control Flow Ratio": "69.8%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.28
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "6.61%",
-                        "Error & Exception Exposure": "9.74%",
-                        "Tech Debt Exposure": "76.47%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "6.95%",
-                        "Concurrency Exposure": "18.44%",
-                        "State Flux Exposure": "12.1%",
-                        "Commented Logic Exposure": "5.87%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "72.34%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "98.92%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "detectBackendType",
-                            "Structural Impact": 97.2,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 23,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "65.7%",
-                            "Start Line": 398,
-                            "End Line": 421
-                        },
-                        {
-                            "Function Name": "initWindow",
-                            "Structural Impact": 51.9,
-                            "Lines of Code (LOC)": 69,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "76.5%",
-                            "Start Line": 147,
-                            "End Line": 215
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 37.2,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 122,
-                            "End Line": 145
-                        },
-                        {
-                            "Function Name": "main",
-                            "Structural Impact": 21.5,
-                            "Lines of Code (LOC)": 15,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 254,
-                            "End Line": 268
-                        },
-                        {
-                            "Function Name": "pushEvent",
-                            "Structural Impact": 18.4,
-                            "Lines of Code (LOC)": 22,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "80.0%",
-                            "Start Line": 313,
-                            "End Line": 334
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 12.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 287,
-                            "End Line": 302
-                        },
-                        {
-                            "Function Name": "presentFrame",
-                            "Structural Impact": 11.6,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "40.0%",
-                            "Start Line": 228,
-                            "End Line": 252
-                        },
-                        {
-                            "Function Name": "tick",
-                            "Structural Impact": 10.9,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 217,
-                            "End Line": 226
-                        },
-                        {
-                            "Function Name": "printUnhandledErrorCallback",
-                            "Structural Impact": 9.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 387,
-                            "End Line": 396
-                        },
-                        {
-                            "Function Name": "outOfMemory",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 339,
-                            "End Line": 343
-                        },
-                        {
-                            "Function Name": "platform_update_callback",
-                            "Structural Impact": 7.5,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 270,
-                            "End Line": 281
-                        },
-                        {
-                            "Function Name": "isKeyPressed",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 444,
-                            "End Line": 446
-                        },
-                        {
-                            "Function Name": "isKeyReleased",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 448,
-                            "End Line": 450
-                        },
-                        {
-                            "Function Name": "isMouseButtonPressed",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 452,
-                            "End Line": 454
-                        },
-                        {
-                            "Function Name": "isMouseButtonReleased",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 456,
-                            "End Line": 458
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 733,
-                            "End Line": 735
-                        },
-                        {
-                            "Function Name": "requestAdapterCallback",
-                            "Structural Impact": 4.3,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 365,
-                            "End Line": 376
-                        },
-                        {
-                            "Function Name": "nextEvent",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 306,
-                            "End Line": 308
-                        },
-                        {
-                            "Function Name": "mousePosition",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 361,
-                            "End Line": 363
-                        },
-                        {
-                            "Function Name": "keyPressed",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 345,
-                            "End Line": 347
-                        },
-                        {
-                            "Function Name": "keyReleased",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 349,
-                            "End Line": 351
-                        },
-                        {
-                            "Function Name": "mousePressed",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 353,
-                            "End Line": 355
-                        },
-                        {
-                            "Function Name": "mouseReleased",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 357,
-                            "End Line": 359
-                        },
-                        {
-                            "Function Name": "assertHasDecl",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 775,
-                            "End Line": 777
-                        },
-                        {
-                            "Function Name": "assertHasField",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 779,
-                            "End Line": 781
-                        },
-                        {
-                            "Function Name": "deviceLostCallback",
-                            "Structural Impact": 2.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 380,
-                            "End Line": 385
-                        },
-                        {
-                            "Function Name": "exit",
-                            "Structural Impact": 2.1,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 283,
-                            "End Line": 285
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 90,
-                        "Sequential Logic Declarations": 39,
-                        "Function Parameters": 27,
-                        "Function/Method Declarations": 27,
-                        "Class/Entity Declarations": 17,
-                        "Defensive Programming Constructs": 23,
-                        "Type/Safety Bypasses": 12,
-                        "High-Risk Execution Commands": 7,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 42,
-                        "State Mutations / Variable Reassignments": 24,
-                        "Commented-out Code (Dead Logic)": 2,
-                        "Structured Documentation Blocks": 65,
-                        "Unit Test Assertions": 0,
-                        "Asynchronous/Concurrent Execution": 1,
-                        "UI / View Layer Components": 31,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 42,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 3,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 6,
-                        "Metaprogramming & Reflection": 2,
-                        "Module Dependencies (Imports)": 19,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 9,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 18,
-                        "Manual Memory Allocation": 2,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 5,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 6,
-                        "Fatal Aborts & Exceptions": 36,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 30,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 44,
-                        "Resource Deallocation & Cleanup": 6,
-                        "Private / Encapsulated Scopes": 26,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 562,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 11,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 4,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 1,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 4,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
-                    },
-                    "9. Extracted Dependencies": [
-                        "build-options",
-                        "builtin",
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/StringTable.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "StringTable.zig",
-                        "Path": "zig/zls/mach/StringTable.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3707.19,
-                        "Y": 317.63,
-                        "Z": 3316.77
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.036,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 13.346,
-                            "file_cluster_1": 13.522,
-                            "file_cluster_2": 13.65,
-                            "file_cluster_3": 14.423,
-                            "file_cluster_4": 13.685,
-                            "file_cluster_5": 13.88,
-                            "file_cluster_6": 13.643,
-                            "file_cluster_7": 13.17,
-                            "file_cluster_8": 13.036,
-                            "file_cluster_9": 13.542,
-                            "file_cluster_10": 14.431,
-                            "file_cluster_11": 13.622,
-                            "file_cluster_12": 13.909,
-                            "file_cluster_13": 13.145,
-                            "file_cluster_14": 16.931,
-                            "file_cluster_15": 13.818,
-                            "file_cluster_16": 13.611,
-                            "file_cluster_17": 13.529
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 109,
-                        "Coding LOC": 85,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 79.0,
-                        "Control Flow Ratio": "73.7%",
-                        "Popularity Rank": 1,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.529
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "14.63%",
-                        "Error & Exception Exposure": "53.53%",
-                        "Tech Debt Exposure": "100.0%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "3.67%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "91.86%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "58.69%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "19.1%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "indexOrPut",
-                            "Structural Impact": 18.6,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "83.3%",
-                            "Start Line": 31,
-                            "End Line": 41
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 71,
-                            "End Line": 74
-                        },
-                        {
-                            "Function Name": "index",
-                            "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 22,
-                            "End Line": 27
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 6.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 57,
-                            "End Line": 60
-                        },
-                        {
-                            "Function Name": "hash",
-                            "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 62,
-                            "End Line": 65
-                        },
-                        {
-                            "Function Name": "hash",
-                            "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 76,
-                            "End Line": 79
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 3.7,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 49,
-                            "End Line": 52
-                        },
-                        {
-                            "Function Name": "string",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 45,
-                            "End Line": 47
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 28,
-                        "Sequential Logic Declarations": 10,
-                        "Function Parameters": 8,
-                        "Function/Method Declarations": 8,
-                        "Class/Entity Declarations": 2,
-                        "Defensive Programming Constructs": 17,
-                        "Type/Safety Bypasses": 4,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 9,
-                        "State Mutations / Variable Reassignments": 6,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 14,
-                        "Unit Test Assertions": 7,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 16,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 0,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 1,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 0,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 9,
-                        "Manual Memory Allocation": 1,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 13,
-                        "Fatal Aborts & Exceptions": 8,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 6,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 23,
-                        "Resource Deallocation & Cleanup": 4,
-                        "Private / Encapsulated Scopes": 15,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 52,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 4,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 1,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 1,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 4
-                    },
-                    "9. Extracted Dependencies": [
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/collision.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "collision.zig",
-                        "Path": "zig/zls/mach/collision.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3215.45,
-                        "Y": 283.8,
-                        "Z": 3276.3
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 13.746,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 13.746,
-                            "file_cluster_1": 14.321,
-                            "file_cluster_2": 14.354,
-                            "file_cluster_3": 14.927,
-                            "file_cluster_4": 14.146,
-                            "file_cluster_5": 14.642,
-                            "file_cluster_6": 13.768,
-                            "file_cluster_7": 13.942,
-                            "file_cluster_8": 13.767,
-                            "file_cluster_9": 13.834,
-                            "file_cluster_10": 14.473,
-                            "file_cluster_11": 13.797,
-                            "file_cluster_12": 14.457,
-                            "file_cluster_13": 13.826,
-                            "file_cluster_14": 17.166,
-                            "file_cluster_15": 14.364,
-                            "file_cluster_16": 14.318,
-                            "file_cluster_17": 13.9
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 825,
-                        "Coding LOC": 715,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 602.6,
-                        "Control Flow Ratio": "80.8%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.524
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "18.69%",
-                        "Error & Exception Exposure": "3.21%",
-                        "Tech Debt Exposure": "88.72%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "1.23%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "11.75%",
-                        "Commented Logic Exposure": "12.91%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "33.3%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "polygonPolygonContact",
-                            "Structural Impact": 130.6,
-                            "Lines of Code (LOC)": 66,
-                            "Control Flow Branches": 20,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "69.0%",
-                            "Start Line": 558,
-                            "End Line": 623
-                        },
-                        {
-                            "Function Name": "collidesLine",
-                            "Structural Impact": 68.8,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "70.6%",
-                            "Start Line": 284,
-                            "End Line": 308
-                        },
-                        {
-                            "Function Name": "collisionRect",
-                            "Structural Impact": 52.9,
-                            "Lines of Code (LOC)": 19,
-                            "Control Flow Branches": 11,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "84.6%",
-                            "Start Line": 40,
-                            "End Line": 58
-                        },
-                        {
-                            "Function Name": "circlePolygonContact",
-                            "Structural Impact": 38.2,
-                            "Lines of Code (LOC)": 71,
-                            "Control Flow Branches": 9,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 698,
-                            "End Line": 768
-                        },
-                        {
-                            "Function Name": "collidesRect",
-                            "Structural Impact": 32.4,
-                            "Lines of Code (LOC)": 24,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "72.7%",
-                            "Start Line": 102,
-                            "End Line": 125
-                        },
-                        {
-                            "Function Name": "findMinSeparation",
-                            "Structural Impact": 29.0,
-                            "Lines of Code (LOC)": 26,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "63.6%",
-                            "Start Line": 501,
-                            "End Line": 526
-                        },
-                        {
-                            "Function Name": "collidesPoly",
-                            "Structural Impact": 27.0,
-                            "Lines of Code (LOC)": 21,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 204,
-                            "End Line": 224
-                        },
-                        {
-                            "Function Name": "findDeepestVertex",
-                            "Structural Impact": 24.8,
-                            "Lines of Code (LOC)": 15,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 420,
-                            "End Line": 434
-                        },
-                        {
-                            "Function Name": "minmaxProjectionDistance",
-                            "Structural Impact": 24.6,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 379,
-                            "End Line": 391
-                        },
-                        {
-                            "Function Name": "circleCircleContact",
-                            "Structural Impact": 19.0,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 786,
-                            "End Line": 802
-                        },
-                        {
-                            "Function Name": "vertices",
-                            "Structural Impact": 8.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 78,
-                            "End Line": 85
-                        },
-                        {
-                            "Function Name": "collidesCircle",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 136,
-                            "End Line": 146
-                        },
-                        {
-                            "Function Name": "collidesTriangle",
-                            "Structural Impact": 7.7,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 244,
-                            "End Line": 259
-                        },
-                        {
-                            "Function Name": "collidesRect",
-                            "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 23,
-                            "End Line": 28
-                        },
-                        {
-                            "Function Name": "collidesRect",
-                            "Structural Impact": 7.2,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 162,
-                            "End Line": 167
-                        },
-                        {
-                            "Function Name": "collidesLine",
-                            "Structural Impact": 5.7,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 332,
-                            "End Line": 342
-                        },
-                        {
-                            "Function Name": "collidesCircle",
-                            "Structural Impact": 5.5,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 185,
-                            "End Line": 190
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 232,
-                        "Sequential Logic Declarations": 55,
-                        "Function Parameters": 17,
-                        "Function/Method Declarations": 17,
-                        "Class/Entity Declarations": 7,
-                        "Defensive Programming Constructs": 117,
-                        "Type/Safety Bypasses": 9,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 22,
-                        "State Mutations / Variable Reassignments": 69,
-                        "Commented-out Code (Dead Logic)": 10,
-                        "Structured Documentation Blocks": 42,
-                        "Unit Test Assertions": 17,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 150,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 38,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 3,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 6,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 2,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 0,
-                        "Fatal Aborts & Exceptions": 29,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 103,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 135,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 145,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 645,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 7,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 2,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 3,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
-                    },
-                    "9. Extracted Dependencies": [
-                        "../testing.zig",
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/graph.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "graph.zig",
-                        "Path": "zig/zls/mach/graph.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3480.33,
-                        "Y": 205.67,
-                        "Z": 2483.83
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 13.858,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 14.077,
-                            "file_cluster_1": 14.36,
-                            "file_cluster_2": 14.401,
-                            "file_cluster_3": 15.157,
-                            "file_cluster_4": 13.966,
-                            "file_cluster_5": 14.708,
-                            "file_cluster_6": 14.347,
-                            "file_cluster_7": 14.028,
-                            "file_cluster_8": 13.858,
-                            "file_cluster_9": 14.234,
-                            "file_cluster_10": 15.116,
-                            "file_cluster_11": 14.274,
-                            "file_cluster_12": 14.657,
-                            "file_cluster_13": 13.982,
-                            "file_cluster_14": 17.403,
-                            "file_cluster_15": 14.585,
-                            "file_cluster_16": 14.42,
-                            "file_cluster_17": 14.149
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 653,
-                        "Coding LOC": 546,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 676.02,
-                        "Control Flow Ratio": "72.2%",
-                        "Popularity Rank": 1,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.835
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "34.03%",
-                        "Error & Exception Exposure": "2.66%",
-                        "Tech Debt Exposure": "61.68%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "1.1%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "95.38%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "81.21%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "processOp",
-                            "Structural Impact": 220.3,
-                            "Lines of Code (LOC)": 66,
-                            "Control Flow Branches": 30,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 227,
-                            "End Line": 292
-                        },
-                        {
-                            "Function Name": "removeChild",
-                            "Structural Impact": 55.9,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "72.7%",
-                            "Start Line": 36,
-                            "End Line": 62
-                        },
-                        {
-                            "Function Name": "acquireResultList",
-                            "Structural Impact": 41.1,
-                            "Lines of Code (LOC)": 23,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "53.8%",
-                            "Start Line": 388,
-                            "End Line": 410
-                        },
-                        {
-                            "Function Name": "getChildren",
-                            "Structural Impact": 33.2,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "58.3%",
-                            "Start Line": 362,
-                            "End Line": 386
-                        },
-                        {
-                            "Function Name": "preallocateNodes2",
-                            "Structural Impact": 32.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "85.7%",
-                            "Start Line": 295,
-                            "End Line": 314
-                        },
-                        {
-                            "Function Name": "getParent",
-                            "Structural Impact": 20.8,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 420,
-                            "End Line": 435
-                        },
-                        {
-                            "Function Name": "hasChild",
-                            "Structural Impact": 17.7,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 15,
-                            "End Line": 21
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 14.5,
-                            "Lines of Code (LOC)": 12,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 188,
-                            "End Line": 199
-                        },
-                        {
-                            "Function Name": "addChild",
-                            "Structural Impact": 14.4,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 24,
-                            "End Line": 33
-                        },
-                        {
-                            "Function Name": "processThread",
-                            "Structural Impact": 14.2,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 209,
-                            "End Line": 215
-                        },
-                        {
-                            "Function Name": "addChild",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 316,
-                            "End Line": 323
-                        },
-                        {
-                            "Function Name": "removeChild",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 325,
-                            "End Line": 331
-                        },
-                        {
-                            "Function Name": "setParent",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 333,
-                            "End Line": 340
-                        },
-                        {
-                            "Function Name": "removeParent",
-                            "Structural Impact": 8.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 342,
-                            "End Line": 346
-                        },
-                        {
-                            "Function Name": "cleanupIsolatedNode",
-                            "Structural Impact": 8.1,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 218,
-                            "End Line": 224
-                        },
-                        {
-                            "Function Name": "getNode",
-                            "Structural Impact": 5.4,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "33.3%",
-                            "Start Line": 202,
-                            "End Line": 206
-                        },
-                        {
-                            "Function Name": "deinit",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 357,
-                            "End Line": 359
-                        },
-                        {
-                            "Function Name": "releaseResultList",
-                            "Structural Impact": 2.9,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 412,
-                            "End Line": 418
-                        },
-                        {
-                            "Function Name": "init",
-                            "Structural Impact": 2.5,
-                            "Lines of Code (LOC)": 9,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 0,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 142,
-                            "End Line": 150
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 197,
-                        "Sequential Logic Declarations": 76,
-                        "Function Parameters": 19,
-                        "Function/Method Declarations": 19,
-                        "Class/Entity Declarations": 5,
-                        "Defensive Programming Constructs": 155,
-                        "Type/Safety Bypasses": 12,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 12,
-                        "State Mutations / Variable Reassignments": 94,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 38,
-                        "Unit Test Assertions": 10,
-                        "Asynchronous/Concurrent Execution": 22,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 69,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 0,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 3,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 0,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 38,
-                        "Manual Memory Allocation": 10,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 0,
-                        "Fatal Aborts & Exceptions": 21,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 48,
-                        "Thread Synchronization Locks": 30,
-                        "Immutable Data Declarations": 48,
-                        "Resource Deallocation & Cleanup": 39,
-                        "Private / Encapsulated Scopes": 74,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 499,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 1,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 6,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 2,
-                        "Direct Downstream (Dependency Blast Radius)": 1,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 4
-                    },
-                    "9. Extracted Dependencies": [
-                        "mpsc.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/main.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "main.zig",
-                        "Path": "zig/zls/mach/main.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3826.65,
-                        "Y": 147.68,
-                        "Z": 2201.41
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 6.731,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 8.524,
-                            "file_cluster_1": 8.034,
-                            "file_cluster_2": 8.611,
-                            "file_cluster_3": 9.792,
-                            "file_cluster_4": 9.002,
-                            "file_cluster_5": 8.923,
-                            "file_cluster_6": 8.93,
-                            "file_cluster_7": 7.683,
-                            "file_cluster_8": 6.731,
-                            "file_cluster_9": 8.766,
-                            "file_cluster_10": 10.094,
-                            "file_cluster_11": 9.288,
-                            "file_cluster_12": 9.098,
-                            "file_cluster_13": 6.787,
-                            "file_cluster_14": 13.521,
-                            "file_cluster_15": 9.514,
-                            "file_cluster_16": 8.381,
-                            "file_cluster_17": 9.088
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 12,
-                        "Coding LOC": 8,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 18.16,
-                        "Control Flow Ratio": "0.0%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.625
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "5.0%",
-                        "Error & Exception Exposure": "0.0%",
-                        "Tech Debt Exposure": "0.0%",
-                        "Testing Exposure": "1.23%",
-                        "API Exposure": "12.55%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "53.33%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "53.33%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "0.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "0.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 0,
-                        "Sequential Logic Declarations": 0,
-                        "Function Parameters": 0,
-                        "Function/Method Declarations": 0,
-                        "Class/Entity Declarations": 0,
-                        "Defensive Programming Constructs": 0,
-                        "Type/Safety Bypasses": 0,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 4,
-                        "State Mutations / Variable Reassignments": 0,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 0,
-                        "Unit Test Assertions": 0,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 4,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 0,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 0,
-                        "Metaprogramming & Reflection": 0,
-                        "Module Dependencies (Imports)": 3,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 0,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 0,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 0,
-                        "Fatal Aborts & Exceptions": 0,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 0,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 4,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 0,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 2,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 0,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 16
-                    },
-                    "9. Extracted Dependencies": []
-                },
-                "zig/zls/mach/module.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "module.zig",
-                        "Path": "zig/zls/mach/module.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3854.74,
-                        "Y": 237.51,
-                        "Z": 3166.74
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 12.473,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 12.838,
-                            "file_cluster_1": 13.099,
-                            "file_cluster_2": 12.951,
-                            "file_cluster_3": 13.822,
-                            "file_cluster_4": 13.189,
-                            "file_cluster_5": 13.413,
-                            "file_cluster_6": 12.695,
-                            "file_cluster_7": 12.722,
-                            "file_cluster_8": 12.675,
-                            "file_cluster_9": 13.072,
-                            "file_cluster_10": 13.667,
-                            "file_cluster_11": 12.521,
-                            "file_cluster_12": 12.588,
-                            "file_cluster_13": 12.686,
-                            "file_cluster_14": 16.386,
-                            "file_cluster_15": 13.141,
-                            "file_cluster_16": 12.473,
-                            "file_cluster_17": 13.076
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 1021,
-                        "Coding LOC": 894,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 2526.58,
-                        "Control Flow Ratio": "69.6%",
-                        "Popularity Rank": 4,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.868
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "30.79%",
-                        "Error & Exception Exposure": "52.93%",
-                        "Tech Debt Exposure": "24.42%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "4.24%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "13.81%",
-                        "Commented Logic Exposure": "5.61%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "84.26%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "Objects",
-                            "Structural Impact": 1186.1,
-                            "Lines of Code (LOC)": 444,
-                            "Control Flow Branches": 95,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "70.4%",
-                            "Start Line": 29,
-                            "End Line": 472
-                        },
-                        {
-                            "Function Name": "Modules",
-                            "Structural Impact": 612.2,
-                            "Lines of Code (LOC)": 205,
-                            "Control Flow Branches": 42,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "77.8%",
-                            "Start Line": 587,
-                            "End Line": 791
-                        },
-                        {
-                            "Function Name": "validate",
-                            "Structural Impact": 467.5,
-                            "Lines of Code (LOC)": 227,
-                            "Control Flow Branches": 33,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 794,
-                            "End Line": 1020
-                        },
-                        {
-                            "Function Name": "ModuleTagEnum",
-                            "Structural Impact": 52.2,
-                            "Lines of Code (LOC)": 38,
-                            "Control Flow Branches": 8,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "72.7%",
-                            "Start Line": 548,
-                            "End Line": 585
-                        },
-                        {
-                            "Function Name": "ModuleFunctionName2",
-                            "Structural Impact": 23.3,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "57.1%",
-                            "Start Line": 528,
-                            "End Line": 545
-                        },
-                        {
-                            "Function Name": "ModFunctionIDs",
-                            "Structural Impact": 14.4,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 505,
-                            "End Line": 524
-                        },
-                        {
-                            "Function Name": "Mod",
-                            "Structural Impact": 10.0,
-                            "Lines of Code (LOC)": 21,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 483,
-                            "End Line": 503
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 190,
-                        "Sequential Logic Declarations": 83,
-                        "Function Parameters": 56,
-                        "Function/Method Declarations": 55,
-                        "Class/Entity Declarations": 10,
-                        "Defensive Programming Constructs": 48,
-                        "Type/Safety Bypasses": 38,
-                        "High-Risk Execution Commands": 3,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 66,
-                        "State Mutations / Variable Reassignments": 70,
-                        "Commented-out Code (Dead Logic)": 2,
-                        "Structured Documentation Blocks": 136,
-                        "Unit Test Assertions": 3,
-                        "Asynchronous/Concurrent Execution": 7,
-                        "UI / View Layer Components": 11,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 130,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 73,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 4,
-                        "Metaprogramming & Reflection": 81,
-                        "Module Dependencies (Imports)": 4,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 22,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 21,
-                        "Manual Memory Allocation": 4,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 19,
-                        "Fatal Aborts & Exceptions": 58,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 103,
-                        "Thread Synchronization Locks": 12,
-                        "Immutable Data Declarations": 128,
-                        "Resource Deallocation & Cleanup": 16,
-                        "Private / Encapsulated Scopes": 123,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 811,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 4,
-                        "Direct Downstream (Dependency Blast Radius)": 4,
-                        "Total Upstream (Absolute Fragility)": 3,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 3
-                    },
-                    "9. Extracted Dependencies": [
-                        "StringTable.zig",
-                        "graph.zig",
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/testing.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "testing.zig",
-                        "Path": "zig/zls/mach/testing.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3027.54,
-                        "Y": 256.77,
-                        "Z": 2744.93
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_2",
-                        "Repository Drift (Z-Score)": 11.627,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 12.331,
-                            "file_cluster_1": 12.198,
-                            "file_cluster_2": 11.627,
-                            "file_cluster_3": 13.222,
-                            "file_cluster_4": 12.806,
-                            "file_cluster_5": 12.598,
-                            "file_cluster_6": 12.343,
-                            "file_cluster_7": 11.882,
-                            "file_cluster_8": 11.748,
-                            "file_cluster_9": 12.556,
-                            "file_cluster_10": 12.49,
-                            "file_cluster_11": 12.198,
-                            "file_cluster_12": 12.422,
-                            "file_cluster_13": 11.887,
-                            "file_cluster_14": 15.734,
-                            "file_cluster_15": 12.511,
-                            "file_cluster_16": 11.737,
-                            "file_cluster_17": 12.312
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 224,
-                        "Coding LOC": 199,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 253.58,
-                        "Control Flow Ratio": "67.9%",
-                        "Popularity Rank": 2,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.317
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "7.51%",
-                        "Error & Exception Exposure": "4.2%",
-                        "Tech Debt Exposure": "20.27%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "5.07%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "0.0%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "99.92%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "100.0%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "0.0%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "Expect",
-                            "Structural Impact": 60.2,
-                            "Lines of Code (LOC)": 41,
-                            "Control Flow Branches": 12,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 114,
-                            "End Line": 154
-                        },
-                        {
-                            "Function Name": "ExpectVector",
-                            "Structural Impact": 48.4,
-                            "Lines of Code (LOC)": 29,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 33,
-                            "End Line": 61
-                        },
-                        {
-                            "Function Name": "ExpectVecMat",
-                            "Structural Impact": 48.3,
-                            "Lines of Code (LOC)": 27,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 63,
-                            "End Line": 89
-                        },
-                        {
-                            "Function Name": "ExpectFloat",
-                            "Structural Impact": 34.8,
-                            "Lines of Code (LOC)": 25,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 7,
-                            "End Line": 31
-                        },
-                        {
-                            "Function Name": "ExpectBytes",
-                            "Structural Impact": 18.5,
-                            "Lines of Code (LOC)": 13,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "75.0%",
-                            "Start Line": 100,
-                            "End Line": 112
-                        },
-                        {
-                            "Function Name": "ExpectComptime",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 91,
-                            "End Line": 98
-                        },
-                        {
-                            "Function Name": "expect",
-                            "Structural Impact": 3.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 204,
-                            "End Line": 206
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 36,
-                        "Sequential Logic Declarations": 17,
-                        "Function Parameters": 20,
-                        "Function/Method Declarations": 20,
-                        "Class/Entity Declarations": 0,
-                        "Defensive Programming Constructs": 10,
-                        "Type/Safety Bypasses": 0,
-                        "High-Risk Execution Commands": 0,
-                        "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 16,
-                        "State Mutations / Variable Reassignments": 6,
-                        "Commented-out Code (Dead Logic)": 0,
-                        "Structured Documentation Blocks": 57,
-                        "Unit Test Assertions": 3,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 19,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 13,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 14,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 23,
-                        "Metaprogramming & Reflection": 2,
-                        "Module Dependencies (Imports)": 2,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 2,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 13,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 5,
-                        "Explicit Type Casts": 5,
-                        "Fatal Aborts & Exceptions": 15,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 0,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 29,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 17,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 129,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 0,
-                        "Orphaned Logic": 0,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 0,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 2,
-                        "Direct Downstream (Dependency Blast Radius)": 2,
-                        "Total Upstream (Absolute Fragility)": 1,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 1
-                    },
-                    "9. Extracted Dependencies": [
-                        "main.zig",
-                        "std"
-                    ]
-                },
-                "zig/zls/mach/win32.zig": {
-                    "1. Artifact Identity": {
-                        "Filename": "win32.zig",
-                        "Path": "zig/zls/mach/win32.zig",
-                        "Language": "Zig",
-                        "Architect": "Unknown Architect",
-                        "Doc Umbrella": 0.0,
-                        "Folder Dominant Lang": "zig",
-                        "Lock Tier": 2,
-                        "Identity Proof": "Single Indicator (Ext: .zig)"
-                    },
-                    "2. Topological Coordinates": {
-                        "X": -3545.36,
-                        "Y": 281.46,
-                        "Z": 3057.12
-                    },
-                    "3. Architectural Profile": {
-                        "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.973,
-                        "Repository Fingerprint": {
-                            "file_cluster_0": 11.825,
-                            "file_cluster_1": 11.8,
-                            "file_cluster_2": 12.054,
-                            "file_cluster_3": 12.858,
-                            "file_cluster_4": 12.338,
-                            "file_cluster_5": 12.344,
-                            "file_cluster_6": 11.937,
-                            "file_cluster_7": 11.463,
-                            "file_cluster_8": 10.973,
-                            "file_cluster_9": 12.037,
-                            "file_cluster_10": 12.779,
-                            "file_cluster_11": 11.954,
-                            "file_cluster_12": 12.124,
-                            "file_cluster_13": 11.416,
-                            "file_cluster_14": 15.848,
-                            "file_cluster_15": 12.331,
-                            "file_cluster_16": 11.646,
-                            "file_cluster_17": 12.316
-                        },
-                        "File Archetype": null,
-                        "File Drift (Z-Score)": 0.0,
-                        "File Fingerprint": {},
-                        "Total LOC": 4254,
-                        "Coding LOC": 4140,
-                        "Documentation LOC": 0,
-                        "Structural Magnitude": 3103.9,
-                        "Control Flow Ratio": "58.8%",
-                        "Popularity Rank": 0,
-                        "Raw Churn Frequency": 0.0,
-                        "Authorship Centralization": 0.0,
-                        "Ownership Entropy": 0.0,
-                        "Raw Cognitive Density": 0.078
-                    },
-                    "4. Vulnerability & Risk Exposures": {
-                        "Cognitive Load Exposure": "6.37%",
-                        "Error & Exception Exposure": "48.72%",
-                        "Tech Debt Exposure": "51.58%",
-                        "Testing Exposure": "80.0%",
-                        "API Exposure": "16.3%",
-                        "Concurrency Exposure": "0.0%",
-                        "State Flux Exposure": "0.0%",
-                        "Commented Logic Exposure": "5.14%",
-                        "Specification Exposure": "100.0%",
-                        "Instability Exposure": "50.0%",
-                        "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "99.99%",
-                        "Indentation Consistency": "Spaces",
-                        "Algorithmic DoS Exposure": "98.45%",
-                        "Obfuscation & Evasion Surface": "0.0%",
-                        "Exploit Generation Surface": "20.0%",
-                        "Weaponizable Injection Vectors": "0.0%",
-                        "Raw Memory Manipulation": "9.99%",
-                        "Hardcoded Payload Artifacts": "0.0%"
-                    },
-                    "5. Function Analysis": [
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 248.2,
-                            "Lines of Code (LOC)": 45,
-                            "Control Flow Branches": 21,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "63.6%",
-                            "Start Line": 1080,
-                            "End Line": 1124
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 203.1,
-                            "Lines of Code (LOC)": 37,
-                            "Control Flow Branches": 17,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "63.0%",
-                            "Start Line": 634,
-                            "End Line": 670
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 158.6,
-                            "Lines of Code (LOC)": 41,
-                            "Control Flow Branches": 13,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "48.1%",
-                            "Start Line": 3591,
-                            "End Line": 3631
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 79.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "46.2%",
-                            "Start Line": 3880,
-                            "End Line": 3899
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 79.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "46.2%",
-                            "Start Line": 3977,
-                            "End Line": 3996
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 79.3,
-                            "Lines of Code (LOC)": 20,
-                            "Control Flow Branches": 6,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "46.2%",
-                            "Start Line": 4058,
-                            "End Line": 4077
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 67.9,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "45.5%",
-                            "Start Line": 3834,
-                            "End Line": 3850
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 67.9,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "45.5%",
-                            "Start Line": 3928,
-                            "End Line": 3944
-                        },
-                        {
-                            "Function Name": "loword",
-                            "Structural Impact": 64.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "77.8%",
-                            "Start Line": 4224,
-                            "End Line": 4233
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "44.4%",
-                            "Start Line": 3684,
-                            "End Line": 3697
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "44.4%",
-                            "Start Line": 3726,
-                            "End Line": 3739
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 56.6,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "44.4%",
-                            "Start Line": 3794,
-                            "End Line": 3807
-                        },
-                        {
-                            "Function Name": "hiword",
-                            "Structural Impact": 48.5,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "71.4%",
-                            "Start Line": 4234,
-                            "End Line": 4243
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 45.5,
-                            "Lines of Code (LOC)": 16,
-                            "Control Flow Branches": 7,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "63.6%",
-                            "Start Line": 496,
-                            "End Line": 511
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 45.3,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "42.9%",
-                            "Start Line": 4014,
-                            "End Line": 4024
-                        },
-                        {
-                            "Function Name": "MethodMixin",
-                            "Structural Impact": 33.9,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "40.0%",
-                            "Start Line": 4090,
-                            "End Line": 4097
-                        },
-                        {
-                            "Function Name": "CoTaskMemFree",
-                            "Structural Impact": 21.5,
-                            "Lines of Code (LOC)": 30,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "37.5%",
-                            "Start Line": 3742,
-                            "End Line": 3771
-                        },
-                        {
-                            "Function Name": "hexVal",
-                            "Structural Impact": 18.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 387,
-                            "End Line": 391
-                        },
-                        {
-                            "Function Name": "SetCursorPos",
-                            "Structural Impact": 16.9,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 3,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "60.0%",
-                            "Start Line": 249,
-                            "End Line": 266
-                        },
-                        {
-                            "Function Name": "pxFromPt",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4193,
-                            "End Line": 4199
-                        },
-                        {
-                            "Function Name": "ptFromPx",
-                            "Structural Impact": 15.3,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 4,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4201,
-                            "End Line": 4207
-                        },
-                        {
-                            "Function Name": "GetDeviceData",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 730,
-                            "End Line": 732
-                        },
-                        {
-                            "Function Name": "CreateEffect",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 754,
-                            "End Line": 756
-                        },
-                        {
-                            "Function Name": "SendDeviceData",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 778,
-                            "End Line": 780
-                        },
-                        {
-                            "Function Name": "EnumEffectsInFile",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 781,
-                            "End Line": 783
-                        },
-                        {
-                            "Function Name": "WriteEffectToFile",
-                            "Structural Impact": 14.8,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 784,
-                            "End Line": 786
-                        },
-                        {
-                            "Function Name": "eql",
-                            "Structural Impact": 14.2,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 393,
-                            "End Line": 399
-                        },
-                        {
-                            "Function Name": "initString",
-                            "Structural Impact": 13.8,
-                            "Lines of Code (LOC)": 7,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 379,
-                            "End Line": 385
-                        },
-                        {
-                            "Function Name": "EnumObjects",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 712,
-                            "End Line": 714
-                        },
-                        {
-                            "Function Name": "Acquire",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 721,
-                            "End Line": 723
-                        },
-                        {
-                            "Function Name": "Unacquire",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 724,
-                            "End Line": 726
-                        },
-                        {
-                            "Function Name": "GetObjectInfo",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 742,
-                            "End Line": 744
-                        },
-                        {
-                            "Function Name": "Initialize",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 751,
-                            "End Line": 753
-                        },
-                        {
-                            "Function Name": "EnumEffects",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 757,
-                            "End Line": 759
-                        },
-                        {
-                            "Function Name": "EnumCreatedEffectObjects",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 769,
-                            "End Line": 771
-                        },
-                        {
-                            "Function Name": "Poll",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 775,
-                            "End Line": 777
-                        },
-                        {
-                            "Function Name": "BuildActionMap",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 787,
-                            "End Line": 789
-                        },
-                        {
-                            "Function Name": "SetActionMap",
-                            "Structural Impact": 13.6,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 790,
-                            "End Line": 792
-                        },
-                        {
-                            "Function Name": "hexVal",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 5,
-                            "Control Flow Branches": 5,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "62.5%",
-                            "Start Line": 351,
-                            "End Line": 355
-                        },
-                        {
-                            "Function Name": "GetProperty",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 715,
-                            "End Line": 717
-                        },
-                        {
-                            "Function Name": "SetProperty",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 718,
-                            "End Line": 720
-                        },
-                        {
-                            "Function Name": "GetDeviceState",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 727,
-                            "End Line": 729
-                        },
-                        {
-                            "Function Name": "SetCooperativeLevel",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 739,
-                            "End Line": 741
-                        },
-                        {
-                            "Function Name": "RunControlPanel",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 748,
-                            "End Line": 750
-                        },
-                        {
-                            "Function Name": "GetEffectInfo",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 760,
-                            "End Line": 762
-                        },
-                        {
-                            "Function Name": "QueryInterface",
-                            "Structural Impact": 12.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 796,
-                            "End Line": 798
-                        },
-                        {
-                            "Function Name": "GetCapabilities",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 709,
-                            "End Line": 711
-                        },
-                        {
-                            "Function Name": "SetDataFormat",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 733,
-                            "End Line": 735
-                        },
-                        {
-                            "Function Name": "SetEventNotification",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 736,
-                            "End Line": 738
-                        },
-                        {
-                            "Function Name": "GetDeviceInfo",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 745,
-                            "End Line": 747
-                        },
-                        {
-                            "Function Name": "GetForceFeedbackState",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 763,
-                            "End Line": 765
-                        },
-                        {
-                            "Function Name": "SendForceFeedbackCommand",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 766,
-                            "End Line": 768
-                        },
-                        {
-                            "Function Name": "Escape",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 772,
-                            "End Line": 774
-                        },
-                        {
-                            "Function Name": "GetImageInfo",
-                            "Structural Impact": 10.5,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 793,
-                            "End Line": 795
-                        },
-                        {
-                            "Function Name": "dpiFromHwnd",
-                            "Structural Impact": 9.4,
-                            "Lines of Code (LOC)": 8,
-                            "Control Flow Branches": 2,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "66.7%",
-                            "Start Line": 4179,
-                            "End Line": 4186
-                        },
-                        {
-                            "Function Name": "GetWindowLongPtrW",
-                            "Structural Impact": 8.3,
-                            "Lines of Code (LOC)": 6,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "100.0%",
-                            "Start Line": 231,
-                            "End Line": 236
-                        },
-                        {
-                            "Function Name": "AddRef",
-                            "Structural Impact": 6.9,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 799,
-                            "End Line": 801
-                        },
-                        {
-                            "Function Name": "Release",
-                            "Structural Impact": 6.9,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 4,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 802,
-                            "End Line": 804
-                        },
-                        {
-                            "Function Name": "SetWindowPos",
-                            "Structural Impact": 5.3,
-                            "Lines of Code (LOC)": 46,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 8,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 283,
-                            "End Line": 328
-                        },
-                        {
-                            "Function Name": "DirectInput8Create",
-                            "Structural Impact": 4.7,
-                            "Lines of Code (LOC)": 42,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 6,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 55,
-                            "End Line": 96
-                        },
-                        {
-                            "Function Name": "PeekMessageW",
-                            "Structural Impact": 4.7,
-                            "Lines of Code (LOC)": 41,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 6,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 123,
-                            "End Line": 163
-                        },
-                        {
-                            "Function Name": "decodeHexByte",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 357,
-                            "End Line": 359
-                        },
-                        {
-                            "Function Name": "getDpiFactor",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 4,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4188,
-                            "End Line": 4191
-                        },
-                        {
-                            "Function Name": "xFromLparam",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4245,
-                            "End Line": 4247
-                        },
-                        {
-                            "Function Name": "yFromLparam",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4248,
-                            "End Line": 4250
-                        },
-                        {
-                            "Function Name": "pointFromLparam",
-                            "Structural Impact": 4.2,
-                            "Lines of Code (LOC)": 3,
-                            "Control Flow Branches": 1,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "50.0%",
-                            "Start Line": 4251,
-                            "End Line": 4253
-                        },
-                        {
-                            "Function Name": "ShowWindow",
-                            "Structural Impact": 4.0,
-                            "Lines of Code (LOC)": 44,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1416,
-                            "End Line": 1459
-                        },
-                        {
-                            "Function Name": "RegisterClassW",
-                            "Structural Impact": 3.2,
-                            "Lines of Code (LOC)": 38,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1322,
-                            "End Line": 1359
-                        },
-                        {
-                            "Function Name": "DefWindowProcW",
-                            "Structural Impact": 3.1,
-                            "Lines of Code (LOC)": 14,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1609,
-                            "End Line": 1622
-                        },
-                        {
-                            "Function Name": "EnumDisplayMonitors",
-                            "Structural Impact": 3.0,
-                            "Lines of Code (LOC)": 11,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 5,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2417,
-                            "End Line": 2427
-                        },
-                        {
-                            "Function Name": "LoadCursorW",
-                            "Structural Impact": 2.9,
-                            "Lines of Code (LOC)": 17,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 3,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 1237,
-                            "End Line": 1253
-                        },
-                        {
-                            "Function Name": "ReleaseCapture",
-                            "Structural Impact": 2.6,
-                            "Lines of Code (LOC)": 18,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2358,
-                            "End Line": 2375
-                        },
-                        {
-                            "Function Name": "ExitProcess",
-                            "Structural Impact": 2.2,
-                            "Lines of Code (LOC)": 10,
-                            "Control Flow Branches": 0,
-                            "Input Parameters": 2,
-                            "Control Flow Ratio": "0.0%",
-                            "Start Line": 2617,
-                            "End Line": 2626
-                        }
-                    ],
-                    "6. Contextual Mitigations & Amplifications": "None Detected",
-                    "7. Structural Signatures (Net Mitigated Signals)": {
-                        "Control Flow Branches": 247,
-                        "Sequential Logic Declarations": 173,
-                        "Function Parameters": 404,
-                        "Function/Method Declarations": 131,
-                        "Class/Entity Declarations": 158,
-                        "Defensive Programming Constructs": 4,
-                        "Type/Safety Bypasses": 154,
-                        "High-Risk Execution Commands": 1,
-                        "I/O and Network Boundaries": 2,
-                        "Exposed API / Public Exports": 1032,
-                        "State Mutations / Variable Reassignments": 3,
-                        "Commented-out Code (Dead Logic)": 4,
-                        "Structured Documentation Blocks": 0,
-                        "Unit Test Assertions": 0,
-                        "Asynchronous/Concurrent Execution": 0,
-                        "UI / View Layer Components": 0,
-                        "Closures and Anonymous Functions": 0,
-                        "Global State Dependencies": 836,
-                        "Decorators and Annotations": 0,
-                        "Generic Type Abstractions": 65,
-                        "Collection Iterators / Comprehensions": 0,
-                        "Scientific & Mathematical Operations": 23,
-                        "Metaprogramming & Reflection": 12,
-                        "Module Dependencies (Imports)": 137,
-                        "Authorship Metadata": 0,
-                        "Planned Work (TODOs)": 27,
-                        "Acknowledged Tech Debt (FIXMEs)": 0,
-                        "Specification Traceability Tags": 0,
-                        "Indentation Faction": 0,
-                        "Server-Side Rendering Contexts": 0,
-                        "Event Publishers / Emitters": 0,
-                        "Dependency Injection Constructs": 0,
-                        "Preprocessor Macros": 0,
-                        "Pointer Arithmetic & Addressing": 728,
-                        "Manual Memory Allocation": 0,
-                        "Inline Assembly Blocks": 0,
-                        "Structured Telemetry & Logging": 0,
-                        "Ad-hoc Print / Debug Statements": 0,
-                        "Explicit Type Casts": 416,
-                        "Fatal Aborts & Exceptions": 139,
-                        "Thread Sleeps & Blocking Waits": 0,
-                        "Bitwise Operations": 32,
-                        "Thread Synchronization Locks": 0,
-                        "Immutable Data Declarations": 1625,
-                        "Resource Deallocation & Cleanup": 0,
-                        "Private / Encapsulated Scopes": 20,
-                        "Event Listeners & Subscribers": 0,
-                        "Bypassed / Skipped Tests": 0,
-                        "Structural Tab Indentations": 0,
-                        "Structural Space Indentations": 3016,
-                        "Hardware Bridge": 0,
-                        "Cryptography": 0,
-                        "Auth Middleware": 0,
-                        "Ipc Rpc Bridges": 0,
-                        "Feature Flags": 0,
-                        "Serialization Parsing": 0,
-                        "Regex Execution": 0,
-                        "Time Date Logic": 0,
-                        "Cloud LLM API Integrations": 0,
-                        "AI Orchestration Frameworks": 0,
-                        "Vector Databases (RAG)": 0,
-                        "Local Inference & Tensor Math": 0,
-                        "Traditional Machine Learning (Stats/Trees)": 0,
-                        "Deep Learning & Neural Networks": 0,
-                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
-                        "Vectorized Math & Tensor Operations": 0,
-                        "Core Var Decl": 0,
-                        "Design Camel Case": 0,
-                        "Design Snake Case": 0,
-                        "Design Pascal Case": 0,
-                        "Design Upper Case": 0,
-                        "Design Short Vars": 0,
-                        "Design Long Vars": 0,
-                        "Duplicate Logic": 16,
-                        "Orphaned Logic": 16,
-                        "Instructional Code Examples": 0,
-                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
-                        "Structured Literature Headers": 0,
-                        "Hyperlinked Literature References": 0,
-                        "High-Entropy / Obfuscated Logic": 0,
-                        "Safety & Constraint Bypasses": 0,
-                        "External Network & I/O Hooks": 0,
-                        "Dynamic Code Execution (Eval/Exec)": 2,
-                        "Global Environment Mutation": 0,
-                        "Commented-Out Executable Logic": 0,
-                        "Low-Level Bitwise / Cryptographic Math": 0,
-                        "Non-Standard / Steganographic Imports": 0,
-                        "Non-Standard Unicode / Homoglyphs": 0,
-                        "Embedded Credentials & Keys": 0,
-                        "Sec Extension Mismatch": 0,
-                        "Sec Entropy": 0,
-                        "Sec Tainted Injection": 0,
-                        "Prompt Injection": 0,
-                        "Agentic Rce": 0
-                    },
-                    "8. Dependency Network": {
-                        "Direct Upstream (Fragility)": 2,
-                        "Direct Downstream (Dependency Blast Radius)": 0,
-                        "Total Upstream (Absolute Fragility)": 0,
-                        "Total Downstream (Absolute Dependency Blast Radius)": 0
-                    },
-                    "9. Extracted Dependencies": [
-                        "builtin",
-                        "std"
-                    ]
-                }
-            }
-        },
         "python/airflow": {
             "Directory Group Magnitude": 7540.6,
             "File Count": 3,
@@ -166893,6 +163816,3097 @@
                         "Tappable",
                         "clause",
                         "stdClass"
+                    ]
+                }
+            }
+        },
+        "zig/zls/mach": {
+            "Directory Group Magnitude": 7340.0,
+            "File Count": 8,
+            "Ecosystem Fingerprint (Archetypes)": {
+                "file_cluster_8": "50.0%",
+                "file_cluster_13": "12.5%",
+                "file_cluster_0": "12.5%",
+                "file_cluster_16": "12.5%",
+                "file_cluster_2": "12.5%"
+            },
+            "Average Risk Exposures": {
+                "Cognitive Load Exposure": "15.45%",
+                "Error & Exception Exposure": "21.87%",
+                "Tech Debt Exposure": "52.89%",
+                "Testing Exposure": "70.15%",
+                "API Exposure": "6.39%",
+                "Concurrency Exposure": "2.3%",
+                "State Flux Exposure": "16.63%",
+                "Commented Logic Exposure": "3.69%",
+                "Specification Exposure": "94.17%",
+                "Instability Exposure": "50.0%",
+                "Volatility Exposure": "0.0%",
+                "Documentation Exposure": "76.98%",
+                "Civil War Exposure": "100.0%",
+                "Algorithmic DoS Exposure": "82.01%",
+                "Obfuscation & Evasion Surface": "0.0%",
+                "Exploit Generation Surface": "17.39%",
+                "Weaponizable Injection Vectors": "0.0%",
+                "Raw Memory Manipulation": "1.25%",
+                "Hardcoded Payload Artifacts": "0.0%"
+            },
+            "Files": {
+                "zig/zls/mach/Core.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "Core.zig",
+                        "Path": "zig/zls/mach/Core.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Alert": "TYPOSQUATTING THREAT: 'build-options' mimics 'build_options'",
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3531.27,
+                        "Y": 207.21,
+                        "Z": -2850.04
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_13",
+                        "Repository Drift (Z-Score)": 10.854,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 11.364,
+                            "file_cluster_1": 11.499,
+                            "file_cluster_2": 11.059,
+                            "file_cluster_3": 12.533,
+                            "file_cluster_4": 11.802,
+                            "file_cluster_5": 11.948,
+                            "file_cluster_6": 11.364,
+                            "file_cluster_7": 11.138,
+                            "file_cluster_8": 10.921,
+                            "file_cluster_9": 11.569,
+                            "file_cluster_10": 12.286,
+                            "file_cluster_11": 11.383,
+                            "file_cluster_12": 11.781,
+                            "file_cluster_13": 10.854,
+                            "file_cluster_14": 15.137,
+                            "file_cluster_15": 11.82,
+                            "file_cluster_16": 11.557,
+                            "file_cluster_17": 11.394
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 798,
+                        "Coding LOC": 683,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 410.86,
+                        "Control Flow Ratio": "69.8%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.28
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "6.61%",
+                        "Error & Exception Exposure": "9.74%",
+                        "Tech Debt Exposure": "76.47%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "6.95%",
+                        "Concurrency Exposure": "18.44%",
+                        "State Flux Exposure": "12.1%",
+                        "Commented Logic Exposure": "5.87%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "72.22%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "98.92%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "detectBackendType",
+                            "Structural Impact": 84.3,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 23,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "65.7%",
+                            "Start Line": 398,
+                            "End Line": 421
+                        },
+                        {
+                            "Function Name": "initWindow",
+                            "Structural Impact": 51.9,
+                            "Lines of Code (LOC)": 69,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "76.5%",
+                            "Start Line": 147,
+                            "End Line": 215
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 32.4,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 122,
+                            "End Line": 145
+                        },
+                        {
+                            "Function Name": "main",
+                            "Structural Impact": 21.5,
+                            "Lines of Code (LOC)": 15,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 254,
+                            "End Line": 268
+                        },
+                        {
+                            "Function Name": "pushEvent",
+                            "Structural Impact": 18.4,
+                            "Lines of Code (LOC)": 22,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "80.0%",
+                            "Start Line": 313,
+                            "End Line": 334
+                        },
+                        {
+                            "Function Name": "presentFrame",
+                            "Structural Impact": 11.6,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "40.0%",
+                            "Start Line": 228,
+                            "End Line": 252
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 11.2,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 287,
+                            "End Line": 302
+                        },
+                        {
+                            "Function Name": "tick",
+                            "Structural Impact": 10.9,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 217,
+                            "End Line": 226
+                        },
+                        {
+                            "Function Name": "printUnhandledErrorCallback",
+                            "Structural Impact": 9.5,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 387,
+                            "End Line": 396
+                        },
+                        {
+                            "Function Name": "platform_update_callback",
+                            "Structural Impact": 7.5,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 270,
+                            "End Line": 281
+                        },
+                        {
+                            "Function Name": "outOfMemory",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 339,
+                            "End Line": 343
+                        },
+                        {
+                            "Function Name": "isKeyPressed",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 444,
+                            "End Line": 446
+                        },
+                        {
+                            "Function Name": "isKeyReleased",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 448,
+                            "End Line": 450
+                        },
+                        {
+                            "Function Name": "isMouseButtonPressed",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 452,
+                            "End Line": 454
+                        },
+                        {
+                            "Function Name": "isMouseButtonReleased",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 456,
+                            "End Line": 458
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 733,
+                            "End Line": 735
+                        },
+                        {
+                            "Function Name": "requestAdapterCallback",
+                            "Structural Impact": 4.3,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 365,
+                            "End Line": 376
+                        },
+                        {
+                            "Function Name": "nextEvent",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 306,
+                            "End Line": 308
+                        },
+                        {
+                            "Function Name": "keyPressed",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 345,
+                            "End Line": 347
+                        },
+                        {
+                            "Function Name": "keyReleased",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 349,
+                            "End Line": 351
+                        },
+                        {
+                            "Function Name": "mousePressed",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 353,
+                            "End Line": 355
+                        },
+                        {
+                            "Function Name": "mouseReleased",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 357,
+                            "End Line": 359
+                        },
+                        {
+                            "Function Name": "mousePosition",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 361,
+                            "End Line": 363
+                        },
+                        {
+                            "Function Name": "assertHasDecl",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 775,
+                            "End Line": 777
+                        },
+                        {
+                            "Function Name": "assertHasField",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 779,
+                            "End Line": 781
+                        },
+                        {
+                            "Function Name": "deviceLostCallback",
+                            "Structural Impact": 2.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 380,
+                            "End Line": 385
+                        },
+                        {
+                            "Function Name": "exit",
+                            "Structural Impact": 1.9,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 283,
+                            "End Line": 285
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 90,
+                        "Sequential Logic Declarations": 39,
+                        "Function Parameters": 27,
+                        "Function/Method Declarations": 27,
+                        "Class/Entity Declarations": 17,
+                        "Defensive Programming Constructs": 23,
+                        "Type/Safety Bypasses": 12,
+                        "High-Risk Execution Commands": 7,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 42,
+                        "State Mutations / Variable Reassignments": 24,
+                        "Commented-out Code (Dead Logic)": 2,
+                        "Structured Documentation Blocks": 65,
+                        "Unit Test Assertions": 0,
+                        "Asynchronous/Concurrent Execution": 1,
+                        "UI / View Layer Components": 31,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 42,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 3,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 6,
+                        "Metaprogramming & Reflection": 2,
+                        "Module Dependencies (Imports)": 19,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 9,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 18,
+                        "Manual Memory Allocation": 2,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 5,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 6,
+                        "Fatal Aborts & Exceptions": 36,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 30,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 44,
+                        "Resource Deallocation & Cleanup": 6,
+                        "Private / Encapsulated Scopes": 26,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 562,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 11,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 4,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 1,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 4,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                    },
+                    "9. Extracted Dependencies": [
+                        "build-options",
+                        "builtin",
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/StringTable.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "StringTable.zig",
+                        "Path": "zig/zls/mach/StringTable.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3853.62,
+                        "Y": 317.57,
+                        "Z": -2404.92
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 13.036,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 13.346,
+                            "file_cluster_1": 13.522,
+                            "file_cluster_2": 13.65,
+                            "file_cluster_3": 14.423,
+                            "file_cluster_4": 13.685,
+                            "file_cluster_5": 13.88,
+                            "file_cluster_6": 13.643,
+                            "file_cluster_7": 13.17,
+                            "file_cluster_8": 13.036,
+                            "file_cluster_9": 13.542,
+                            "file_cluster_10": 14.431,
+                            "file_cluster_11": 13.622,
+                            "file_cluster_12": 13.909,
+                            "file_cluster_13": 13.145,
+                            "file_cluster_14": 16.931,
+                            "file_cluster_15": 13.818,
+                            "file_cluster_16": 13.611,
+                            "file_cluster_17": 13.529
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 109,
+                        "Coding LOC": 85,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 79.0,
+                        "Control Flow Ratio": "73.7%",
+                        "Popularity Rank": 1,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.529
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "14.63%",
+                        "Error & Exception Exposure": "53.53%",
+                        "Tech Debt Exposure": "100.0%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "3.67%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "91.86%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "58.69%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "19.1%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "indexOrPut",
+                            "Structural Impact": 18.6,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "83.3%",
+                            "Start Line": 31,
+                            "End Line": 41
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 71,
+                            "End Line": 74
+                        },
+                        {
+                            "Function Name": "index",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 22,
+                            "End Line": 27
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 6.2,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 57,
+                            "End Line": 60
+                        },
+                        {
+                            "Function Name": "hash",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 62,
+                            "End Line": 65
+                        },
+                        {
+                            "Function Name": "hash",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 76,
+                            "End Line": 79
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 49,
+                            "End Line": 52
+                        },
+                        {
+                            "Function Name": "string",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 45,
+                            "End Line": 47
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 28,
+                        "Sequential Logic Declarations": 10,
+                        "Function Parameters": 8,
+                        "Function/Method Declarations": 8,
+                        "Class/Entity Declarations": 2,
+                        "Defensive Programming Constructs": 17,
+                        "Type/Safety Bypasses": 4,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 9,
+                        "State Mutations / Variable Reassignments": 6,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 14,
+                        "Unit Test Assertions": 7,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 16,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 0,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 1,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 0,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 9,
+                        "Manual Memory Allocation": 1,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 13,
+                        "Fatal Aborts & Exceptions": 8,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 6,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 23,
+                        "Resource Deallocation & Cleanup": 4,
+                        "Private / Encapsulated Scopes": 15,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 52,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 4,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 1,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 1,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
+                    },
+                    "9. Extracted Dependencies": [
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/collision.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "collision.zig",
+                        "Path": "zig/zls/mach/collision.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4344.54,
+                        "Y": 283.66,
+                        "Z": -2445.23
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_0",
+                        "Repository Drift (Z-Score)": 13.744,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 13.744,
+                            "file_cluster_1": 14.319,
+                            "file_cluster_2": 14.353,
+                            "file_cluster_3": 14.926,
+                            "file_cluster_4": 14.144,
+                            "file_cluster_5": 14.641,
+                            "file_cluster_6": 13.767,
+                            "file_cluster_7": 13.94,
+                            "file_cluster_8": 13.765,
+                            "file_cluster_9": 13.833,
+                            "file_cluster_10": 14.472,
+                            "file_cluster_11": 13.796,
+                            "file_cluster_12": 14.456,
+                            "file_cluster_13": 13.824,
+                            "file_cluster_14": 17.165,
+                            "file_cluster_15": 14.362,
+                            "file_cluster_16": 14.317,
+                            "file_cluster_17": 13.899
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 825,
+                        "Coding LOC": 715,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 601.5,
+                        "Control Flow Ratio": "80.8%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.524
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "18.69%",
+                        "Error & Exception Exposure": "3.21%",
+                        "Tech Debt Exposure": "88.72%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "1.23%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "11.75%",
+                        "Commented Logic Exposure": "12.91%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "33.3%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "polygonPolygonContact",
+                            "Structural Impact": 130.6,
+                            "Lines of Code (LOC)": 66,
+                            "Control Flow Branches": 20,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "69.0%",
+                            "Start Line": 558,
+                            "End Line": 623
+                        },
+                        {
+                            "Function Name": "collidesLine",
+                            "Structural Impact": 68.8,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.6%",
+                            "Start Line": 284,
+                            "End Line": 308
+                        },
+                        {
+                            "Function Name": "collisionRect",
+                            "Structural Impact": 52.9,
+                            "Lines of Code (LOC)": 19,
+                            "Control Flow Branches": 11,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "84.6%",
+                            "Start Line": 40,
+                            "End Line": 58
+                        },
+                        {
+                            "Function Name": "circlePolygonContact",
+                            "Structural Impact": 38.2,
+                            "Lines of Code (LOC)": 71,
+                            "Control Flow Branches": 9,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 698,
+                            "End Line": 768
+                        },
+                        {
+                            "Function Name": "collidesRect",
+                            "Structural Impact": 32.4,
+                            "Lines of Code (LOC)": 24,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "72.7%",
+                            "Start Line": 102,
+                            "End Line": 125
+                        },
+                        {
+                            "Function Name": "findMinSeparation",
+                            "Structural Impact": 29.0,
+                            "Lines of Code (LOC)": 26,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "63.6%",
+                            "Start Line": 501,
+                            "End Line": 526
+                        },
+                        {
+                            "Function Name": "collidesPoly",
+                            "Structural Impact": 27.0,
+                            "Lines of Code (LOC)": 21,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 204,
+                            "End Line": 224
+                        },
+                        {
+                            "Function Name": "findDeepestVertex",
+                            "Structural Impact": 24.8,
+                            "Lines of Code (LOC)": 15,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 420,
+                            "End Line": 434
+                        },
+                        {
+                            "Function Name": "minmaxProjectionDistance",
+                            "Structural Impact": 24.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 379,
+                            "End Line": 391
+                        },
+                        {
+                            "Function Name": "circleCircleContact",
+                            "Structural Impact": 19.0,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 786,
+                            "End Line": 802
+                        },
+                        {
+                            "Function Name": "collidesCircle",
+                            "Structural Impact": 8.3,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 136,
+                            "End Line": 146
+                        },
+                        {
+                            "Function Name": "collidesTriangle",
+                            "Structural Impact": 7.7,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 244,
+                            "End Line": 259
+                        },
+                        {
+                            "Function Name": "vertices",
+                            "Structural Impact": 7.3,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 78,
+                            "End Line": 85
+                        },
+                        {
+                            "Function Name": "collidesRect",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 23,
+                            "End Line": 28
+                        },
+                        {
+                            "Function Name": "collidesRect",
+                            "Structural Impact": 7.2,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 162,
+                            "End Line": 167
+                        },
+                        {
+                            "Function Name": "collidesLine",
+                            "Structural Impact": 5.7,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 332,
+                            "End Line": 342
+                        },
+                        {
+                            "Function Name": "collidesCircle",
+                            "Structural Impact": 5.5,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 185,
+                            "End Line": 190
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 232,
+                        "Sequential Logic Declarations": 55,
+                        "Function Parameters": 17,
+                        "Function/Method Declarations": 17,
+                        "Class/Entity Declarations": 7,
+                        "Defensive Programming Constructs": 117,
+                        "Type/Safety Bypasses": 9,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 22,
+                        "State Mutations / Variable Reassignments": 69,
+                        "Commented-out Code (Dead Logic)": 10,
+                        "Structured Documentation Blocks": 42,
+                        "Unit Test Assertions": 17,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 150,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 38,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 3,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 6,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 2,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 0,
+                        "Fatal Aborts & Exceptions": 29,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 103,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 135,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 145,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 645,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 7,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 2,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 3,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                    },
+                    "9. Extracted Dependencies": [
+                        "../testing.zig",
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/graph.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "graph.zig",
+                        "Path": "zig/zls/mach/graph.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4080.15,
+                        "Y": 205.76,
+                        "Z": -3236.02
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 13.857,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 14.076,
+                            "file_cluster_1": 14.358,
+                            "file_cluster_2": 14.4,
+                            "file_cluster_3": 15.156,
+                            "file_cluster_4": 13.965,
+                            "file_cluster_5": 14.707,
+                            "file_cluster_6": 14.346,
+                            "file_cluster_7": 14.027,
+                            "file_cluster_8": 13.857,
+                            "file_cluster_9": 14.233,
+                            "file_cluster_10": 15.115,
+                            "file_cluster_11": 14.273,
+                            "file_cluster_12": 14.656,
+                            "file_cluster_13": 13.981,
+                            "file_cluster_14": 17.402,
+                            "file_cluster_15": 14.584,
+                            "file_cluster_16": 14.418,
+                            "file_cluster_17": 14.148
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 653,
+                        "Coding LOC": 546,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 675.42,
+                        "Control Flow Ratio": "72.2%",
+                        "Popularity Rank": 1,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.835
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "34.03%",
+                        "Error & Exception Exposure": "2.66%",
+                        "Tech Debt Exposure": "61.68%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "1.1%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "95.38%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "81.21%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "processOp",
+                            "Structural Impact": 220.3,
+                            "Lines of Code (LOC)": 66,
+                            "Control Flow Branches": 30,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 227,
+                            "End Line": 292
+                        },
+                        {
+                            "Function Name": "removeChild",
+                            "Structural Impact": 55.9,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "72.7%",
+                            "Start Line": 36,
+                            "End Line": 62
+                        },
+                        {
+                            "Function Name": "acquireResultList",
+                            "Structural Impact": 41.1,
+                            "Lines of Code (LOC)": 23,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "53.8%",
+                            "Start Line": 388,
+                            "End Line": 410
+                        },
+                        {
+                            "Function Name": "getChildren",
+                            "Structural Impact": 33.2,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "58.3%",
+                            "Start Line": 362,
+                            "End Line": 386
+                        },
+                        {
+                            "Function Name": "preallocateNodes2",
+                            "Structural Impact": 32.3,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "85.7%",
+                            "Start Line": 295,
+                            "End Line": 314
+                        },
+                        {
+                            "Function Name": "getParent",
+                            "Structural Impact": 20.8,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 420,
+                            "End Line": 435
+                        },
+                        {
+                            "Function Name": "hasChild",
+                            "Structural Impact": 17.7,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 15,
+                            "End Line": 21
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 14.5,
+                            "Lines of Code (LOC)": 12,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 188,
+                            "End Line": 199
+                        },
+                        {
+                            "Function Name": "addChild",
+                            "Structural Impact": 14.4,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 24,
+                            "End Line": 33
+                        },
+                        {
+                            "Function Name": "processThread",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 209,
+                            "End Line": 215
+                        },
+                        {
+                            "Function Name": "addChild",
+                            "Structural Impact": 13.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 316,
+                            "End Line": 323
+                        },
+                        {
+                            "Function Name": "removeChild",
+                            "Structural Impact": 13.8,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 325,
+                            "End Line": 331
+                        },
+                        {
+                            "Function Name": "setParent",
+                            "Structural Impact": 13.8,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 333,
+                            "End Line": 340
+                        },
+                        {
+                            "Function Name": "removeParent",
+                            "Structural Impact": 8.2,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 342,
+                            "End Line": 346
+                        },
+                        {
+                            "Function Name": "cleanupIsolatedNode",
+                            "Structural Impact": 8.1,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 218,
+                            "End Line": 224
+                        },
+                        {
+                            "Function Name": "getNode",
+                            "Structural Impact": 5.4,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "33.3%",
+                            "Start Line": 202,
+                            "End Line": 206
+                        },
+                        {
+                            "Function Name": "deinit",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 357,
+                            "End Line": 359
+                        },
+                        {
+                            "Function Name": "releaseResultList",
+                            "Structural Impact": 2.9,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 412,
+                            "End Line": 418
+                        },
+                        {
+                            "Function Name": "init",
+                            "Structural Impact": 2.5,
+                            "Lines of Code (LOC)": 9,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 142,
+                            "End Line": 150
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 197,
+                        "Sequential Logic Declarations": 76,
+                        "Function Parameters": 19,
+                        "Function/Method Declarations": 19,
+                        "Class/Entity Declarations": 5,
+                        "Defensive Programming Constructs": 155,
+                        "Type/Safety Bypasses": 12,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 12,
+                        "State Mutations / Variable Reassignments": 94,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 38,
+                        "Unit Test Assertions": 10,
+                        "Asynchronous/Concurrent Execution": 22,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 69,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 0,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 3,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 0,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 38,
+                        "Manual Memory Allocation": 10,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 0,
+                        "Fatal Aborts & Exceptions": 21,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 48,
+                        "Thread Synchronization Locks": 30,
+                        "Immutable Data Declarations": 48,
+                        "Resource Deallocation & Cleanup": 39,
+                        "Private / Encapsulated Scopes": 74,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 499,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 1,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 6,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 2,
+                        "Direct Downstream (Dependency Blast Radius)": 1,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 4
+                    },
+                    "9. Extracted Dependencies": [
+                        "mpsc.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/main.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "main.zig",
+                        "Path": "zig/zls/mach/main.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3734.34,
+                        "Y": 147.81,
+                        "Z": -3518.55
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 6.864,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 8.605,
+                            "file_cluster_1": 8.147,
+                            "file_cluster_2": 8.712,
+                            "file_cluster_3": 9.883,
+                            "file_cluster_4": 9.102,
+                            "file_cluster_5": 9.021,
+                            "file_cluster_6": 9.026,
+                            "file_cluster_7": 7.794,
+                            "file_cluster_8": 6.864,
+                            "file_cluster_9": 8.856,
+                            "file_cluster_10": 10.185,
+                            "file_cluster_11": 9.372,
+                            "file_cluster_12": 9.197,
+                            "file_cluster_13": 6.91,
+                            "file_cluster_14": 13.547,
+                            "file_cluster_15": 9.608,
+                            "file_cluster_16": 8.485,
+                            "file_cluster_17": 9.182
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 12,
+                        "Coding LOC": 8,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 18.16,
+                        "Control Flow Ratio": "0.0%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.625
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "5.0%",
+                        "Error & Exception Exposure": "0.0%",
+                        "Tech Debt Exposure": "0.0%",
+                        "Testing Exposure": "1.23%",
+                        "API Exposure": "12.55%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "53.33%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "53.33%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "0.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "0.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 0,
+                        "Sequential Logic Declarations": 0,
+                        "Function Parameters": 0,
+                        "Function/Method Declarations": 0,
+                        "Class/Entity Declarations": 0,
+                        "Defensive Programming Constructs": 0,
+                        "Type/Safety Bypasses": 0,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 4,
+                        "State Mutations / Variable Reassignments": 0,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 0,
+                        "Unit Test Assertions": 0,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 4,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 0,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 0,
+                        "Metaprogramming & Reflection": 0,
+                        "Module Dependencies (Imports)": 3,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 0,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 0,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 0,
+                        "Fatal Aborts & Exceptions": 0,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 0,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 4,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 0,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 2,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 3,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 16
+                    },
+                    "9. Extracted Dependencies": [
+                        "Frequency.zig",
+                        "Timer.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/module.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "module.zig",
+                        "Path": "zig/zls/mach/module.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 3707.19,
+                        "Y": 237.53,
+                        "Z": -2555.29
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_16",
+                        "Repository Drift (Z-Score)": 12.45,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 12.817,
+                            "file_cluster_1": 13.077,
+                            "file_cluster_2": 12.929,
+                            "file_cluster_3": 13.801,
+                            "file_cluster_4": 13.167,
+                            "file_cluster_5": 13.392,
+                            "file_cluster_6": 12.674,
+                            "file_cluster_7": 12.7,
+                            "file_cluster_8": 12.652,
+                            "file_cluster_9": 13.05,
+                            "file_cluster_10": 13.647,
+                            "file_cluster_11": 12.499,
+                            "file_cluster_12": 12.566,
+                            "file_cluster_13": 12.665,
+                            "file_cluster_14": 16.368,
+                            "file_cluster_15": 13.12,
+                            "file_cluster_16": 12.45,
+                            "file_cluster_17": 13.055
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 1021,
+                        "Coding LOC": 894,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 2387.88,
+                        "Control Flow Ratio": "69.6%",
+                        "Popularity Rank": 4,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.868
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "30.79%",
+                        "Error & Exception Exposure": "52.93%",
+                        "Tech Debt Exposure": "24.42%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "4.24%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "13.81%",
+                        "Commented Logic Exposure": "5.61%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "84.05%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "Objects",
+                            "Structural Impact": 1186.1,
+                            "Lines of Code (LOC)": 444,
+                            "Control Flow Branches": 95,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "70.4%",
+                            "Start Line": 29,
+                            "End Line": 472
+                        },
+                        {
+                            "Function Name": "Modules",
+                            "Structural Impact": 531.6,
+                            "Lines of Code (LOC)": 205,
+                            "Control Flow Branches": 42,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "77.8%",
+                            "Start Line": 587,
+                            "End Line": 791
+                        },
+                        {
+                            "Function Name": "validate",
+                            "Structural Impact": 419.4,
+                            "Lines of Code (LOC)": 227,
+                            "Control Flow Branches": 33,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 794,
+                            "End Line": 1020
+                        },
+                        {
+                            "Function Name": "ModuleTagEnum",
+                            "Structural Impact": 46.9,
+                            "Lines of Code (LOC)": 38,
+                            "Control Flow Branches": 8,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "72.7%",
+                            "Start Line": 548,
+                            "End Line": 585
+                        },
+                        {
+                            "Function Name": "ModuleFunctionName2",
+                            "Structural Impact": 20.9,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "57.1%",
+                            "Start Line": 528,
+                            "End Line": 545
+                        },
+                        {
+                            "Function Name": "ModFunctionIDs",
+                            "Structural Impact": 13.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 505,
+                            "End Line": 524
+                        },
+                        {
+                            "Function Name": "Mod",
+                            "Structural Impact": 9.1,
+                            "Lines of Code (LOC)": 21,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 483,
+                            "End Line": 503
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 190,
+                        "Sequential Logic Declarations": 83,
+                        "Function Parameters": 56,
+                        "Function/Method Declarations": 55,
+                        "Class/Entity Declarations": 10,
+                        "Defensive Programming Constructs": 48,
+                        "Type/Safety Bypasses": 38,
+                        "High-Risk Execution Commands": 3,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 66,
+                        "State Mutations / Variable Reassignments": 70,
+                        "Commented-out Code (Dead Logic)": 2,
+                        "Structured Documentation Blocks": 136,
+                        "Unit Test Assertions": 3,
+                        "Asynchronous/Concurrent Execution": 7,
+                        "UI / View Layer Components": 11,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 130,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 73,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 4,
+                        "Metaprogramming & Reflection": 81,
+                        "Module Dependencies (Imports)": 4,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 22,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 21,
+                        "Manual Memory Allocation": 4,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 19,
+                        "Fatal Aborts & Exceptions": 58,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 103,
+                        "Thread Synchronization Locks": 12,
+                        "Immutable Data Declarations": 128,
+                        "Resource Deallocation & Cleanup": 16,
+                        "Private / Encapsulated Scopes": 123,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 811,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 4,
+                        "Direct Downstream (Dependency Blast Radius)": 4,
+                        "Total Upstream (Absolute Fragility)": 3,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 3
+                    },
+                    "9. Extracted Dependencies": [
+                        "StringTable.zig",
+                        "graph.zig",
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/testing.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "testing.zig",
+                        "Path": "zig/zls/mach/testing.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4531.33,
+                        "Y": 256.69,
+                        "Z": -2974.77
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_2",
+                        "Repository Drift (Z-Score)": 11.603,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 12.309,
+                            "file_cluster_1": 12.174,
+                            "file_cluster_2": 11.603,
+                            "file_cluster_3": 13.201,
+                            "file_cluster_4": 12.784,
+                            "file_cluster_5": 12.576,
+                            "file_cluster_6": 12.321,
+                            "file_cluster_7": 11.858,
+                            "file_cluster_8": 11.723,
+                            "file_cluster_9": 12.534,
+                            "file_cluster_10": 12.468,
+                            "file_cluster_11": 12.177,
+                            "file_cluster_12": 12.399,
+                            "file_cluster_13": 11.864,
+                            "file_cluster_14": 15.716,
+                            "file_cluster_15": 12.489,
+                            "file_cluster_16": 11.713,
+                            "file_cluster_17": 12.289
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 224,
+                        "Coding LOC": 199,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 230.68,
+                        "Control Flow Ratio": "67.9%",
+                        "Popularity Rank": 2,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.317
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "7.51%",
+                        "Error & Exception Exposure": "4.2%",
+                        "Tech Debt Exposure": "20.27%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "5.07%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "0.0%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "99.91%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "100.0%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "0.0%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "Expect",
+                            "Structural Impact": 54.0,
+                            "Lines of Code (LOC)": 41,
+                            "Control Flow Branches": 12,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 114,
+                            "End Line": 154
+                        },
+                        {
+                            "Function Name": "ExpectVector",
+                            "Structural Impact": 43.5,
+                            "Lines of Code (LOC)": 29,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 33,
+                            "End Line": 61
+                        },
+                        {
+                            "Function Name": "ExpectVecMat",
+                            "Structural Impact": 43.4,
+                            "Lines of Code (LOC)": 27,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 63,
+                            "End Line": 89
+                        },
+                        {
+                            "Function Name": "ExpectFloat",
+                            "Structural Impact": 31.2,
+                            "Lines of Code (LOC)": 25,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 7,
+                            "End Line": 31
+                        },
+                        {
+                            "Function Name": "ExpectBytes",
+                            "Structural Impact": 16.6,
+                            "Lines of Code (LOC)": 13,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "75.0%",
+                            "Start Line": 100,
+                            "End Line": 112
+                        },
+                        {
+                            "Function Name": "ExpectComptime",
+                            "Structural Impact": 12.4,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 91,
+                            "End Line": 98
+                        },
+                        {
+                            "Function Name": "expect",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 204,
+                            "End Line": 206
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 36,
+                        "Sequential Logic Declarations": 17,
+                        "Function Parameters": 20,
+                        "Function/Method Declarations": 20,
+                        "Class/Entity Declarations": 0,
+                        "Defensive Programming Constructs": 10,
+                        "Type/Safety Bypasses": 0,
+                        "High-Risk Execution Commands": 0,
+                        "I/O and Network Boundaries": 0,
+                        "Exposed API / Public Exports": 16,
+                        "State Mutations / Variable Reassignments": 6,
+                        "Commented-out Code (Dead Logic)": 0,
+                        "Structured Documentation Blocks": 57,
+                        "Unit Test Assertions": 3,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 19,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 13,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 14,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 23,
+                        "Metaprogramming & Reflection": 2,
+                        "Module Dependencies (Imports)": 2,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 2,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 13,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 5,
+                        "Explicit Type Casts": 5,
+                        "Fatal Aborts & Exceptions": 15,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 0,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 29,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 17,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 129,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 0,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 0,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 2,
+                        "Direct Downstream (Dependency Blast Radius)": 2,
+                        "Total Upstream (Absolute Fragility)": 1,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 1
+                    },
+                    "9. Extracted Dependencies": [
+                        "main.zig",
+                        "std"
+                    ]
+                },
+                "zig/zls/mach/win32.zig": {
+                    "1. Artifact Identity": {
+                        "Filename": "win32.zig",
+                        "Path": "zig/zls/mach/win32.zig",
+                        "Language": "Zig",
+                        "Architect": "Unknown Architect",
+                        "Doc Umbrella": 0.0,
+                        "Folder Dominant Lang": "zig",
+                        "Lock Tier": 2,
+                        "Identity Proof": "Single Indicator (Ext: .zig)"
+                    },
+                    "2. Topological Coordinates": {
+                        "X": 4015.2,
+                        "Y": 281.46,
+                        "Z": -2663.67
+                    },
+                    "3. Architectural Profile": {
+                        "Repository Archetype": "file_cluster_8",
+                        "Repository Drift (Z-Score)": 10.995,
+                        "Repository Fingerprint": {
+                            "file_cluster_0": 11.845,
+                            "file_cluster_1": 11.821,
+                            "file_cluster_2": 12.074,
+                            "file_cluster_3": 12.877,
+                            "file_cluster_4": 12.356,
+                            "file_cluster_5": 12.364,
+                            "file_cluster_6": 11.958,
+                            "file_cluster_7": 11.485,
+                            "file_cluster_8": 10.995,
+                            "file_cluster_9": 12.058,
+                            "file_cluster_10": 12.799,
+                            "file_cluster_11": 11.972,
+                            "file_cluster_12": 12.144,
+                            "file_cluster_13": 11.437,
+                            "file_cluster_14": 15.863,
+                            "file_cluster_15": 12.351,
+                            "file_cluster_16": 11.667,
+                            "file_cluster_17": 12.334
+                        },
+                        "File Archetype": null,
+                        "File Drift (Z-Score)": 0.0,
+                        "File Fingerprint": {},
+                        "Total LOC": 4254,
+                        "Coding LOC": 4140,
+                        "Documentation LOC": 0,
+                        "Structural Magnitude": 2936.5,
+                        "Control Flow Ratio": "58.8%",
+                        "Popularity Rank": 0,
+                        "Raw Churn Frequency": 0.0,
+                        "Authorship Centralization": 0.0,
+                        "Ownership Entropy": 0.0,
+                        "Raw Cognitive Density": 0.078
+                    },
+                    "4. Vulnerability & Risk Exposures": {
+                        "Cognitive Load Exposure": "6.37%",
+                        "Error & Exception Exposure": "48.72%",
+                        "Tech Debt Exposure": "51.58%",
+                        "Testing Exposure": "80.0%",
+                        "API Exposure": "16.3%",
+                        "Concurrency Exposure": "0.0%",
+                        "State Flux Exposure": "0.0%",
+                        "Commented Logic Exposure": "5.14%",
+                        "Specification Exposure": "100.0%",
+                        "Instability Exposure": "50.0%",
+                        "Volatility Exposure": "0.0%",
+                        "Documentation Exposure": "99.99%",
+                        "Indentation Consistency": "Spaces",
+                        "Algorithmic DoS Exposure": "98.45%",
+                        "Obfuscation & Evasion Surface": "0.0%",
+                        "Exploit Generation Surface": "20.0%",
+                        "Weaponizable Injection Vectors": "0.0%",
+                        "Raw Memory Manipulation": "9.99%",
+                        "Hardcoded Payload Artifacts": "0.0%"
+                    },
+                    "5. Function Analysis": [
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 222.2,
+                            "Lines of Code (LOC)": 45,
+                            "Control Flow Branches": 21,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "63.6%",
+                            "Start Line": 1080,
+                            "End Line": 1124
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 181.8,
+                            "Lines of Code (LOC)": 37,
+                            "Control Flow Branches": 17,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "63.0%",
+                            "Start Line": 634,
+                            "End Line": 670
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 142.1,
+                            "Lines of Code (LOC)": 41,
+                            "Control Flow Branches": 13,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "48.1%",
+                            "Start Line": 3591,
+                            "End Line": 3631
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 71.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "46.2%",
+                            "Start Line": 3880,
+                            "End Line": 3899
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 71.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "46.2%",
+                            "Start Line": 3977,
+                            "End Line": 3996
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 71.0,
+                            "Lines of Code (LOC)": 20,
+                            "Control Flow Branches": 6,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "46.2%",
+                            "Start Line": 4058,
+                            "End Line": 4077
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 60.9,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "45.5%",
+                            "Start Line": 3834,
+                            "End Line": 3850
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 60.9,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "45.5%",
+                            "Start Line": 3928,
+                            "End Line": 3944
+                        },
+                        {
+                            "Function Name": "loword",
+                            "Structural Impact": 55.9,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "77.8%",
+                            "Start Line": 4224,
+                            "End Line": 4233
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 50.7,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "44.4%",
+                            "Start Line": 3684,
+                            "End Line": 3697
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 50.7,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "44.4%",
+                            "Start Line": 3726,
+                            "End Line": 3739
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 50.7,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "44.4%",
+                            "Start Line": 3794,
+                            "End Line": 3807
+                        },
+                        {
+                            "Function Name": "hiword",
+                            "Structural Impact": 42.1,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "71.4%",
+                            "Start Line": 4234,
+                            "End Line": 4243
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 40.8,
+                            "Lines of Code (LOC)": 16,
+                            "Control Flow Branches": 7,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "63.6%",
+                            "Start Line": 496,
+                            "End Line": 511
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 40.5,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "42.9%",
+                            "Start Line": 4014,
+                            "End Line": 4024
+                        },
+                        {
+                            "Function Name": "MethodMixin",
+                            "Structural Impact": 30.4,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "40.0%",
+                            "Start Line": 4090,
+                            "End Line": 4097
+                        },
+                        {
+                            "Function Name": "CoTaskMemFree",
+                            "Structural Impact": 18.8,
+                            "Lines of Code (LOC)": 30,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "37.5%",
+                            "Start Line": 3742,
+                            "End Line": 3771
+                        },
+                        {
+                            "Function Name": "SetCursorPos",
+                            "Structural Impact": 16.9,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 3,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "60.0%",
+                            "Start Line": 249,
+                            "End Line": 266
+                        },
+                        {
+                            "Function Name": "hexVal",
+                            "Structural Impact": 15.8,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 387,
+                            "End Line": 391
+                        },
+                        {
+                            "Function Name": "pxFromPt",
+                            "Structural Impact": 15.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4193,
+                            "End Line": 4199
+                        },
+                        {
+                            "Function Name": "ptFromPx",
+                            "Structural Impact": 15.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 4,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4201,
+                            "End Line": 4207
+                        },
+                        {
+                            "Function Name": "GetDeviceData",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 730,
+                            "End Line": 732
+                        },
+                        {
+                            "Function Name": "CreateEffect",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 754,
+                            "End Line": 756
+                        },
+                        {
+                            "Function Name": "SendDeviceData",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 778,
+                            "End Line": 780
+                        },
+                        {
+                            "Function Name": "EnumEffectsInFile",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 781,
+                            "End Line": 783
+                        },
+                        {
+                            "Function Name": "WriteEffectToFile",
+                            "Structural Impact": 14.8,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 784,
+                            "End Line": 786
+                        },
+                        {
+                            "Function Name": "eql",
+                            "Structural Impact": 14.2,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 393,
+                            "End Line": 399
+                        },
+                        {
+                            "Function Name": "EnumObjects",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 712,
+                            "End Line": 714
+                        },
+                        {
+                            "Function Name": "GetObjectInfo",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 742,
+                            "End Line": 744
+                        },
+                        {
+                            "Function Name": "Initialize",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 751,
+                            "End Line": 753
+                        },
+                        {
+                            "Function Name": "EnumEffects",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 757,
+                            "End Line": 759
+                        },
+                        {
+                            "Function Name": "EnumCreatedEffectObjects",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 769,
+                            "End Line": 771
+                        },
+                        {
+                            "Function Name": "BuildActionMap",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 787,
+                            "End Line": 789
+                        },
+                        {
+                            "Function Name": "SetActionMap",
+                            "Structural Impact": 13.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 4,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 790,
+                            "End Line": 792
+                        },
+                        {
+                            "Function Name": "initString",
+                            "Structural Impact": 12.3,
+                            "Lines of Code (LOC)": 7,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 379,
+                            "End Line": 385
+                        },
+                        {
+                            "Function Name": "GetProperty",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 715,
+                            "End Line": 717
+                        },
+                        {
+                            "Function Name": "SetProperty",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 718,
+                            "End Line": 720
+                        },
+                        {
+                            "Function Name": "Acquire",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 721,
+                            "End Line": 723
+                        },
+                        {
+                            "Function Name": "Unacquire",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 724,
+                            "End Line": 726
+                        },
+                        {
+                            "Function Name": "GetDeviceState",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 727,
+                            "End Line": 729
+                        },
+                        {
+                            "Function Name": "SetCooperativeLevel",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 739,
+                            "End Line": 741
+                        },
+                        {
+                            "Function Name": "RunControlPanel",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 748,
+                            "End Line": 750
+                        },
+                        {
+                            "Function Name": "GetEffectInfo",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 760,
+                            "End Line": 762
+                        },
+                        {
+                            "Function Name": "Poll",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 775,
+                            "End Line": 777
+                        },
+                        {
+                            "Function Name": "QueryInterface",
+                            "Structural Impact": 12.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 796,
+                            "End Line": 798
+                        },
+                        {
+                            "Function Name": "hexVal",
+                            "Structural Impact": 10.6,
+                            "Lines of Code (LOC)": 5,
+                            "Control Flow Branches": 5,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "62.5%",
+                            "Start Line": 351,
+                            "End Line": 355
+                        },
+                        {
+                            "Function Name": "GetCapabilities",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 709,
+                            "End Line": 711
+                        },
+                        {
+                            "Function Name": "SetDataFormat",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 733,
+                            "End Line": 735
+                        },
+                        {
+                            "Function Name": "SetEventNotification",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 736,
+                            "End Line": 738
+                        },
+                        {
+                            "Function Name": "GetDeviceInfo",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 745,
+                            "End Line": 747
+                        },
+                        {
+                            "Function Name": "GetForceFeedbackState",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 763,
+                            "End Line": 765
+                        },
+                        {
+                            "Function Name": "SendForceFeedbackCommand",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 766,
+                            "End Line": 768
+                        },
+                        {
+                            "Function Name": "Escape",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 772,
+                            "End Line": 774
+                        },
+                        {
+                            "Function Name": "GetImageInfo",
+                            "Structural Impact": 10.5,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 793,
+                            "End Line": 795
+                        },
+                        {
+                            "Function Name": "GetWindowLongPtrW",
+                            "Structural Impact": 8.3,
+                            "Lines of Code (LOC)": 6,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "100.0%",
+                            "Start Line": 231,
+                            "End Line": 236
+                        },
+                        {
+                            "Function Name": "dpiFromHwnd",
+                            "Structural Impact": 8.2,
+                            "Lines of Code (LOC)": 8,
+                            "Control Flow Branches": 2,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "66.7%",
+                            "Start Line": 4179,
+                            "End Line": 4186
+                        },
+                        {
+                            "Function Name": "AddRef",
+                            "Structural Impact": 6.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 799,
+                            "End Line": 801
+                        },
+                        {
+                            "Function Name": "Release",
+                            "Structural Impact": 6.2,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 802,
+                            "End Line": 804
+                        },
+                        {
+                            "Function Name": "SetWindowPos",
+                            "Structural Impact": 5.3,
+                            "Lines of Code (LOC)": 46,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 8,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 283,
+                            "End Line": 328
+                        },
+                        {
+                            "Function Name": "DirectInput8Create",
+                            "Structural Impact": 4.7,
+                            "Lines of Code (LOC)": 42,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 6,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 55,
+                            "End Line": 96
+                        },
+                        {
+                            "Function Name": "PeekMessageW",
+                            "Structural Impact": 4.7,
+                            "Lines of Code (LOC)": 41,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 6,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 123,
+                            "End Line": 163
+                        },
+                        {
+                            "Function Name": "ShowWindow",
+                            "Structural Impact": 4.0,
+                            "Lines of Code (LOC)": 44,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1416,
+                            "End Line": 1459
+                        },
+                        {
+                            "Function Name": "getDpiFactor",
+                            "Structural Impact": 3.7,
+                            "Lines of Code (LOC)": 4,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4188,
+                            "End Line": 4191
+                        },
+                        {
+                            "Function Name": "decodeHexByte",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 357,
+                            "End Line": 359
+                        },
+                        {
+                            "Function Name": "xFromLparam",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4245,
+                            "End Line": 4247
+                        },
+                        {
+                            "Function Name": "yFromLparam",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4248,
+                            "End Line": 4250
+                        },
+                        {
+                            "Function Name": "pointFromLparam",
+                            "Structural Impact": 3.6,
+                            "Lines of Code (LOC)": 3,
+                            "Control Flow Branches": 1,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "50.0%",
+                            "Start Line": 4251,
+                            "End Line": 4253
+                        },
+                        {
+                            "Function Name": "RegisterClassW",
+                            "Structural Impact": 3.2,
+                            "Lines of Code (LOC)": 38,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1322,
+                            "End Line": 1359
+                        },
+                        {
+                            "Function Name": "DefWindowProcW",
+                            "Structural Impact": 3.1,
+                            "Lines of Code (LOC)": 14,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1609,
+                            "End Line": 1622
+                        },
+                        {
+                            "Function Name": "EnumDisplayMonitors",
+                            "Structural Impact": 3.0,
+                            "Lines of Code (LOC)": 11,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 5,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2417,
+                            "End Line": 2427
+                        },
+                        {
+                            "Function Name": "LoadCursorW",
+                            "Structural Impact": 2.9,
+                            "Lines of Code (LOC)": 17,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 3,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 1237,
+                            "End Line": 1253
+                        },
+                        {
+                            "Function Name": "ExitProcess",
+                            "Structural Impact": 2.2,
+                            "Lines of Code (LOC)": 10,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 2,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2617,
+                            "End Line": 2626
+                        },
+                        {
+                            "Function Name": "ReleaseCapture",
+                            "Structural Impact": 1.5,
+                            "Lines of Code (LOC)": 18,
+                            "Control Flow Branches": 0,
+                            "Input Parameters": 0,
+                            "Control Flow Ratio": "0.0%",
+                            "Start Line": 2358,
+                            "End Line": 2375
+                        }
+                    ],
+                    "6. Contextual Mitigations & Amplifications": "None Detected",
+                    "7. Structural Signatures (Net Mitigated Signals)": {
+                        "Control Flow Branches": 247,
+                        "Sequential Logic Declarations": 173,
+                        "Function Parameters": 404,
+                        "Function/Method Declarations": 181,
+                        "Class/Entity Declarations": 158,
+                        "Defensive Programming Constructs": 4,
+                        "Type/Safety Bypasses": 154,
+                        "High-Risk Execution Commands": 1,
+                        "I/O and Network Boundaries": 2,
+                        "Exposed API / Public Exports": 1032,
+                        "State Mutations / Variable Reassignments": 3,
+                        "Commented-out Code (Dead Logic)": 4,
+                        "Structured Documentation Blocks": 0,
+                        "Unit Test Assertions": 0,
+                        "Asynchronous/Concurrent Execution": 0,
+                        "UI / View Layer Components": 0,
+                        "Closures and Anonymous Functions": 0,
+                        "Global State Dependencies": 836,
+                        "Decorators and Annotations": 0,
+                        "Generic Type Abstractions": 65,
+                        "Collection Iterators / Comprehensions": 0,
+                        "Scientific & Mathematical Operations": 23,
+                        "Metaprogramming & Reflection": 12,
+                        "Module Dependencies (Imports)": 137,
+                        "Authorship Metadata": 0,
+                        "Planned Work (TODOs)": 27,
+                        "Acknowledged Tech Debt (FIXMEs)": 0,
+                        "Specification Traceability Tags": 0,
+                        "Indentation Faction": 0,
+                        "Server-Side Rendering Contexts": 0,
+                        "Event Publishers / Emitters": 0,
+                        "Dependency Injection Constructs": 0,
+                        "Preprocessor Macros": 0,
+                        "Pointer Arithmetic & Addressing": 728,
+                        "Manual Memory Allocation": 0,
+                        "Inline Assembly Blocks": 0,
+                        "Structured Telemetry & Logging": 0,
+                        "Ad-hoc Print / Debug Statements": 0,
+                        "Explicit Type Casts": 416,
+                        "Fatal Aborts & Exceptions": 139,
+                        "Thread Sleeps & Blocking Waits": 0,
+                        "Bitwise Operations": 32,
+                        "Thread Synchronization Locks": 0,
+                        "Immutable Data Declarations": 1625,
+                        "Resource Deallocation & Cleanup": 0,
+                        "Private / Encapsulated Scopes": 20,
+                        "Event Listeners & Subscribers": 0,
+                        "Bypassed / Skipped Tests": 0,
+                        "Structural Tab Indentations": 0,
+                        "Structural Space Indentations": 3016,
+                        "Hardware Bridge": 0,
+                        "Cryptography": 0,
+                        "Auth Middleware": 0,
+                        "Ipc Rpc Bridges": 0,
+                        "Feature Flags": 0,
+                        "Serialization Parsing": 0,
+                        "Regex Execution": 0,
+                        "Time Date Logic": 0,
+                        "Cloud LLM API Integrations": 0,
+                        "AI Orchestration Frameworks": 0,
+                        "Vector Databases (RAG)": 0,
+                        "Local Inference & Tensor Math": 0,
+                        "Traditional Machine Learning (Stats/Trees)": 0,
+                        "Deep Learning & Neural Networks": 0,
+                        "Lazy Evaluation & Generators (O(1) Memory)": 0,
+                        "Vectorized Math & Tensor Operations": 0,
+                        "Core Var Decl": 0,
+                        "Design Camel Case": 0,
+                        "Design Snake Case": 0,
+                        "Design Pascal Case": 0,
+                        "Design Upper Case": 0,
+                        "Design Short Vars": 0,
+                        "Design Long Vars": 0,
+                        "Duplicate Logic": 16,
+                        "Orphaned Logic": 16,
+                        "Instructional Code Examples": 0,
+                        "Architectural Diagrams (Mermaid/PlantUML)": 0,
+                        "Structured Literature Headers": 0,
+                        "Hyperlinked Literature References": 0,
+                        "High-Entropy / Obfuscated Logic": 0,
+                        "Safety & Constraint Bypasses": 0,
+                        "External Network & I/O Hooks": 0,
+                        "Dynamic Code Execution (Eval/Exec)": 2,
+                        "Global Environment Mutation": 0,
+                        "Commented-Out Executable Logic": 0,
+                        "Low-Level Bitwise / Cryptographic Math": 0,
+                        "Non-Standard / Steganographic Imports": 0,
+                        "Non-Standard Unicode / Homoglyphs": 0,
+                        "Embedded Credentials & Keys": 0,
+                        "Sec Extension Mismatch": 0,
+                        "Sec Entropy": 0,
+                        "Sec Tainted Injection": 0,
+                        "Prompt Injection": 0,
+                        "Agentic Rce": 0
+                    },
+                    "8. Dependency Network": {
+                        "Direct Upstream (Fragility)": 2,
+                        "Direct Downstream (Dependency Blast Radius)": 0,
+                        "Total Upstream (Absolute Fragility)": 0,
+                        "Total Downstream (Absolute Dependency Blast Radius)": 0
+                    },
+                    "9. Extracted Dependencies": [
+                        "builtin",
+                        "std"
                     ]
                 }
             }
@@ -192659,9 +192673,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4554.93,
+                        "X": -4554.73,
                         "Y": -213.15,
-                        "Z": 3307.89
+                        "Z": 3307.75
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_4",
@@ -192873,9 +192887,9 @@
                         "Identity Proof": "Metadata Anchor (Makefile.PL)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5048.09,
+                        "X": -5047.89,
                         "Y": -176.96,
-                        "Z": 3266.82
+                        "Z": 3266.68
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
@@ -193057,9 +193071,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4846.61,
+                        "X": -4846.42,
                         "Y": -219.45,
-                        "Z": 3402.92
+                        "Z": 3402.78
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_4",
@@ -193297,9 +193311,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4472.92,
+                        "X": -4472.72,
                         "Y": -141.29,
-                        "Z": 2949.21
+                        "Z": 2949.07
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -193512,9 +193526,9 @@
                         "Identity Proof": "Single Indicator (Ext: .pm)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4191.0,
+                        "X": -4190.8,
                         "Y": -215.6,
-                        "Z": 3794.05
+                        "Z": 3793.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
@@ -248705,9 +248719,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (100% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3778.16,
+                        "X": -3777.96,
                         "Y": -67.5,
-                        "Z": 3903.15
+                        "Z": 3902.95
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -248978,9 +248992,9 @@
                         "Identity Proof": "Single Indicator (Shebang)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3744.02,
+                        "X": -3743.83,
                         "Y": 72.52,
-                        "Z": 3376.07
+                        "Z": 3375.87
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -249429,9 +249443,9 @@
                         "Identity Proof": "Single Indicator (Shebang)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3526.73,
+                        "X": -3526.54,
                         "Y": -42.48,
-                        "Z": 4453.41
+                        "Z": 4453.21
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -249697,9 +249711,9 @@
                         "Identity Proof": "Sibling Anchor (.m)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3437.4,
+                        "X": -3437.2,
                         "Y": 109.91,
-                        "Z": 3590.0
+                        "Z": 3589.8
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -249893,9 +249907,9 @@
                         "Identity Proof": "Sibling Anchor (.h)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4117.1,
+                        "X": -4116.9,
                         "Y": -83.53,
-                        "Z": 4025.38
+                        "Z": 4025.18
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -250206,9 +250220,9 @@
                         "Identity Proof": "Single Indicator (Shebang)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4307.01,
+                        "X": -4306.81,
                         "Y": -87.83,
-                        "Z": 3983.89
+                        "Z": 3983.69
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -267405,9 +267419,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1750.39,
+                        "X": -1750.35,
                         "Y": -221.18,
-                        "Z": -4306.51
+                        "Z": -4306.42
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -267596,9 +267610,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2000.08,
+                        "X": -2000.04,
                         "Y": -198.6,
-                        "Z": -5145.5
+                        "Z": -5145.42
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_15",
@@ -267921,9 +267935,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2038.92,
+                        "X": -2038.88,
                         "Y": -210.0,
-                        "Z": -4404.36
+                        "Z": -4404.28
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -268247,9 +268261,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2255.63,
+                        "X": -2255.6,
                         "Y": -121.61,
-                        "Z": -4478.99
+                        "Z": -4478.91
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -268528,9 +268542,9 @@
                         "Identity Proof": "Single Indicator (Ext: .go)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2477.08,
+                        "X": -2477.04,
                         "Y": -76.62,
-                        "Z": -4780.82
+                        "Z": -4780.74
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -276689,9 +276703,9 @@
                         "Identity Proof": "Prose Extension (.md)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4144.48,
+                        "X": 4142.82,
                         "Y": 98.22,
-                        "Z": -3540.29
+                        "Z": -3538.86
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -276850,9 +276864,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4413.16,
+                        "X": 4411.5,
                         "Y": 192.22,
-                        "Z": -4033.4
+                        "Z": -4031.97
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -277037,9 +277051,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4661.74,
+                        "X": 4660.08,
                         "Y": 187.55,
-                        "Z": -3387.26
+                        "Z": -3385.83
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -277237,9 +277251,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 3908.02,
+                        "X": 3906.36,
                         "Y": 106.83,
-                        "Z": -3920.58
+                        "Z": -3919.15
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -277435,9 +277449,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4336.1,
+                        "X": 4334.44,
                         "Y": 179.55,
-                        "Z": -3758.76
+                        "Z": -3757.33
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -277708,9 +277722,9 @@
                         "Identity Proof": "Ecosystem Consensus Lock (75% Local Dominance)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4756.61,
+                        "X": 4754.95,
                         "Y": 254.32,
-                        "Z": -4134.84
+                        "Z": -4133.41
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -285389,9 +285403,9 @@
                         "Identity Proof": "Metadata Anchor (COPYING)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4865.26,
+                        "X": -4865.06,
                         "Y": 211.06,
-                        "Z": 4423.64
+                        "Z": 4423.46
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -285550,9 +285564,9 @@
                         "Identity Proof": "Metadata Anchor (configure.ac)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4623.85,
+                        "X": -4623.65,
                         "Y": 251.14,
-                        "Z": 4005.29
+                        "Z": 4005.11
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -285997,9 +286011,9 @@
                         "Identity Proof": "Single Indicator (Ext: .xml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2430.95,
+                        "X": -2430.91,
                         "Y": 119.54,
-                        "Z": -3825.55
+                        "Z": -3825.48
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -286177,9 +286191,9 @@
                         "Identity Proof": "Single Indicator (Ext: .xml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3134.26,
+                        "X": -3134.21,
                         "Y": 255.82,
-                        "Z": -4276.45
+                        "Z": -4276.38
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -286357,9 +286371,9 @@
                         "Identity Proof": "Single Indicator (Ext: .xml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2286.39,
+                        "X": -2286.34,
                         "Y": 90.51,
-                        "Z": -4368.4
+                        "Z": -4368.33
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -286537,9 +286551,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cls)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2735.24,
+                        "X": -2735.2,
                         "Y": 135.41,
-                        "Z": -4188.91
+                        "Z": -4188.84
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -286868,9 +286882,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cls)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2726.06,
+                        "X": -2726.02,
                         "Y": 152.26,
-                        "Z": -4536.57
+                        "Z": -4536.5
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -287079,9 +287093,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cls)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2987.85,
+                        "X": -2987.81,
                         "Y": 234.28,
-                        "Z": -4020.05
+                        "Z": -4019.98
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -293689,9 +293703,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3627.49,
+                        "X": -3627.46,
                         "Y": 14.83,
-                        "Z": -3971.9
+                        "Z": -3971.86
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -293878,9 +293892,9 @@
                         "Identity Proof": "Single Indicator (Ext: .cs)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3412.16,
+                        "X": -3412.13,
                         "Y": -7.95,
-                        "Z": -3980.53
+                        "Z": -3980.5
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
@@ -296977,9 +296991,9 @@
                         "Identity Proof": "Single Indicator (Ext: .td)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4877.82,
+                        "X": 4876.18,
                         "Y": -130.72,
-                        "Z": -3807.62
+                        "Z": -3806.38
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -297157,9 +297171,9 @@
                         "Identity Proof": "Single Indicator (Ext: .td)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 5144.65,
+                        "X": 5143.01,
                         "Y": -71.47,
-                        "Z": -4000.79
+                        "Z": -3999.54
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -297757,9 +297771,9 @@
                         "Identity Proof": "Single Indicator (Ext: .nix)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5337.22,
+                        "X": -5337.03,
                         "Y": 96.0,
-                        "Z": 3207.7
+                        "Z": 3207.58
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -297937,9 +297951,9 @@
                         "Identity Proof": "Single Indicator (Ext: .nix)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -5554.35,
+                        "X": -5554.16,
                         "Y": 86.12,
-                        "Z": 3444.61
+                        "Z": 3444.49
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299107,9 +299121,9 @@
                         "Identity Proof": "Single Indicator (Ext: .mlir)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2166.23,
+                        "X": -2166.2,
                         "Y": -161.46,
-                        "Z": -5240.67
+                        "Z": -5240.59
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299287,9 +299301,9 @@
                         "Identity Proof": "Single Indicator (Ext: .mlir)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -1976.87,
+                        "X": -1976.84,
                         "Y": -190.21,
-                        "Z": -5209.37
+                        "Z": -5209.29
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299497,9 +299511,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4734.33,
+                        "X": -4733.83,
                         "Y": 92.28,
-                        "Z": 2083.73
+                        "Z": 2083.52
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -299677,9 +299691,9 @@
                         "Identity Proof": "Single Indicator (Ext: .yml)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4515.15,
+                        "X": -4514.66,
                         "Y": 141.88,
-                        "Z": 1735.24
+                        "Z": 1735.03
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -302177,9 +302191,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2843.71,
+                        "X": -2843.67,
                         "Y": 112.5,
-                        "Z": -4925.21
+                        "Z": -4925.14
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -302338,9 +302352,9 @@
                         "Identity Proof": "Single Indicator (Ext: .html)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3031.39,
+                        "X": -3031.35,
                         "Y": 183.94,
-                        "Z": -4556.54
+                        "Z": -4556.48
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
@@ -307404,9 +307418,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4174.28,
+                        "X": -4174.1,
                         "Y": 12.49,
-                        "Z": 4525.88
+                        "Z": 4525.67
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -308525,9 +308539,9 @@
                         "Identity Proof": "Single Indicator (Ext: .sql)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3515.99,
+                        "X": -3515.94,
                         "Y": 104.77,
-                        "Z": -3451.56
+                        "Z": -3451.51
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -308766,9 +308780,9 @@
                         "Identity Proof": "Prose Extension (.md)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 4682.63,
+                        "X": 4681.07,
                         "Y": 161.35,
-                        "Z": -4327.28
+                        "Z": -4325.81
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -309148,9 +309162,9 @@
                         "Identity Proof": "Single Indicator (Ext: .sql)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4891.99,
+                        "X": -4891.8,
                         "Y": -179.88,
-                        "Z": 3960.5
+                        "Z": 3960.36
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
@@ -309379,9 +309393,9 @@
                         "Identity Proof": "Metadata Anchor (COPYRIGHT)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3318.33,
+                        "X": -3318.28,
                         "Y": 181.11,
-                        "Z": -4654.53
+                        "Z": -4654.47
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -311154,9 +311168,9 @@
                         "Identity Proof": "Single Indicator (Exact Match)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -4310.22,
+                        "X": -4309.76,
                         "Y": 29.45,
-                        "Z": 2380.88
+                        "Z": 2380.63
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",
@@ -312929,9 +312943,9 @@
                         "Identity Proof": "Prose Extension (.txt)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -2500.75,
+                        "X": -2500.71,
                         "Y": -114.88,
-                        "Z": -4945.57
+                        "Z": -4945.49
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "Static: Literature & Documentation",


### PR DESCRIPTION
Fix Extraction hardening: zig #838: Harden Zig extraction rules for multi-line and nested syntax

This fix was developed using the rigorous 5-stage agent pipeline, addressing critical extraction flaws in Zig:

What the Agents Found:
1. `func_start`: The previous regex failed to handle string literals inside function modifiers (like `extern "c" fn`). Additionally, it entirely missed Zig's `@""` syntax for arbitrary string-literal identifiers.
2. `class_start`: Was overly restrictive with newlines and failed to handle multi-line assignments or quoted identifier syntax (`@"My Struct"`).
3. `args`: The extraction engine used a negated set `[^)]*` that brutally truncated parameters at the very first nested parenthesis. Given that Zig function-pointer parameters nest constantly (e.g. `cb: fn(fn(i32) void) void`), the old extraction was silently truncating most complex signatures.
4. `_dependency_capture`: The regex completely failed on public imports (`pub const x = @import(...)`) and quoted identifiers (`const @"lib" = @import(...)`), blinding the dependency graph to major ecosystem segments.

Red Team Adversarial Testing:
Constructed a comprehensive Zig adversarial testing suite with 32 distinct test scenarios encompassing:
- Deeply nested function pointer arguments up to 2 levels.
- Extreme whitespace and multi-line definitions (`pub \n fn ...`).
- Quoted custom identifier syntax across all constructs.
- Invalid lookalike shielding for string and comment edge cases.

Engineering Implementation:
- Upgraded `args` to use bounded recursive group extraction up to 2 levels of nested parentheses: `\(((?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\)`
- Expanded `func_start` and `class_start` to permit all whitespace boundaries (`[ \t\n]`) and handle `@"..."` literal identifier groups.
- Refactored `_dependency_capture` to gracefully parse `@import` and `@cInclude` regardless of `pub` export status, properly capturing the dependency target into Group 1.

QA Auditing (Crucible):
Verified the changes via `crucible_check.py`. As expected, this successfully updated the architectural profile for the Zig test payloads, updating golden masters with the newly unblinded types and nested arguments. The updated Zig golden masters (`golden_master_audit.json` and `golden_master_zero_dep_audit.json`) have been committed.

Known Limitations:
- **No Block Shielding for Args:** Without AST support, the regex engine will hallucinate matching `args` if a structural lookalike (like `// fn (a: i32)`) appears inside a comment or a string literal. Tests for this have been explicitly marked as `xfail`.
