### PR TITLE
docs(wiki): fix dead links across the GitGalaxy wiki

### DIFF
--- a/docs/wiki/02-01-pipeline-overview.md
+++ b/docs/wiki/02-01-pipeline-overview.md
@@ -1,6 +1,6 @@
 # Static Analysis Pipeline Overview
 
-> **File Reference:** [`gitgalaxy/galaxyscope.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/galaxyscope.py)
+> **File Reference:** [`gitgalaxy/galaxyscope.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/galaxyscope.py)
 
 ## Engineering Summary
 This subsystem is the main orchestration engine for automated, deterministic static analysis and dependency mapping of multi-language software repositories. It solves the problem of extracting structural metrics, computing risk exposures, and validating statistical integrity without relying on fragile Abstract Syntax Tree (AST) compilation or non-deterministic LLM inference. It exists to coordinate the execution phases—from data ingestion to output serialization—ensuring that all modules run efficiently and in the correct order. Within the larger architecture, this component acts as the high-speed, modular process manager known as GitGalaxy.
@@ -51,6 +51,6 @@ Achieves high-speed processing through a multi-core `ProcessPoolExecutor` that b
 Expand incremental delta analysis support for more complex Git state transitions, and refine the statistical outlier detection model.
 
 ## Related Components
-- [Pipeline Orchestration Framework](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-02-optical-orchestration.md)
-- [Aperture Filter](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-03-aperture-filter.md)
+- [Pipeline Orchestration Framework](02-02-optical-orchestration.md)
+- [Aperture Filter](02-03-aperture-filter.md)
 

--- a/docs/wiki/02-02-optical-orchestration.md
+++ b/docs/wiki/02-02-optical-orchestration.md
@@ -1,6 +1,6 @@
 # Pipeline Orchestration Framework
 
-> **File Reference:** [`gitgalaxy/galaxyscope.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/galaxyscope.py)
+> **File Reference:** [`gitgalaxy/galaxyscope.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/galaxyscope.py)
 
 ## Engineering Summary
 This subsystem is the primary execution engine and process manager for the static analysis framework. It solves the problem of coordinating data ingestion, multi-pass metric evaluations, worker process pools, and serialization exporters in a deterministic sequence. It exists to ensure that all pipeline phases execute reliably, aggregating global repository properties and eliminating non-code noise early. Within the broader system, it functions as the central controller orchestrating GitGalaxy.
@@ -53,6 +53,6 @@ Utilizes an $O(1)$ pre-computed suffix hash map to resolve import strings to phy
 Enhancing the spatial layout algorithms for larger scale codebases and optimizing memory usage during delta rehydration.
 
 ## Related Components
-- [Pipeline Overview](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-01-pipeline-overview.md)
-- [Aperture Filter](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-03-aperture-filter.md)
+- [Pipeline Overview](02-01-pipeline-overview.md)
+- [Aperture Filter](02-03-aperture-filter.md)
 

--- a/docs/wiki/02-03-aperture-filter.md
+++ b/docs/wiki/02-03-aperture-filter.md
@@ -1,6 +1,6 @@
 # File Filtering and Ingestion Shield
 
-> **File Reference:** [`gitgalaxy/core/aperture.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/aperture.py)
+> **File Reference:** [`gitgalaxy/core/aperture.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/aperture.py)
 
 ## Engineering Summary
 This subsystem acts as the primary perimeter security gate and ingestion filter prior to heavy analysis. It solves the problem of wasted computational resources on non-code noise such as compiled binaries, minified bundles, vendor packages, and excluded directories. It exists to strip out irrelevant assets and classify them into operational ingestion buckets, ensuring subsequent processing focuses strictly on actionable source code logic. Within the ecosystem, it functions as the foundational ingestion shield for GitGalaxy.
@@ -48,5 +48,5 @@ Executes zero-overhead filesystem checks. Binary header inspection is limited to
 Enhancing secrets detection patterns and allowing user-defined dynamic quota adjustments.
 
 ## Related Components
-- [Orchestration Framework](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-02-optical-orchestration.md)
+- [Orchestration Framework](02-02-optical-orchestration.md)
 

--- a/docs/wiki/02-04-guidestar-protocol.md
+++ b/docs/wiki/02-04-guidestar-protocol.md
@@ -1,6 +1,6 @@
 # Project Manifest and Metadata Resolution
 
-> **File Reference:** [`gitgalaxy/core/guidestar_lens.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/guidestar_lens.py)
+> **File Reference:** [`gitgalaxy/core/guidestar_lens.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/guidestar_lens.py)
 
 ## Engineering Summary
 This subsystem acts as the project metadata parser and contextual intelligence engine. It solves the problem of analyzing files with ambiguous extensions or no extensions by parsing build manifests (e.g., `package.json`, `Cargo.toml`, `Makefiles`) and repository attributes (`.gitattributes`) to assign initial language priors and intent locks before lexical analysis. It exists to establish file importance and language hints based on verified developer intent, ensuring downstream components prioritize analysis correctly. Within the overall pipeline, this component is known as GitGalaxy's GuideStar.
@@ -46,6 +46,6 @@ Path lookup resolution occurs in $O(1)$ to $O(N)$ strict sequence, avoiding deep
 Expanding manifest support to emerging build systems like Bazel and Buck2.
 
 ## Related Components
-- [Aperture Filter](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-03-aperture-filter.md)
-- [Language Lens](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-05-language-lens.md)
+- [Aperture Filter](02-03-aperture-filter.md)
+- [Language Lens](02-05-language-lens.md)
 

--- a/docs/wiki/02-05-language-lens.md
+++ b/docs/wiki/02-05-language-lens.md
@@ -1,6 +1,6 @@
 # Language Identification Engine
 
-> **File Reference:** [`gitgalaxy/standards/language_lens.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/standards/language_lens.py)
+> **File Reference:** [`gitgalaxy/standards/language_lens.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/standards/language_lens.py)
 
 ## Engineering Summary
 This subsystem is the primary language identification engine. It solves the problem of inaccurately identifying programming languages in complex repositories where file extensions are misleading or non-existent. It exists to provide a deterministic language identifier and a confidence score for every analyzed file, combining metadata rules with deep lexical analysis. Within the system, this module is the language recognition layer for GitGalaxy.
@@ -48,6 +48,6 @@ Uses ecosystem mass computation to skip regex verification on heavily dominant e
 Expanding the transition marker registry to better handle nested JSX/TSX and template engines.
 
 ## Related Components
-- [Guidestar Protocol](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-04-guidestar-protocol.md)
-- [The Prism](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-07-the-prism.md)
+- [Guidestar Protocol](02-04-guidestar-protocol.md)
+- [The Prism](02-07-the-prism.md)
 (index.md)**

--- a/docs/wiki/02-06-security-lens.md
+++ b/docs/wiki/02-06-security-lens.md
@@ -1,6 +1,6 @@
 # Vulnerability & Threat Scanner
 
-> **File Reference:** [`gitgalaxy/security/security_lens.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/security/security_lens.py)
+> **File Reference:** [`gitgalaxy/security/security_lens.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/security/security_lens.py)
 
 ## Engineering Summary
 This subsystem is the pattern-based security analysis and threat detection engine. It solves the problem of static vulnerability databases (CVEs) and simple string-matching failing against custom obfuscation, zero-days, or unmitigated taint flows. It exists to evaluate structural density of high-risk operations and behavioral execution mechanics. Within the architecture, this module acts as the AppSec scanner for GitGalaxy.
@@ -42,4 +42,4 @@ Employs hardware-optimized regular expression engines. Uses a minification guard
 Expanding inter-procedural taint analysis capabilities and tuning the XGBoost threat classifier integration.
 
 ## Related Components
-- [Optical Orchestration](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-02-optical-orchestration.md)
+- [Optical Orchestration](02-02-optical-orchestration.md)

--- a/docs/wiki/02-07-the-prism.md
+++ b/docs/wiki/02-07-the-prism.md
@@ -1,6 +1,6 @@
 # Lexical Stream Splicer
 
