### PR TITLE
Use Delta Scan for self-scan DB regen; add self-scan-query skill

### DIFF
--- a/.claude/skills/self-scan-query/SKILL.md
+++ b/.claude/skills/self-scan-query/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: self-scan-query
+description: Query GitGalaxy's own self-scan SQLite DB (docs/self_scan/gitgalaxy_master.db) for per-file/function complexity, LOC, call graphs, and blast-radius ranking -- near-zero-token compared to grep or an Explore subagent for these questions. Use before touching a file to gauge how big/complex/depended-on it is, before a large refactor to find the real blast-radius ranking, or to answer "what does function X call" / "which functions in this file are heaviest" / "which directory has the most code". Do NOT use for finding string literals, dict/list-literal keys, exact line numbers, or any non-function symbol -- the DB has no line numbers and doesn't parse literal internals; grep or Read for those.
+---
+
+Source of truth for the DB's purpose and schema notes is the docstring at the top of
+`tests/tools/self_scan.py` -- read it if anything here seems stale, since the recorder schema
+evolves. This skill exists because an LLM session in this repo can burn real tokens re-deriving
+basic structural facts (how big is this file, how many functions does it have, what's the
+heaviest function here) via grep or an Explore subagent, when GitGalaxy's own engine already
+extracted that as a Structural Signature about itself.
+
+## Step 1 -- freshness check (do this before trusting any file-specific result)
+
+The DB is a snapshot of the working tree at generation time, not a live view. Check it's still
+current before relying on it for anything about a *specific* file you're about to edit (a stale
+snapshot is fine for broad orientation like "which directory group is heaviest" -- less fine for
+"how complex is this file right now"):
+
+```bash
+git rev-parse HEAD
+sqlite3 docs/self_scan/gitgalaxy_master.db "SELECT DISTINCT commit_hash FROM file_data;"
+git status --porcelain   # anything uncommitted touching files you care about?
+```
+
+If the DB is missing, `commit_hash` doesn't match current `HEAD`, or there are uncommitted
+changes to files relevant to your question, regenerate before querying:
+
+```bash
+python tests/tools/self_scan.py
+```
+
+Takes ~6-8s. Requires `galaxyscope` on PATH (an activated venv with `pip install -e .`) and
+`networkx`/`tiktoken`/`numpy`/`pandas`/`xgboost`/`pyyaml` importable -- the script itself checks
+for all six and aborts loudly with an install hint if any are missing, rather than silently
+producing a degraded (NULL pagerank/blast-radius) DB. Don't try to work around a failed
+regeneration by querying the stale DB anyway for a file-specific question -- fall back to
+grep/Read instead, and say why.
+
+## Step 2 -- always confirm schema before querying
+
+Column names have drifted before. Never guess:
+
+```bash
+sqlite3 docs/self_scan/gitgalaxy_master.db ".schema file_data"
+sqlite3 docs/self_scan/gitgalaxy_master.db ".schema function_data"
+```
+
+## Query cookbook
+
+Heaviest/most complex functions in a file, before editing it:
+
+```bash
+sqlite3 docs/self_scan/gitgalaxy_master.db \
+  "SELECT f.func_name, f.complexity, f.loc, f.calls_out_to
+   FROM function_data f JOIN file_data fd ON f.file_id = fd.id
+   WHERE fd.file_path LIKE '%detector.py%' ORDER BY f.complexity DESC LIMIT 10;"
+```
+
+What does function X call (approximate call graph, no cross-file resolution -- `calls_out_to` is
+a raw text list, not linked to `function_data.id`):
+
+```bash
+sqlite3 docs/self_scan/gitgalaxy_master.db \
+  "SELECT func_name, calls_out_to FROM function_data WHERE func_name = 'parse_manifest';"
+```
+
+Who calls function X (grep-the-column, since `calls_out_to` is text, not a foreign key):
+
+```bash
+sqlite3 docs/self_scan/gitgalaxy_master.db \
+  "SELECT fd.file_path, f.func_name FROM function_data f JOIN file_data fd ON f.file_id = fd.id
+   WHERE f.calls_out_to LIKE '%parse_manifest%';"
+```
+
+File-level orientation before deciding where new code belongs, or before a refactor (blast
+radius / fan-in ranking):
+
+```bash
+sqlite3 docs/self_scan/gitgalaxy_master.db \
+  "SELECT file_path, function_count, class_count, total_loc, avg_func_complexity,
+          pagerank_score, normalized_blast_radius
+   FROM file_data ORDER BY pagerank_score DESC LIMIT 10;"
+
+sqlite3 docs/self_scan/gitgalaxy_master.db \
+  "SELECT directory_group, COUNT(*) files, SUM(total_loc) loc, SUM(function_count) funcs
+   FROM file_data GROUP BY directory_group ORDER BY loc DESC LIMIT 8;"
+```
+
+If `pagerank_score`/`normalized_blast_radius` come back NULL across the board, the scan ran in
+Zero-Dependency Mode (one of the six full-precision packages wasn't importable at scan time) --
+rerun `python tests/tools/self_scan.py` in an environment that has all of them, don't trust
+blast-radius rankings from a NULL column.
+
+## Boundaries -- when to fall back to grep/Read/Explore instead
+
+- Finding a string literal, comment, config key, or anything inside a dict/list literal (the DB
+  explicitly can't see inside e.g. `language_standards.py`'s `LANGUAGE_DEFINITIONS` dict).
+- Getting an exact line number -- the DB doesn't store one; once you know *which file* from a DB
+  query, grep or Read that file for the actual location.
+- Any symbol that isn't a function or class (variables, constants, types, imports by name).
+- A file too new/uncommitted to be in the DB at all, or one excluded by `.galaxyscope.yaml`
+  (check `excluded_artifacts` table if a file you expect is missing).

--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -2964,7 +2964,7 @@ def main():
         scope = Orchestrator(args.target, full_config)
 
         if args.incremental:
-            from gitgalaxy.state_rehydrator import StateRehydrator
+            from gitgalaxy.core.state_rehydrator import StateRehydrator
 
             logging.info(f"🔄 Delta Scan Requested: Attempting to rehydrate from {args.incremental}")
 

--- a/tests/tools/self_scan.py
+++ b/tests/tools/self_scan.py
@@ -18,9 +18,15 @@ orientation and prioritization, not symbol lookup.
 
 The DB is gitignored (*.db, see .gitignore) and NOT committed -- it's a local,
 disposable, cheaply-regenerable artifact, same spirit as .crucible_venvs/.
-Regenerate it whenever it's gone stale enough to matter (e.g. after a batch
-of merged PRs); there's no incremental-staleness tracking here, just a fast
-full rescan (~6-8s on this repo as of 2026-07).
+
+Regeneration uses galaxyscope's own `--incremental` Delta Scan (gitgalaxy/state_rehydrator.py)
+when a usable baseline already exists at DB_PATH: it rehydrates the previous structural state
+from SQLite, diffs the working tree against the baseline commit, and only re-parses
+added/modified files -- the same mechanism CI uses for large repos. If the DB already exactly
+matches current HEAD with a clean working tree, the scan is skipped entirely. First run (or a
+DB from before this existed) falls back to a full scan. Either way, run() prunes the DB back
+down to a single commit's rows afterward -- see _prune_stale_commits()'s docstring for why that
+matters.
 
 USAGE
     python tests/tools/self_scan.py               # regenerate, print a summary
