### PR TITLE
feat(standards): implement Ada & SPARK structural signatures (#76)

### DIFF
--- a/gitgalaxy/core/prism.py
+++ b/gitgalaxy/core/prism.py
@@ -351,6 +351,15 @@ class Prism:
                 p = rf"({d[0]}[^\n]*|{d[1]}.*?{d[2]})"
             elif fam_key == "line_exclusive" and len(d) >= 1:
                 p = rf"({d[0]}[^\n]*)"
+            elif fam_key == "line_exclusive_dash" and len(d) >= 1:
+                # #76: unlike "line_exclusive" above (whose single-delimiter
+                # form here is actually dead code -- _strip_segment_comments
+                # intercepts "line_exclusive" via _strip_single_line_comments
+                # before this matrix is ever consulted), "line_exclusive_dash"
+                # has no such interception, so this branch is the real,
+                # active stripping path for it. Same shape (one delimiter,
+                # runs to end of line) since Ada's `--` behaves identically.
+                p = rf"({d[0]}[^\n]*)"
             elif fam_key == "embedded_syntax" and len(d) >= 3:
                 # If len is 4, include d[3], otherwise just [0,1,2]
                 if len(d) >= 4:

--- a/gitgalaxy/standards/gitgalaxy_config.py
+++ b/gitgalaxy/standards/gitgalaxy_config.py
@@ -529,6 +529,20 @@ LEXICAL_FAMILY_HEURISTICS = {
         # The language possesses no native multi-line block syntax. The engine ignores closing tags.
         # Examples: Python, Shell, Makefile, Ruby, Perl, Assembly.
         "line_exclusive": {"delimiters": ["#", "<#", "#>", "=begin", "=end", ";", "dnl", "%"]},
+        # 3b. Line Exclusive, Dash dialect (#76)
+        # Same stateless single-token stripper as line_exclusive, but scoped
+        # to its own delimiter list rather than joining the shared one above.
+        # `--` cannot safely join line_exclusive's grab-bag: several of that
+        # family's members (Perl, Assembly) use `--` as a real operator/
+        # decrement, and #621's own history is exactly this failure mode
+        # (a shared delimiter list swallowing real code, e.g. `i-- > 0`) --
+        # the fix there was splitting into narrower families, not widening
+        # this one. Ada/SPARK has no native block-comment form at all (unlike
+        # multi_style_dash's sqlite/lua/haskell, which all pair `--` with a
+        # real block form), so it gets its own single-token family instead of
+        # joining multi_style_dash too.
+        # Examples: ada.
+        "line_exclusive_dash": {"delimiters": ["--"]},
         # 4. Block Exclusive
         # The language possesses no native single-line comment syntax. All text must be enclosed.
         # Examples: HTML, XML.

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -12762,9 +12762,16 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             # (e.g. memory-mapped hardware register) state.
             "globals": re.compile(r"\bGlobal[ \t]*=>|\bpragma[ \t]+Volatile\b", re.I),
             # decorators: Ada 2012 aspect specifications (`with Pre => ...`)
-            # attached to a declaration. Must NOT overlap the plain `with`
-            # import clause below -- distinguished by a fixed, known
-            # aspect-mark vocabulary rather than by punctuation, since
+            # attached to a declaration, PLUS SPARK's data-flow refinement
+            # aspects (Abstract_State/Initializes/Refined_Global/
+            # Refined_Post/Refined_State/Refined_Depends -- how a package's
+            # private state gets formally modeled for the prover; common in
+            # real SPARK code, distinct from the Pre/Post/Global/Depends
+            # contract basics above) and the `pragma SPARK_Mode (On);` form
+            # (a structurally different shape from the `with SPARK_Mode`
+            # aspect form -- both are real and common). Must NOT overlap the
+            # plain `with` import clause below -- distinguished by a fixed,
+            # known aspect-mark vocabulary rather than by punctuation, since
             # several boolean aspects (Inline, Pure, ...) have no `=>` at
             # all and would otherwise be lexically identical to a bare
             # package-name import list. Keep this list in sync with
@@ -12772,7 +12779,9 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             "decorators": re.compile(
                 r"\bwith[ \t]+(?:Pre|Post|Invariant|Static_Predicate|Dynamic_Predicate|Global|Depends"
                 r"|Convention|Import|Export|Inline|Volatile|Atomic|Pack|SPARK_Mode|No_Return"
-                r"|Pure|Preelaborate|Elaborate_Body)\b",
+                r"|Pure|Preelaborate|Elaborate_Body"
+                r"|Abstract_State|Initializes|Refined_Global|Refined_Post|Refined_State|Refined_Depends)\b"
+                r"|\bpragma[ \t]+SPARK_Mode\b",
                 re.I,
             ),
             # generics: `generic` keyword, and instantiation scoped to
@@ -12802,14 +12811,17 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             "import": re.compile(
                 r"^[ \t]*with[ \t\n]+(?!(?:Pre|Post|Invariant|Static_Predicate|Dynamic_Predicate|Global|Depends"
                 r"|Convention|Import|Export|Inline|Volatile|Atomic|Pack|SPARK_Mode|No_Return"
-                r"|Pure|Preelaborate|Elaborate_Body)\b)"
+                r"|Pure|Preelaborate|Elaborate_Body"
+                r"|Abstract_State|Initializes|Refined_Global|Refined_Post|Refined_State|Refined_Depends)\b)"
                 r"[A-Za-z_][A-Za-z0-9_.]*(?:[ \t\n]*,[ \t\n]*[A-Za-z_][A-Za-z0-9_.]*){0,20}[ \t\n]*;",
                 re.I | re.M,
             ),
             "_dependency_capture": re.compile(
                 r"^[ \t]*with[ \t\n]+(?!(?:Pre|Post|Invariant|Static_Predicate|Dynamic_Predicate|Global|Depends"
                 r"|Convention|Import|Export|Inline|Volatile|Atomic|Pack|SPARK_Mode|No_Return"
-                r"|Pure|Preelaborate|Elaborate_Body)\b)([A-Za-z_][A-Za-z0-9_.]*)",
+                r"|Pure|Preelaborate|Elaborate_Body"
+                r"|Abstract_State|Initializes|Refined_Global|Refined_Post|Refined_State|Refined_Depends)\b)"
+                r"([A-Za-z_][A-Za-z0-9_.]*)",
                 re.I | re.M,
             ),
             # ownership: header comment convention, same shape as the JCL/

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -12583,6 +12583,349 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
             "debug_prints": None,
         },
     },
