### PR TITLE
ci: revert workflow_dispatch on muninn.yml from #1109

### DIFF
--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- #1109 added `workflow_dispatch:` to both `gitgalaxy.yml` and `muninn.yml` while diagnosing a GitHub Actions outage that was blocking push-triggered scans.
- `muninn.yml` is a different contributor's setup and didn't need to be touched — reverting that half. `gitgalaxy.yml` keeps its `workflow_dispatch` trigger.

## Test plan
- [x] YAML parses
- [x] Diff is an exact revert of the muninn.yml hunk from #1109