@@ -47,11 +53,15 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SELF_SCAN_DIR = REPO_ROOT / "docs" / "self_scan"
 DB_PATH = SELF_SCAN_DIR / "gitgalaxy_master.db"
+# Matches target_path.name in galaxyscope.py's main() -- the exact string both
+# the recorder (repo_name column) and StateRehydrator.load_latest_state() key on.
+PROJECT_NAME = REPO_ROOT.name
 
 # Mirrors the HAS_NETWORKX / HAS_TIKTOKEN / ML_AVAILABLE / HAS_PYYAML checks in
 # galaxyscope.py / network_risk_sensor.py / security_auditor.py. Without every
@@ -78,30 +88,97 @@ def _check_full_precision_deps() -> None:
         )
 
 
-def regenerate() -> None:
+def _git(*args: str) -> str:
+    return subprocess.check_output(  # noqa: S603 -- fixed "git" binary via PATH, args are literals/constants only
+        ["git", *args], cwd=REPO_ROOT, text=True, stderr=subprocess.DEVNULL
+    ).strip()
+
+
+def _current_head() -> str:
+    return _git("rev-parse", "HEAD")
+
+
+def _working_tree_dirty() -> bool:
+    return bool(_git("status", "--porcelain"))
+
+
+def _db_commit_hashes() -> set[str]:
+    if not DB_PATH.exists():
+        return set()
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT commit_hash FROM file_data WHERE repo_name = ?", (PROJECT_NAME,)
+        ).fetchall()
+        return {r[0] for r in rows}
+    except sqlite3.OperationalError:
+        # Pre-existing DB predates a column/table this query relies on -- treat as unusable.
+        return set()
+    finally:
+        conn.close()
+
+
+def _prune_stale_commits(keep_hash: str) -> None:
+    """
+    record_mission() (gitgalaxy/recorders/record_keeper.py) DELETEs-then-INSERTs keyed on
+    (repo_name, commit_hash) -- a Delta Scan against a moved HEAD writes a NEW commit_hash's
+    rows without touching the old baseline's, so left alone they'd accumulate forever as HEAD
+    moves. This DB is meant to reflect current state only (no history queries), so collapse it
+    back down to a single commit after every scan, incremental or not.
+
+    file_data/folder_data/repo_data all carry commit_hash directly and have no FK relationship
+    to each other (checked: file_data has no FK back to repo_data), so each needs its own
+    DELETE. function_data/class_data are NOT touched directly -- they cascade automatically via
+    their file_id -> file_data(id) ON DELETE CASCADE foreign key.
+    """
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        for table in ("repo_data", "folder_data", "file_data"):
+            conn.execute(f"DELETE FROM {table} WHERE repo_name = ? AND commit_hash != ?", (PROJECT_NAME, keep_hash))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def regenerate() -> bool:
+    """Returns True if a scan actually ran, False if the existing DB was already current."""
     _check_full_precision_deps()
     SELF_SCAN_DIR.mkdir(parents=True, exist_ok=True)
     galaxyscope = shutil.which("galaxyscope")
     if not galaxyscope:
         sys.exit("galaxyscope not found on PATH -- activate the venv with gitgalaxy installed (pip install -e .)")
 