+    "ada": {
+        "_meta": {
+            "target_version": "Ada 2012 / SPARK 2014 (GNAT Pro / GNAT CE)",
+            "last_updated": "2026-08-07",
+            "blueprint_version": "v6.3",
+            "status": "production",
+        },
+        # COMPREHENSIVE SURFACE AREA: .ads (package/subprogram specs), .adb
+        # (bodies), and the historic single-extension convention .ada.
+        "extensions": [".adb", ".ads", ".ada"],
+        "exact_matches": [],
+        # ECOSYSTEM ANCHORS: GNAT project files (.gpr) are the dominant
+        # Ada build-system anchor (GPRbuild/GNAT Studio), the closest
+        # analogue to a manifest file for disambiguation purposes.
+        "discriminators": [".adb", ".ads", ".gpr"],
+        # EXECUTION SIGNATURES: Ada is compiled; there is no interpreter
+        # shebang convention in real-world use.
+        "shebangs": [],
+        # Rationale (Lexical-family sanity check, how_to_add_a_language.md
+        # Step 4 item 8): issue #76 / epic #75 both label this "hybrid_dash",
+        # but Ada genuinely has no block-comment form at all -- "no native
+        # block comments historically" is stated directly in #76's own
+        # checklist, which contradicts the "hybrid_dash" name it also asks
+        # for. Reusing the existing "line_exclusive" family was also
+        # rejected: that family's shared delimiter list is consumed by a
+        # literal-string family-name check in prism.py, and several of its
+        # existing members (Perl, Assembly) use `--` as a real
+        # operator/decrement -- widening that shared list would silently
+        # truncate real code in unrelated languages (the exact failure mode
+        # #621 already fixed once by narrowing "standard_block"). Registered
+        # a new, properly-wired "line_exclusive_dash" family instead (single
+        # `--` delimiter, no block form) -- see gitgalaxy_config.py's
+        # LEXICAL_FAMILY_HEURISTICS and prism.py's _compile_regex_matrix.
+        "lexical_family": "line_exclusive_dash",
+        "rules": {
+            # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
+            # branch: Ada's short-circuit forms are the two-word "and then"/
+            # "or else" (no && / || symbols exist in Ada).
+            "branch": re.compile(
+                r"\b(?:if|elsif|else|case|when|for|while|loop|exit)\b|\band[ \t]+then\b|\bor[ \t]+else\b",
+                re.I,
+            ),
+            # args: parameter profile following a procedure/function name.
+            # Bounded 3-level nested-paren capture (Rule 11) since default
+            # expressions routinely contain nested calls/aggregates, e.g.
+            # `Y : Integer := Compute(A, (B + C))`.
+            "args": re.compile(
+                r"\b(?:procedure|function)\b[ \t\n]+[A-Za-z_][A-Za-z0-9_]*[ \t\n]*"
+                r"\(((?:[^()]|\((?:[^()]|\([^()]*\))*\))*)\)",
+                re.I,
+            ),
+            # structural_boundaries: procedure/function/begin/end (per #76's
+            # explicit checklist) plus package (Ada's module/namespace
+            # boundary keyword) and return (statement form, distinct from
+            # func_start's own "return TYPE" clause).
+            "structural_boundaries": re.compile(r"\b(?:procedure|function|package|begin|end|return)\b", re.I),
+            # func_start: STRICT EXECUTION ANCHORING (Rule 7) -- only a real
+            # subprogram BODY, not a bare spec-only declaration. Ada's spec
+            # declaration ends `;` right after the profile/return type with
+            # no "is"; a body always has a literal "is" there instead. Must
+            # also exclude "is abstract"/"is null" (null procedures, both
+            # still declarations, not bodies) and "is new" (generic
+            # subprogram instantiation, not a body either). SPARK code
+            # commonly attaches `with Pre => ..., Post => ...` aspect
+            # clauses directly on a body between the profile and "is" --
+            # bounded (not unbounded `.*`) so it can't cross a statement
+            # terminator or blow up on an adversarial payload.
+            "func_start": re.compile(
+                r"\b(?:procedure|function)[ \t\n]+([A-Za-z_][A-Za-z0-9_]*)"
+                r"(?:[ \t\n]*\((?:[^()]|\((?:[^()]|\([^()]*\))*\))*\))?"
+                r"(?:[ \t\n]+return[ \t\n]+[A-Za-z_][A-Za-z0-9_.]*)?"
+                r"(?:[ \t\n]+with[ \t\n]+[^;{}]{0,300}?)?"
+                r"[ \t\n]*is\b(?![ \t\n]*(?:abstract|null|new)\b)",
+                re.I,
+            ),
+            # class_start: Ada's OOP entity is a *tagged* type, either a root
+            # declaration (`type Foo is tagged record ...`) or a derived/
+            # extended one (`type Dog is new Animal with record ...` --
+            # inheritance is expressed via "is new BASE with", the literal
+            # word "tagged" is NOT repeated on a derived type, so both forms
+            # need their own alternative or the (more common, in an
+            # OOP-heavy codebase) derived form is entirely invisible).
+            "class_start": re.compile(
+                r"\btype[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t\n]+is[ \t\n]+"
+                r"(?:(?:abstract[ \t\n]+)?(?:limited[ \t\n]+)?tagged\b"
+                r"|(?:abstract[ \t\n]+)?new[ \t\n]+[A-Za-z_][A-Za-z0-9_.]*[ \t\n]+with\b)",
+                re.I,
+            ),
+            # --- PHASE 2: SAFETY & EXECUTION RISK ---
+            # safety: per #76's explicit ask -- strict-typing range
+            # constraints (`type ... is range`, but also the equally common
+            # `subtype X is Base range Lo .. Hi` form, where "is" and
+            # "range" are NOT adjacent -- matching only "is range" verbatim
+            # would miss the subtype form entirely) and safety-oriented
+            # pragmas/aspects (Assert, Precondition, Postcondition,
+            # Invariant, Predicate) -- deliberately NOT bare "pragma" (Rule
+            # 1: many pragmas, e.g. Pack or Import, have nothing to do with
+            # safety; matching all of them would be keyword-stuffing, not
+            # semantic intent). Also real exception-handling constructs.
+            # (?<!') on "range" excludes the unrelated `Arr'Range` attribute
+            # (array index-range query), which shares the bare word but has
+            # nothing to do with a type's strict-typing constraint.
+            "safety": re.compile(
+                r"\bexception\b|\bwhen[ \t]+others\b"
+                r"|\bpragma[ \t]+(?:Assert|Assertion_Policy|Precondition|Postcondition|Invariant|Predicate)\b"
+                r"|(?<!')\brange\b",
+                re.I,
+            ),
+            # safety_bypasses: Unchecked_Conversion (raw memory
+            # reinterpretation -- Rule 2's own canonical example),
+            # pragma Suppress (disables compiler-inserted runtime checks),
+            # pragma Import (FFI boundary bypassing Ada's normal safety),
+            # and the GNAT-specific 'Unrestricted_Access attribute
+            # (bypasses accessibility/aliasing rules entirely).
+            "safety_bypasses": re.compile(
+                r"\bUnchecked_Conversion\b|\bpragma[ \t]+Suppress\b|\bpragma[ \t]+Import\b"
+                r"|'Unrestricted_Access\b",
+                re.I,
+            ),
+            # high_risk_execution: GNAT.OS_Lib.OS_Exit is Ada's real
+            # equivalent of process.exit -- an immediate, uncatchable
+            # process termination (distinct from `raise`/`abort`, which are
+            # ordinary language-level exception/task-termination constructs
+            # routed to panics_and_aborts per the branch/func_start
+            # exclusion notes above).
+            "high_risk_execution": re.compile(r"\bOS_Exit\b|\bGNAT\.OS_Lib\.OS_Exit\b", re.I),
+            # io: disk/network/external-system boundaries. EXCLUDES
+            # Put_Line/Put (stdout -- debug_prints below).
+            "io": re.compile(
+                r"\bAda\.Text_IO\.(?:Open|Create|Close|Delete|Reset)\b"
+                r"|\bAda\.Directories\b|\bAda\.Streams\b|\bAda\.Direct_IO\b"
+                r"|\bAda\.Sequential_IO\b|\bGNAT\.Sockets\b",
+                re.I,
+            ),
+            # api: per #76's explicit ask -- package specifications. EXCLUDES
+            # "package body" (private implementation, not a public spec) and
+            # "package X is new ..." (generic package instantiation, not a
+            # spec declaration -- both use negative lookaheads, not an
+            # optional group, per Rule 15).
+            "api": re.compile(
+                r"\bpackage[ \t]+(?!body\b)(?:private[ \t]+)?([A-Za-z_][A-Za-z0-9_.]*)[ \t\n]+is\b(?![ \t\n]*new\b)",
+                re.I,
+            ),
+            # state_mutation: Ada's assignment operator `:=` is lexically
+            # distinct from `=` (equality) -- no ambiguity to guard against.
+            "state_mutation": re.compile(r":="),
+            # dead_code: commented-out structural code (line_exclusive_dash
+            # has exactly one comment style, so no completeness gap per
+            # Rule 12).
+            "dead_code": re.compile(r"--[ \t]*(?:procedure|function|if|for|while|begin|end|type|package)\b", re.I),
+            # doc: structured doc-comment conventions (GNATdoc-style tags;
+            # Ada has no single standardized docstring format).
+            "doc": re.compile(
+                r"--[ \t]*(?:@param|@return|@exception|Purpose:|Parameters?:|Returns?:|Preconditions?:|Postconditions?:)",
+                re.I,
+            ),
+            # test: AUnit (the dominant Ada unit-testing framework) and the
+            # standard-library Ada.Assertions.Assert.
+            "test": re.compile(r"\bAUnit\b|\bAda\.Assertions\b|\bAssert[ \t]*\(", re.I),
+            # --- PHASE 3: ARCHITECTURE & DOMAIN SENSORS ---
+            # concurrency: Ada's built-in hardware concurrency model --
+            # tasks, protected objects, the select/accept rendezvous, and
+            # delay. Broad domain signal, intentionally overlapping the more
+            # specific sync_locks/thread_sleeps/events/listeners below (same
+            # design already established for COBOL's EXEC CICS ENQ/DELAY).
+            "concurrency": re.compile(r"\btask\b|\bprotected\b|\bselect\b|\bdelay\b|\baccept\b|\bentry\b", re.I),
+            # ui_framework: no idiomatic built-in UI paradigm (GtkAda exists
+            # but isn't a realistic default host -- Strict Feature Parity,
+            # Rule 4: an empty/never-matching rule is worse than an absent
+            # one, since it implies detection coverage that doesn't exist).
+            "ui_framework": None,
+            # closures: Ada has no anonymous-function/lambda literal syntax.
+            "closures": None,
+            # globals: SPARK's own Global aspect explicitly declares a
+            # subprogram's global-state dependencies -- a direct, idiomatic
+            # match for this key. pragma Volatile marks genuinely shared
+            # (e.g. memory-mapped hardware register) state.
+            "globals": re.compile(r"\bGlobal[ \t]*=>|\bpragma[ \t]+Volatile\b", re.I),
+            # decorators: Ada 2012 aspect specifications (`with Pre => ...`)
+            # attached to a declaration. Must NOT overlap the plain `with`
+            # import clause below -- distinguished by a fixed, known
+            # aspect-mark vocabulary rather than by punctuation, since
+            # several boolean aspects (Inline, Pure, ...) have no `=>` at
+            # all and would otherwise be lexically identical to a bare
+            # package-name import list. Keep this list in sync with
+            # import/_dependency_capture's exclusion lookahead below.
+            "decorators": re.compile(
+                r"\bwith[ \t]+(?:Pre|Post|Invariant|Static_Predicate|Dynamic_Predicate|Global|Depends"
+                r"|Convention|Import|Export|Inline|Volatile|Atomic|Pack|SPARK_Mode|No_Return"
+                r"|Pure|Preelaborate|Elaborate_Body)\b",
+                re.I,
+            ),
+            # generics: `generic` keyword, and instantiation scoped to
+            # `package|procedure|function NAME is new ...` specifically --
+            # NOT bare "is new" alone, which would collide with
+            # class_start's tagged-type derivation (`type Dog is new Animal
+            # with ...`), a genuinely different construct sharing the same
+            # two words.
+            "generics": re.compile(
+                r"\bgeneric\b|\b(?:package|procedure|function)\b[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t\n]+is[ \t\n]+new\b",
+                re.I,
+            ),
+            # comprehensions: Ada 2012 quantified expressions (`for all` /
+            # `for some`), the closest analogue to an inline iterator/
+            # comprehension.
+            "comprehensions": re.compile(r"\bfor[ \t]+(?:all|some)\b", re.I),
+            # scientific: Ada.Numerics and its generic elementary-functions
+            # children.
+            "scientific": re.compile(r"\bAda\.Numerics\b", re.I),
+            # reflection_metaprogramming: tagged-type dispatch/RTTI --
+            # 'Class and 'Tag attributes, Ada.Tags.
+            "reflection_metaprogramming": re.compile(r"'Class\b|'Tag\b|\bAda\.Tags\b", re.I),
+            # import: context-clause `with` (compilation-unit dependency),
+            # explicitly excluding the same known aspect-mark vocabulary
+            # decorators uses above so a `with Pre => ...` aspect clause on
+            # a declaration is never miscounted as a dependency.
+            "import": re.compile(
+                r"^[ \t]*with[ \t\n]+(?!(?:Pre|Post|Invariant|Static_Predicate|Dynamic_Predicate|Global|Depends"
+                r"|Convention|Import|Export|Inline|Volatile|Atomic|Pack|SPARK_Mode|No_Return"
+                r"|Pure|Preelaborate|Elaborate_Body)\b)"
+                r"[A-Za-z_][A-Za-z0-9_.]*(?:[ \t\n]*,[ \t\n]*[A-Za-z_][A-Za-z0-9_.]*){0,20}[ \t\n]*;",
+                re.I | re.M,
+            ),
+            "_dependency_capture": re.compile(
+                r"^[ \t]*with[ \t\n]+(?!(?:Pre|Post|Invariant|Static_Predicate|Dynamic_Predicate|Global|Depends"
+                r"|Convention|Import|Export|Inline|Volatile|Atomic|Pack|SPARK_Mode|No_Return"
+                r"|Pure|Preelaborate|Elaborate_Body)\b)([A-Za-z_][A-Za-z0-9_.]*)",
+                re.I | re.M,
+            ),
+            # ownership: header comment convention, same shape as the JCL/
+            # COBOL entries.
+            "ownership": re.compile(r"^[ \t]*--[ \t]*(?:Author|Created by|Maintainer)[ \t]*:[ \t]*(.*)$", re.I | re.M),
+            # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
+            "planned_debt": GLOBAL_PLANNED_DEBT,
+            "fragile_debt": GLOBAL_FRAGILE_DEBT,
+            # hardcoded_secrets: assigned Ada string-literal declarations
+            # for common secret-shaped identifiers.
+            "hardcoded_secrets": re.compile(
+                r"\b(?:password|secret|token|api[_-]?key|private[_-]?key|client[_-]?secret)\b"
+                r"[ \t]*:[ \t]*(?:constant[ \t]+)?[A-Za-z_][A-Za-z0-9_.]*[ \t]*:=[ \t]*\"[^\"]{8,}\"",
+                re.I,
+            ),
+            "spec_exposure": re.compile(r"\[(?:SPEC[ \t]*-[ \t]*\d{1,6}|spec|audit)\]", re.I),
+            # tabs_vs_spaces: not a distinct structural signature in this
+            # engine's model for any language (consistently None registry-
+            # wide -- formatting-inconsistency tracking, not a language
+            # feature).
+            "tabs_vs_spaces": None,
+            # ssr_boundaries: no idiomatic Ada web-application framework
+            # (Strict Feature Parity, Rule 4).
+            "ssr_boundaries": None,
+            # events: a task/protected object *accepting* an entry call --
+            # the moment a message/event is actually handled. Intentionally
+            # overlaps concurrency's broader domain signal above.
+            "events": re.compile(r"\baccept\b", re.I),
+            # dependency_injection: no idiomatic IoC/DI framework or
+            # convention in Ada (generics already cover its real compile-
+            # time parameterization mechanism).
+            "dependency_injection": None,
+            # macros: gnatprep, GNAT's optional conditional-compilation
+            # preprocessor (`#if` / `#elsif` / `#else` / `#end if;`) --
+            # real and commonly used in embedded/avionics Ada for
+            # per-target-hardware conditional builds.
+            "macros": re.compile(r"^[ \t]*#[ \t]*(?:if|elsif|else|end[ \t]+if)\b", re.I | re.M),
+            # pointers: Ada access types -- declarations, `access all`/
+            # `access constant`, and the 'Access/'Unchecked_Access
+            # attributes.
+            "pointers": re.compile(
+                r"\bis[ \t]+access\b|\baccess[ \t]+all\b|\baccess[ \t]+constant\b"
+                r"|'Access\b|'Unchecked_Access\b",
+                re.I,
+            ),
+            # memory_alloc: the `new` allocator.
+            "memory_alloc": re.compile(r"\bnew[ \t]+[A-Za-z_]", re.I),
+            # inline_asm: System.Machine_Code's Asm construct -- a real,
+            # if niche, GNAT-standard extension used in kernel/embedded Ada.
+            "inline_asm": re.compile(r"\bSystem\.Machine_Code\b|\bAsm[ \t]*\(", re.I),
+            # --- PHASE 5: RESOURCE MANAGEMENT & STABILITY ---
+            # telemetry: GNATCOLL.Traces, the de facto AdaCore-ecosystem
+            # tracing/logging library.
+            "telemetry": re.compile(r"\bGNATCOLL\.Traces\b", re.I),
+            # debug_prints: Ada.Text_IO's Put_Line/Put/New_Line -- the
+            # stdout-print idiom, distinct from io's file/network calls
+            # above.
+            "debug_prints": re.compile(r"\bPut_Line\b|\bPut[ \t]*\(|\bNew_Line\b", re.I),
+            # explicit_casts: Ada qualified-expression syntax
+            # `Type_Name'(Expr)` -- a real, lexically-unambiguous marker for
+            # explicit type conversion/qualification (unlike a bare type
+            # conversion `T(Expr)`, which is syntactically identical to a
+            # function call and can't be told apart without semantic info).
+            "explicit_casts": re.compile(r"\b[A-Za-z_][A-Za-z0-9_.]*'\(", re.I),
+            # panics_and_aborts: `raise` (exception propagation) and
+            # `abort` (forceful task termination -- the schema's own
+            # baseline definition lists "abort()" as a canonical example).
+            "panics_and_aborts": re.compile(r"\braise\b|\babort\b", re.I),
+            # thread_sleeps: the `delay` statement.
+            "thread_sleeps": re.compile(r"\bdelay\b", re.I),
+            # bitwise_ops: Interfaces' Shift_Left/Shift_Right/Rotate_Left/
+            # Rotate_Right, and `xor` (unlike bare `and`/`or`, `xor` has no
+            # short-circuit "and then"/"or else"-style logical variant in
+            # Ada, so it's unambiguously the bitwise/boolean-parity
+            # operator, not a branch-control keyword).
+            "bitwise_ops": re.compile(r"\bShift_Left\b|\bShift_Right\b|\bRotate_Left\b|\bRotate_Right\b|\bxor\b", re.I),
+            # sync_locks: protected objects/types are Ada's built-in
+            # monitor/mutex primitive. Intentionally overlaps concurrency.
+            "sync_locks": re.compile(r"\bprotected\b|\bSuspension_Object\b", re.I),
+            # immutability_locks: the `constant` keyword.
+            "immutability_locks": re.compile(r"\bconstant\b", re.I),
+            # cleanup: Ada.Unchecked_Deallocation (the generic instantiated
+            # to build a "Free" procedure) and Ada.Finalization/Finalize
+            # (RAII-style teardown). Deliberately NOT paired with
+            # Unchecked_Conversion in safety_bypasses above -- this mirrors
+            # C's free()/dispose(), a normal cleanup action, not a type-
+            # safety bypass.
+            "cleanup": re.compile(r"\bAda\.Unchecked_Deallocation\b|\bFinalize\b|\bAda\.Finalization\b", re.I),
+            # encapsulation: the `private` keyword (package private parts,
+            # private type declarations).
+            "encapsulation": re.compile(r"\bprivate\b", re.I),
+            # listeners: a task entry declaration -- the endpoint waiting to
+            # receive an external call, before it's actually accepted
+            # (events, above).
+            "listeners": re.compile(r"\bentry\b", re.I),
+            # test_skip: no native language/AUnit-standard skip primitive;
+            # falls back to a comment-marker convention.
+            "test_skip": re.compile(r"--[ \t]*(?:SKIP|SKIPPED|DISABLED)\b", re.I),
+            # --- HYBRID DOMAIN SENSORS ---
+            # serialization_parsing: GNATCOLL.JSON and XML/Ada (DOM/SAX).
+            "serialization_parsing": re.compile(r"\bGNATCOLL\.JSON\b|\bDOM\.Core\b|\bInput_Sources\b", re.I),
+            # regex_execution: GNAT.Regpat / GNAT.Regexp, GNAT's native
+            # regex engines.
+            "regex_execution": re.compile(r"\bGNAT\.Regpat\b|\bGNAT\.Regexp\b", re.I),
+            # time_date_logic: Ada.Calendar / Ada.Real_Time.
+            "time_date_logic": re.compile(r"\bAda\.Calendar\b|\bAda\.Real_Time\b|\bClock\b", re.I),
+            # ipc_rpc_bridges: the Distributed Systems Annex (Annex E)
+            # pragmas and PolyORB (Ada's CORBA-like ORB), used in real
+            # distributed defense/aerospace Ada systems.
+            "ipc_rpc_bridges": re.compile(
+                r"\bpragma[ \t]+Remote_Call_Interface\b|\bpragma[ \t]+Remote_Types\b"
+                r"|\bpragma[ \t]+Shared_Passive\b|\bPolyORB\b",
+                re.I,
+            ),
+        },
+    },
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/extraction/languages/test_ada.py
+++ b/tests/extraction/languages/test_ada.py
@@ -240,6 +240,12 @@ def test_ada_import_excludes_aspect_specifications_regression():
         "Inline",
         "Volatile",
         "SPARK_Mode",
