### PR TITLE
test(extraction): close missing signature-case gaps, python/js AI/ML pack first

### DIFF
--- a/tests/extraction/languages/test_haskell_strict.py
+++ b/tests/extraction/languages/test_haskell_strict.py
@@ -73,6 +73,15 @@ _HS_SIMPLE_CASES = [
     ("regex_execution", "text =~ pattern", None),
     ("time_date_logic", "getCurrentTime", None),
     ("ipc_rpc_bridges", "createProcess someProc", None),
+    # --- Issue #1072: signature keys with zero _SIMPLE_CASES coverage ---
+    ("api", "module MyLib (foo, bar) where", "import MyLib (foo, bar)"),
+    ("bitwise_ops", "y = shiftL x 2", "y = x + 2"),
+    (
+        "encapsulation",
+        "module Data.Vector (Vector, empty, fromList) where",
+        "module MyLib where",
+    ),
+    ("import", "import qualified Data.Map as Map", "-- import Data.Map"),
 ]
 
 

--- a/tests/extraction/languages/test_javascript_strict.py
+++ b/tests/extraction/languages/test_javascript_strict.py
@@ -75,6 +75,31 @@ _JS_SIMPLE_CASES = [
     ("regex_execution", "str.match(/foo/);", None),
     ("time_date_logic", "Date.now();", None),
     ("ipc_rpc_bridges", "worker.postMessage(data);", None),
+    # --- Issue #1072: signature keys with zero _SIMPLE_CASES coverage ---
+    ("bitwise_ops", "const mask = flags << 2;", "const power = base ** exponent;"),
+    ("closures", "const add = (x) => { return x + 1; };", "const add = (x) => x + 1;"),
+    ("cryptography", "import bcrypt from 'bcrypt';", "const hash = require('hash.js');"),
+    (
+        "dl_frameworks",
+        "import * as tf from '@tensorflow/tfjs';",
+        "import { RandomForestClassifier } from 'ml-random-forest';",
+    ),
+    (
+        "exfiltration_camouflage",
+        "fetch('https://telemetry.example.com/collect', { method: 'POST', body: JSON.stringify(payload) })",
+        "fetch('https://api.example.com/users', { method: 'POST', body: JSON.stringify(payload) })",
+    ),
+    ("hardware_bridge", "import { SerialPort } from 'serialport';", "import net from 'net';"),
+    ("import", "import React from 'react';", "important = true;"),
+    ("lazy_evaluation", "function* generator() { yield 1; }", "function regular() { return 1; }"),
+    ("llm_api", "import OpenAI from 'openai';", "import axios from 'axios';"),
+    ("llm_orchestrator", "import { LLMChain } from 'langchain';", "import express from 'express';"),
+    ("llm_vector_store", "import { ChromaClient } from 'chromadb';", "import mongoose from 'mongoose';"),
+    ("ml_traditional", "import x from 'sklearn';", "import * as tf from 'tensorflow';"),
+    ("rce_funnel", "child_process.exec('bash deploy.sh')", "child_process.exec('./cleanup.sh')"),
+    ("structural_boundaries", "export class Widget {}", "function widget() {}"),
+    ("test", "describe('widget', () => { expect(true).toBe(true); })", "myRegex.test('x')"),
+    ("vectorized_math", "const result = matmul(a, b);", "const result = a * b;"),
 ]
 
 

--- a/tests/extraction/languages/test_objectivec_strict.py
+++ b/tests/extraction/languages/test_objectivec_strict.py
@@ -78,6 +78,10 @@ _OBJC_SIMPLE_CASES = [
     ),
     ("time_date_logic", "NSDate *now = [NSDate date];", None),
     ("ipc_rpc_bridges", "NSTask *task = [[NSTask alloc] init];", None),
+    # --- Issue #1072: signature keys with zero _SIMPLE_CASES coverage ---
+    ("api", "@property (nonatomic, strong) NSString *name;", "static NSString *name;"),
+    ("bitwise_ops", "NSUInteger mask = flags & 0x0F;", "if (a && b) {"),
+    ("import", "#import <Foundation/Foundation.h>", "// #import <Foundation/Foundation.h>"),
 ]
 
 