-> **File Reference:** [`gitgalaxy/core/prism.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/prism.py)
+> **File Reference:** [`gitgalaxy/core/prism.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/prism.py)
 
 ## Engineering Summary
 This subsystem is the source code tokenizer and stream separator. It solves the problem of metric distortion caused by commented-out code blocks or documentation text intermingled with executable logic. It exists to split the source file into isolated executable code and comment streams using language-specific rules. Within the pipeline, this component functions as the structural lexical splicer for GitGalaxy.
@@ -46,5 +46,5 @@ The atomic literal shield uses timed execution loops. Spatial coordinate mapping
 Adding support for more exotic string literal formats in niche languages and improving the speed of the heredoc state machine.
 
 ## Related Components
-- [Language Lens](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-05-language-lens.md)
-- [The Detector](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-08-the-detector.md)
+- [Language Lens](02-05-language-lens.md)
+- [The Detector](02-08-the-detector.md)

--- a/docs/wiki/02-08-the-detector.md
+++ b/docs/wiki/02-08-the-detector.md
@@ -1,6 +1,6 @@
 # Structural Code Analyzer & Spatial Cartographer
 
-> **File Reference:** [`gitgalaxy/core/detector.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/detector.py)
+> **File Reference:** [`gitgalaxy/core/detector.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/detector.py)
 
 ## Engineering Summary
 This subsystem is the structural code analyzer and spatial cartography module. It solves the problem of extracting code complexity metrics and generating spatial layout coordinates without compiling the code. It exists to map structural logic (like function definitions, parameter counts, and control-flow density) into a fixed schema, and then calculate coordinates for rendering a 3D node graph. Within the pipeline, this component functions as the primary detector for GitGalaxy.
@@ -45,5 +45,5 @@ Employs a backtracking latency guard that issues a warning if regex shielding ex
 Enhancing the layout algorithm to better support millions of nodes without geometric overlapping.
 
 ## Related Components
-- [Signal Processing](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-09-signal-processing.md)
-- [The Prism](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-07-the-prism.md)
+- [Signal Processing](02-09-signal-processing.md)
+- [The Prism](02-07-the-prism.md)

--- a/docs/wiki/02-09-signal-processing.md
+++ b/docs/wiki/02-09-signal-processing.md
@@ -1,6 +1,6 @@
 # Metrics Normalization & Risk Score Processor
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 This subsystem is the metrics normalization and risk evaluation engine. It solves the problem of translating raw structural counts into scaled, comparable risk scores across different languages and project structures. It exists to evaluate files in context—comparing individual metrics against directory distributions, repository-wide baseline curves, and Git commit history—to pinpoint systemic bottlenecks and anomalous code. Within the ecosystem, it functions as the risk signal processor for GitGalaxy.
@@ -44,5 +44,5 @@ Pass 2 temporal normalization and biaxial drift computation execute across pre-a
 Integrating dynamic machine learning models to adjust language tier normalizations based on empirical data.
 
 ## Related Components
-- [The Detector](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-08-the-detector.md)
-- [Spectral Audit](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-11-spectral-audit.md)
+- [The Detector](02-08-the-detector.md)
+- [Spectral Audit](02-11-spectral-audit.md)

--- a/docs/wiki/02-11-spectral-audit.md
+++ b/docs/wiki/02-11-spectral-audit.md
@@ -1,6 +1,6 @@
 # Statistical Quality Auditor & Bayesian Data Validation
 
-> **File Reference:** [`gitgalaxy/metrics/statistical_auditor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/statistical_auditor.py)
+> **File Reference:** [`gitgalaxy/metrics/statistical_auditor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/statistical_auditor.py)
 
 ## Engineering Summary
 This subsystem acts as the statistical quality control and data validation gate. It solves the problem of distinguishing valid source code from anomalous non-code artifacts (like data dumps or unparseable blobs) that might skew repository-wide metrics. It exists to apply Bayesian accountability models to ensure assigned classifications and structural metrics are mathematically plausible. Within the pipeline, this component functions as the spectral statistical auditor for GitGalaxy.
