### PR TITLE
ci: add workflow_dispatch to gitgalaxy.yml and muninn.yml

### DIFF
--- a/.github/workflows/gitgalaxy.yml
+++ b/.github/workflows/gitgalaxy.yml
@@ -6,6 +6,13 @@ on:
     paths-ignore: ["docs/**"]
   push:
     branches: [main]
+  # Manual re-fire for the post-gate (SARIF/SBOM/LLM brief) without needing a
+  # new commit -- added after push-to-main events silently stopped creating
+  # runs for ~4.5h on 2026-08-06 (GitHub recorded the PushEvents; no run was
+  # ever created for this workflow or muninn.yml). Root cause unconfirmed
+  # (suspected Actions run-creation throttling from this repo's push volume,
+  # see the LLM-brief auto-merge loop below); this is the recovery lever.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -74,8 +81,9 @@ jobs:
   # ============================================================
   full-report:
     if: |
-      github.event_name == 'push' &&
-      !startsWith(github.event.head_commit.message, 'docs: auto-update LLM architectural brief')
+      (github.event_name == 'push' &&
+       !startsWith(github.event.head_commit.message, 'docs: auto-update LLM architectural brief')) ||
+      github.event_name == 'workflow_dispatch'
     name: Full Report (SARIF, SBOM, LLM Brief)
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Push-to-`main` events stopped creating workflow runs for both `gitgalaxy.yml`'s `full-report` job (SARIF/SBOM upload to the Security tab) and `muninn.yml` after 2026-08-06 15:09 UTC. GitHub's PushEvent log confirms the pushes for the next 4 merges to `main` (including #1103's RCE/exfiltration-claims removal) were received, but no workflow run was ever created for either workflow against them.
- Neither workflow had a `workflow_dispatch` trigger, so there was no way to manually re-fire the scan while waiting for push-triggering to recover (or if it doesn't recover on its own).
- Adds `workflow_dispatch:` to both, and widens `full-report`'s `if:` condition so a manual dispatch actually runs the job (previously gated to `github.event_name == 'push'` only).

## Test plan
- [x] Both YAML files parse (`yaml.safe_load`)
- [ ] After merge, manually dispatch `gitgalaxy.yml` on `main` and confirm a fresh SARIF lands on the Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)