### PR TITLE
🚀 Hardening & Stability Upgrades: Groovy Extraction

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -12158,10 +12158,10 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # lookahead func_start already uses.
             "args": re.compile(
                 r"^[ \t]*(?:(?:public|private|protected|static|final|def|abstract)[ \t]+){0,5}"
-                r"(?:(?:(?:void|int|long|short|byte|char|float|double|boolean)(?:\[\])?|[A-Z][a-zA-Z0-9_<>\[\]?,]*)[ \t]+){0,3}"
+                r"(?:(?:(?:void|int|long|short|byte|char|float|double|boolean)(?:\[\])?|[a-zA-Z_][a-zA-Z0-9_<>\[\]?,\.]*)[ \t]+){0,3}"
                 r"(?!(?:if|for|while|switch|catch|synchronized)\b)"
-                r"[A-Za-z_$][\w_$]*\s*\((?:[^()]|\([^()]*\))*\)"
-                r"|(?:\((?:[^()]|\([^()]*\))*\)|[a-zA-Z_$][\w_$]{0,100})\s*->",
+                r"[A-Za-z_$][\w_$]*[ \t\n]*\((?:[^()]|\([^()]*\))*\)"
+                r"|(?:(?:\{[ \t\n]*)?(?:\((?:[^()]|\([^()]*\))*\)|[a-zA-Z_$][\w_$]{0,100})?)[ \t\n]*->",
                 re.M,
             ),
             # 3. linear (Sequential Boundaries)
@@ -12182,10 +12182,12 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # return-type fix above); added to the exclusion list alongside
             # the other control-flow-shaped keywords.
             "func_start": re.compile(
-                r"^[ \t]*(?:(?:public|private|protected|static|final|def)[ \t]+){0,5}"
-                r"(?:(?:(?:void|int|long|short|byte|char|float|double|boolean)(?:\[\])?|[A-Z][a-zA-Z0-9_<>\[\]?,]*)[ \t]+){0,3}"
+                r"^[ \t]*(?:@[A-Za-z0-9_.]+(?:\([^)]*\))?[ \t\n]+){0,5}"
+                r"(?:(?:public|private|protected|static|final|def)[ \t\n]+){0,5}"
+                r"(?:<[^>]{0,100}(?:<[^>]{0,100}>[^>]{0,100}){0,5}>[ \t\n]+)?"
+                r"(?:(?:(?:void|int|long|short|byte|char|float|double|boolean)(?:\[\])?|[a-zA-Z_][a-zA-Z0-9_<>\[\]?,\.]*)[ \t\n]+){0,3}"
                 r"(?!(?:if|for|while|switch|catch|synchronized|new|return|class|interface|enum|trait|implementation|testImplementation|api|compileOnly|runtimeOnly|classpath|dependency|from|file|mavenCentral|plugins|dependencies|repositories|task|project|allprojects|subprojects|ext)\b)"
-                r"([A-Za-z_$][\w_$]*)(?=[ \t]*\()",
+                r"([A-Za-z_$][\w_$]*|\"[^\"]*\"|'[^']*')(?=[ \t\n]*\()",
                 re.M,
             ),
             # 5. class_start (Object / Entity Declarations)
@@ -12294,7 +12296,7 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # `import` with a `_dependency_capture` group. Groovy imports
             # follow the identical syntax, so this was a coverage gap, not
             # an intentional Strict-Feature-Parity `None`.
-            "_dependency_capture": re.compile(r"^[ \t]*import[ \t]+(?:static[ \t]+)?([\w.]+)[ \t]*;?", re.M),
+            "_dependency_capture": re.compile(r"^[ \t]*import[ \t\n\\]+(?:static[ \t\n\\]+)?([\w*]+(?:[ \t\n]*\.[ \t\n]*[\w*]+)*)[ \t]*;?", re.M),
             # 25. ownership (Authorship Metadata)
             "ownership": re.compile(r"@author\s+(.*)", re.I),
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -12296,7 +12296,9 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # `import` with a `_dependency_capture` group. Groovy imports
             # follow the identical syntax, so this was a coverage gap, not
             # an intentional Strict-Feature-Parity `None`.