@@ -44,4 +44,4 @@ Calculates MAD statistics in $O(N)$ operations. The 50/0 rule (files >50 lines w
 Expanding the Bayesian consensus model to incorporate project-specific history.
 
 ## Related Components
-- [Signal Processing](file:///home/joe/nyx_projects/gitgalaxy/docs/wiki/02-09-signal-processing.md)
+- [Signal Processing](02-09-signal-processing.md)

--- a/docs/wiki/02-12-audit-recorder.md
+++ b/docs/wiki/02-12-audit-recorder.md
@@ -1,6 +1,6 @@
 # Audit Recorder
 
-> **File Reference:** [`gitgalaxy/recorders/audit_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/audit_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/audit_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/audit_recorder.py)
 
 ## Engineering Summary
 This subsystem is the final compliance and reporting module of the static analysis pipeline. It extracts raw structural telemetry from memory and serializes it into a verbose, human-readable forensic JSON audit manifest. It solves the problem of providing end-to-end traceability for every analyzed file, acting as an enhanced Software Bill of Materials (SBOM) that incorporates structural health telemetry. It exists to provide detailed mathematical metrics covering code quality, security exposure, and structural integrity across the repository for enterprise compliance, software supply chain auditing, and deep security inspection. Within the system, this module is known as the GitGalaxy Audit Recorder.

--- a/docs/wiki/02-13-gpu-recorder.md
+++ b/docs/wiki/02-13-gpu-recorder.md
@@ -1,6 +1,6 @@
 # GPU Recorder
 
-> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/gpu_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/gpu_recorder.py)
 
 ## Engineering Summary
 This subsystem is the high-performance data transformation module of the pipeline. It converts verbose, object-oriented JSON telemetry into a hypercompressed columnar format (Structure of Arrays / SoA) designed specifically for WebGL/WebGPU 3D rendering engines. It solves the problem of high latency and memory overhead when loading large codebase models into the browser. It exists to prioritize memory efficiency, low payload transfer size, and fast buffer loading over human readability. Within the system, this module is known as the GitGalaxy GPU Recorder.

--- a/docs/wiki/02-14-llm-recorder.md
+++ b/docs/wiki/02-14-llm-recorder.md
@@ -1,6 +1,6 @@
 # LLM Recorder
 
-> **File Reference:** [`gitgalaxy/recorders/llm_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/llm_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/llm_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/llm_recorder.py)
 
 ## Engineering Summary
 This subsystem formats static analysis telemetry into token-dense artifacts optimized for AI context windows, Retrieval-Augmented Generation (RAG) pipelines, and autonomous coding agents. Instead of requiring Large Language Models to parse raw, verbose JSON structures, it generates structured markdown briefs and a relational SQLite database. It solves the problem of inefficient context utilization by AI models when reasoning over large codebases. It exists to bridge the gap between static analysis and agentic tooling. Within the system, this module is known as the GitGalaxy LLM Recorder.

--- a/docs/wiki/02-15-chronometer.md
+++ b/docs/wiki/02-15-chronometer.md
@@ -1,6 +1,6 @@
 # Chronometer (Git History Analysis)
 
-> **File Reference:** [`gitgalaxy/metrics/chronometer.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/chronometer.py)
+> **File Reference:** [`gitgalaxy/metrics/chronometer.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/chronometer.py)
 
 The Chronometer component measures code churn (frequency of changes) and file stability by analyzing Git history. While the rest of the pipeline performs static analysis on the codebase at a single point in time, the Chronometer provides the historical context required by the Signal Processor to calculate risk exposure metrics.
 

--- a/docs/wiki/02-16-network-risk-sensor.md
+++ b/docs/wiki/02-16-network-risk-sensor.md
@@ -1,6 +1,6 @@
 # Network Risk Sensor
 
-> **File Reference:** [`gitgalaxy/core/network_risk_sensor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/network_risk_sensor.py)
+> **File Reference:** [`gitgalaxy/core/network_risk_sensor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/network_risk_sensor.py)
 
 ## Engineering Summary
 This subsystem constructs an $N$-dimensional Directed Graph from raw import statements extracted across all scanned files. By mapping inter-file module dependencies, it transforms isolated file metrics into a systemic dependency analysis engine. It solves the problem of understanding cascading failure risks and architectural bottlenecks in large codebases. It exists to compute blast radius values, classify component roles, and evaluate repository-wide network resilience. Within the system, this module is known as the GitGalaxy Network Risk Sensor.

--- a/docs/wiki/02-17-ai-appsec-sensor.md
+++ b/docs/wiki/02-17-ai-appsec-sensor.md
@@ -1,6 +1,6 @@
 # AI AppSec Sensor
 
-> **File Reference:** [`gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py)
+> **File Reference:** [`gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/ai_guardrails/ai_appsec_sensor.py)
 
 ## Engineering Summary
 This subsystem flags one specific AI-integration architecture risk: an agent-orchestration framework (langchain/llama_index) bound to raw network/disk write access in a file with weak defensive programming density. It exists to proactively surface unreviewed autonomous data-corruption risk. Within the system, this module is known as the GitGalaxy AI AppSec Sensor.

--- a/docs/wiki/02-18-dev-agent-firewall.md
+++ b/docs/wiki/02-18-dev-agent-firewall.md
@@ -1,6 +1,6 @@
 # Dev Agent Firewall
 
-> **File Reference:** [`gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py)
+> **File Reference:** [`gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/ai_guardrails/dev_agent_firewall.py)
 
 ## Engineering Summary
 This subsystem evaluates codebase complexity and network graph metrics to determine safety boundaries for autonomous AI coding agents. It analyzes token mass, algorithmic complexity, graph topology, and documentation density. It solves the problem of AI agents causing silent regressions, context window degradation, or API hallucinations when editing critical architectural choke points. It exists to enforce statistical safety guardrails for autonomous code modifications. Within the system, this module is known as the GitGalaxy Dev Agent Firewall.

--- a/docs/wiki/02-19-neural-auditor.md
+++ b/docs/wiki/02-19-neural-auditor.md
@@ -1,6 +1,6 @@
 # Tensor Model Scanner
 
-> **File Reference:** [`gitgalaxy/metrics/tensor_scanner.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/tensor_scanner.py)
+> **File Reference:** [`gitgalaxy/metrics/tensor_scanner.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/tensor_scanner.py)
 
 ## Engineering Summary
 This subsystem inspects large Machine Learning model weights (`.safetensors`, `.gguf`) stored within repositories without loading multi-gigabyte files into system RAM. By parsing binary headers using zero-RAM byte reads, it extracts parameter counts, quantization levels, and architecture metadata. It solves the problem of auditing massive ML binaries during static analysis without causing memory exhaustion. It exists to track model architecture attributes and physical node mass across repository boundaries. Within the system, this module is historically known as the GitGalaxy Neural Auditor or Tensor Model Scanner.

--- a/docs/wiki/02-20-security-auditor.md
+++ b/docs/wiki/02-20-security-auditor.md
@@ -1,6 +1,6 @@
 # Security Auditor
 
-> **File Reference:** [`gitgalaxy/security/security_auditor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/security/security_auditor.py)
+> **File Reference:** [`gitgalaxy/security/security_auditor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/security/security_auditor.py)
 
 ## Engineering Summary
 This subsystem executes a trained XGBoost multiclass classification model across extracted codebase feature vectors. It evaluates structural metrics, code complexity distributions, and graph topology to predict malicious software patterns (such as Trojans, Stealers, Droppers, or Botnets). It solves the problem of detecting sophisticated code obfuscation and zero-day threats that evade traditional static analysis rules. It exists to provide machine learning-backed security intelligence and supply chain integrity verification. Within the system, this module is known as the GitGalaxy Security Auditor.

--- a/docs/wiki/02-21-record-keeper.md
+++ b/docs/wiki/02-21-record-keeper.md
@@ -1,6 +1,6 @@
 # Record Keeper
 
-> **File Reference:** [`gitgalaxy/recorders/record_keeper.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/record_keeper.py)
+> **File Reference:** [`gitgalaxy/recorders/record_keeper.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/record_keeper.py)
 
 ## Engineering Summary
 This subsystem is the database serialization module responsible for writing GitGalaxy's in-memory static analysis state into a portable, relational SQLite database (`_galaxy_graph.sqlite`). It solves the problem of persisting complex, relational dependency graph data without requiring external infrastructure. It exists to provide a normalized relational schema designed for autonomous AI agents, Retrieval-Augmented Generation (RAG) workflows, and CI/CD analytics pipelines. Within the system, this module is known as the GitGalaxy Record Keeper.

--- a/docs/wiki/02-22-state-rehydrator.md
+++ b/docs/wiki/02-22-state-rehydrator.md
@@ -1,6 +1,6 @@
 # State Rehydrator
 
-> **File Reference:** [`gitgalaxy/core/state_rehydrator.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/state_rehydrator.py)
+> **File Reference:** [`gitgalaxy/core/state_rehydrator.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/state_rehydrator.py)
 
 ## Engineering Summary
 This subsystem enables efficient incremental scans within Continuous Integration/Continuous Deployment (CI/CD) pipelines. It solves the problem of high compute overhead caused by re-parsing large, unmodified codebases on every commit. It exists to load previously analyzed state from the SQLite database into memory, restoring the repository baseline and exclusively analyzing modified source files. Within the system, this module is known as the GitGalaxy State Rehydrator.

--- a/docs/wiki/04-00-security_landscape.md
+++ b/docs/wiki/04-00-security_landscape.md
@@ -1,6 +1,6 @@
 # Security Architecture & Competitive Analysis
 
-> **File Reference:** [gitgalaxy/security/security_auditor.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/security/security_auditor.py)
+> **File Reference:** [gitgalaxy/security/security_auditor.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/security/security_auditor.py)
 
 ## Engineering Summary
 The DevSecOps ecosystem is populated by static analysis and software composition analysis (SCA) platforms that traditionally rely on full source code compilation, heavy Abstract Syntax Tree (AST) generation, or reliance on external vulnerability databases. These approaches introduce performance bottlenecks in high-throughput CI/CD pipelines, making real-time analysis difficult. To address this, a compilation-free, multi-language static security analysis framework evaluates raw code structures, lexical patterns, and heuristic signatures across 50+ programming languages simultaneously. By computing risk metrics, generating call reachability graphs, and identifying potential vulnerabilities without pre-compiled build artifacts, it provides low-latency feedback. This subsystem is the GitGalaxy analysis engine.

--- a/docs/wiki/04-01-full-api-network-map.md
+++ b/docs/wiki/04-01-full-api-network-map.md
@@ -1,6 +1,6 @@
 # Full API Network Map (Shadow & Ghost API Audit)
 
-> **File Reference:** [gitgalaxy/tools/network_auditing/full_api_network_map.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/network_auditing/full_api_network_map.py)
+> **File Reference:** [gitgalaxy/tools/network_auditing/full_api_network_map.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/network_auditing/full_api_network_map.py)
 
 ## Engineering Summary
 While internal dependency tools map file-to-file imports, they do not track the external network boundary of a repository. Web API surfaces drift out of sync with official documentation, leaving undocumented endpoints exposed or deprecated endpoints cluttering specifications. To solve this, an automated attack surface mapping module evaluates executable router code signatures against official OpenAPI/Swagger documentation. By performing a set theory comparison, it identifies undocumented "Shadow APIs" and deprecated "Ghost APIs". This subsystem is the GitGalaxy API Network Mapper.

--- a/docs/wiki/04-02-sbom-generator.md
+++ b/docs/wiki/04-02-sbom-generator.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials (SBOM) Generator
 
-> **File Reference:** [gitgalaxy/recorders/sbom_recorder.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/sbom_recorder.py)
+> **File Reference:** [gitgalaxy/recorders/sbom_recorder.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/sbom_recorder.py)
 
 ## Engineering Summary
 Software supply chains rely heavily on declarative package manifests (like `package.json` or `requirements.txt`) to determine the bill of materials. However, relying solely on manifests fails to confirm whether the deployed code on disk matches what was declared, exposing environments to malware payloads and dependency spoofing. A physical verification tool inspects installed packages on disk to ensure component integrity before generating CycloneDX 1.4 compliant records. This subsystem is the GitGalaxy SbomRecorder.

--- a/docs/wiki/04-03-supply-chain-firewall.md
+++ b/docs/wiki/04-03-supply-chain-firewall.md
@@ -1,6 +1,6 @@
 # Supply Chain Firewall (Zero-Trust Dependency Gate)
 
-> **File Reference:** [gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py)
+> **File Reference:** [gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/supply_chain_security/supply_chain_firewall.py)
 
 ## Engineering Summary
 Modern applications heavily rely on third-party dependencies, which can introduce severe supply chain risks such as malicious updates, namespace hijacking, or embedded malware. Relying solely on asynchronous vulnerability scans allows bad code to enter the environment during the build phase. To proactively block threats, an in-memory logic gate evaluates package imports, resolves aliases, and enforces risk thresholds before third-party code reaches production build environments. This subsystem is the GitGalaxy Supply Chain Firewall.

--- a/docs/wiki/04-04-vault-sentinel.md
+++ b/docs/wiki/04-04-vault-sentinel.md
@@ -1,6 +1,6 @@
 # Vault Sentinel (High-Speed Secrets Scanner)
 
-> **File Reference:** [gitgalaxy/tools/supply_chain_security/vault_sentinel.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/supply_chain_security/vault_sentinel.py)
+> **File Reference:** [gitgalaxy/tools/supply_chain_security/vault_sentinel.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/supply_chain_security/vault_sentinel.py)
 
 ## Engineering Summary
 Developer environments often accidentally leak sensitive credentials via hardcoded keys or committed configuration files. Catching these leaks requires scanning code before it enters version control. To solve this, a high-speed secret scanning module acts as a pre-commit hook and CI/CD validator, detecting hardcoded API keys, SaaS credentials, private key certificates, and uncommitted `.env` files. It emphasizes sub-second execution speeds to avoid blocking local developer workflows. This subsystem is the GitGalaxy Vault Sentinel.

--- a/docs/wiki/04-05-binary-anomaly-detector.md
+++ b/docs/wiki/04-05-binary-anomaly-detector.md
@@ -1,6 +1,6 @@
 # Binary Anomaly Detector (Heuristic File Integrity Scanner)
 
-> **File Reference:** [gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py)
+> **File Reference:** [gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/supply_chain_security/binary_anomaly_detector.py)
 
 ## Engineering Summary
 Standard source code parsers drop binary assets to conserve memory and avoid parsing errors. However, attackers exploit this blind spot by embedding malware, packed executables, or steganographic payloads inside seemingly benign files like images or archives. To combat this, a heuristic file integrity scanner explicitly targets binary files, inspecting byte-level headers and calculating mathematical entropy to flag hidden threats. This subsystem is the GitGalaxy Binary Anomaly Detector.

--- a/docs/wiki/04-06-pii-leak-hunter.md
+++ b/docs/wiki/04-06-pii-leak-hunter.md
@@ -1,6 +1,6 @@
 # PII Leak Hunter (Log Privacy & Incident Responder)
 
-> **File Reference:** [gitgalaxy/tools/terabyte_log_scanning/pii_leak_hunter.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/terabyte_log_scanning/pii_leak_hunter.py)
+> **File Reference:** [gitgalaxy/tools/terabyte_log_scanning/pii_leak_hunter.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/terabyte_log_scanning/pii_leak_hunter.py)
 
 ## Engineering Summary
 Server logs and database dumps often inadvertently capture Personally Identifiable Information (PII) such as credit cards, SSNs, and API keys. Scanning terabyte-scale log files for these leaks using standard text parsers causes immense memory overhead and CPU starvation due to string decoding. To solve this, a high-throughput stream processor evaluates raw binary data against byte-level regular expressions, decoding strings only upon a positive match. It sanitizes sensitive data and provides chronological histograms of exposure events. This subsystem is the GitGalaxy PII Leak Hunter.

--- a/docs/wiki/04-07-terabyte-log-scanner.md
+++ b/docs/wiki/04-07-terabyte-log-scanner.md
@@ -1,6 +1,6 @@
 # Terabyte Log Scanner (High-Volume Telemetry & Dead Code Validator)
 
-> **File Reference:** [gitgalaxy/tools/terabyte_log_scanning/terabyte_log_scanner.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/terabyte_log_scanning/terabyte_log_scanner.py)
+> **File Reference:** [gitgalaxy/tools/terabyte_log_scanning/terabyte_log_scanner.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/terabyte_log_scanning/terabyte_log_scanner.py)
 
 ## Engineering Summary
 Static code analysis often flags legacy code as "dead" or unused, but removing it without runtime verification can cause catastrophic production outages. Validating execution requires scanning massive server or mainframe logs to find module invocation signatures. To accomplish this, a high-speed log processor streams multi-terabyte files in binary mode, matching dynamic telemetry against statically generated program lists to confirm execution state. This subsystem is the GitGalaxy Terabyte Log Scanner.

--- a/docs/wiki/05-01-legacy-refraction-controller.md
+++ b/docs/wiki/05-01-legacy-refraction-controller.md
@@ -1,6 +1,6 @@
 # COBOL Refactoring Controller
 
-> **File Reference:** [`gitgalaxy/cobol_refractor_controller.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/cobol_refractor_controller.py)
+> **File Reference:** [`gitgalaxy/cobol_refractor_controller.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/cobol_refractor_controller.py)
 
 ## Engineering Summary
 This subsystem is an orchestration engine that parses procedural legacy source code to extract deterministic business logic into a structured format. It solves the problem of analyzing massive monolithic codebases by converting source text into a machine-readable intermediate representation. It exists to provide the foundational data structures required for downstream code generation and architectural visualization. Within the ecosystem, it functions as the primary entry point for static analysis, producing artifacts consumed by the rest of GitGalaxy.

--- a/docs/wiki/05-02-spring-boot-scaffolding.md
+++ b/docs/wiki/05-02-spring-boot-scaffolding.md
@@ -1,6 +1,6 @@
 # Spring Boot Scaffolding Architecture
 
-> **File Reference:** [`gitgalaxy/cobol_to_java_controller.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/cobol_to_java_controller.py)
+> **File Reference:** [`gitgalaxy/cobol_to_java_controller.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/cobol_to_java_controller.py)
 
 ## Engineering Summary
 This subsystem automatically generates a complete Java project structure from parsed legacy application state. It solves the problem of manually translating procedural environments into modern, compilable application frameworks. It exists to eliminate boilerplate setup and ensure consistency across migrated microservices. This orchestrator functions as the bridge between static analysis outputs and target application architectures within GitGalaxy.

--- a/docs/wiki/05-03-entity-and-memory-mapping.md
+++ b/docs/wiki/05-03-entity-and-memory-mapping.md
@@ -1,6 +1,6 @@
 # Entity & Memory Mapping
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_java/cobol_to_java_spring_forge.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_java/cobol_to_java_spring_forge.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_java/cobol_to_java_spring_forge.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_java/cobol_to_java_spring_forge.py)
 
 ## Engineering Summary
 This subsystem translates procedural memory layouts into relational database entity mappings. It solves the problem of converting byte-level memory overlays, fixed-length arrays, and specialized numeric constraints into object-relational mapping (ORM) structures. It exists to bridge the gap between contiguous memory segments and normalized SQL tables. Within the GitGalaxy pipeline, it generates the data access layer for target microservices.

--- a/docs/wiki/05-04-api-and-service-contracts.md
+++ b/docs/wiki/05-04-api-and-service-contracts.md
@@ -1,6 +1,6 @@
 # API & Service Contracts
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_java/cobol_to_java_api_contract_forge.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_java/cobol_to_java_api_contract_forge.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_java/cobol_to_java_api_contract_forge.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_java/cobol_to_java_api_contract_forge.py)
 
 ## Engineering Summary
 This subsystem constructs the network interfaces and dependency injection scaffolding for modernized microservices. It solves the problem of exposing legacy procedural entry points over modern HTTP protocols and wiring inter-module dependencies. It exists to provide the structural skeleton required before business logic can be injected. In GitGalaxy, this layer connects the web controllers to the underlying business services.