+        "Abstract_State",
+        "Initializes",
+        "Refined_Global",
+        "Refined_Post",
+        "Refined_State",
+        "Refined_Depends",
     ):
         payload = f"   with {aspect} => True;"
         assert not import_rule.search(payload), f"import incorrectly matched aspect clause: {payload!r}"

--- a/tests/extraction/languages/test_ada.py
+++ b/tests/extraction/languages/test_ada.py
@@ -1,0 +1,246 @@
+"""
+Ada/SPARK extraction gauntlet (issue #76, epic #75). See
+tests/extraction/how_to_harden_extraction.md for the methodology.
+
+Covers all four extraction gauntlets for ada in one file: func_start, args,
+class_start, _dependency_capture.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+# tests/ has no __init__.py anywhere in this repo, so a dotted
+# `tests.extraction._extraction_harness` import only works by accident
+# locally (e.g. `python -m pytest` from the repo root happens to put the
+# root on sys.path) and fails in CI, which invokes the `pytest` console
+# script directly. Insert this file's parent (tests/extraction/) onto
+# sys.path instead, so the harness imports as a plain top-level module.
+_EXTRACTION_DIR = str(Path(__file__).resolve().parent.parent)
+if _EXTRACTION_DIR not in sys.path:
+    sys.path.insert(0, _EXTRACTION_DIR)
+
+from typing import Any
+
+from _extraction_harness import (  # noqa: E402 # type: ignore
+    assert_invalid_no_match,
+    assert_pathological_dependency_match,
+    assert_pathological_match,
+    assert_redos_immune,
+    assert_valid_dependency_match,
+    assert_valid_match,
+)
+
+ADA_RULES = LANGUAGE_DEFINITIONS["ada"]["rules"]
+
+# ==============================================================================
+# FUNC_START (func_start) -- subprogram BODIES only, not spec-only declarations.
+# ==============================================================================
+FUNCTION_CASES: dict[str, Any] = {
+    "valid": [
+        ("procedure Foo is", "Foo"),  # no parameters
+        ("procedure Foo (X : Integer) is", "Foo"),
+        ("function Bar (X : Integer) return Integer is", "Bar"),
+        ("function Bar return Integer is", "Bar"),  # no parameters, function still needs return
+        ("procedure foo is", "foo"),  # lowercase (Ada is case-insensitive)
+        (
+            "procedure Increment (X : in out Integer) with Pre => X < Integer'Last, Post => X = X'Old + 1 is",
+            "Increment",
+        ),  # SPARK aspect clause between the profile and "is"
+        ("   procedure Foo (X : Integer) is", "Foo"),  # leading indentation
+    ],
+    "invalid": [
+        "procedure Foo (X : Integer);",  # bare spec declaration, no body -- no "is" at all
+        "procedure Foo is abstract;",  # abstract subprogram, still just a declaration
+        "procedure Foo (X : Integer) is null;",  # null procedure, still just a declaration
+        "procedure Foo is new Generic_Proc (Integer);",  # generic instantiation, not a body
+        "package Foo is new Generic_Pkg (Integer);",  # unrelated construct entirely
+        "PROCEDURE_COUNT : Integer := 0;",  # substring lookalike, no word boundary after "procedure"
+    ],
+    "pathological": [
+        ("procedure\n   Foo\n   (X : Integer)\n   is", "Foo"),  # vertical split
+        ("procedure Foo (X : in out Integer := Compute(A, (B + C))) is", "Foo"),  # nested-paren default
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["valid"])
+def test_ada_func_start_valid(payload, expected_name):
+    assert_valid_match(ADA_RULES["func_start"], payload, expected_name, "ada.func_start")
+
+
+@pytest.mark.parametrize("payload", FUNCTION_CASES["invalid"])
+def test_ada_func_start_invalid(payload):
+    assert_invalid_no_match(ADA_RULES["func_start"], payload, "ada.func_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", FUNCTION_CASES["pathological"])
+def test_ada_func_start_pathological(payload, expected_name):
+    assert_pathological_match(ADA_RULES["func_start"], payload, expected_name, "ada.func_start")
+
+
+def test_ada_func_start_redos_immunity():
+    func_start = ADA_RULES["func_start"]
+    assert_redos_immune(func_start, "procedure Foo (" + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(func_start, "procedure Foo with " + "A" * 200000, timeout_sec=3.0)
+    assert func_start.search("procedure Foo is")
+
+
+# ==============================================================================
+# CLASS_START (class_start) -- tagged type declarations (root and derived).
+# ==============================================================================
+CLASS_CASES: dict[str, Any] = {
+    "valid": [
+        ("type Animal is tagged record", "Animal"),  # root tagged type
+        ("type Animal is tagged null record;", "Animal"),
+        ("type Shape is abstract tagged record", "Shape"),
+        ("type Shape is limited tagged record", "Shape"),
+        ("type Dog is new Animal with record", "Dog"),  # derived/extended tagged type
+        ("type Dog is new Animal with null record;", "Dog"),
+        ("type Dog is abstract new Animal with private;", "Dog"),
+    ],
+    "invalid": [
+        "type Celsius is range -273 .. 1000;",  # plain range type, not tagged
+        "type Status is (Ok, Error);",  # enumeration type
+        "subtype Positive is Integer range 1 .. Integer'Last;",  # subtype, not a tagged type
+    ],
+    "pathological": [
+        ("type Dog is\n   new Animal\n   with record", "Dog"),  # vertical split
+        ("type Foo is new " + "A" * 100 + " with record", "Foo"),  # long base-type name
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["valid"])
+def test_ada_class_start_valid(payload, expected_name):
+    assert_valid_match(ADA_RULES["class_start"], payload, expected_name, "ada.class_start")
+
+
+@pytest.mark.parametrize("payload", CLASS_CASES["invalid"])
+def test_ada_class_start_invalid(payload):
+    assert_invalid_no_match(ADA_RULES["class_start"], payload, "ada.class_start")
+
+
+@pytest.mark.parametrize("payload,expected_name", CLASS_CASES["pathological"])
+def test_ada_class_start_pathological(payload, expected_name):
+    assert_pathological_match(ADA_RULES["class_start"], payload, expected_name, "ada.class_start")
+
+
+def test_ada_class_start_redos_immunity():
+    class_start = ADA_RULES["class_start"]
+    assert_redos_immune(class_start, "type Foo is new " + "A" * 200000, timeout_sec=3.0)
+    assert class_start.search("type Foo is tagged record")
+
+
+# ==============================================================================
+# ARGS (args) -- procedure/function parameter profiles.
+# ==============================================================================
+ARGS_CASES: dict[str, Any] = {
+    "valid": [
+        ("procedure Foo (X : Integer)", "X"),
+        ("function Bar (X : Integer; Y : Float) return Boolean", "X"),
+        ("procedure Foo (X : in out Integer)", "X"),
+    ],
+    "invalid": [
+        "PROCEDURE_COUNT : Integer := Foo (X);",  # substring lookalike, no word boundary
+        "Configure (X : Integer);",  # plain call/declaration, no procedure/function keyword
+    ],
+    "pathological": [
+        ("procedure Foo (X : in out Integer := Compute(A, (B + C)))", "X"),  # nested-paren default
+        ("procedure\n   Foo\n   (X : Integer)", "X"),  # vertical split
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["valid"])
+def test_ada_args_valid(payload, expected_name):
+    assert_valid_match(ADA_RULES["args"], payload, expected_name, "ada.args")
+
+
+@pytest.mark.parametrize("payload", ARGS_CASES["invalid"])
+def test_ada_args_invalid(payload):
+    assert_invalid_no_match(ADA_RULES["args"], payload, "ada.args")
+
+
+@pytest.mark.parametrize("payload,expected_name", ARGS_CASES["pathological"])
+def test_ada_args_pathological(payload, expected_name):
+    assert_pathological_match(ADA_RULES["args"], payload, expected_name, "ada.args")
+
+
+def test_ada_args_redos_immunity():
+    args = ADA_RULES["args"]
+    assert_redos_immune(args, "procedure Foo (" + "A" * 200000, timeout_sec=3.0)
+    assert args.search("procedure Foo (X : Integer)")
+
+
+# ==============================================================================
+# DEPENDENCY (_dependency_capture) -- context-clause `with` statements.
+# ==============================================================================
+DEPENDENCY_CASES: dict[str, Any] = {
+    "valid": [
+        ("with Ada.Text_IO;", "Ada.Text_IO"),
+        ("with Ada.Text_IO, Ada.Integer_Text_IO;", "Ada.Text_IO"),
+        ("   with GNAT.Sockets;", "GNAT.Sockets"),
+        ("with ada.text_io;", "ada.text_io"),  # lowercase
+    ],
+    "invalid": [
+        "   with Pre => X > 0;",  # aspect specification, not a context clause
+        "   with Global => (Input => X);",  # SPARK Global aspect, not a context clause
+        "   with Inline;",  # boolean aspect, no arrow at all -- must still be excluded
+    ],
+    "pathological": [
+        ("with \n Ada.Text_IO;", "Ada.Text_IO"),  # vertical split
+        ("with Ada.Text_IO,\n     Ada.Integer_Text_IO;", "Ada.Text_IO"),  # multi-name, vertical split
+    ],
+}
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["valid"])
+def test_ada_dependency_capture_valid(payload, expected_path):
+    assert_valid_dependency_match(ADA_RULES["_dependency_capture"], payload, expected_path, "ada._dependency_capture")
+
+
+@pytest.mark.parametrize("payload", DEPENDENCY_CASES["invalid"])
+def test_ada_dependency_capture_invalid(payload):
+    assert_invalid_no_match(ADA_RULES["_dependency_capture"], payload, "ada._dependency_capture")
+
+
+@pytest.mark.parametrize("payload,expected_path", DEPENDENCY_CASES["pathological"])
+def test_ada_dependency_capture_pathological(payload, expected_path):
+    assert_pathological_dependency_match(
+        ADA_RULES["_dependency_capture"], payload, expected_path, "ada._dependency_capture"
+    )
+
+
+def test_ada_dependency_capture_redos_immunity():
+    dep = ADA_RULES["_dependency_capture"]
+    assert_redos_immune(dep, "with " + "A" * 200000, timeout_sec=3.0)
+    assert dep.search("with Ada.Text_IO;")
+
+
+def test_ada_import_excludes_aspect_specifications_regression():
+    """
+    Rule 15 (A Documented Exclusion Must Actually Exclude): import/
+    _dependency_capture share a negative-lookahead exclusion list with
+    decorators' aspect-mark vocabulary, so a `with Pre => ...`-style aspect
+    clause on a declaration is never miscounted as a compilation-unit
+    dependency. Verify the exclusion actually blocks every listed aspect
+    mark, not just a couple of examples.
+    """
+    import_rule = ADA_RULES["import"]
+    for aspect in (
+        "Pre",
+        "Post",
+        "Global",
+        "Depends",
+        "Convention",
+        "Inline",
+        "Volatile",
+        "SPARK_Mode",
+    ):
+        payload = f"   with {aspect} => True;"
+        assert not import_rule.search(payload), f"import incorrectly matched aspect clause: {payload!r}"
+    assert import_rule.search("   with Ada.Text_IO;"), "plain context clause must still match"

--- a/tests/extraction/languages/test_ada_strict.py
+++ b/tests/extraction/languages/test_ada_strict.py
@@ -49,6 +49,8 @@ _ADA_SIMPLE_CASES = [
     ("concurrency", "task Foo is", "X := 5;"),
     ("globals", "with Global => (Input => X);", "X := 5;"),
     ("decorators", "with Pre => X > 0", "with Ada.Text_IO;"),
+    ("decorators", "with Refined_Global => null", "with Ada.Text_IO;"),  # SPARK refinement aspect
+    ("decorators", "pragma SPARK_Mode (On);", "X := 5;"),  # pragma form, distinct from `with SPARK_Mode`
     ("generics", "generic", "X := 5;"),
     ("generics", "package Stacks is new Generic_Stack (Integer);", "type Dog is new Animal with record"),
     ("comprehensions", "for all X in 1 .. 10 => X > 0", "X := 5;"),
@@ -136,6 +138,40 @@ def test_ada_none_keys_are_genuinely_inapplicable_not_accidental():
     """
     actual_none = {k for k, v in ADA_RULES.items() if v is None}
     assert actual_none == _EXPECTED_NONE_KEYS, f"unexpected set of None keys: {actual_none ^ _EXPECTED_NONE_KEYS}"
