### PR TITLE
tooling: audit/verify/skill scaffold for strict-signature hardening (epic #1069)

### DIFF
--- a/.claude/agents/strict-signature-scout.md
+++ b/.claude/agents/strict-signature-scout.md
@@ -1,0 +1,61 @@
+---
+name: strict-signature-scout
+description: Mechanical gap-reporting and candidate-verification for epic #1069 (hardening tests/extraction/languages/test_<lang>_strict.py). Runs tests/extraction/tools/audit_strict_coverage.py and tests/extraction/tools/verify_candidates.py and reports structured results -- it does not draft test cases or judge realism, only executes scripts and formats their output. Use before a case-writing pass (to get one language's exact gap list without loading language_standards.py cold) and after drafting candidate cases (to batch-verify them against the real compiled regex before they're written into a test file).
+tools: Bash, Read
+model: haiku
+---
+
+You run two scripts and report their output cleanly. You do not write test cases, judge whether a
+snippet is "realistic," or decide whether a failing verification is a real bug — that judgment
+belongs to whoever asked for the scout pass (the main conversation or a case-authoring subagent).
+
+## Job 1 — gap report for a language
+
+Run:
+```
+python tests/extraction/tools/audit_strict_coverage.py --lang <LANG> --json
+```
+Report back the parsed JSON verbatim (or lightly reformatted for readability) — the missing-case
+list, the no-negative-case list, and the current ReDoS-assertion counts. Don't summarize it away;
+the caller needs the exact key names to draft against.
+
+## Job 2 — batch-verify drafted candidates
+
+You'll be handed a list of candidate `(rule, payload, expect_match, expect_name, label)` tuples
+for one language. Verify them with `verify_candidates.py`'s library functions, not a fresh regex
+implementation of your own:
+
+```bash
+python -c "
+import sys; sys.path.insert(0, 'tests/extraction/tools')
+from verify_candidates import check_many
+check_many('<LANG>', [
+    ('<rule>', '<payload>', <True|False>, <'<expect_name>'|None>, '<label>'),
+    ...
+])
+"
+```
+
+Report every case's PASS/FAIL/SKIP status verbatim (the script already prints this — don't
+re-summarize it into just a pass count, the caller needs to know *which* cases failed and why).
+
+## Job 3 (optional) — ReDoS scaling diagnostic
+
+If asked to check a specific rule for hidden quadratic behavior:
+```bash
+python -c "
+import sys; sys.path.insert(0, 'tests/extraction/tools')
+from verify_candidates import check_redos_scaling
+check_redos_scaling('<LANG>', '<rule>', lambda n: <payload expression using n>)
+"
+```
+Report the raw durations and ratios. Do not judge whether a ratio "means" a bug — that's the
+caller's call (a ~2x-per-doubling ratio is linear, ~4x is the O(n²) signature, per
+`tests/extraction/how_to_harden_strict_signatures.md`), you just report the numbers accurately.
+
+## When you're unsure
+
+If a script errors, a language key doesn't resolve, or output looks malformed/unexpected, report
+that directly rather than guessing at what it "probably" means or silently retrying with different
+arguments. This agent has no judgment calls to make beyond "did the script run and what did it
+print" — anything murkier goes back to the caller.

