### PR TITLE
fix(lint): use contextlib.suppress for regex compile in language_lens.py

### DIFF
--- a/gitgalaxy/standards/language_lens.py
+++ b/gitgalaxy/standards/language_lens.py
@@ -7,6 +7,7 @@
 # A copy of the license can be found in the LICENSE file in the root directory
 # of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
 # ==============================================================================
+import contextlib
 import logging
 import math
 import re
@@ -129,10 +130,9 @@ class LanguageDetector:
             if "rules" in data:
                 for rule_name, regex in data["rules"].items():
                     if isinstance(regex, str):
-                        try:
+                        # Safely bypass malformed strings in external definitions
+                        with contextlib.suppress(re.error):
                             data["rules"][rule_name] = re.compile(regex)
-                        except re.error:
-                            pass  # Safely bypass malformed strings in external definitions
 
         for anchor in self.PROSE_ANCHORS:
             if anchor not in self.anchor_map:


### PR DESCRIPTION
Fixes #498

Fix SIM105 in language_lens.py by replacing try/except/pass with contextlib.suppress(re.error); only this finding had exact source available.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.