### PR TITLE
docs: give Claude and Antigravity dedicated /tmp scratch dirs (follow-up to #1091)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,33 @@ histogram_matcher.py
 archive/
 *.odt
 
+# AGENT SCRATCH/DEBUG FILES (Claude Code & Antigravity), repo-root only.
+# Primary control is CLAUDE.md / ANTIGRAVITY.md: throwaway scripts, repro
+# cases, and generated test artifacts belong in each model's dedicated
+# /tmp working directory, never in the repo tree. This is just the
+# backstop in case one slips through anyway -- patterns match the file
+# names that have recurred across past cleanups (see #1091).
+/scratch*.py
+/fix*.py
+/patch*.py
+/add_*.py
+/append_*.py
+/generate_*.py
+/redos_scanner.py
+/remove_invalid_tests.py
+/resolve.py
+/run_tests.sh
+/test_*.py
+/update*.py
+/wait_test.py
+/Makefile.test*
+/pr_*body*.md
+/pr_*body*.txt
+/pr_body.*
+/*_lessons.txt
+/LESSONS_LEARNED.md
+/rewrite_docs.py
+
 # GITGALAXY HEAVY DATA
 data/
 museum/

--- a/ANTIGRAVITY.md
+++ b/ANTIGRAVITY.md
@@ -101,6 +101,23 @@ When generating or submitting a Pull Request for this repository, it is critical
   - **Do not leave the PR body blank, sparse, or lame.** A poor description will cause the PR to be rejected.
 - **Add relevant labels:** Ensure the PR has descriptive labels attached so it integrates correctly into the project's tracking and CI processes.
 
+## 9. Scratch Files & Working Directory
+
+Throwaway scripts, reproduction cases, one-off debug output, and generated test artifacts that
+aren't meant to become part of the repo do **not** belong in the repo tree, not even temporarily.
+Repeated ad hoc file drops like this (`scratch_func.py`, `pr_groovy_body.txt`, `pr_body.txt`, and
+~130 similar files across both agents) required two full manual cleanup passes (see #1091).
+
+- **Use `/tmp/gitgalaxy-scratch/antigravity/`** (create it if missing) for anything throwaway.
+  This is outside the git repo, so nothing written there ever risks a `git add`.
+- Claude Code uses its own separate directory, `/tmp/gitgalaxy-scratch/claude/` (see `CLAUDE.md`)
+  — keep to your own directory so concurrent sessions from the two models don't collide when
+  working the same worktree.
+- If a throwaway file genuinely must live inside the repo temporarily (e.g. something that only
+  works via relative pytest discovery), prefix its name `scratch_` at minimum so the root
+  `.gitignore` backstop patterns catch it, and delete it before opening the PR rather than leaving
+  it for a future cleanup pass.
+
 ## CI Ruff Audit
 The `ruff-audit.yml` CI job enforces a STRICT EXACT MATCH against `tests/ruff_audit_baseline.json`. 
 This baseline uses the line number as part of the JSON keys (e.g. `"gitgalaxy/core/detector.py:1002: PERF401"`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,22 @@ discipline: only commit files relevant to the change at hand (never a broad `git
 `main..HEAD` doesn't carry unrelated in-progress work before committing, and run the relevant
 baseline-gated audits / `crucible_check.py` before pushing anything that touches parsing logic.
 
+## Scratch files & working directory
+
+Throwaway scripts, reproduction cases, one-off debug output, and generated test artifacts that
+aren't meant to become part of the repo do **not** belong in the repo tree, not even temporarily
+— that's how `scratch3.py`, `fix_java_strict.py`, `pr_949_body.md`, and ~130 similar files ended
+up committed and had to be purged twice (see #1091). Use `/tmp/gitgalaxy-scratch/claude/` (create
+it if missing) instead, or the harness-provided per-session Scratchpad Directory named in your own
+system prompt if one is present — either is fine, both are outside the repo and never risk a
+`git add`. Antigravity (agy) has the same convention under its own `/tmp/gitgalaxy-scratch/antigravity/`
+— see `ANTIGRAVITY.md` — so the two models don't collide in a shared directory.
+
+If a throwaway file genuinely must live inside the repo temporarily (e.g. something that only
+works via relative pytest discovery), prefix its name `scratch_` at minimum so `.gitignore`'s
+backstop patterns catch it, and delete it before ending the task rather than leaving it for a
+future cleanup pass.
+
 ## Architecture
 
 Data flows through `gitgalaxy/core/` in a fixed pipeline, each stage handing off to the next


### PR DESCRIPTION
### Description of Structural Changes

Follow-up to #1091, which was squash-merged (`65c47d87`) slightly before this last commit was pushed to `docs-testing-updates`, orphaning it off `main`. This PR is that one commit, cherry-picked cleanly onto current `main` (no conflicts, no other drift).

**`docs`: dedicated `/tmp` scratch directories for Claude and Antigravity**
- Repeated ad hoc scratch/debug files dropped straight into the repo root by both agents (`scratch*.py`, `fix_*.py`, `pr_*_body.md`, etc.) required two full manual cleanup passes on `docs-testing-updates` alone.
- `CLAUDE.md` and `ANTIGRAVITY.md` (agy's own project-instructions file, mirrors `CLAUDE.md`) now each document a dedicated, non-colliding `/tmp` working directory per model — `/tmp/gitgalaxy-scratch/claude/` and `/tmp/gitgalaxy-scratch/antigravity/` — for throwaway scripts, repro cases, and generated test artifacts that shouldn't enter the repo tree at all.
- Added a `.gitignore` backstop matching the recurring filename patterns from past cleanups (`scratch*.py`, `fix*.py`, `patch*.py`, `pr_*body*`, `test_*.py` at repo root, etc.), anchored to repo-root only so it can't shadow legitimate nested files under `gitgalaxy/`/`tests/`. Verified via `git check-ignore` that it catches new files matching those patterns without affecting any currently-tracked file.

### Testing

Docs/config only — no code paths touched. `git check-ignore -v` confirmed the new `.gitignore` patterns catch representative filenames without matching anything in `git ls-files`.

### Visual Observatory Testing
- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.

_N/A — docs/config only, no rendering or engine-output changes._

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.

_No target repository — this is a repo-hygiene/process fix, not an engine change. No parsing logic touched, so no differential scan drift is possible._