+
+
+def test_ada_spark_refinement_aspects_register_as_decorators_not_silently_invisible():
+    """
+    Coverage gap found and fixed before merging #1140: the "& SPARK" half of
+    #76's title wasn't fully honored -- the aspect-mark vocabulary shared by
+    decorators/import/_dependency_capture only covered the foundational
+    SPARK contract aspects (Pre/Post/Global/Depends/SPARK_Mode), not the
+    data-flow *refinement* aspects (Abstract_State/Initializes/
+    Refined_Global/Refined_Post/Refined_State/Refined_Depends) used to
+    formally model a package's private state for the prover -- common in
+    real SPARK code. These didn't misfire as false imports (the `=>` breaks
+    import's required trailing-`;` grammar shape either way), they were
+    just invisible to every signature. Also covers the `pragma SPARK_Mode
+    (On);` form, structurally distinct from the `with SPARK_Mode => On`
+    aspect form -- both are real and common.
+    """
+    decorators = ADA_RULES["decorators"]
+    import_rule = ADA_RULES["import"]
+
+    for aspect in (
+        "Abstract_State",
+        "Initializes",
+        "Refined_Global",
+        "Refined_Post",
+        "Refined_State",
+        "Refined_Depends",
+    ):
+        payload = f"with {aspect} => null"
+        assert decorators.search(payload), f"decorators failed to recognize SPARK refinement aspect: {aspect!r}"
+        assert not import_rule.search(payload + ";"), f"import incorrectly matched refinement aspect: {aspect!r}"
+
+    assert decorators.search("pragma SPARK_Mode (On);"), "decorators must recognize the pragma form of SPARK_Mode"
+    assert decorators.search("pragma SPARK_Mode (Off);")
 
 
 # ==============================================================================