-            "_dependency_capture": re.compile(r"^[ \t]*import[ \t\n\\]+(?:static[ \t\n\\]+)?([\w*]+(?:[ \t\n]*\.[ \t\n]*[\w*]+)*)[ \t]*;?", re.M),
+            "_dependency_capture": re.compile(
+                r"^[ \t]*import[ \t\n\\]+(?:static[ \t\n\\]+)?([\w*]+(?:[ \t\n]*\.[ \t\n]*[\w*]+)*)[ \t]*;?", re.M
+            ),
             # 25. ownership (Authorship Metadata)
             "ownership": re.compile(r"@author\s+(.*)", re.I),
             # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/tests/extraction/languages/test_groovy.py
+++ b/tests/extraction/languages/test_groovy.py
@@ -49,22 +49,25 @@ FUNCTION_CASES: dict[str, Any] = {
         "synchronized (lock) {",
         "for (Map.Entry<String, String> entry : map.entrySet()) {",
         "/* def hiddenMethod() { */",
-        "\"def stringMethod() {\"",
+        '"def stringMethod() {"',
         "def myClosure = { -> }",
     ],
     "pathological": [
         ("public \n void \n weirdSpacing \n ( \n ) \n {", "weirdSpacing"),
-        ("def \n \"pathological string name\" \n ( \n ) \n {", "\"pathological string name\""),
+        ('def \n "pathological string name" \n ( \n ) \n {', '"pathological string name"'),
     ],
 }
+
 
 @pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
 def test_groovy_func_start_valid(payload, expected_name):
     assert_valid_match(GROOVY_RULES["func_start"], payload, expected_name, "groovy.func_start")
 
+
 @pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
 def test_groovy_func_start_invalid(payload):
     assert_invalid_no_match(GROOVY_RULES["func_start"], payload, "groovy.func_start")
+
 
 @pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
 def test_groovy_func_start_pathological(payload, expected_name):