--- a/tests/extraction/languages/test_python_strict.py
+++ b/tests/extraction/languages/test_python_strict.py
@@ -66,6 +66,30 @@ _PY_SIMPLE_CASES = [
     ("regex_execution", "re.compile(r'foo')", None),
     ("time_date_logic", "datetime.datetime.now()", None),
     ("ipc_rpc_bridges", "import multiprocessing", None),
+    # --- Issue #1072: signature keys with zero _SIMPLE_CASES coverage ---
+    ("api", "@app.get('/users')\ndef list_users():\n    pass", "def _internal_helper():\n    pass"),
+    ("bitwise_ops", "x = a << 2", "result = base ** exponent"),
+    ("closures", "f = lambda x: x + 1", "def f(x):\n    return x + 1"),
+    ("comprehensions", "[x**2 for x in range(10)]", "for x in range(10):\n    print(x)"),
+    ("cryptography", "import bcrypt", "import hashlib"),
+    ("dl_frameworks", "import torch", "import sklearn"),
+    ("encapsulation", "self._private_value = 1", "self.public_value = 1"),
+    (
+        "exfiltration_camouflage",
+        "requests.post('https://telemetry.example.com/collect', json=payload)",
+        "requests.post('https://api.example.com/users', json=payload)",
+    ),
+    ("hardware_bridge", "import usb.core", "import socket"),
+    ("import", "import os", "importance = 1"),
+    ("lazy_evaluation", "yield x", "return x"),
+    ("llm_api", "import openai", "import requests"),
+    ("llm_orchestrator", "from langchain.chains import LLMChain", "from flask import Flask"),
+    ("llm_vector_store", "import chromadb", "import sqlite3"),
+    ("memory_scraping", "path = '/proc/' + str(pid) + '/mem'", "path = '/proc/self/status'"),
+    ("ml_traditional", "from sklearn.linear_model import LogisticRegression", "from scipy import stats"),
+    ("structural_boundaries", "return x", "yield x"),
+    ("test", "def test_addition():\n    assert 1 + 1 == 2", "def calculate_addition(a, b):\n    return a + b"),
+    ("vectorized_math", "result = A @ B", "result = a * b"),
 ]
 
 

--- a/tests/extraction/languages/test_solidity_strict.py
+++ b/tests/extraction/languages/test_solidity_strict.py
@@ -67,6 +67,8 @@ _SOLIDITY_SIMPLE_CASES = [
     ("regex_execution", "keccak256(abi.encodePacked(a, b));", None),
     ("time_date_logic", "uint256 x = block.timestamp + 1 days;", None),
     ("ipc_rpc_bridges", "target.delegatecall(data);", None),
+    # --- Issue #1072: signature keys with zero _SIMPLE_CASES coverage ---
+    ("hardcoded_secrets", 'secret = "0xABCDEF1234567890";', 'secretary = "Jane Doe";'),
 ]
 
 

--- a/tests/extraction/languages/test_yaml_strict.py
+++ b/tests/extraction/languages/test_yaml_strict.py
@@ -91,6 +91,8 @@ _YAML_SIMPLE_CASES = [
     ),
     ("listeners", "webhook: http://example.com/hook", "endpoint: http://example.com/hook"),
     ("test_skip", "run: npm test -- --passWithNoTests", "run: npm test"),
+    # --- Issue #1072: signature keys with zero _SIMPLE_CASES coverage ---
+    ("hardcoded_secrets", 'api_key: "AKIAIOSFODNN7EXAMPLE1"', 'name: "AKIAIOSFODNN7EXAMPLE1"'),
 ]
 
 # NOTE: this test was originally grouped under a shared "cross-language sweep"


### PR DESCRIPTION
## Summary
- Closes #1072 (issue #1069's Section C: `audit_strict_coverage.py`'s `missing_case_entirely` list).
- 44 `LANGUAGE_DEFINITIONS` keys across 6 languages had zero `_SIMPLE_CASES` coverage in their `test_<lang>_strict.py` files. Most notably, **python's and javascript's entire AI/ML extension pack** (`llm_api`, `llm_orchestrator`, `llm_vector_store`, `ml_traditional`, `dl_frameworks`) had no detection test coverage at all — a real blind spot in a supply-chain-risk detection feature, not just a test-depth nit.
- Coverage added: python (19 keys), javascript (16), haskell (4), objective-c (3), solidity (1), yaml (1).
- Every candidate case was empirically verified with `verify_candidates.py`'s `check_case` against the real compiled regex before being added — no engine bugs surfaced (expected per `how_to_harden_strict_signatures.md`: this suite proves presence/absence of a construct, not exact-identifier extraction, so it's almost entirely test-writing, not regex-fixing).

## Test plan
- [x] `pytest tests/extraction/languages/test_{python,javascript,haskell,objectivec,solidity,yaml}_strict.py` — 330 passed
- [x] `pytest tests/extraction/` (full suite) — 4852 passed, 2 skipped, 10 xfailed, 3 xpassed
- [x] `python tests/tools/audit_check.py` — clean, no new ruff/mypy/dead-key findings
- [x] `python tests/extraction/tools/audit_strict_coverage.py --lang <x> --json` re-run for all 6 languages — `missing_case_entirely: []` for each

🤖 Generated with [Claude Code](https://claude.com/claude-code)