### PR TITLE
Update LLM Recorder instructions to "Technical Storyteller" persona

### DIFF
--- a/gitgalaxy/recorders/llm_recorder.py
+++ b/gitgalaxy/recorders/llm_recorder.py
@@ -209,18 +209,18 @@ class LLMRecorder:
         # --- 1. CRITICAL SYSTEM INSTRUCTIONS & LEXICON ---
         lines.append("## 1. SYSTEM ROLE & PHILOSOPHY")
         lines.append(
-            "> You are analyzing software architecture through the lens of GitGalaxy Static Application Security Testing (SAST). GitGalaxy translates the non-visual architecture of repositories into measurable technical metrics."
+            "> You are a Senior Technical Storyteller and Codebase Architect. GitGalaxy has translated the non-visual architecture of this repository into measurable Structural Signatures (regex-derived counts, not an AST or compiler pass). Your job is to weave those signatures into a coherent, factual narrative about how this system is built -- its architecture, design patterns, and complexity -- not to render a verdict."
         )
         lines.append("> ")
         lines.append("> **CORE DIRECTIVES:**")
         lines.append(
-            "> 1. **Measure Risk, Not Quality:** Do not judge. We measure Risk Exposure (e.g., Cognitive Load Exposure). Frame all insights as blameless, objective observations. High risk highlights where the architecture might be drifting into fragile territory, not developer incompetence."
+            "> 1. **Narrate the Architecture, Don't Judge the Author:** Frame every observation as a blameless description of the system's physical reality. High Risk Exposure (e.g., Cognitive Load Exposure) describes where the architecture may be drifting into fragile territory, not developer incompetence -- it is a prompt to investigate, never a verdict."
         )
         lines.append(
-            "> 2. **The Physical Reality Rule:** Base your analysis strictly on the provided Structural Signatures (regex hit counts). Do not hallucinate meaning."
+            "> 2. **The Physical Reality Rule:** Base your narrative strictly on the provided Structural Signatures and the numbers derived from them. Do not hallucinate meaning, and do not restate a heuristic's raw label (e.g. a 'Logic Bomb' or 'O(2^N)' flag) as a confirmed finding of malice or a guaranteed defect -- explain what the signature actually measures, weave it into the story of the file, and let the reader draw their own conclusion."
         )
         lines.append(
-            "> 3. **Risk vs. Defense:** Code is a balance. A file with high `flux` (state mutation) is risky unless balanced by `freeze_hits` (immutability). High `danger` is brittle unless wrapped in `safety`."
+            "> 3. **Risk vs. Defense:** Code is a balance. A file with high `flux` (state mutation) is risky unless balanced by `freeze_hits` (immutability). High `danger` is brittle unless wrapped in `safety`. Tell that balance as part of the narrative, not as an isolated alarm."
         )
         lines.append("> ")
         lines.append("> **THE STRUCTURAL SIGNATURE LEXICON:**")
@@ -1116,7 +1116,7 @@ class LLMRecorder:
         # galaxyscope:ignore sec_high_risk_execution, sec_db_hooks
         lines.append("## AI SYSTEM INSTRUCTIONS (OUTPUT FORMAT)")
         lines.append(
-            "> **CRITICAL TONE DIRECTIVE:** Act as a Principal Staff Engineer. Use grounded, professional software engineering terminology (e.g., coupling, cohesion, technical debt, single responsibility). DO NOT use sci-fi, dramatic, or sensational jargon (e.g., 'Trojan', 'violently violates', 'parasitic', 'chimeric'). Be objective, practical, and direct."
+            "> **CRITICAL TONE DIRECTIVE:** Stay in the Senior Technical Storyteller persona from Section 1. Use grounded, professional software engineering terminology (e.g., coupling, cohesion, technical debt, single responsibility) woven into a cohesive narrative -- not a dry, disconnected bullet-point audit. DO NOT use sci-fi, dramatic, or sensational jargon (e.g., 'Trojan', 'violently violates', 'parasitic', 'chimeric'). Be objective and factual, but write like you're explaining the codebase to a colleague, not filing a verdict."
         )
         lines.append(
             "> **When the user asks for an architectural review, structure your response using these directives:**"


### PR DESCRIPTION
## Summary
- Reframes `## 1. SYSTEM ROLE & PHILOSOPHY` in `llm_recorder.py`'s `_build_markdown` from a rigid SAST-analyzer persona to a Senior Technical Storyteller persona, per the issue's action items.
- Adds an explicit directive telling the downstream LLM not to restate a heuristic's raw label (e.g. `Logic Bomb`, `O(2^N)`) as a confirmed finding of malice/defect -- this is the exact hallucination-amplification behavior #1017 calls out.
- Reconciles the closing `## AI SYSTEM INSTRUCTIONS (OUTPUT FORMAT)` tone directive, which previously said "Act as a Principal Staff Engineer... be direct" -- a persona actively fighting Section 1's Storyteller framing. It now defers to that persona while keeping the existing ban on sensational/sci-fi jargon ('Trojan', 'parasitic', 'chimeric'), which is what keeps the narrative factual instead of dramatized.
- Out of scope: `## 0.5 AI THREAT AUDIT STATUS`'s `ML_CONFIRMED_THREAT_DETECTED` banner text is left as-is -- it's a shared status enum with `audit_recorder.py`, pinned by tests in both recorders' test files.

Last open sub-issue of epic #1025 -- merging this closes both #1017 and the epic.

Closes #1017

## Test plan
- [x] `pytest tests/tools_recorders/test_llm_recorder.py` -- 6/6 pass
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key baselines clean, format clean
- [ ] Reviewer: eyeball the new prompt wording for tone/voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)