--- a/docs/wiki/05-05-autonomous-agent-tickets.md
+++ b/docs/wiki/05-05-autonomous-agent-tickets.md
@@ -1,6 +1,6 @@
 # Autonomous Agent Task Tickets
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_java/cobol_to_java_agent_forge.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_java/cobol_to_java_agent_forge.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_java/cobol_to_java_agent_forge.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_java/cobol_to_java_agent_forge.py)
 
 ## Engineering Summary
 This subsystem formats isolated segments of legacy code into bounded task payloads for large language models. It solves the problem of context window saturation and hallucination when translating large source files. It exists to enforce strict constraints on AI code generation by limiting the provided context to exact business logic paths. Within GitGalaxy, it bridges the deterministic static analysis pipeline with probabilistic AI generation.

--- a/docs/wiki/05-06-batch-test-harness.md
+++ b/docs/wiki/05-06-batch-test-harness.md
@@ -1,6 +1,6 @@
 # Batch Test Harness
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_java/batch_test_harness.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_java/batch_test_harness.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_java/batch_test_harness.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_java/batch_test_harness.py)
 
 ## Engineering Summary
 This subsystem is an automated verification framework that executes the entire end-to-end modernization pipeline across multiple repositories. It solves the problem of detecting regressions in static analysis or code generation logic by compiling the output artifacts. It exists to guarantee that changes to the core engine do not break downstream compilability. In GitGalaxy, it serves as the primary CI/CD integration testing tool.