--- a/.claude/skills/harden-strict-signatures/SKILL.md
+++ b/.claude/skills/harden-strict-signatures/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: harden-strict-signatures
+description: Deepen the non-extraction-pillar structural-signature test coverage in tests/extraction/languages/test_<lang>_strict.py (branch/io/safety_bypasses/ReDoS/etc. -- NOT func_start/args/class_start/_dependency_capture, that's harden-language-extraction's job) using the epic #1069 methodology. Use when the user asks to "harden strict signature tests for X", "close the ReDoS gap for X", "add missing signature cases for X", or references epic #1069 / issues #1070-1074.
+---
+
+Source of truth is `tests/extraction/how_to_harden_strict_signatures.md` — read it directly, it
+has the corrected ReDoS methodology (don't assume `_best_of_timing` mechanically replaces
+`assert_redos_immune`; the doc explains why) and the section-by-section checklist mapped onto
+issues #1070–#1074. It's the sibling to `tests/extraction/how_to_harden_extraction.md`
+(`harden-language-extraction` skill) — read that one too if you're unsure which suite a rule
+belongs to.
+
+## Process
+
+1. **Scope the request.** One language across all applicable sections (A–D from the doc), one
+   section across a batch of languages, or a specific issue number (#1070–#1074). Sub-issues are
+   grouped by problem type, not per-language — don't default to "just do #1070" if the user asked
+   for a language.
+2. **Get the gap report before reading anything else.** Either run
+   `python tests/extraction/tools/audit_strict_coverage.py --lang <X> --json` yourself, or delegate
+   it to the `strict-signature-scout` subagent (Haiku-pinned — this step is pure script execution,
+   no judgment, exactly what that agent is for). Don't open `language_standards.py` cold to figure
+   out what's missing; the script already slices it.
+3. **Draft candidate cases** (the judgment step — keep this in the main conversation or a
+   Sonnet-tier agent, not the scout). For each gap the report surfaced:
+   - a realistic positive snippet (real code shape, not a synthetic string engineered to match)
+   - a realistic negative/lookalike snippet where the doc's section D applies
+   - for ReDoS work, an adversarial "never closes" payload per the doc's diagnose-first sequence
+4. **Verify every candidate before writing it in** — either run `verify_candidates.py`'s
+   `check_case`/`check_many` yourself, or hand the drafted tuples to `strict-signature-scout` for
+   batch verification (mechanical execution + reporting, same reasoning as step 2). A failing
+   verification is a finding to triage, not something to quietly drop or auto-fix.
+5. **Write the survivors into `test_<lang>_strict.py`**, then run
+   `pytest tests/extraction/languages/test_<lang>_strict.py` and
+   `python tests/tools/audit_check.py` before considering the language done.
+6. **If a real regex bug surfaced**, fix it with the full discipline the doc describes (ReDoS
+   scaling proof, `crucible_check.py` if `language_standards.py`/`detector.py`/`prism.py` changed)
+   — keep this part in the main conversation; it needs the same tight iteration and judgment
+   `harden-language-extraction` reserves for step 5 of its own process, not a subagent.
+
+## Parallelizing across languages
+
+Each language owns its own `test_<lang>_strict.py` file with zero cross-file overlap, so batches
+of languages can run as concurrent subagents once step 3's case-drafting judgment is understood
+for that batch (e.g. one agent per ~5 languages for issue #1073's 17-language ghost-prevention
+sweep). Two-tier split:
+
+- **`strict-signature-scout` (Haiku)**: gap reports and candidate verification — mechanical,
+  well-defined output, no realism judgment. Cheap to run per-language or per-batch.
+- **Case-drafting agent (Sonnet, e.g. `general-purpose` or the main session)**: the actual
+  "is this snippet realistic" and "does this failing verification mean a real bug" judgment calls.
+
+If running truly in parallel (multiple case-drafting agents editing different `_strict.py` files
+at once), consider `isolation: "worktree"` per batch so concurrent edits don't collide on commit —
+or have each agent report its diff back for serial application instead.
+
+## Closing the loop
+
+Use the `issue-generation` skill to close out #1070–#1074 (or comment progress) as batches
+complete, and update `how_to_harden_strict_signatures.md` itself if a genuinely new recurring-bug
+class turns up — this suite is getting adversarial attention for the first time, so a new class is
+plausible, not just a repeat of `how_to_add_a_language.md`'s existing 16 rules.

--- a/tests/extraction/how_to_harden_strict_signatures.md
+++ b/tests/extraction/how_to_harden_strict_signatures.md
@@ -1,0 +1,134 @@
+# How to Harden the Strict Structural-Signature Test Suite
+
+This is the companion doc to `how_to_harden_extraction.md`, scoped to the *other* test concern
+that lives alongside it in `tests/extraction/languages/`: `test_<lang>_strict.py`, one file per
+language, proving `language_standards.py`'s ~43-key structural-signature rules (`branch`, `io`,
+`safety_bypasses`, ReDoS immunity, etc.) — **not** the four extraction pillars (`func_start`,
+`args`, `class_start`, `_dependency_capture`), which stay `how_to_harden_extraction.md`'s job.
+If you're not sure which concern a rule belongs to: the four pillars extract an *exact identifier*
+via a capture group; everything else here just proves *presence/absence* of a construct.
+
+Tracked by epic [#1069](https://github.com/squid-protocol/gitgalaxy/issues/1069), which is the
+`#518`-lineage follow-on applying epic `#813`'s harder-won rigor standard (born from auditing the
+sibling extraction-pillar suite and finding it "dangerously sparse") to this suite, which never
+got the same re-audit. Sub-issues #1070–#1074 map onto the five sections below.
+
+## Why this doc exists
+
+A 2026-08-05 audit (`tests/extraction/tools/audit_strict_coverage.py` — run it yourself, don't
+trust a stale snapshot) found this suite thinner than what #813's founding audit already rejected
+for the sibling one: roughly one positive/negative pair per signature, no pathological-tier depth
+at all, 6 languages with zero per-language ReDoS regression coverage, and — most concretely —
+python's and javascript's entire AI/ML extension pack (`llm_api`, `cryptography`, `rce_funnel`,
+etc.) completely untested despite being a real detection-capability claim, not just a nice-to-have.
+
+## Tooling — use these, don't rebuild them
+
+- **`tests/extraction/tools/audit_strict_coverage.py`** — the gap detector. Run
+  `--lang <x> --json` before touching any language to get its exact missing-signature list,
+  ghost-prevention gaps, and current ReDoS-assertion count, instead of reading
+  `language_standards.py` cold to figure out what's missing.
+- **`tests/extraction/tools/verify_candidates.py`** — `check_case`/`check_many` (empirically
+  verify a candidate `(rule, payload, expect_match)` against the real compiled regex before
+  writing it into a test file) and `check_redos_scaling` (geometric-sweep diagnostic, see below).
+  This module started as epic #813's tool but its checker functions were never extraction-pillar-
+  specific — reuse it rather than writing a second copy for this suite.
+- **`tests/extraction/languages/_strict_harness.py`** — the two helpers that actually get compiled
+  into permanent pytest assertions: `assert_redos_immune` (single payload, single timeout — proves
+  a *specific* pattern survives a *specific* adversarial payload) and `_best_of_timing` (min-of-N
+  timing at one size — see the ReDoS section below for how the two combine in a real regression
+  test, not as interchangeable alternatives).
+
+## Work language-by-language, not category-by-category
+
+Same reasoning as the extraction-pillar doc: load one language's full `rules` dict once
+(`audit_strict_coverage.py --lang X --json` gives you the sliced, relevant subset — you don't need
+the whole multi-thousand-line `LANGUAGE_DEFINITIONS` file in context), close as many of that
+language's gaps across sections A–D below as apply in one sitting, then move on.
+
+### A/B — ReDoS coverage (issues #1070, #1071)
+
+**Read the actual mechanics before writing anything** — `assert_redos_immune` and `_best_of_timing`
+are not interchangeable, and #1071's framing of "migrate to the scaling-ratio method" needs this
+correction: they serve two different moments in the workflow, both visible in
+`test_css_strict.py`'s `test_css_class_start_redos_regression` (the reference example):
+
+1. **Diagnose first, with `check_redos_scaling`** (from `verify_candidates.py`, or `_best_of_timing`
+   called directly) — sweep a rule's pattern against a "never closes" adversarial payload at
+   several geometrically increasing sizes (start at n=2000, not n=32000 — some shapes, like the
+   Rule 14 adjacent-quantifier bug, blow up dramatically faster than the usual nested-delimiter
+   case). A ~2x-per-doubling ratio is linear and fine — **stop here, no permanent test needed
+   beyond what's already there.** A ~4x-per-doubling ratio is real O(n²) backtracking and is a bug.
+2. **If it's clean:** for the 6 zero-coverage languages (#1070: haskell, kotlin, lua, ruby, scala,
+   swift), add a straightforward `assert_redos_immune(pattern, adversarial_payload, timeout_sec=...)`
+   call per rule with an unbounded-looking quantifier, proving the *current* pattern survives a
+   large payload within a generous timeout. This alone closes #1070 — it does not require
+   `_best_of_timing` if there's no bug to document.
+3. **If you find a real bug:** fix the regex (bound the quantifier), then write the two-part
+   regression pattern `test_css_strict.py` already uses: `_best_of_timing` proving the *old, buggy*
+   pattern's quadratic signature (reconstruct it inline as a comparison, exactly like the CSS
+   example's `old_pattern`), paired with `assert_redos_immune` proving the *new* pattern is immune
+   at an even larger payload. This is what #1071 is actually asking for in the 37
+   `assert_redos_immune`-only languages: **run the diagnostic sweep to check for an undiscovered
+   bug a single generous timeout might be masking** — not a mechanical rewrite of every passing
+   test. Most of those 37 will come back clean; only the ones that don't need the two-part pattern.
+
+### C — Missing signature-case coverage (issue #1072)
+
+`audit_strict_coverage.py --lang X --json`'s `missing_case_entirely` list is the exact punch list
+— no need to diff `LANGUAGE_DEFINITIONS.keys()` against the test file by hand. For each missing
+key, add one realistic positive snippet (real code you'd find in an actual file of that language,
+not a synthetic string engineered to match — same bar as the extraction gauntlets' `valid` tier)
+plus a realistic negative/lookalike snippet, verify both with `verify_candidates.py`'s `check_case`
+before writing them in, then add to the language's `_XXX_SIMPLE_CASES` list.
+
+Prioritize **python's and javascript's AI/ML extension pack** first (`llm_api`,
+`llm_orchestrator`, `llm_vector_store`, `ml_traditional`, `dl_frameworks`, `cryptography`,
+`rce_funnel`, `hardware_bridge`, `exfiltration_camouflage`, `lazy_evaluation`, `vectorized_math`)
+— see `gitgalaxy/standards/how_to_add_a_language.md`'s "AI/ML Extension Pack" section for what
+each key is supposed to detect. This is a real blind spot in a supply-chain-risk detection
+feature, not a test-depth nit.
+
+### D — Ghost-prevention / negative-case coverage (issue #1073)
+
+`audit_strict_coverage.py`'s `no_negative_case` list per language is every signature currently
+paired with `None` in the negative slot. For each, add a realistic lookalike that should **not**
+match — same discipline as the extraction gauntlets' `invalid` tier (Ghost Prevention): a different
+keyword entirely is a weak test; a structural lookalike (a string literal containing the keyword,
+a comment, an unrelated construct that shares surface tokens) is a real one. Verify with
+`check_case` before writing it in — a negative case that turns out to actually match is a bug
+finding, not a test to quietly drop.
+
+Sequence the 17 flagged languages by real-world scan frequency if you need to prioritize (python,
+javascript, java, go, ruby, php, typescript, c/cpp/csharp before less common ones) — the doc
+doesn't mandate a fixed order.
+
+### E — Case depth beyond the ~1-pair floor (issue #1074, stretch)
+
+Deliberately last. Once A–D close the correctness/security gaps, revisit whichever signatures
+turned out to be highest-ambiguity while working through them (multiple false-positive shapes
+found, or the rule covers a construct with real historical syntax variation) and add multiple case
+variants — different syntax eras, modifier stacking — approaching (not necessarily matching) the
+extraction gauntlets' pathological-tier depth. Don't force depth onto a signature that's already
+unambiguous just to hit a number.
+
+## Verification discipline (same as the extraction-pillar doc, not repeated in full)
+
+1. Empirically verify every candidate with `verify_candidates.py` before adding it — never guess.
+2. A failing verification is a finding to triage (real engine bug vs. unrealistic payload), not an
+   automatic fix.
+3. Real bugs get the full discipline: ReDoS scaling check on any quantifier change,
+   `python tests/tools/audit_check.py`, `pytest tests/extraction/languages/test_<lang>_strict.py`,
+   and `python tests/tools/crucible_check.py` if `language_standards.py`/`detector.py`/`prism.py`
+   changed (see `CLAUDE.md`'s Differential Scan section — never point a shared/stale venv at this).
+4. This suite is almost entirely test-writing, not regex-fixing — expect far fewer real bugs than
+   epic #813 found, since these rules were never claiming to isolate an *exact* identifier, only to
+   detect presence. Don't manufacture a "finding" to justify a regex change that isn't needed.
+
+## Closing the loop
+
+Once a language's gaps in A–D are closed, update its entry in `audit_strict_coverage.py`'s output
+implicitly (rerun the script, don't hand-track), and note any newly-confirmed recurring-bug-class
+in `gitgalaxy/standards/how_to_add_a_language.md` itself if you find one that isn't already listed
+there (Rules 1–16) — this suite is exactly where a new boundary/ReDoS bug class is most likely to
+surface next, since it's getting adversarial attention for the first time.

--- a/tests/extraction/tools/audit_strict_coverage.py
+++ b/tests/extraction/tools/audit_strict_coverage.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Rerunnable audit of tests/extraction/languages/test_<lang>_strict.py against
+gitgalaxy/standards/language_standards.py's LANGUAGE_DEFINITIONS -- the
+coverage-gap detector behind epic #1069 (the #518-lineage follow-on that
+applies epic #813's harder rigor standard to the non-extraction-pillar
+structural-signature suite).
+
+Why this exists: the audit that founded #1069 was a one-off scratch script.
+That's the same mistake epic #813 avoided by checking in
+tests/extraction/tools/verify_candidates.py -- an ad hoc audit script dies
+in a session's scratchpad and has to be reconstructed from scratch the next
+time someone wants to know "how much of the gap is left." This is that
+script, made permanent.
+
+What it checks per language, cross-referenced against LANGUAGE_DEFINITIONS'
+actual non-None rule keys (excluding func_start/args/class_start/
+_dependency_capture/_named_token_capture, which are epic #813's concern via
+test_<lang>.py, not this file's):
+  - which signature keys have literally zero case coverage in `_SIMPLE_CASES`
+  - how many cases have `None` in the negative/ghost-prevention slot
+  - how many `assert_redos_immune`/`_best_of_timing` calls the file makes
+
+USAGE
+    python tests/extraction/tools/audit_strict_coverage.py                # full table, all languages
+    python tests/extraction/tools/audit_strict_coverage.py --lang python  # one language, human-readable
+    python tests/extraction/tools/audit_strict_coverage.py --lang python --json   # machine-readable
+
+The --json form is meant for a cheap/mechanical "scout" pass (see
+tests/extraction/how_to_harden_strict_signatures.md) -- it hands a case-
+writing agent the exact gap list for one language without that agent
+needing to read language_standards.py or the existing _strict.py file cold.
+"""
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LANG_DIR = REPO_ROOT / "tests" / "extraction" / "languages"
+
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(LANG_DIR))
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS  # noqa: E402
+
+# filename-stem -> LANGUAGE_DEFINITIONS key, for the handful that don't match
+# a straight underscore-stripped transform (e.g. the dict key has a hyphen).
+LANG_KEY_OVERRIDES = {
+    "objectivec": "objective-c",
+}
+
+# These are the four extraction-pillar rules (epic #813's concern, tested in
+# test_<lang>.py) plus python/typescript's dependency-precision extension --
+# their absence from a _strict.py file's cases is by design, not a gap.
+EXTRACTION_PILLAR_KEYS = {"func_start", "args", "class_start", "_dependency_capture", "_named_token_capture"}
+
+
+def _lang_key_for(stem: str) -> str:
+    lang = stem[len("test_") : -len("_strict")]
+    return LANG_KEY_OVERRIDES.get(lang, lang)
+
+
+def _load_simple_cases(path: Path):
+    """Import the test module for real and grab its `..._SIMPLE_CASES` list.
+
+    Deliberately a real import (not ast.literal_eval) -- some files build
+    entries with non-literal expressions (e.g. dockerfile's
+    `"FROM alpine@sha256:" + "a" * 64`), which a literal-only parse can't
+    evaluate.
+    """
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    for name, val in vars(mod).items():
+        if name.endswith("_SIMPLE_CASES") and isinstance(val, list):
+            return val
+    return None
+
+
+def audit_language(path: Path) -> dict:
+    lang = _lang_key_for(path.stem)
+    src = path.read_text()
+
+    cases = _load_simple_cases(path)
+    signatures_covered = {c[0] for c in cases if len(c) >= 1} if cases is not None else set()
+    no_negative = [c[0] for c in cases if len(c) >= 3 and c[2] is None] if cases is not None else []
+
+    rules = LANGUAGE_DEFINITIONS.get(lang, {}).get("rules", {})
+    non_none_keys = {k for k, v in rules.items() if v is not None}
+    missing_entirely = sorted(non_none_keys - signatures_covered - EXTRACTION_PILLAR_KEYS)
+
+    return {
+        "lang": lang,
+        "file": str(path.relative_to(REPO_ROOT)),
+        "n_signatures_applicable": len(non_none_keys - EXTRACTION_PILLAR_KEYS),
+        "n_cases": len(cases) if cases is not None else None,
+        "missing_case_entirely": missing_entirely,
+        "no_negative_case": sorted(no_negative),
+        "redos_immune_calls": len(re.findall(r"\bassert_redos_immune\(", src)),
+        "best_of_timing_calls": len(re.findall(r"\b_best_of_timing\(", src)),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--lang", default=None, help="audit a single language (e.g. python); default: all")
+    parser.add_argument("--json", action="store_true", help="machine-readable output for the given --lang")
+    args = parser.parse_args()
+
+    paths = sorted(LANG_DIR.glob("test_*_strict.py"))
+    if args.lang:
+        paths = [p for p in paths if _lang_key_for(p.stem) == args.lang]
+        if not paths:
+            print(f"no _strict.py file found for lang={args.lang!r}", file=sys.stderr)
+            return 1
+
+    results = [audit_language(p) for p in paths]
+
+    if args.json:
+        print(json.dumps(results[0] if args.lang else results, indent=2))
+        return 0
+
+    header = f"{'lang':<16}{'sigs':>6}{'cases':>7}{'missing':>9}{'no_neg':>8}{'redos':>7}{'scaled':>8}"
+    print(header)
+    zero_redos, has_missing, thin_negative = [], [], []
+    for r in results:
+        n_cases = r["n_cases"] if r["n_cases"] is not None else -1
+        print(
+            f"{r['lang']:<16}{r['n_signatures_applicable']:>6}{n_cases:>7}"
+            f"{len(r['missing_case_entirely']):>9}{len(r['no_negative_case']):>8}"
+            f"{r['redos_immune_calls']:>7}{r['best_of_timing_calls']:>8}"
+        )
+        if r["redos_immune_calls"] == 0 and r["best_of_timing_calls"] == 0:
+            zero_redos.append(r["lang"])
+        if r["missing_case_entirely"]:
+            has_missing.append((r["lang"], r["missing_case_entirely"]))
+        if r["n_cases"] and len(r["no_negative_case"]) / r["n_cases"] > 0.7:
+            thin_negative.append((r["lang"], len(r["no_negative_case"]), r["n_cases"]))
+
+    if not args.lang:
+        print(f"\n=== Zero per-language ReDoS assertions ({len(zero_redos)}) ===")
+        for lang in zero_redos:
+            print(f" - {lang}")
+
+        print(f"\n=== Signature keys missing case coverage entirely ({len(has_missing)} languages) ===")
+        for lang, missing in has_missing:
+            print(f" - {lang}: {missing}")
+
+        print(f"\n=== >70% of cases have no negative/ghost-prevention check ({len(thin_negative)} languages) ===")
+        for lang, no_neg, total in thin_negative:
+            print(f" - {lang}: {no_neg}/{total}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/extraction/tools/verify_candidates.py
+++ b/tests/extraction/tools/verify_candidates.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
 """
 Reusable "verify a candidate test case against the real compiled regex
-before adding it" harness for extraction-hardening work (epic #813).
+before adding it" harness. Originally built for extraction-hardening work
+(epic #813, the func_start/args/class_start/_dependency_capture pillars),
+but check_case/check_many/check_redos_scaling only ever call
+`pattern.search()` against whatever rule_key is passed in -- there's
+nothing extraction-pillar-specific about them. Epic #1069 (hardening the
+OTHER ~43 structural-signature rules in test_<lang>_strict.py: branch, io,
+safety_bypasses, etc.) reuses this same module rather than duplicating it;
+only the CLI's --rule flag used to be hard-restricted to the 4 pillars,
+loosened below since the underlying check works for any LANGUAGE_DEFINITIONS
+rule key.
 
 Why this exists: the methodology doc's own non-negotiable step is
 "empirically verify every candidate case against the real compiled regex
@@ -130,7 +139,12 @@ def check_redos_scaling(lang: str, rule_key: str, payload_fn, sizes=(2000, 4000,
 def _cli() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--lang", required=True)
-    parser.add_argument("--rule", required=True, choices=["func_start", "args", "class_start", "_dependency_capture"])
+    parser.add_argument(
+        "--rule",
+        required=True,
+        help="any LANGUAGE_DEFINITIONS rule key for this language (not restricted to the 4 "
+        "extraction pillars -- e.g. 'branch', 'safety_bypasses', 'llm_api' work too)",
+    )
     parser.add_argument("--payload", required=True)
     parser.add_argument("--expect-match", action="store_true")
     parser.add_argument("--expect-name", default=None)


### PR DESCRIPTION
## Summary
- Checks in `tests/extraction/tools/audit_strict_coverage.py`, the coverage-gap detector behind epic #1069's founding audit (was a one-off scratch script) — reports missing signature-case coverage, thin ghost-prevention coverage, and ReDoS-assertion counts per language, with `--lang X --json` for machine-readable output.
- Generalizes `verify_candidates.py`'s CLI beyond the 4 extraction-pillar rules — its `check_case`/`check_many`/`check_redos_scaling` functions were already rule-agnostic (just `pattern.search()` under the hood), only the `--rule` choices restriction needed loosening so this suite can reuse it instead of duplicating it.
- Adds `tests/extraction/how_to_harden_strict_signatures.md`, the checklist doc mapped section-by-section onto issues #1070–#1074, including a corrected ReDoS methodology (diagnose first via scaling sweep; `_best_of_timing` is a regression anchor for confirmed-fixed bugs, not a blanket replacement for `assert_redos_immune` — see the correcting comment on #1071).
- Adds the `harden-strict-signatures` skill and a new Haiku-pinned `strict-signature-scout` subagent, so mechanical gap-reporting/candidate-verification stays off the expensive model per this repo's model-tiering convention (CLAUDE.md).

No changes to `language_standards.py`, `detector.py`, or `prism.py` — this PR is tooling/docs only, no engine behavior changes, so no crucible check needed.

Epic: #1069. Sub-issues: #1070, #1071, #1072, #1073, #1074.

## Test plan
- [x] `ruff format`/`ruff check`/`python tests/tools/audit_check.py` all clean (no new baseline findings)
- [x] `pytest tests/extraction/languages/test_css_strict.py tests/extraction/languages/test_python_strict.py` — 90/90 passed (sanity check that the generalized `verify_candidates.py` didn't regress existing usage)
- [x] `audit_strict_coverage.py --lang python --json` output cross-checked against the original scratch-script audit — matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)