-    # The recorder DELETEs-then-INSERTs keyed on (repo_name, commit_hash), so it
-    # only replaces rows from a run at the SAME commit -- rows from a previous
-    # commit would otherwise accumulate forever as HEAD moves. Since this DB is
-    # meant to reflect current state only (no history queries), just start
-    # from a clean file every time instead of relying on that keyed replace.
-    DB_PATH.unlink(missing_ok=True)
+    head = _current_head()
+    existing = _db_commit_hashes()
 
+    # DB already reflects exactly this commit with nothing uncommitted on top -- a rescan
+    # (incremental or not) would produce byte-identical structural facts. Skip the subprocess.
+    if existing == {head} and not _working_tree_dirty():
+        return False
+
+    # StateRehydrator.load_latest_state() needs a real baseline row to rehydrate from -- if the
+    # DB is missing, or predates this repo_name/schema, there's nothing to diff against, so
+    # start clean instead of passing --incremental at a baseline it can't use.
+    incremental = DB_PATH.exists() and bool(existing)
+    if not incremental:
+        DB_PATH.unlink(missing_ok=True)
+
+    cmd = [
+        galaxyscope,
+        str(REPO_ROOT),
+        "--config",
+        str(REPO_ROOT / ".galaxyscope.yaml"),
+        "--db-only",
+        "--output",
+        str(SELF_SCAN_DIR / "gitgalaxy.json"),
+    ]
+    if incremental:
+        cmd += ["--incremental", str(DB_PATH)]
+
+    start = time.time()
     result = subprocess.run(  # noqa: S603 -- galaxyscope resolved absolute via shutil.which, fixed args
-        [
-            galaxyscope,
-            str(REPO_ROOT),
-            "--config",
-            str(REPO_ROOT / ".galaxyscope.yaml"),
-            "--db-only",
-            "--output",
-            str(SELF_SCAN_DIR / "gitgalaxy.json"),
-        ],
+        cmd,
         cwd=REPO_ROOT,
         # Merge with (not replace) the parent env -- galaxyscope shells out to
         # `git` to resolve commit_hash, which needs PATH/HOME/etc. A bare
@@ -112,19 +189,33 @@ def regenerate() -> None:
         text=True,
         timeout=120,
     )