--- a/docs/wiki/05-07-mainframe-compiler-forge.md
+++ b/docs/wiki/05-07-mainframe-compiler-forge.md
@@ -1,6 +1,6 @@
 # Mainframe Compiler Generator
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_cobol/cobol_compiler_forge.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_compiler_forge.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_cobol/cobol_compiler_forge.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_compiler_forge.py)
 
 ## Engineering Summary
 This subsystem constructs Job Control Language (JCL) build scripts required to compile legacy modules on MVS mainframe architectures. It solves the problem of manually determining the correct compiler utility and dataset allocations based on source code dialects. It exists to automate the deployment process for legacy environments. In GitGalaxy, it supports in-place modernization and testing on legacy architectures.

--- a/docs/wiki/05-08-dag-architect.md
+++ b/docs/wiki/05-08-dag-architect.md
@@ -1,6 +1,6 @@
 # DAG Architect (Data Lineage)
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_cobol/cobol_dag_architect.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_dag_architect.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_cobol/cobol_dag_architect.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_dag_architect.py)
 
 ## Engineering Summary
 This subsystem constructs a Directed Acyclic Graph (DAG) to model data flow across procedural programs. It solves the problem of understanding implicit execution orders in batch environments driven by dataset dependencies. It exists to provide a deterministic sequence for executing legacy jobs or migrating data. Within GitGalaxy, it serves as the core mapping engine for macro-level architectural views.

--- a/docs/wiki/05-09-etl-unpacker.md
+++ b/docs/wiki/05-09-etl-unpacker.md
@@ -1,6 +1,6 @@
 # ETL Unpacker (EBCDIC to CSV)
 
-> **File Reference:** [`gitgalaxy/tools/cobol_to_cobol/cobol_etl_unpacker.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_etl_unpacker.py)
+> **File Reference:** [`gitgalaxy/tools/cobol_to_cobol/cobol_etl_unpacker.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_etl_unpacker.py)
 
 ## Engineering Summary
 This subsystem translates raw legacy binary data into standard character-delimited formats. It solves the problem of migrating fixed-width, non-delimited mainframe datasets encoded in EBCDIC and COMP-3 into modern relational databases. It exists to decouple data migration from application logic execution. In GitGalaxy, this tool enables the seamless transition of legacy state to cloud-native data stores.

--- a/docs/wiki/05-10-graveyard-reaper.md
+++ b/docs/wiki/05-10-graveyard-reaper.md
@@ -1,6 +1,6 @@
 # Dead Code & Unused Data Analysis
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_graveyard_finder.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_graveyard_finder.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_graveyard_finder.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_graveyard_finder.py)
 
 ## Engineering Summary
 This subsystem performs static analysis on COBOL source files to isolate unused variable declarations in memory and unreachable execution logic in control flow. It solves the problem of legacy code bloat by preventing the propagation of unused data structures and dead paragraphs into modern systems. It exists to reduce the footprint of generated databases and microservices during migration. Within the larger migration pipeline, it acts as a filter prior to schema and service generation. This subsystem is known as the Deprecated Trails Analyzer.

--- a/docs/wiki/05-11-jcl-meta-auditor.md
+++ b/docs/wiki/05-11-jcl-meta-auditor.md
@@ -1,6 +1,6 @@
 # JCL Security & Reduction Auditor
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_jcl_auditor.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_jcl_auditor.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_jcl_auditor.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_jcl_auditor.py)
 
 ## Engineering Summary
 This subsystem acts as a verification tool that compares generated, program-specific Job Control Language (JCL) scripts against legacy IBM JCL files. It solves the problem of verifying the effectiveness and security posture of newly generated execution scripts by quantifying code bloat reduction and measuring the elimination of over-permissioned I/O access boundaries. It exists to provide measurable proof that the modernized JCL scripts enforce least privilege. It fits into GitGalaxy as the final audit step in the JCL modernization pipeline. This subsystem is known as the Zero-Trust JCL Auditor.

--- a/docs/wiki/05-12-zero-trust-jcl-forge.md
+++ b/docs/wiki/05-12-zero-trust-jcl-forge.md
@@ -1,6 +1,6 @@
 # Job Control Language (JCL) Generator
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_jcl_forge.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_jcl_forge.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_jcl_forge.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_jcl_forge.py)
 
 ## Engineering Summary
 This subsystem converts physical file requirements and execution intent extracted from COBOL source code into streamlined Job Control Language (JCL) scripts. It solves the problem of manually writing execution scripts by automatically provisioning only the exact dataset permissions required for a given program. It exists to enforce least-privilege resource access and modernize mainframe execution workflows. It fits into GitGalaxy by taking static analysis results and outputting operational execution environments. This subsystem is known as the Zero-Trust JCL Generator.

--- a/docs/wiki/05-13-lexical-patcher.md
+++ b/docs/wiki/05-13-lexical-patcher.md
@@ -1,6 +1,6 @@
 # Lexical Control Flow Preprocessor
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_lexical_patcher.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_lexical_patcher.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_lexical_patcher.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_lexical_patcher.py)
 
 ## Engineering Summary
 This subsystem is a source code preprocessor that identifies legacy control flow constructs and safely refactors them into explicit scope terminators prior to Abstract Syntax Tree (AST) parsing or static analysis. It solves the problem of implicit jump mechanics disrupting modern code parsers. It exists to ensure stable control flow graphs can be extracted from legacy COBOL. Within GitGalaxy, it acts as an immediate preprocessing step on source code before deeper static analysis tools are invoked. This subsystem is known as the Lexical Patcher.

--- a/docs/wiki/05-14-microservice-slicer.md
+++ b/docs/wiki/05-14-microservice-slicer.md
@@ -1,6 +1,6 @@
 # Microservice Business Logic Extractor
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_microservice_slicer.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_microservice_slicer.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_microservice_slicer.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_microservice_slicer.py)
 
 ## Engineering Summary
 This subsystem isolates specific business rules from monolithic procedural programs by recursively tracking a target variable through data assignment and computation statements. It solves the problem of disentangling core business logic from tangled legacy monoliths. It exists to enable automated microservice refactoring by creating isolated rule slices. Within the GitGalaxy pipeline, it acts as the primary extraction engine after static analysis and dead code filtering are complete. This subsystem is known as the Microservice Logic Extractor.

--- a/docs/wiki/05-15-cloud-schema-forge.md
+++ b/docs/wiki/05-15-cloud-schema-forge.md
@@ -1,6 +1,6 @@
 # Relational Database & JSON Schema Generator
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_schema_forge.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_schema_forge.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_schema_forge.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_schema_forge.py)
 
 ## Engineering Summary
 The Relational Database & JSON Schema Generator translates legacy memory-bound structure definitions into modern database and application schemas. It solves the problem of data interoperability during modernization by automatically converting byte-mapped `DATA DIVISION` declarations into strongly-typed structures for downstream storage and API consumption. This subsystem is a key data transformation component in GitGalaxy, bridging static analysis of legacy code with cloud-native data representations. It is commonly referred to within the project as the Cloud Schema Forge.