@@ -79,7 +82,7 @@ ARGS_CASES: dict[str, Any] = {
     "valid": [
         ("def foo(int a, String b) {", ""),
         ("void bar(Map<String, ? extends List<Object>> complex, int... varargs) {", ""),
-        ("def baz(\n  @Inject\n  MyType myVar,\n  @Qualifier(\"foo\") String foo\n) {", ""),
+        ('def baz(\n  @Inject\n  MyType myVar,\n  @Qualifier("foo") String foo\n) {', ""),
         ("{ a, b ->", ""),
         ("{ String x, def y ->", ""),
         ("{ ->", ""),
@@ -91,26 +94,33 @@ ARGS_CASES: dict[str, Any] = {
         "while (matcher.find())",
         "catch (Exception e)",
         "/* (a, b) */",
-        "\"(String a, int b)\"",
+        '"(String a, int b)"',
         "def foo = (a + b) * c",
     ],
     "pathological": [
-        ("def \n foo \n ( \n String \n a \n = \n \"default), with, commas\", \n int \n b \n = \n [1,2,3].size() \n ) \n {", ""),
+        (
+            'def \n foo \n ( \n String \n a \n = \n "default), with, commas", \n int \n b \n = \n [1,2,3].size() \n ) \n {',
+            "",
+        ),
     ],
 }
+
 
 @pytest.mark.parametrize("payload,expected", ARGS_CASES["valid"])
 def test_groovy_args_valid(payload, expected):
     assert_valid_match(GROOVY_RULES["args"], payload, expected, "groovy.args")
 
+
 @pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
 def test_groovy_args_invalid(payload):
     assert_invalid_no_match(GROOVY_RULES["args"], payload, "groovy.args")
+
 
 @pytest.mark.parametrize("payload,expected", ARGS_CASES["pathological"])
 def test_groovy_args_pathological(payload, expected):
     assert_pathological_match(GROOVY_RULES["args"], payload, expected, "groovy.args")
     assert_redos_immune(GROOVY_RULES["args"], payload)
+
 
 # ==============================================================================
 # CLASS_START (class_start)
@@ -118,7 +128,10 @@ def test_groovy_args_pathological(payload, expected):
 CLASS_CASES: dict[str, Any] = {
     "valid": [
         ("class SimpleClass {", "SimpleClass"),
-        ("public abstract class ComplexClass<T extends Number & Comparable<T>> extends BaseClass<T> implements InterfaceA, InterfaceB {", "ComplexClass"),
+        (
+            "public abstract class ComplexClass<T extends Number & Comparable<T>> extends BaseClass<T> implements InterfaceA, InterfaceB {",
+            "ComplexClass",
+        ),
         ("trait MyTrait {", "MyTrait"),
         ("interface MyInterface extends BaseInterface {", "MyInterface"),
         ("@CompileStatic\n@EqualsAndHashCode(callSuper = true)\nclass AnnotatedClass {", "AnnotatedClass"),
@@ -135,18 +148,22 @@ CLASS_CASES: dict[str, Any] = {
     ],
 }
 
+
 @pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
 def test_groovy_class_start_valid(payload, expected_name):
     assert_valid_match(GROOVY_RULES["class_start"], payload, expected_name, "groovy.class_start")
+
 
 @pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
 def test_groovy_class_start_invalid(payload):
     assert_invalid_no_match(GROOVY_RULES["class_start"], payload, "groovy.class_start")
 
+
 @pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
 def test_groovy_class_start_pathological(payload, expected_name):
     assert_pathological_match(GROOVY_RULES["class_start"], payload, expected_name, "groovy.class_start")
     assert_redos_immune(GROOVY_RULES["class_start"], payload)
+
 
 # ==============================================================================
 # DEPENDENCY (_dependency_capture)
@@ -161,9 +178,9 @@ DEPENDENCY_CASES: dict[str, Any] = {
     ],
     "invalid": [
         "def importData() {",
-        "String myImport = \"import foo.bar\"",
+        'String myImport = "import foo.bar"',
         "// import java.util.List",
-        "String s = \"import java.util.List\"",
+        'String s = "import java.util.List"',
         "importantVariable = true",
     ],
     "pathological": [
@@ -172,15 +189,22 @@ DEPENDENCY_CASES: dict[str, Any] = {
     ],
 }
 
+
 @pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
 def test_groovy_dependency_capture_valid(payload, expected_path):
-    assert_valid_dependency_match(GROOVY_RULES["_dependency_capture"], payload, expected_path, "groovy._dependency_capture")
+    assert_valid_dependency_match(
+        GROOVY_RULES["_dependency_capture"], payload, expected_path, "groovy._dependency_capture"
+    )
+
 
 @pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
 def test_groovy_dependency_capture_invalid(payload):
     assert_invalid_no_match(GROOVY_RULES["_dependency_capture"], payload, "groovy._dependency_capture")
 
+
 @pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
 def test_groovy_dependency_capture_pathological(payload, expected_path):
-    assert_pathological_dependency_match(GROOVY_RULES["_dependency_capture"], payload, expected_path, "groovy._dependency_capture")
+    assert_pathological_dependency_match(
+        GROOVY_RULES["_dependency_capture"], payload, expected_path, "groovy._dependency_capture"
+    )
     assert_redos_immune(GROOVY_RULES["_dependency_capture"], payload)

--- a/tests/extraction/languages/test_groovy.py
+++ b/tests/extraction/languages/test_groovy.py
@@ -1,0 +1,186 @@
+"""
+Groovy extraction hardening (epic #813, issue #829). See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for groovy in one file: func_start,
+args, class_start, _dependency_capture. Migrated out of the old
+monolithic dict files.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any  # noqa: E402
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+GROOVY_RULES = LANGUAGE_DEFINITIONS["groovy"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start)
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        ("def foo() {", "foo"),
+        ("public static final Map<String, List<String>> getComplexData() {", "getComplexData"),
+        ("def \"method with spaces and 'quotes'\"() {", "\"method with spaces and 'quotes'\""),
+        ("@Override\nprotected <T extends Comparable<T>> List<T> sort(List<T> list) throws Exception {", "sort"),
+        ("java.lang.String[] fullyQualifiedArrayReturn(int a) {", "fullyQualifiedArrayReturn"),
+        ("MyClass(String constructorArg) {", "MyClass"),
+    ],
+    "invalid": [
+        "if (condition()) {",
+        "catch (Exception e) {",
+        "synchronized (lock) {",
+        "for (Map.Entry<String, String> entry : map.entrySet()) {",
+        "/* def hiddenMethod() { */",
+        "\"def stringMethod() {\"",
+        "def myClosure = { -> }",
+    ],
+    "pathological": [
+        ("public \n void \n weirdSpacing \n ( \n ) \n {", "weirdSpacing"),
+        ("def \n \"pathological string name\" \n ( \n ) \n {", "\"pathological string name\""),
+    ],
+}
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_groovy_func_start_valid(payload, expected_name):
+    assert_valid_match(GROOVY_RULES["func_start"], payload, expected_name, "groovy.func_start")
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_groovy_func_start_invalid(payload):
+    assert_invalid_no_match(GROOVY_RULES["func_start"], payload, "groovy.func_start")
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_groovy_func_start_pathological(payload, expected_name):
+    assert_pathological_match(GROOVY_RULES["func_start"], payload, expected_name, "groovy.func_start")
+    assert_redos_immune(GROOVY_RULES["func_start"], payload)
+
+
+# ==============================================================================
+# ARGS (args)
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        ("def foo(int a, String b) {", ""),
+        ("void bar(Map<String, ? extends List<Object>> complex, int... varargs) {", ""),
+        ("def baz(\n  @Inject\n  MyType myVar,\n  @Qualifier(\"foo\") String foo\n) {", ""),
+        ("{ a, b ->", ""),
+        ("{ String x, def y ->", ""),
+        ("{ ->", ""),
+    ],
+    "invalid": [
+        "dependencies {",
+        "tasks.register('myTask') {",
+        "if (a > b && c < d)",
+        "while (matcher.find())",
+        "catch (Exception e)",
+        "/* (a, b) */",
+        "\"(String a, int b)\"",
+        "def foo = (a + b) * c",
+    ],
+    "pathological": [
+        ("def \n foo \n ( \n String \n a \n = \n \"default), with, commas\", \n int \n b \n = \n [1,2,3].size() \n ) \n {", ""),
+    ],
+}
+
+@pytest.mark.parametrize("payload,expected", ARGS_CASES["valid"])
+def test_groovy_args_valid(payload, expected):
+    assert_valid_match(GROOVY_RULES["args"], payload, expected, "groovy.args")
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_groovy_args_invalid(payload):
+    assert_invalid_no_match(GROOVY_RULES["args"], payload, "groovy.args")
+
+@pytest.mark.parametrize("payload,expected", ARGS_CASES["pathological"])
+def test_groovy_args_pathological(payload, expected):
+    assert_pathological_match(GROOVY_RULES["args"], payload, expected, "groovy.args")
+    assert_redos_immune(GROOVY_RULES["args"], payload)
+
+# ==============================================================================
+# CLASS_START (class_start)
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("class SimpleClass {", "SimpleClass"),
+        ("public abstract class ComplexClass<T extends Number & Comparable<T>> extends BaseClass<T> implements InterfaceA, InterfaceB {", "ComplexClass"),
+        ("trait MyTrait {", "MyTrait"),
+        ("interface MyInterface extends BaseInterface {", "MyInterface"),
+        ("@CompileStatic\n@EqualsAndHashCode(callSuper = true)\nclass AnnotatedClass {", "AnnotatedClass"),
+    ],
+    "invalid": [
+        "def classLoader = new ClassLoader()",
+        "String myclass = 'class Foo {'",
+        "/* class HiddenClass { */",
+        "def myMethod() { classLoader.loadClass('Foo') }",
+        "classyMethod()",
+    ],
+    "pathological": [
+        ("class \n Pathological \n <T> \n {", "Pathological"),
+    ],
+}
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_groovy_class_start_valid(payload, expected_name):
+    assert_valid_match(GROOVY_RULES["class_start"], payload, expected_name, "groovy.class_start")
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_groovy_class_start_invalid(payload):
+    assert_invalid_no_match(GROOVY_RULES["class_start"], payload, "groovy.class_start")
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_groovy_class_start_pathological(payload, expected_name):
+    assert_pathological_match(GROOVY_RULES["class_start"], payload, expected_name, "groovy.class_start")
+    assert_redos_immune(GROOVY_RULES["class_start"], payload)
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture)
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("import foo.bar.Baz", "foo.bar.Baz"),
+        ("import static java.lang.Math.PI", "java.lang.Math.PI"),
+        ("import java.util.concurrent.atomic.AtomicInteger as AtomicInt", "java.util.concurrent.atomic.AtomicInteger"),
+        ("import java.util.*", "java.util.*"),
+        ("import foo.bar.Baz;", "foo.bar.Baz"),
+    ],
+    "invalid": [
+        "def importData() {",
+        "String myImport = \"import foo.bar\"",
+        "// import java.util.List",
+        "String s = \"import java.util.List\"",
+        "importantVariable = true",
+    ],
+    "pathological": [
+        ("import \\\n  java.util.List", "java.util.List"),
+        ("import      java  .  util  .  Map", "java  .  util  .  Map"),
+    ],
+}
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_groovy_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(GROOVY_RULES["_dependency_capture"], payload, expected_path, "groovy._dependency_capture")
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_groovy_dependency_capture_invalid(payload):
+    assert_invalid_no_match(GROOVY_RULES["_dependency_capture"], payload, "groovy._dependency_capture")
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_groovy_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(GROOVY_RULES["_dependency_capture"], payload, expected_path, "groovy._dependency_capture")
+    assert_redos_immune(GROOVY_RULES["_dependency_capture"], payload)

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S101
 import pytest
 
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
@@ -50,7 +51,6 @@ EXTRACTION_CASES = {
             )
         ],
     },
-
     "apex": {
         "valid": [
             ("public static void TargetFunc()", "TargetFunc"),
@@ -231,7 +231,6 @@ EXTRACTION_CASES = {
         "invalid": ["set TargetFunc", "if {$TargetFunc}"],
         "pathological": [("proc \t TargetFunc \t {", "TargetFunc")],
     },
-
 }
 
 

--- a/tests/extraction/test_function_extraction_strict.py
+++ b/tests/extraction/test_function_extraction_strict.py
@@ -1,4 +1,5 @@
 import pytest
+
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 
 # =======================================================================# THE UNIVERSAL EXTRACTION GAUNTLET
@@ -199,11 +200,6 @@ EXTRACTION_CASES = {
         "valid": [("function TargetFunc()", "TargetFunc"), ("modifier TargetFunc()", "TargetFunc")],
         "invalid": ["contract TargetFunc", "struct TargetFunc"],
         "pathological": [("function \n TargetFunc \n (", "TargetFunc")],
-    },
-    "groovy": {
-        "valid": [("def TargetFunc()", "TargetFunc"), ("public void TargetFunc()", "TargetFunc")],
-        "invalid": ["class TargetFunc", "if (TargetFunc)"],
-        "pathological": [("public \t static \t def \t TargetFunc \t (", "TargetFunc")],
     },
     "jcl": {
         "valid": [("//TargetFunc EXEC PGM=PROG", "TargetFunc")],


### PR DESCRIPTION
## 🚀 Hardening & Stability Upgrades: Groovy Extraction
Closes #829.
Part of Epic #813 (Extraction Hardening & CI/CD Rigor).

### 🎯 Objectives & Status
- [x] Migrate legacy tests into a dedicated suite (`tests/extraction/languages/test_groovy.py`).
- [x] Harden all 4 core extraction rules (`func_start`, `class_start`, `args`, `_dependency_capture`) against ReDoS.
- [x] Verify multi-gauntlet extraction (Valid, Invalid, Pathological cases).
- [x] Ensure strict core engine structural tests pass.
- [x] Golden Masters verified (No drift).

### 🔎 Discovery & What We Found
During the hardening process for Groovy, we discovered significant gaps in the legacy extraction logic:
1. **Spock Testing Framework**: The previous `func_start` rule could not parse Groovy methods declared with string literal names (e.g., `def "should do something"()`), which is highly common in Spock tests.
2. **Generics Constraints**: The legacy rule failed to parse methods with nested generic return types (e.g., `List<Map<String, String>> func()`).
3. **Capture Group Flaws**: `_dependency_capture` lacked strict grouping, causing false positives and failures in the `test_language_standards_strict.py` gauntlet.

### 🛡️ Improvements & Tests Added
We fully modernized the Groovy extraction rules:
1. **Spock & Generics Support**: Upgraded `func_start` to cleanly extract both standard identifiers and string-literal function names, while supporting nested generic bounded parameters.
2. **Strict Mode Compliance**: Fixed `_dependency_capture` to perfectly align with the engine's strict group capturing rules (e.g., extracting just the package name without the `import` keyword).
3. **Adversarial Test Suite**: Added a robust suite of 53 tests targeting pathologically complex closures, multiline attributes, and adversarial whitespace.

### ⚠️ Engine Limitations & Known Constraints
Due to the lack of an AST, parsing deeply nested, multi-line Spock function names with embedded closures can occasionally overwhelm the regex boundary. We mitigated this by enforcing bounded quantifiers in the generic step-over logic, preventing catastrophic backtracking at the cost of failing to extract extremely deformed method signatures.

All extraction gauntlets and CI pipeline checks have successfully passed.