+    elapsed = time.time() - start
     if result.returncode != 0 or not DB_PATH.exists():
         print(result.stdout)
         print(result.stderr, file=sys.stderr)
         sys.exit(f"self-scan failed -- {DB_PATH} was not produced")
 
+    # galaxyscope falls back to a full scan internally if the delta (git diff against the
+    # baseline commit) fails, so the DB may hold more than just {head} even on the incremental
+    # path -- and on the happy path, the keyed DELETE-then-INSERT above never touches the old
+    # baseline's rows either way. Collapse to current HEAD regardless of which path ran.
+    _prune_stale_commits(_current_head())
 
-def print_summary() -> None:
+    mode = "incremental" if incremental else "full"
+    print(f"   ({mode} scan, {elapsed:.1f}s)")
+    return True
+
+
+def print_summary(ran: bool) -> None:
     conn = sqlite3.connect(DB_PATH)
     try:
         (total_files,) = conn.execute("SELECT COUNT(*) FROM file_data").fetchone()
         (total_funcs,) = conn.execute("SELECT COUNT(*) FROM function_data").fetchone()
         (total_classes,) = conn.execute("SELECT COUNT(*) FROM class_data").fetchone()
-        print(f"✅ Regenerated {DB_PATH.relative_to(REPO_ROOT)}")
+        if ran:
+            print(f"✅ Regenerated {DB_PATH.relative_to(REPO_ROOT)}")
+        else:
+            print(f"✅ {DB_PATH.relative_to(REPO_ROOT)} already current at HEAD -- scan skipped")
         print(f"   {total_files} files, {total_funcs} functions, {total_classes} classes indexed.")
 
         # Belt-and-suspenders: _check_full_precision_deps() confirms the
@@ -149,8 +240,8 @@ def main() -> int:
     parser.add_argument("--query", help="Ad hoc SQL to run against the DB after regenerating, printed as rows")
     args = parser.parse_args()
 
-    regenerate()
-    print_summary()
+    ran = regenerate()
+    print_summary(ran)
 
     if args.query:
         conn = sqlite3.connect(DB_PATH)


### PR DESCRIPTION
## Summary
- `tests/tools/self_scan.py` now skips regeneration entirely when the DB already matches current `HEAD` on a clean working tree, and otherwise uses galaxyscope's existing `--incremental` Delta Scan (`gitgalaxy/core/state_rehydrator.py`) to only re-parse added/modified files instead of always doing a full rescan.
- Since a Delta Scan's `DELETE`-then-`INSERT` is keyed on `(repo_name, commit_hash)`, the DB is pruned back to a single commit's rows after every run (`_prune_stale_commits`) so it keeps reflecting current state only, rather than accumulating history as `HEAD` moves.
- **Bug fix**: `gitgalaxy/galaxyscope.py` imported `from gitgalaxy.state_rehydrator import StateRehydrator`, but the module lives at `gitgalaxy/core/state_rehydrator.py` -- `--incremental` has been broken (`ModuleNotFoundError`) since it was added. Masked by `test_main_cli_incremental_diff_parsing`, which injects a mock at both the correct and incorrect `sys.modules` path "to ensure any underlying import passes smoothly."
- Adds a `self-scan-query` skill documenting how to query the self-scan DB (function/file complexity, LOC, call graphs, blast-radius ranking) instead of reaching for grep or an Explore subagent for these questions -- including the freshness check to run before trusting file-specific results.

## Test plan
- [x] `python tests/tools/audit_check.py` -- clean (ruff/mypy/dead-key/format)
- [x] `python -m pytest tests/core_engine/test_galaxyscope.py tests/core_engine/test_state_rehydrator.py -q` -- 51 passed
- [x] Row-for-row parity check: incremental scan vs. a fresh full scan of the same commit -- identical `file_data` (loc/function/class counts), `pagerank_score`, `normalized_blast_radius`, and per-function `complexity`/`loc` across all 224 files / 1170 functions. (Only divergence found -- `calls_out_to` set sampling on ~38 functions -- reproduces identically between two independent full scans of the same commit, confirming it's pre-existing non-determinism unrelated to this change.)
- [x] Verified the skip-path condition (`DB commit == HEAD` and clean tree) in isolation without disturbing a real working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)