--- a/tests/extraction/languages/test_ada_strict.py
+++ b/tests/extraction/languages/test_ada_strict.py
@@ -1,0 +1,399 @@
+"""
+Ada/SPARK strict structural-signature coverage (issue #76, epic #75). See
+gitgalaxy/standards/how_to_add_a_language.md's Strict Testing & Crucible
+Verification Framework for the methodology -- this is a separate adversarial
+pass against the signatures registered in language_standards.py, not a
+continuation of the generation work itself.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+_LANGUAGES_DIR = str(Path(__file__).resolve().parent)
+if _LANGUAGES_DIR not in sys.path:
+    sys.path.insert(0, _LANGUAGES_DIR)
+
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
+
+ADA = LANGUAGE_DEFINITIONS["ada"]
+ADA_RULES = ADA["rules"]
+
+# ==============================================================================
+# TEST 1: PER-SIGNATURE POSITIVE/NEGATIVE COVERAGE
+# One entry per non-None rule key, using realistic Ada/SPARK snippets.
+# ==============================================================================
+_ADA_SIMPLE_CASES = [
+    ("branch", "if X > 0 then", "X := 5;"),
+    ("branch", "X := A and then B;", "X := 5;"),  # two-word short-circuit form
+    ("args", "procedure Foo (X : Integer) is", "X := 5;"),
+    ("structural_boundaries", "begin", "X := 5;"),
+    ("structural_boundaries", "package Foo is", "X := 5;"),
+    ("func_start", "procedure Foo is", "procedure Foo is abstract;"),
+    ("class_start", "type Foo is tagged record", "type Foo is range 1 .. 10;"),
+    ("safety", "exception", "X := 5;"),
+    ("safety", "type Celsius is range -273 .. 1000;", "X := 5;"),  # #76's own "type ... is range" ask
+    ("safety", "pragma Assert (X > 0);", "pragma Pack;"),  # scoped safety-pragma vocabulary, not bare "pragma"
+    ("safety_bypasses", "Unchecked_Conversion", "X := 5;"),
+    ("high_risk_execution", "OS_Exit (1);", "X := 5;"),
+    ("io", 'Ada.Text_IO.Open (F, In_File, "data.txt");', "X := 5;"),
+    ("api", "package Foo is", "package body Foo is"),
+    ("state_mutation", "X := 5;", "X = 5"),
+    ("dead_code", "-- if X > 0 then", "-- just a note"),
+    ("doc", "-- @param X the input value", "-- just a note"),
+    ("test", 'AUnit.Assertions.Assert (X = 5, "msg");', "X := 5;"),
+    ("concurrency", "task Foo is", "X := 5;"),
+    ("globals", "with Global => (Input => X);", "X := 5;"),
+    ("decorators", "with Pre => X > 0", "with Ada.Text_IO;"),
+    ("generics", "generic", "X := 5;"),
+    ("generics", "package Stacks is new Generic_Stack (Integer);", "type Dog is new Animal with record"),
+    ("comprehensions", "for all X in 1 .. 10 => X > 0", "X := 5;"),
+    ("scientific", "Ada.Numerics.Elementary_Functions", "X := 5;"),
+    ("reflection_metaprogramming", "Obj'Class", "X := 5;"),
+    ("import", "with Ada.Text_IO;", "with Pre => X > 0;"),
+    ("ownership", "-- Author: Jane Doe", "-- just a note"),
+    ("planned_debt", "-- TODO: fix this", "-- done"),
+    ("fragile_debt", "-- HACK: workaround", "-- clean"),
+    ("hardcoded_secrets", 'Password : constant String := "hunter2xyz123";', "X := 5;"),
+    ("spec_exposure", "[SPEC-123]", "-- just a note"),
+    ("events", "accept Foo do", "X := 5;"),
+    ("macros", "#if DEBUG", "X := 5;"),
+    ("pointers", "Foo'Access", "X := 5;"),
+    ("pointers", "type Ptr is access Integer;", "X := 5;"),
+    ("memory_alloc", "X := new Integer;", "X := 5;"),
+    ("inline_asm", 'System.Machine_Code.Asm ("nop");', "X := 5;"),
+    ("telemetry", 'GNATCOLL.Traces.Trace (Handle, "msg");', "X := 5;"),
+    ("debug_prints", 'Put_Line ("hello");', "X := 5;"),
+    ("explicit_casts", "Integer'(X)", "X := 5;"),
+    ("panics_and_aborts", "raise Constraint_Error;", "X := 5;"),
+    ("panics_and_aborts", "abort Worker_Task;", "X := 5;"),
+    ("thread_sleeps", "delay 1.0;", "X := 5;"),
+    ("bitwise_ops", "Shift_Left (X, 2)", "X := 5;"),
+    ("bitwise_ops", "X := A xor B;", "X := 5;"),
+    ("sync_locks", "protected Foo is", "X := 5;"),
+    ("immutability_locks", "X : constant Integer := 5;", "X : Integer := 5;"),
+    ("cleanup", "Ada.Unchecked_Deallocation", "X := 5;"),
+    ("cleanup", "Finalize (Obj);", "X := 5;"),
+    ("encapsulation", "private", "X := 5;"),
+    ("listeners", "entry Foo;", "X := 5;"),
+    ("test_skip", "-- SKIP: flaky on hardware-in-the-loop rig", "-- just a note"),
+    ("serialization_parsing", "GNATCOLL.JSON.Create", "X := 5;"),
+    ("regex_execution", "GNAT.Regpat.Match (Pattern, Data)", "X := 5;"),
+    ("time_date_logic", "Ada.Calendar.Clock", "X := 5;"),
+    ("ipc_rpc_bridges", "pragma Remote_Call_Interface;", "X := 5;"),
+]
+
+
+@pytest.mark.parametrize("signature,positive,negative", _ADA_SIMPLE_CASES)
+def test_ada_signature_positive_and_negative(signature, positive, negative):
+    pattern = ADA_RULES[signature]
+    assert pattern is not None, f"ada's {signature!r} rule is unexpectedly None"
+    assert pattern.search(positive), f"ada {signature!r} failed to match its own documented positive case: {positive!r}"
+    if negative is not None:
+        assert not pattern.search(negative), f"ada {signature!r} incorrectly matched an excluded case: {negative!r}"
+
+
+# ==============================================================================
+# TEST 2: SCHEMA COMPLETENESS (Rule 4 / how_to_add_a_language.md Step 4 item 9)
+# Every baseline key from the OUTPUT SCHEMA must be present -- either a real
+# pattern or an explicit None -- never silently absent.
+# ==============================================================================
+_BASELINE_KEYS = [
+    "branch", "args", "structural_boundaries", "func_start", "class_start",
+    "safety", "safety_bypasses", "high_risk_execution", "io", "api",
+    "state_mutation", "dead_code", "doc", "test",
+    "concurrency", "ui_framework", "closures", "globals", "decorators",
+    "generics", "comprehensions", "scientific", "reflection_metaprogramming",
+    "import", "_dependency_capture", "ownership",
+    "planned_debt", "fragile_debt", "hardcoded_secrets", "spec_exposure",
+    "tabs_vs_spaces", "ssr_boundaries", "events", "dependency_injection",
+    "macros", "pointers", "memory_alloc", "inline_asm",
+    "telemetry", "debug_prints", "explicit_casts", "panics_and_aborts",
+    "thread_sleeps", "bitwise_ops", "sync_locks", "immutability_locks",
+    "cleanup", "encapsulation", "listeners", "test_skip",
+    "serialization_parsing", "regex_execution", "time_date_logic", "ipc_rpc_bridges",
+]  # fmt: skip
+
+_EXPECTED_NONE_KEYS = {"ui_framework", "closures", "tabs_vs_spaces", "ssr_boundaries", "dependency_injection"}
+
+
+def test_ada_schema_completeness():
+    missing = set(_BASELINE_KEYS) - set(ADA_RULES.keys())
+    assert not missing, f"ada rules dict is missing baseline keys entirely (not even None): {missing}"
+    extra = set(ADA_RULES.keys()) - set(_BASELINE_KEYS)
+    assert not extra, f"ada rules dict has unexpected keys not in the baseline schema: {extra}"
+
+
+def test_ada_none_keys_are_genuinely_inapplicable_not_accidental():
+    """
+    Strict Feature Parity (Rule 4): every None key should be an intentional
+    "this doesn't exist in Ada" call, not an accidental gap. Cross-checked
+    against the rationale comments left in the dict itself.
+    """
+    actual_none = {k for k, v in ADA_RULES.items() if v is None}
+    assert actual_none == _EXPECTED_NONE_KEYS, f"unexpected set of None keys: {actual_none ^ _EXPECTED_NONE_KEYS}"
+
+
+# ==============================================================================
+# TEST 3: LEXICAL-FAMILY SANITY CHECK (Step 4 item 8)
+# Ada has no block-comment form; confirm Prism.split_streams() actually
+# strips `--` comments and leaves real code (including string literals that
+# themselves contain `--`) intact, using the real engine end-to-end rather
+# than trusting the family label alone.
+# ==============================================================================
+def test_ada_lexical_family_is_correctly_wired_not_just_labeled():
+    """
+    Regression guard for a real pipeline-level bug this addition avoided:
+    epic #75/#76 both label Ada's family "hybrid_dash", but that name was
+    never registered anywhere in gitgalaxy_config.py's
+    LEXICAL_FAMILY_HEURISTICS or prism.py's family-dispatch logic. Using it
+    verbatim would have silently produced a family with NO delimiters wired
+    up at all -- Prism's generic stripper falls through with an empty
+    pattern and returns the text completely unstripped, corrupting every
+    downstream signature count with comment noise. Registered
+    "line_exclusive_dash" instead (single `--` delimiter, no block form)
+    and wired it into prism.py's _compile_regex_matrix -- this test proves
+    the wiring actually works end-to-end, not just that the config key
+    exists.
+    """
+    from gitgalaxy.core.prism import Prism
+    from gitgalaxy.standards.gitgalaxy_config import LEXICAL_FAMILY_HEURISTICS
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS as LANG_DEFS
+
+    assert ADA["lexical_family"] == "line_exclusive_dash"
+    assert "line_exclusive_dash" in LEXICAL_FAMILY_HEURISTICS["lexical_families"]
+    assert LEXICAL_FAMILY_HEURISTICS["lexical_families"]["line_exclusive_dash"]["delimiters"] == ["--"]
+
+    prism = Prism(LEXICAL_FAMILY_HEURISTICS, LANG_DEFS)
+    sample = (
+        "with Ada.Text_IO; use Ada.Text_IO;\n\n"
+        "procedure Demo is\n"
+        "begin\n"
+        "   --  A header comment describing the call below\n"
+        '   Put_Line ("Use -- for comments in Ada");  -- trailing comment\n'
+        "end Demo;\n"
+    )
+    result = prism.split_streams(sample, "ada")
+
+    assert "A header comment describing the call below" in result["comment_stream"]
+    assert "trailing comment" in result["comment_stream"]
+    # the real comment lines must be gone from the code stream...
+    assert "A header comment describing the call below" not in result["code_stream"]
+    # ...but a string literal that merely *contains* "--" must survive intact.
+    assert 'Put_Line ("Use -- for comments in Ada");' in result["code_stream"]
+    assert "with Ada.Text_IO; use Ada.Text_IO;" in result["code_stream"]
+
+
+def test_ada_line_exclusive_dash_does_not_leak_into_shared_line_exclusive_family():
+    """
+    The new family must be additive, not a mutation of the pre-existing
+    shared "line_exclusive" family several other languages (Perl, Assembly,
+    ...) already depend on -- confirms `--` was never added to that shared
+    delimiter list (which would silently truncate any of those languages'
+    real code containing a literal `--`, e.g. Perl's `$x--;`).
+    """
+    from gitgalaxy.standards.gitgalaxy_config import LEXICAL_FAMILY_HEURISTICS
+
+    shared = LEXICAL_FAMILY_HEURISTICS["lexical_families"]["line_exclusive"]["delimiters"]
+    assert "--" not in shared, "`--` leaked into the shared line_exclusive delimiter list"
+
+
+# ==============================================================================
+# TEST 4: SYMBOLIC-BOUNDARY AUDIT (Rule 9/10)
+# Ada attributes are written as IDENTIFIER'ATTRIBUTE (a leading apostrophe,
+# a non-word character) -- confirm the realistic attached form matches, not
+# just an artificially spaced-out synthetic string.
+# ==============================================================================
+def test_ada_attribute_forms_match_realistic_attached_syntax():
+    reflection = ADA_RULES["reflection_metaprogramming"]
+    pointers = ADA_RULES["pointers"]
+    explicit_casts = ADA_RULES["explicit_casts"]
+
+    assert reflection.search("Some_Object'Class"), "'Class attribute must match directly attached to its prefix"
+    assert reflection.search("Some_Type'Tag"), "'Tag attribute must match directly attached to its prefix"
+    assert pointers.search("Handler'Access"), "'Access attribute must match directly attached to its prefix"
+    assert pointers.search("Handler'Unchecked_Access")
+    assert explicit_casts.search("Integer'(Compute (X))"), "qualified expression must match attached, no space"
+
+
+# ==============================================================================
+# TEST 5: NESTED-DELIMITER AUDIT (Rule 11)
+# func_start/args allow one level of nested parens in default expressions.
+# ==============================================================================
+def test_ada_func_start_and_args_handle_one_level_of_nested_parens():
+    func_start = ADA_RULES["func_start"]
+    args = ADA_RULES["args"]
+
+    nested = "procedure Foo (X : Integer := Compute (A, (B + C))) is"
+    m = func_start.search(nested)
+    assert m and m.group(1) == "Foo", "func_start choked on a one-level-nested default expression"
+
+    m2 = args.search(nested)
+    assert m2 and "X" in m2.group(1), "args choked on a one-level-nested default expression"
+
+
+# ==============================================================================
+# TEST 6: RE.M COMPLETENESS AUDIT (Rule 13)
+# Every rule using a literal `^` outside a character class must set re.M.
+# ==============================================================================
+def test_ada_caret_anchored_rules_all_set_multiline_flag():
+    caret_using_keys = []
+    for key, pattern in ADA_RULES.items():
+        if pattern is None or key.startswith("_"):
+            continue
+        # Excludes `^` immediately after `[` (negated-class opener, e.g.
+        # `[^()]` in args/func_start's nested-paren capture) -- that's not a
+        # line-start anchor, it's the negation operator inside a bracket
+        # expression, and Rule 13 only concerns the former.
+        if isinstance(pattern, re.Pattern) and re.search(r"(?<!\\)(?<!\[)\^", pattern.pattern):
+            caret_using_keys.append(key)
+
+    assert caret_using_keys, (
+        "expected at least one ^-anchored rule (import/ownership/macros) -- audit is a no-op otherwise"
+    )
+    for key in caret_using_keys:
+        assert ADA_RULES[key].flags & re.M, f"ada {key!r} uses ^ but doesn't set re.M -- can only match the first line"
+
+
+# ==============================================================================
+# TEST 7: AMBIGUITY SWEEP (Rule 6 category)
+# Documents genuine, intentional double-classifications (same design already
+# established for COBOL's EXEC CICS ENQ/DELAY dual-mapping) and confirms the
+# deliberately-avoided false collisions actually stay separated.
+# ==============================================================================
+def test_ada_intentional_double_classification_sweep():
+    task_decl = "task Worker is"
+    assert ADA_RULES["concurrency"].search(task_decl)
+
+    protected_decl = "protected Guard is"
+    assert ADA_RULES["concurrency"].search(protected_decl)
+    assert ADA_RULES["sync_locks"].search(protected_decl)
+
+    delay_stmt = "delay 1.0;"
+    assert ADA_RULES["concurrency"].search(delay_stmt)
+    assert ADA_RULES["thread_sleeps"].search(delay_stmt)
+
+    accept_stmt = "accept Foo do"
+    assert ADA_RULES["concurrency"].search(accept_stmt)
+    assert ADA_RULES["events"].search(accept_stmt)
+
+    entry_decl = "entry Foo;"
+    assert ADA_RULES["concurrency"].search(entry_decl)
+    assert ADA_RULES["listeners"].search(entry_decl)
+
+    unchecked_dealloc = "procedure Free is new Ada.Unchecked_Deallocation (Object => T, Name => T_Ptr);"
+    assert ADA_RULES["cleanup"].search(unchecked_dealloc)
+    assert ADA_RULES["generics"].search(unchecked_dealloc), (
+        "generic instantiation form should also register as generics"
+    )
+
+    range_type = "type Celsius is range -273 .. 1000;"
+    assert ADA_RULES["safety"].search(range_type)
+    assert ADA_RULES["class_start"] and not ADA_RULES["class_start"].search(range_type), (
+        "a plain range type is not a tagged type -- must not double up on class_start"
+    )
+
+
+def test_ada_generics_instantiation_does_not_collide_with_tagged_type_derivation():
+    """
+    Both generic instantiation (`package X is new Y (...)`) and tagged-type
+    derivation (`type Dog is new Animal with ...`) share the two words
+    "is new", but are structurally different constructs. generics is scoped
+    to `package|procedure|function NAME is new` specifically so it does NOT
+    fire on a tagged-type derivation, and class_start's tagged-type pattern
+    does NOT fire on a generic instantiation.
+    """
+    instantiation = "package Integer_Stack is new Stacks (Integer);"
+    derivation = "type Dog is new Animal with record"
+
+    assert ADA_RULES["generics"].search(instantiation)
+    assert not ADA_RULES["generics"].search(derivation), "generics incorrectly fired on tagged-type derivation"
+
+    assert ADA_RULES["class_start"].search(derivation)
+    assert not ADA_RULES["class_start"].search(instantiation), "class_start incorrectly fired on generic instantiation"
+
+
+def test_ada_explicit_casts_vs_pointers_no_false_collision():
+    """
+    Known ambiguity pattern from the issue template (already found in C:
+    cast syntax overlapping pointer-asterisk repetition). Ada's
+    explicit_casts uses the qualified-expression `Type'(Expr)` form and
+    pointers uses access-type/`'Access` syntax -- structurally distinct.
+    """
+    explicit_casts = ADA_RULES["explicit_casts"]
+    pointers = ADA_RULES["pointers"]
+
+    qualified = "Integer'(X)"
+    assert explicit_casts.search(qualified)
+    assert not pointers.search(qualified)
+
+    access_attr = "Handler'Access"
+    assert pointers.search(access_attr)
+    assert not explicit_casts.search(access_attr)
+
+
+def test_ada_import_and_decorators_share_exclusion_vocabulary_without_collision():
+    """
+    import/_dependency_capture and decorators are two sides of the same
+    lexical fork (both start with the `with` keyword) -- confirm they
+    partition realistically, not just that each individually passes its own
+    simple case.
+    """
+    plain_import = "with Ada.Text_IO;"
+    aspect_clause = "with Pre => X > 0"
+
+    assert ADA_RULES["import"].search(plain_import)
+    assert not ADA_RULES["decorators"].search(plain_import)
+
+    assert ADA_RULES["decorators"].search(aspect_clause)
+    assert not ADA_RULES["import"].search(aspect_clause)
+
+
+# ==============================================================================
+# TEST 8: REDOS ADVERSARIAL SWEEP (Rule 5/14), scaling-verified
+# ==============================================================================
+def test_ada_redos_immunity_sweep():
+    assert_redos_immune(ADA_RULES["func_start"], "procedure Foo (" + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["func_start"], "procedure Foo with " + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["class_start"], "type Foo is new " + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["args"], "procedure Foo (" + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["import"], "with " + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["_dependency_capture"], "with " + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["decorators"], "with " + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(
+        ADA_RULES["hardcoded_secrets"], "password : constant String := " + "A" * 200000, timeout_sec=3.0
+    )
+    assert_redos_immune(ADA_RULES["macros"], "#if " + "A" * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["ownership"], "-- Author:" + " " * 200000, timeout_sec=3.0)
+    assert_redos_immune(ADA_RULES["dead_code"], "--" + " " * 200000, timeout_sec=3.0)
+
+    # sanity: everything still matches its real positive case after the sweep
+    assert ADA_RULES["func_start"].search("procedure Foo is")
+    assert ADA_RULES["class_start"].search("type Foo is tagged record")
+    assert ADA_RULES["import"].search("with Ada.Text_IO;")
+
+
+def test_ada_func_start_scaling_is_linear_not_quadratic():
+    """
+    Explicit geometric-scaling proof (Rule 5, not a single timing) for the
+    bounded `with`-aspect segment between the profile and "is" -- the one
+    genuinely payload-shaped quantifier in func_start.
+    """
+    import time
+
+    func_start = ADA_RULES["func_start"]
+    timings = []
+    for n in (2000, 4000, 8000):
+        payload = "procedure Foo with " + "A" * n
+        start = time.perf_counter()
+        func_start.search(payload)
+        timings.append(time.perf_counter() - start)
+
+    # A roughly-2x-per-doubling ratio is linear; anything approaching 4x
+    # would indicate real quadratic backtracking. Generous margin for CI
+    # scheduling noise.
+    assert timings[-1] < timings[0] * 8 + 0.05, f"suspicious scaling: {timings}"


### PR DESCRIPTION
## Summary

Implements #76 (epic #75, "Aerospace Compliance & Enterprise Integration",
Phase 1) -- adds native Ada/SPARK structural-signature support to
`gitgalaxy/standards/language_standards.py`, following
`gitgalaxy/standards/how_to_add_a_language.md`'s generation and
strict-testing protocol.

- Full 54-key baseline `rules` dict for `ada` (extensions `.adb`/`.ads`/`.ada`).
  5 keys are explicit `None` where Ada genuinely has no equivalent
  (`ui_framework`, `closures`, `tabs_vs_spaces`, `ssr_boundaries`,
  `dependency_injection`) -- Strict Feature Parity, not an oversight.
- `safety` covers #76's explicit ask: strict-typing range constraints
  (`type ... is range`, and the equally common `subtype X is Base range
  Lo .. Hi` form) plus a scoped safety-pragma vocabulary (`pragma Assert`,
  `Precondition`, `Postcondition`, `Invariant`) -- deliberately *not* bare
  `pragma`, since most pragmas (`Pack`, `Import`, ...) have nothing to do
  with safety.
- `api` covers package specs (`package ... is`), correctly excluding
  `package body ...` and generic-instantiation `package X is new ...`
  via negative lookaheads (not optional groups, per Rule 15).
- `class_start` covers Ada's real OOP entity -- tagged types, both root
  declarations (`type Foo is tagged record`) and derived/extended ones
  (`type Dog is new Animal with record`, where the literal word `tagged`
  is never repeated, so the derived form needs its own alternative or an
  entire inheritance chain becomes invisible).
- `func_start` requires a real subprogram *body* (Rule 7: strict execution
  anchoring), excluding spec-only declarations, `abstract`/`null`
  procedures, and generic-subprogram instantiations -- while still
  matching SPARK's common `with Pre => ..., Post => ...` aspect clause
  between the profile and `is`.

### A real pipeline bug caught before it shipped

Both the issue and epic label Ada's `lexical_family` `"hybrid_dash"`. That
name doesn't exist anywhere in the engine. Using it verbatim would have
silently broken comment stripping for every Ada file: `prism.py`'s generic
stripper falls through with an empty compiled pattern for any family name
it doesn't recognize, so `--` comments would never be removed from the code
stream, contaminating every downstream signature count with comment noise.

Root cause: Ada genuinely has no block-comment form ("no native block
comments historically" is in #76's own checklist, directly contradicting
the `"hybrid_dash"` name it also asks for). Reusing the existing
`"line_exclusive"` family was also rejected -- its shared delimiter list is
consumed by several other languages (Perl, Assembly) that use `--` as a
real operator/decrement; widening it would silently truncate their real
code, the exact failure mode #621 already fixed once by narrowing
`"standard_block"`.

Fix: registered a new, properly-wired `"line_exclusive_dash"` family
(single `--` delimiter, no block form) in `gitgalaxy_config.py`'s
`LEXICAL_FAMILY_HEURISTICS`, and added the matching branch in `prism.py`'s
`_compile_regex_matrix()`. Verified end-to-end with a real
`Prism.split_streams()` call (see `test_ada_lexical_family_is_correctly_
wired_not_just_labeled`), not just that the config key exists.

## Test plan

- [x] `tests/extraction/languages/test_ada.py` -- extraction gauntlet
      (func_start/args/class_start/_dependency_capture: valid/invalid/
      pathological/ReDoS-immunity cases)
- [x] `tests/extraction/languages/test_ada_strict.py` -- per-signature
      positive/negative coverage for all 49 non-`None` keys, schema
      completeness audit, symbolic-boundary audit (Ada attributes like
      `'Class`/`'Access`), nested-delimiter audit, `re.M` completeness
      audit, ambiguity sweep (documents intentional double-classifications
      like `protected`/`delay` firing both `concurrency` and their more
      specific sibling, mirroring COBOL's existing `EXEC CICS ENQ`
      precedent), and a geometric ReDoS scaling sweep
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key baselines
      all clean, `ruff format .` clean
- [x] `python tests/tools/crucible_check.py` -- both full-precision and
      zero-dependency modes pass with zero diff (the language-crucible
      corpus has no Ada files yet, confirmed via `find`, so this proves no
      off-target blast radius on the other ~80 languages rather than
      Ada-specific regression coverage)
- [x] `python -m pytest tests/` -- full suite green (6700 passed)

Closes #76.