### PR TITLE
test(extraction): add ReDoS regression coverage for 6 zero-coverage languages

### DIFF
--- a/tests/extraction/languages/test_haskell_strict.py
+++ b/tests/extraction/languages/test_haskell_strict.py
@@ -19,6 +19,8 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
 
 # ==============================================================================
 # HASKELL: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #585)
@@ -172,3 +174,23 @@ def test_haskell_globals_unsafeperformio_bug():
     assert not pattern.search("counter :: IORef Int\ncounter = newIORef 0"), (
         "Incorrectly matched a plain IORef binding with no unsafePerformIO at all"
     )
+
+
+def test_haskell_redos_immunity_sweep():
+    """
+    Issue #1070: haskell had zero per-language ReDoS regression coverage.
+    `args`, `func_start`, and `class_start` all repeat the same
+    comment-skipping alternation `(?:[ \\t\\n]|--[^\\n]*\\n|\\{-(?:[^-]|-(?!\\}))*-\\})*`
+    -- three disjoint-prefix branches, one of which nests its own `*` --
+    which is exactly the "alternation with overlapping prefixes / nested
+    quantifiers" shape epic #518 found repeatedly. Diagnosed clean via
+    `check_redos_scaling` (consistent ~2x-per-doubling ratios up to
+    n=128000, reruns included to rule out timing noise) before writing
+    these as permanent regression pins.
+    """
+    assert_redos_immune(HS_RULES["args"], "x :: {-" + "-" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HS_RULES["func_start"], "foo {-" + "-" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HS_RULES["class_start"], "data Foo {-" + "-" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HS_RULES["class_start"], "data Foo " + "bar " * 30000, timeout_sec=3.0)
+    assert_redos_immune(HS_RULES["generics"], "forall " + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(HS_RULES["globals"], "counter :: IORef Int" + "\n" * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_kotlin_strict.py
+++ b/tests/extraction/languages/test_kotlin_strict.py
@@ -19,6 +19,8 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
 
 # NOTE: this test was originally grouped under a shared "cross-language sweep"
 # section in tests/core_engine/test_language_standards_strict.py (before that file
@@ -227,3 +229,20 @@ def test_kotlin_explicit_casts_and_pointers_no_false_collision():
     assert not casts.search("val p: CPointer<IntVar>"), "explicit_casts incorrectly matched a Kotlin/Native pointer"
     assert pointers.search("val p: CPointer<IntVar>")
     assert not pointers.search("x as String"), "pointers incorrectly matched an explicit cast"
+
+
+def test_kotlin_redos_immunity_sweep():
+    """
+    Issue #1070: kotlin had zero per-language ReDoS regression coverage.
+    `args`/`func_start` both use the 1-level-nesting-trick paren stepper
+    plus a generic-parameter stepper `(?:[^<>]|<[^<>]*>)*`, and
+    `decorators` has an unbounded dotted-chain repeat -- the "nested
+    quantifiers" and "alternation" shapes epic #518 flagged repeatedly.
+    Diagnosed clean via `check_redos_scaling` (consistent ~2x-per-doubling
+    ratios) before writing these as permanent regression pins.
+    """
+    assert_redos_immune(KOTLIN_RULES["args"], "fun foo(" + "(" * 100000, timeout_sec=3.0)
+    assert_redos_immune(KOTLIN_RULES["args"], "fun foo<" + "<" * 100000, timeout_sec=3.0)
+    assert_redos_immune(KOTLIN_RULES["func_start"], "fun foo<" + "<" * 100000, timeout_sec=3.0)
+    assert_redos_immune(KOTLIN_RULES["class_start"], "@a(" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(KOTLIN_RULES["decorators"], "@a" + ".a" * 50000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_lua_strict.py
+++ b/tests/extraction/languages/test_lua_strict.py
@@ -19,6 +19,8 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
 
 # ==============================================================================
 # LUA: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #594)
@@ -160,3 +162,15 @@ def test_lua_explicit_casts_and_pointers_no_false_collision():
     assert not casts.search('ffi.new("int[1]")'), "explicit_casts incorrectly matched an unrelated ffi.new call"
     assert pointers.search('ffi.new("int[1]")')
     assert not pointers.search("tonumber(x)"), "pointers incorrectly matched an explicit cast"
+
+
+def test_lua_redos_immunity_sweep():
+    """
+    Issue #1070: lua had zero per-language ReDoS regression coverage.
+    `args` is an explicit 3-level manually-nested paren structure
+    (`\\([^()]*(?:\\([^()]*(?:\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)`), the
+    "nested quantifiers" shape epic #518 flagged repeatedly elsewhere.
+    Diagnosed clean via `check_redos_scaling` (consistent ~2x-per-doubling
+    ratios) before writing this as a permanent regression pin.
+    """
+    assert_redos_immune(LUA_RULES["args"], "function foo(" + "(" * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_ruby_strict.py
+++ b/tests/extraction/languages/test_ruby_strict.py
@@ -19,6 +19,8 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
 
 # ==============================================================================
 # RUBY: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #607)
@@ -215,3 +217,19 @@ def test_ruby_explicit_casts_and_pointers_no_false_collision():
     assert not casts.search("FFI::Pointer.new(:int)"), "explicit_casts incorrectly matched an FFI pointer type"
     assert pointers.search("FFI::Pointer.new(:int)")
     assert not pointers.search("Integer(x)"), "pointers incorrectly matched an explicit cast"
+
+
+def test_ruby_redos_immunity_sweep():
+    """
+    Issue #1070: ruby had zero per-language ReDoS regression coverage.
+    `args` is a 3-level manually-nested paren structure with an inner
+    quoted-string alternation at every level (mirrors CSS's already-proven
+    `args` shape, see test_css_strict.py) -- the "nested quantifiers"
+    shape epic #518 flagged repeatedly elsewhere. Diagnosed clean via
+    `check_redos_scaling` (consistent ~2x-per-doubling ratios) before
+    writing these as permanent regression pins.
+    """
+    assert_redos_immune(RUBY_RULES["args"], "def foo(" + "(" * 100000, timeout_sec=3.0)
+    assert_redos_immune(RUBY_RULES["args"], "def foo('" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(RUBY_RULES["args"], 'def foo("' + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(RUBY_RULES["spec_exposure"], "[SPEC-" + "1" * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_scala_strict.py
+++ b/tests/extraction/languages/test_scala_strict.py
@@ -19,6 +19,8 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
 
 # NOTE: this test was originally grouped under a shared "cross-language sweep"
 # section in tests/core_engine/test_language_standards_strict.py (before that file
@@ -262,3 +264,18 @@ def test_scala_explicit_casts_and_pointers_no_false_collision():
     assert not casts.search("val p: Ptr[Int] = ???"), "explicit_casts incorrectly matched a Scala Native pointer type"
     assert pointers.search("val p: Ptr[Int] = ???")
     assert not pointers.search("x.toInt"), "pointers incorrectly matched an explicit cast"
+
+
+def test_scala_redos_immunity_sweep():
+    """
+    Issue #1070: scala had zero per-language ReDoS regression coverage.
+    `args`'s generic-parameter stepper `(?:\\[(?:[^\\[\\]]|\\[[^\\[\\]]*\\])*\\])?`
+    uses the same 1-level-nesting-trick already proven for the square-
+    bracket variant elsewhere (epic #813/#825); `func_start`/`class_start`
+    both stack an unclosed-annotation-paren step-over. Diagnosed clean via
+    `check_redos_scaling` (consistent ~2x-per-doubling ratios) before
+    writing these as permanent regression pins.
+    """
+    assert_redos_immune(SCALA_RULES["args"], "def foo[" + "[" * 100000, timeout_sec=3.0)
+    assert_redos_immune(SCALA_RULES["func_start"], "@a(" + "a" * 100000, timeout_sec=3.0)
+    assert_redos_immune(SCALA_RULES["class_start"], "@a(" + "a" * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_swift_strict.py
+++ b/tests/extraction/languages/test_swift_strict.py
@@ -19,6 +19,8 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
 
 # NOTE: this test was originally grouped under a shared "cross-language sweep"
 # section in tests/core_engine/test_language_standards_strict.py (before that file
@@ -268,3 +270,19 @@ def test_swift_explicit_casts_and_pointers_no_false_collision():
     assert not casts.search("UnsafeMutablePointer<Int>"), "explicit_casts incorrectly matched an unsafe pointer type"
     assert pointers.search("UnsafeMutablePointer<Int>")
     assert not pointers.search("let x = value as? String"), "pointers incorrectly matched an explicit cast"
+
+
+def test_swift_redos_immunity_sweep():
+    """
+    Issue #1070: swift had zero per-language ReDoS regression coverage.
+    `args`/`func_start` both use the 1-level-nesting-trick paren stepper
+    (the escaping-closure shield) plus a generic-parameter stepper
+    `(?:[^<>]|<[^<>]*>)*` -- the "nested quantifiers" shape epic #518
+    flagged repeatedly elsewhere. Diagnosed clean via `check_redos_scaling`
+    (consistent ~2x-per-doubling ratios) before writing these as permanent
+    regression pins.
+    """
+    assert_redos_immune(SWIFT_RULES["args"], "func foo(" + "(" * 100000, timeout_sec=3.0)
+    assert_redos_immune(SWIFT_RULES["args"], "func foo<" + "<" * 100000, timeout_sec=3.0)
+    assert_redos_immune(SWIFT_RULES["func_start"], "func foo<" + "<" * 100000, timeout_sec=3.0)
+    assert_redos_immune(SWIFT_RULES["class_start"], "@a(" + "a" * 100000, timeout_sec=3.0)


### PR DESCRIPTION
## Summary
- Closes #1070: haskell, kotlin, lua, ruby, scala, and swift had zero `assert_redos_immune`/`_best_of_timing` calls in their `tests/extraction/languages/test_<lang>_strict.py` files.
- For each language, identified the rules with the riskiest quantifier shapes (nested-paren "1-level-nesting-trick" `args`/`func_start` steppers, generic-parameter steppers, haskell's comment-skipping alternation with a nested `*`, unbounded decorator chains).
- Diagnosed every candidate with `verify_candidates.py`'s `check_redos_scaling` before writing anything, per `tests/extraction/how_to_harden_strict_signatures.md`'s "diagnose first" sequence — all came back linear (~2x per doubling). A couple of borderline ratios (haskell `class_start`) turned out to be timing noise on rerun at larger sizes, not real O(n²) backtracking.
- No actual regex bugs found, so this closes with plain `assert_redos_immune` regression pins rather than the two-part `_best_of_timing` fix pattern (`test_css_strict.py`'s reference example) — consistent with the how-to doc's expectation that most of this sweep comes back clean.

## Test plan
- [x] `pytest tests/extraction/languages/test_{haskell,kotlin,lua,ruby,scala,swift}_strict.py` — 339 passed
- [x] Plain `pytest` invoked from an unrelated cwd (reproduces CI's invocation style per `CLAUDE.md`'s testing-conventions section)
- [x] `python tests/extraction/tools/audit_strict_coverage.py` — zero-ReDoS-coverage language list is now empty
- [x] `python tests/tools/audit_check.py` — no new ruff/mypy/dead-key findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)