### PR TITLE
docs: clarify self-scan orientation applies even with issue line numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,12 @@ session cheaper and safer to run — reach for these *before* an Explore subagen
 or reading a large file cold, when the question is really "how big/risky/depended-on is this
 thing" rather than "what does this specific code do."
 
+This still applies even when a task already points at exact file/line locations — e.g. a GitHub
+issue that quotes the specific lines to change. Knowing *where* to edit isn't the same as knowing
+the file's risk standing: check the brief's blast-radius/risk lists (Sections 7, 8, 11) or query
+the DB for that file's complexity/fan-in anyway before editing, so "how conservative should this
+diff be" is answered from data instead of a guess informed only by the issue text.
+
 - **`docs/gitgalaxy_architecture_brief.md`** — auto-committed on every merge to main (a byproduct
   of the CI scan that also produces SARIF/SBOM), so it's always close to current HEAD. This scan
   always installs `networkx`/`tiktoken`/`xgboost`/`pandas`/`numpy` first (`gitgalaxy.yml`'s


### PR DESCRIPTION
## Summary
- CLAUDE.md's "Using GitGalaxy's self-scan output for orientation" section currently frames the DB/brief as a lookup tool for cold-search scenarios ("before an Explore subagent, a broad grep, or reading a large file cold, when the question is really 'how big/risky/depended-on is this thing'").
- That framing doesn't cover the case where a task already has exact locations handed to it (e.g. a GitHub issue quoting the specific lines to change) — even though the orientation value (is this a high-risk file? should the diff be more conservative?) is unrelated to whether the location was already known.
- Prompted directly by #1054/#1063: that fix skipped both artifacts since the issue already quoted line numbers, and only afterward did checking the brief show `detector.py` sits at 100% exposure in its risk lists — a signal worth having up front, not after the fact.
- Adds one paragraph making explicit that "knowing where to edit" and "knowing the file's risk standing" are different questions, and the second one still needs an answer even when the first is already given.

## Test plan
- Docs-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)