--- a/docs/wiki/05-16-anomaly-agent-task-forge.md
+++ b/docs/wiki/05-16-anomaly-agent-task-forge.md
@@ -1,6 +1,6 @@
 # Autonomous Agent Remediation Task Generator
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_agent_task_forge.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_agent_task_forge.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_agent_task_forge.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_agent_task_forge.py)
 
 ## Engineering Summary
 The Autonomous Agent Remediation Task Generator orchestrates LLM-based refactoring by packaging static analysis results and local code context into bounded execution constraints. It solves the problem of AI hallucination and context window exhaustion when attempting to refactor legacy monoliths in a single pass. This system acts as a dispatch router in GitGalaxy, transforming raw structural violation data into structured tasks for automated agent workers. It is known internally as the Anomaly Agent Task Forge.

--- a/docs/wiki/05-17-system-limits-reporter.md
+++ b/docs/wiki/05-17-system-limits-reporter.md
@@ -1,6 +1,6 @@
 # Architectural Anomaly & Boundary Detector
 
-> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_system_limits_reporter.py](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/tools/cobol_to_cobol/cobol_system_limits_reporter.py)
+> **File Reference:** [gitgalaxy/tools/cobol_to_cobol/cobol_system_limits_reporter.py](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/tools/cobol_to_cobol/cobol_system_limits_reporter.py)
 
 ## Engineering Summary
 The Architectural Anomaly & Boundary Detector is a static analysis sensor that evaluates the deterministic nature of legacy code structures. It solves the problem of unsafe modernization by identifying logic constructs that dynamically alter execution paths or memory states at runtime. This subsystem serves as a critical safety gate in GitGalaxy, ensuring code meets static analysis requirements before being passed to automated dependency mappers or LLM agents. It is commonly referred to as the System Limits Reporter.

--- a/docs/wiki/06-01-gitgalaxy-config.md
+++ b/docs/wiki/06-01-gitgalaxy-config.md
@@ -1,6 +1,6 @@
 # GitGalaxy Configuration Registry
 
-> **File Reference:** [`gitgalaxy/standards/gitgalaxy_config.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/standards/gitgalaxy_config.py)
+> **File Reference:** [`gitgalaxy/standards/gitgalaxy_config.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/standards/gitgalaxy_config.py)
 
 ## Engineering Summary
 A centralized configuration module manages global constants and dynamic overrides for static analysis. It solves the problem of hardcoded configuration drift by decoupling analysis thresholds, stream timeouts, and project-specific parsing rules from the core execution logic. This subsystem provides a single source of truth for tuning execution parameters without mutating the underlying analysis pipeline, operating as the `gitgalaxy_config` within GitGalaxy.

--- a/docs/wiki/06-02-language-standards.md
+++ b/docs/wiki/06-02-language-standards.md
@@ -1,6 +1,6 @@
 # Language Standards Registry
 
-> **File Reference:** [`gitgalaxy/standards/language_standards.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/standards/language_standards.py)
+> **File Reference:** [`gitgalaxy/standards/language_standards.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/standards/language_standards.py)
 
 ## Engineering Summary
 A central dictionary maps programming languages to syntax schemas and extraction rules. It solves the challenge of cross-language static analysis by providing a unified definition layer for regular expressions, block delimiters, and comment structures. This decoupling allows engineers to add new language support without modifying the core parsing logic, known as `language_standards` in GitGalaxy.

--- a/docs/wiki/06-03-analysis-lens.md
+++ b/docs/wiki/06-03-analysis-lens.md
@@ -1,6 +1,6 @@
 # Analysis Lens & Schema Registry
 
-> **File Reference:** [`gitgalaxy/standards/analysis_lens.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/standards/analysis_lens.py)
+> **File Reference:** [`gitgalaxy/standards/analysis_lens.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/standards/analysis_lens.py)
 
 ## Engineering Summary
 Mathematical schemas and normalization formulas for extracted source code metrics form the core of this module. It solves the problem of standardizing disparate telemetry data by flattening object-oriented syntax counts into contiguous numerical arrays. This subsystem transforms raw syntax hits into calculated risk vectors and visual attributes, acting as the mathematical normalization layer for GitGalaxy.

--- a/docs/wiki/07-01-code-complexity.md
+++ b/docs/wiki/07-01-code-complexity.md
@@ -1,6 +1,6 @@
 # Visual Code Complexity Mapping Specifications
 
-> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/gpu_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/gpu_recorder.py)
 
 ## Engineering Summary
 A rendering configuration translates static analysis metrics into 3D geometric attributes. It solves the challenge of interpreting complex codebase structures by converting multidimensional data (size, dependencies, complexity) into spatial and physical properties. This subsystem acts as the translation layer between calculated numerical metrics and WebGL rendering buffers, operating as the visual code complexity mapping system in GitGalaxy.

--- a/docs/wiki/07-02-stars-size.md
+++ b/docs/wiki/07-02-stars-size.md
@@ -1,6 +1,6 @@
 # File Node Scaling & Structural Mass Calculation
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 A composite metric determines the 3D radius of file nodes. It solves the problem of relying solely on line counts, which misrepresent the architectural weight of dense algorithmic files compared to verbose configuration files. This subsystem ensures that complex, tightly coupled components are visually prominent, functioning as the structural mass calculation within GitGalaxy.

--- a/docs/wiki/07-03-stars-pulse-rate.md
+++ b/docs/wiki/07-03-stars-pulse-rate.md
@@ -1,6 +1,6 @@
 # Node Emissive Intensity & Pulse Rate Mapping
 
-> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/gpu_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/gpu_recorder.py)
 
 ## Engineering Summary
 A mapping system converts a file's dependency in-degree into shader animation parameters. It solves the challenge of identifying structural bottlenecks in large systems by translating inbound reference counts into visual brightness and pulse frequencies. This subsystem allows architects to instantly locate core dependencies and popular modules, operating as the node emissive intensity mapping within GitGalaxy.

--- a/docs/wiki/07-04-stars-shape.md
+++ b/docs/wiki/07-04-stars-shape.md
@@ -1,6 +1,6 @@
 # Node Geometry & Control Flow Ratio Mapping
 
-> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/gpu_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/gpu_recorder.py)
 
 ## Engineering Summary
 A geometric classification system alters 3D mesh primitives based on the ratio of decision-making logic to structural data declarations within a file. It solves the problem of visually differentiating between data-heavy files and algorithmic routines. By morphing mesh shapes, this subsystem explicitly defines the functional archetype of code modules, known as the node geometry mapping in GitGalaxy.

--- a/docs/wiki/07-05-satellite-unit.md
+++ b/docs/wiki/07-05-satellite-unit.md
@@ -1,6 +1,6 @@
 # Function Sub-Node Units & Impact Ranking
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 An extraction and ranking system surfaces individual function declarations to render them as child entities orbiting parent files. It solves the problem of hidden internal complexity within large monolithic files by exposing internal modularity. This subsystem provides a visual inventory of discrete logic blocks directly in the 3D environment, acting as the function sub-node system in GitGalaxy.

--- a/docs/wiki/07-06-satellite-orbital-distance.md
+++ b/docs/wiki/07-06-satellite-orbital-distance.md
@@ -1,6 +1,6 @@
 # Sub-Node Orbital Distance & Logarithmic Scaling
 
-> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/recorders/gpu_recorder.py)
+> **File Reference:** [`gitgalaxy/recorders/gpu_recorder.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/gpu_recorder.py)
 
 ## Engineering Summary
 A spatial sorting mechanism determines the 3D distance between a child function and its parent file node based on physical line count. It solves the challenge of visually identifying bloated functions by correlating spatial displacement with length. This subsystem explicitly visualizes code bloat by pushing large functions further out into space, operating as the sub-node orbital distance mapping in GitGalaxy.

--- a/docs/wiki/07-07-number-of-satellites.md
+++ b/docs/wiki/07-07-number-of-satellites.md
@@ -1,6 +1,6 @@
 # Child Component Density & Function Complexity
 
-> **File Reference:** [`gitgalaxy/core/detector.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/detector.py)
+> **File Reference:** [`gitgalaxy/core/detector.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/detector.py)
 
 ## Engineering Summary
 This subsystem measures and visualizes logic complexity within individual functions by calculating a composite complexity score. It solves the problem of developers needing to quickly assess the cognitive load of code modules during codebase exploration. It exists to map textual code complexity into physical object density within a 3D visualization. Within GitGalaxy, this subsystem defines the child satellite node count for function components.

--- a/docs/wiki/07-08-relative-positioning.md
+++ b/docs/wiki/07-08-relative-positioning.md
@@ -1,6 +1,6 @@
 # Angular Positioning of Child Nodes
 
-> **File Reference:** [`gitgalaxy/core/spatial_mapper.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/spatial_mapper.py)
+> **File Reference:** [`gitgalaxy/core/spatial_mapper.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/spatial_mapper.py)
 
 ## Engineering Summary
 This spatial configuration subsystem distributes sub-nodes within a function unit based on its control flow ratio. It solves the problem of visual uniformity obscuring code behavior differences. It exists to differentiate algorithmic routing logic from declarative structures through physical divergence angles. Within GitGalaxy, this process scales visual node spreading dynamically.

--- a/docs/wiki/07-09-node-size.md
+++ b/docs/wiki/07-09-node-size.md
@@ -1,6 +1,6 @@
 # Function Component Node Scaling
 
-> **File Reference:** [`gitgalaxy/core/detector.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/detector.py)
+> **File Reference:** [`gitgalaxy/core/detector.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/detector.py)
 
 ## Engineering Summary
 This geometry processing subsystem calculates the visual scale of function nodes based on their input parameter count. It solves the problem of identifying high-coupling or high-state-complexity methods. It exists to create a visual footprint hierarchy that mirrors I/O signature weight. In GitGalaxy, this component dictates the 3D radius bounds of function meshes.

--- a/docs/wiki/07-10-planetary-rings.md
+++ b/docs/wiki/07-10-planetary-rings.md
@@ -1,6 +1,6 @@
 # External Dependency Rings
 
-> **File Reference:** [`gitgalaxy/core/detector.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/detector.py)
+> **File Reference:** [`gitgalaxy/core/detector.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/detector.py)
 
 ## Engineering Summary
 This visualization module generates dependency indicators around file nodes based on external import volumes. It solves the problem of identifying heavy integration modules and dependency coupling risks. It exists to separate self-contained utilities from orchestration layers visually. Within GitGalaxy, this subsystem renders translucent dependency rings in 3D space.

--- a/docs/wiki/07-11-sequence-affinity.md
+++ b/docs/wiki/07-11-sequence-affinity.md
@@ -1,6 +1,6 @@
 # Spatial Layout & Directory Sector Clustering
 
-> **File Reference:** [`gitgalaxy/core/spatial_mapper.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/spatial_mapper.py)
+> **File Reference:** [`gitgalaxy/core/spatial_mapper.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/spatial_mapper.py)
 
 ## Engineering Summary
 This spatial engine subsystem clusters related source files into 3D directory sectors using a deterministic sorting algorithm. It solves the problem of arbitrary file placement producing chaotic, unreadable topology maps. It exists to create clear spatial neighborhoods driven by directory metadata and architectural role. In GitGalaxy, it generates the final $X, Y, Z$ Cartesian coordinates for the entire repository.

--- a/docs/wiki/07-12-misc-equations.md
+++ b/docs/wiki/07-12-misc-equations.md
@@ -1,6 +1,6 @@
 # Component Layout Clearance Formulas
 
-> **File Reference:** [`gitgalaxy/core/spatial_mapper.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/spatial_mapper.py)
+> **File Reference:** [`gitgalaxy/core/spatial_mapper.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/spatial_mapper.py)
 
 ## Engineering Summary
 This collision management subsystem calculates the orbital clearance radius for child nodes based on their parent's code volume. It solves the problem of child geometries colliding with or rendering inside oversized parent file nodes. It exists to maintain structural visibility across massively varying file sizes in the 3D view. In GitGalaxy, this equation is a foundational utility for spatial orchestration.

--- a/docs/wiki/08-01-methodology.md
+++ b/docs/wiki/08-01-methodology.md
@@ -1,6 +1,6 @@
 # Overview of Methodology & Risk Exposure Index
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 This subsystem forms the analytical core that translates raw regex heuristic counts into structured risk exposure ratings. It solves the problem of converting massive volumes of static analysis data into actionable, normalized health indicators without manual inspection. It exists to objectively map structural anomalies to a universal risk spectrum. Within GitGalaxy, it processes data across five architectural scopes to generate the primary knowledge graph attributes.

--- a/docs/wiki/08-02-sub-equations.md
+++ b/docs/wiki/08-02-sub-equations.md
@@ -1,6 +1,6 @@
 # Sub-Equations & Scanner Variables
 
-> **File Reference:** [`gitgalaxy/core/detector.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/core/detector.py)
+> **File Reference:** [`gitgalaxy/core/detector.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/core/detector.py)
 
 ## Engineering Summary
 This static analysis extraction subsystem defines the raw regular expression inputs used by the metrics engine. It solves the problem of extracting standardized structural and behavioral indicators from diverse programming languages. It exists to provide a language-agnostic data foundation for risk assessment. In GitGalaxy, this process runs over a strict 5-phase extraction sequence to generate core variables.

--- a/docs/wiki/08-03-transforming-regex-counts.md
+++ b/docs/wiki/08-03-transforming-regex-counts.md
@@ -1,6 +1,6 @@
 # Transforming Regex Counts (Universal Exposure Framework)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 This metric normalization subsystem, known as the Universal Exposure Framework (UEF), recalibrates raw static regex counts into stable architectural indicators. It solves the problem of raw hit counts being noisy, misleading, or skewed by codebase size. It exists to provide deterministic, language-aware filtering of heuristic signals. Within GitGalaxy, the UEF calculates final, tiered risk outputs from raw data variables.

--- a/docs/wiki/08-04-ownership-entropy.md
+++ b/docs/wiki/08-04-ownership-entropy.md
@@ -1,6 +1,6 @@
 # Authorship Distribution (Ownership Entropy)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 This statistical analysis component calculates the Shannon Entropy of Git blame data to measure contribution dispersion across modules. It solves the problem of identifying knowledge silos and bus-factor risks hidden behind simple contributor headcounts. It exists to map authorship concentration to the Universal Risk Spectrum. Within GitGalaxy, it highlights whether a module is a single-author bottleneck or a highly distributed community effort.

--- a/docs/wiki/08-05-cognitive-load.md
+++ b/docs/wiki/08-05-cognitive-load.md
@@ -1,6 +1,6 @@
 # Cognitive Load Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Density of Decision-Making & Logic Complexity
 >

--- a/docs/wiki/08-06-deep-churn.md
+++ b/docs/wiki/08-06-deep-churn.md
@@ -1,6 +1,6 @@
 # Deep Churn (Codebase Volatility)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Relative Commit Volatility & Change Frequency
 >

--- a/docs/wiki/08-07-structural-fortification.md
+++ b/docs/wiki/08-07-structural-fortification.md
@@ -1,6 +1,6 @@
 # Structural Fortification (Safety Exposure)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Ratio of Defensive Controls to Execution Stressors
 >

--- a/docs/wiki/08-08-technical-debt.md
+++ b/docs/wiki/08-08-technical-debt.md
@@ -1,6 +1,6 @@
 # Tech Debt Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Density of Planned vs. Fragile Work Markers
 >

--- a/docs/wiki/08-09-documentation-risk.md
+++ b/docs/wiki/08-09-documentation-risk.md
@@ -1,6 +1,6 @@
 # Documentation Risk Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Contextual Knowledge Debt & Undocumented Risk Density
 >

--- a/docs/wiki/08-10-file-stability.md
+++ b/docs/wiki/08-10-file-stability.md
@@ -1,6 +1,6 @@
 # File Stability (Commit Age & Timestamp Heat)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Relative Temporal Distance & File Modifications
 >

--- a/docs/wiki/08-11-test-coverage.md
+++ b/docs/wiki/08-11-test-coverage.md
@@ -1,6 +1,6 @@
 # Verification Risk Exposure (Test Coverage)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Logic Complexity vs. Defensive Test Verification
 >

--- a/docs/wiki/08-12-civil-war.md
+++ b/docs/wiki/08-12-civil-war.md
@@ -1,6 +1,6 @@
 # Layout Uniformity (Indentation Consistency)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Indentation Polarization (Tabs vs. Spaces)
 >

--- a/docs/wiki/08-13-graveyard-detector.md
+++ b/docs/wiki/08-13-graveyard-detector.md
@@ -1,6 +1,6 @@
 # Graveyard Exposure (Dead & Commented-Out Code)
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Dead Code Density & Inactive Logic Retention
 >

--- a/docs/wiki/08-14-api-exposure.md
+++ b/docs/wiki/08-14-api-exposure.md
@@ -1,6 +1,6 @@
 # API Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 >
 > **Metric:** Public API Surface Area & Export Ratio
 >

--- a/docs/wiki/08-15-concurrency-exposure.md
+++ b/docs/wiki/08-15-concurrency-exposure.md
@@ -1,6 +1,6 @@
 # Concurrency Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Evaluates the density of asynchronous execution primitives and multithreading logic within a source file. Concurrent programming increases non-deterministic execution paths, raising cognitive load and introducing risks such as race conditions, deadlocks, and resource contention. This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the Concurrency Exposure metric.
@@ -106,6 +106,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/08-16-state-flux-exposure.md
+++ b/docs/wiki/08-16-state-flux-exposure.md
@@ -1,6 +1,6 @@
 # State Flux Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Evaluates the density of variable mutations and state modifications within a module. State flux measures data volatility by tracking property reassignments, array mutations, and side effects. High state flux indicates unstable data structures where tracking state transitions increases cognitive load and defect probability. This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the State Flux Exposure metric.
@@ -97,6 +97,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/08-18-specification-alignment.md
+++ b/docs/wiki/08-18-specification-alignment.md
@@ -1,6 +1,6 @@
 # Specification Alignment Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Measures the gap between executable logic entities (classes and functions) and formal architectural specifications, design documents, or RFC references. Higher spec exposure hits lead to lower risk scores; conversely, modules with numerous functions/classes lacking specification references produce high risk exposure scores ("untraced logic"). This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the Specification Alignment Exposure metric.
@@ -80,6 +80,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/08-19-obscured-payload-exposure.md
+++ b/docs/wiki/08-19-obscured-payload-exposure.md
@@ -1,6 +1,6 @@
 # Obscured Payload Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Evaluates source code for obfuscation techniques, evasion patterns, and high-risk execution capabilities. The metric identifies modules that combine code hiding mechanisms (metaprogramming, reflection, bitwise operations, shadow imports, file extension mismatches) with high-risk capabilities (dynamic code execution, data exfiltration, safety bypasses). This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the Obscured Payload Exposure metric.
@@ -166,6 +166,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/08-21-injection-surface-exposure.md
+++ b/docs/wiki/08-21-injection-surface-exposure.md
@@ -1,6 +1,6 @@
 # Injection Surface Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Measures exposure to injection attack vectors by analyzing external input boundaries (network requests, user input, SSR parameters) operating near dynamic execution sinks (`eval`, `exec`, shell command execution, dynamic SQL execution) without safety validation. This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the Injection Surface Exposure metric.
@@ -145,6 +145,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/08-22-memory-corruption-exposure.md
+++ b/docs/wiki/08-22-memory-corruption-exposure.md
@@ -1,6 +1,6 @@
 # Memory Corruption Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Measures exposure to low-level memory corruption vulnerabilities (e.g., Use-After-Free, buffer overflows, unmitigated pointer arithmetic, unsafe casting, inline assembly). This metric operates on an **Opt-In Whitelist** basis, evaluating only native unmanaged programming languages. Managed runtime languages bypass memory corruption calculations entirely. This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the Memory Corruption Exposure metric.
@@ -81,6 +81,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/08-23-hardcoded-secrets-exposure.md
+++ b/docs/wiki/08-23-hardcoded-secrets-exposure.md
@@ -1,6 +1,6 @@
 # Hardcoded Secrets Exposure
 
-> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)
+> **File Reference:** [`gitgalaxy/metrics/signal_processor.py`](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)
 
 ## Engineering Summary
 Evaluates the presence of exposed sensitive credentials (API keys, private tokens, passwords, database connections) and analyzes careless code handling (e.g., debug log statements, dead code, global variable assignments) that increases the likelihood of accidental credential leakage. This subsystem evaluates the input signals to calculate a formalized risk score. In GitGalaxy, this subsystem is known as the Hardcoded Secrets Exposure metric.
@@ -116,6 +116,6 @@ The calculation operates in $O(1)$ time leveraging pre-computed token counts, ma
 * Expand language support and framework-specific annotations.
 
 ## Related Components
-* **[Signal Processor Module](file:///home/joe/nyx_projects/gitgalaxy/gitgalaxy/metrics/signal_processor.py)**
+* **[Signal Processor Module](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/metrics/signal_processor.py)**
 * **[GitGalaxy Platform](https://gitgalaxy.io/)**
 * **[⬅️ Back to Master Index](index.md)**

--- a/docs/wiki/museum-of-code/index.md
+++ b/docs/wiki/museum-of-code/index.md
@@ -21,7 +21,6 @@ Using the **GitGalaxy blAST engine**, we have stripped away the abstractions of 
 * 👁️ **[NVDA](teardown-of-nvda.md)** - The Python/C++ hybrid making Windows accessible.
 * 👁️‍🗨️ **[OpenCV](teardown-of-opencv.md)** - The computer vision library.
 * 🐼 **[Pandas](teardown-of-pandas.md)** - The God Nodes of the Python data science ecosystem.
-* 🛤️ **[Ruby on Rails](teardown-of-rails.md)** - The web framework that championed convention over configuration.
 * ⚛️ **[ROOT](teardown-of-root.md)** - CERN's C++ data analysis framework.
 * 🗄️ **[SQLite](teardown-of-sqlite.md)** - The most deployed database engine in human history.
 * 🧠 **[TensorFlow](teardown-of-tensorflow.md)** - The heavily coupled AI operations monolith.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -313,7 +313,6 @@ nav:
       - 'State Flux Exposure': "08-16-state-flux-exposure.md"
       - 'Specification Alignment': "08-18-specification-alignment.md"
       - 'Obscured Payload Exposure': "08-19-obscured-payload-exposure.md"
-      - 'Logic Bomb Exposure': "08-20-logic-bomb-exposure.md"
       - 'Injection Surface Exposure': "08-21-injection-surface-exposure.md"
       - 'Memory Corruption Exposure': "08-22-memory-corruption-exposure.md"
       - 'Hardcoded Secrets Exposure': "08-23-hardcoded-secrets-exposure.md"


### PR DESCRIPTION
## Summary
- Rewrites 106 `file:///home/joe/...` absolute-path links across 82 wiki pages into working links — 89 source-code "File Reference" links now point at GitHub blob URLs (`https://github.com/squid-protocol/gitgalaxy/blob/main/...`), 17 internal cross-links now use relative wiki paths. These previously resolved only on the author's local machine and were dead for every reader of the deployed site (verified all 48 unique target source paths still exist in the repo).
- Removes the `mkdocs.yml` nav entry for `08-20-logic-bomb-exposure.md` — the page was never created, and the underlying `logic_bomb` metric was removed from the risk engine in #1029 (false-positive rate), so this isn't a missing page, it's dead nav pointing at a retired feature.
- Removes the dead `teardown-of-rails.md` link from the Museum of Code index — no such page was ever authored (checked git history, confirmed).

## Test plan
- [x] Scripted check: 0 remaining `file:///home/joe` links in `docs/wiki`
- [x] Scripted check: 0 broken relative markdown links in `docs/wiki`
- [x] Scripted check: 0 nav entries in `mkdocs.yml` pointing at nonexistent files
- [x] Verified all 48 unique GitHub blob URL targets exist in the current repo tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)