### PR TITLE
docs: add language-status skill and docs/language_status/ (Python worked example)

### DIFF
--- a/.claude/skills/language-status/SKILL.md
+++ b/.claude/skills/language-status/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: language-status
+description: Create or refresh a per-language coverage doc under docs/language_status/<lang>.md -- what GitGalaxy's structural-signature engine actually detects for that language, what it explicitly doesn't, how deep the test coverage is, which closed issues/PRs shaped it, and real-world scan evidence from gitgalaxy-raw-output. Use when the user asks "what does gitgalaxy support for X", "document language status", "write a coverage doc for <lang>", "is python/rust/cobol fully covered", or similar. Not for changing engine behavior -- that's harden-language-extraction or harden-strict-signatures.
+---
+
+Closed epics (#518, #813, #1069, #1071...) already did the hard work of finding and fixing
+per-language gaps, but that history is scattered across ~150 individual issues with no single
+place a reader (or a future Claude session) can go to answer "what does this scanner actually do
+for Python?" without re-deriving it from `language_standards.py` and a pile of `gh issue list`
+searches. `docs/language_status/<lang>.md` is that place: one file per language, built entirely
+from primary sources (never from memory of a past pass, since coverage keeps changing), with
+`docs/language_status/README.md` as the index. See `docs/language_status/python.md` for a
+finished example of what "done" looks like.
+
+**Scope discipline:** this skill only writes documentation. If gathering the material for a doc
+surfaces a real gap worth fixing (a missing signature, a stale test count, a regex bug), that's a
+finding for `harden-language-extraction` / `harden-strict-signatures` / a filed issue
+(`issue-generation` skill) -- don't fix it inline as a side effect of a docs pass, and don't let
+the doc quietly launder an unfixed gap into looking resolved.
+
+## Where the material lives (read these fresh every time, don't trust a prior doc's numbers)
+
+1. **`gitgalaxy/standards/language_standards.py`** -- `LANGUAGE_DEFINITIONS["<lang>"]`. This is
+   the ground truth for: `_meta` (target_version, blueprint_version, status, last_updated),
+   `extensions`/`exact_matches`/`discriminators`/`shebangs` (identification surface),
+   `lexical_family`, and the `rules` dict (every structural-signature key, `None` for the ones
+   the language doesn't have -- read the inline comment next to each `None`, it usually explains
+   why, e.g. `"macros": None,  # Python lacks a C-style preprocessor.`). The ~66 possible rule
+   keys and what each one is *supposed* to mean are documented in
+   `gitgalaxy/standards/how_to_add_a_language.md`'s OUTPUT SCHEMA section -- read that once for
+   vocabulary, then describe what the language's *actual* regex captures (its own comments and
+   alternation list), not the generic schema definition.
+2. **`tests/extraction/languages/test_<lang>.py`** and **`test_<lang>_strict.py`** -- the
+   evidentiary test depth. Get real counts with pytest collection, not `grep -c "^def test_"`
+   (parametrized cases don't show up as separate `def`s):
+   ```bash
+   source venv/bin/activate   # or whatever this checkout's env is called
+   python -m pytest tests/extraction/languages/test_<lang>.py tests/extraction/languages/test_<lang>_strict.py --collect-only -q | tail -1
+   ```
+   If a language hasn't been migrated to the per-language file yet (extraction epic #813 isn't
+   100% closed out across every language), its extraction-gauntlet cases may still be sitting in
+   the four old monolithic files (`test_function_extraction.py`, `test_args_extraction.py`,
+   `test_class_extraction.py`, `test_dependency_extraction.py`) -- grep those for the language's
+   dict key before reporting a suspiciously low or missing count.
+   Also grep both files for `known_limitation` in the test name -- those are documented,
+   deliberately-not-fixed gaps and are exactly the "what it doesn't do" material a status doc
+   needs; don't skip past them as just more passing tests.
+3. **Closed issues/PRs** -- search, don't guess from memory (issue numbers drift and get
+   reused-in-spirit across epics):
+   ```bash
+   gh issue list --repo squid-protocol/gitgalaxy --search 'in:title "Extraction hardening: <lang>"' --state all --json number,title,state
+   gh issue list --repo squid-protocol/gitgalaxy --search 'in:title "Strict parsing tests: `<lang>`"' --state all --json number,title,state
+   gh issue list --repo squid-protocol/gitgalaxy --search 'in:title <lang>' --state closed --json number,title
+   ```
+   The third query is noisy (matches unrelated issues that merely mention the language name) --
+   skim titles and keep only ones that actually changed behavior for this language (a regex bug
+   fix, a new signature key, a ReDoS fix). Cross-check against the epic parents (#518, #813,
+   #1069, #1071) if the language's sub-issue number isn't obvious from title search alone.
+4. **`gitgalaxy-raw-output`** (separate repo, `squid-protocol/gitgalaxy-raw-output`) -- real,
+   unedited scan output on production code, for the "see it in action" close-out section. Find
+   2-4 well-known repos whose primary language is the one you're documenting:
+   ```bash
+   gh api repos/squid-protocol/gitgalaxy-raw-output/contents/v2.4.7 --jq '.[].name' > /tmp/raw_output_repos.txt
+   grep -i -E '<candidate1>|<candidate2>|...' /tmp/raw_output_repos.txt   # match against well-known projects in that language's ecosystem
+   ```
+   (bump `v2.4.7` to whatever the newest version directory is -- `gh api
+   repos/squid-protocol/gitgalaxy-raw-output/contents/` lists them). Each matched repo directory
+   contains `<repo>_galaxy_llm.md`, `_galaxy_audit.json.gz`, `_galaxy_sbom.json.gz`, etc. -- link
+   the `_galaxy_llm.md` (human-readable) as the primary reference. Don't invent candidate names;
+   pick ones you can actually confirm exist in the listing, and prefer a size/era spread (a small
+   library, a large framework, and something adversarial like the language's own reference
+   implementation if it's in the corpus) over four similar mid-size web apps.
+
+## Per-language doc structure (`docs/language_status/<lang>.md`)
+
+Follow `python.md`'s section order:
+1. **At a glance** -- one table: status, target/blueprint version, last_updated, lexical_family,
+   rule keys wired/total, extraction-gauntlet test count, strict-signature test count.
+2. **Identification surface** -- extensions/exact_matches/discriminators/shebangs, terse.
+3. **What GitGalaxy detects** -- every wired (non-`None`) rule key, grouped by the same phase
+   headers `language_standards.py` and `how_to_add_a_language.md` already use (topology/
+   structure, safety/risk, architecture/domain sensors, specialized subsystems, resource
+   management), one line each describing what the language's *actual* pattern matches -- not the
+   generic cross-language definition.
+4. **What GitGalaxy explicitly does not track** -- every `None` key plus its inline reason.
+5. **Known limitations (accepted, not fixed)** -- from the `known_limitation`-named tests found
+   in step 2 above. If there are none for this language, say so plainly rather than omitting the
+   section -- an absent section reads as "not checked," not "nothing found."
+6. **Test depth** -- the counts from step 2, with a one-line note on where the extraction-gauntlet
+   cases live if not yet migrated to the per-language file.
+7. **Relevant closed work** -- the issues/PRs from step 3, grouped (epic-level hardening passes vs.
+   real bugs found along the way vs. cross-language fixes that happened to touch this language).
+8. **Real-world evidence** -- the `gitgalaxy-raw-output` links from step 4, one line each on what
+   makes that particular repo a useful data point (size, age, adversarial shape).
+
+## Process
+
+1. Confirm the language exists in `LANGUAGE_DEFINITIONS` and whether it has any non-`None` rules
+   at all -- ~13 entries (`json`, `xml`, `csv`, `plaintext`, ...) are pure data/text formats with
+   nothing to structurally signature-match. Those don't get a full doc; note them in the index
+   table only (see `docs/language_status/README.md`'s "Data formats" section) rather than writing
+   an empty prose doc for each.
+2. Gather all four source categories above for the target language before writing anything --
+   writing section-by-section from a half-gathered picture is how a doc ends up contradicting
+   itself between "what it detects" and "known limitations."
+3. Write the doc following the structure above. Keep descriptions grounded in what you actually
+   read (the regex's own alternation list, the comment next to it) -- don't paraphrase the
+   generic schema definition from `how_to_add_a_language.md` as if it were language-specific.
+4. Add or update the language's row in `docs/language_status/README.md`'s index table (same
+   columns as the "at a glance" table above, plus a link to the new doc).
+5. This is documentation, not a parsing-logic change -- no `crucible_check.py` or
+   `audit_check.py` needed. Normal commit/PR discipline still applies (CLAUDE.md's "Working
+   autonomously" section pre-authorizes commits/PRs against `main` in this repo).
+
+## Rolling this out across all languages
+
+Writing all ~46 signature-bearing languages' docs in one sitting is exactly the kind of work
+epic #813 and epic #1069 already proved goes better as one-sub-issue-per-language than one giant
+PR -- if the user wants full coverage, propose the same shape (an epic + per-language sub-issues,
+via the `issue-generation` skill) rather than attempting all of them inline. This skill handles
+one language's doc at a time, same granularity as `harden-language-extraction` and
+`harden-strict-signatures`.
+
+## Keeping docs from going stale
+
+A language's status doc is a snapshot, not a live view. Re-run this skill for a language whenever
+`harden-language-extraction` or `harden-strict-signatures` closes a pass on it (new test counts,
+possibly closed "known limitations"), or when a `language_standards.py` PR changes its `rules`
+dict. There's no automated staleness check -- if the user asks for a "status check" on a language
+whose doc looks old (compare its "last_updated"/test counts against a fresh run of step 2 above),
+say so explicitly rather than presenting stale numbers as current.

--- a/.claude/skills/language-status/SKILL.md
+++ b/.claude/skills/language-status/SKILL.md
@@ -15,8 +15,11 @@ finished example of what "done" looks like.
 **Scope discipline:** this skill only writes documentation. If gathering the material for a doc
 surfaces a real gap worth fixing (a missing signature, a stale test count, a regex bug), that's a
 finding for `harden-language-extraction` / `harden-strict-signatures` / a filed issue
-(`issue-generation` skill) -- don't fix it inline as a side effect of a docs pass, and don't let
-the doc quietly launder an unfixed gap into looking resolved.
+(`issue-generation` skill, or `gh issue create` directly if you already have the full technical
+detail from the investigation) -- don't fix it inline as a side effect of a docs pass, and don't
+let the doc quietly launder an unfixed gap into looking resolved. The §9 measured-accuracy pass
+below is *expected* to surface exactly this kind of finding -- filing real issues from it (see
+python.md's #1182/#1183/#1184) is the correct outcome, not scope creep.
 
 ## Where the material lives (read these fresh every time, don't trust a prior doc's numbers)
 
@@ -70,6 +73,35 @@ the doc quietly launder an unfixed gap into looking resolved.
    pick ones you can actually confirm exist in the listing, and prefer a size/era spread (a small
    library, a large framework, and something adversarial like the language's own reference
    implementation if it's in the corpus) over four similar mid-size web apps.
+5. **Real-world measured accuracy** (optional, deeper pass -- see python.md §9 for the finished
+   example) -- everything above describes what's wired and how it's tested *in isolation*. The
+   strongest possible evidence is diffing GitGalaxy's actual extraction against an independent
+   ground-truth parser on real code, because that's the only thing that exercises the
+   segment-routing/scope-boundary machinery the isolated per-rule tests don't touch. For Python
+   this is `ast` (stdlib, zero setup). For other languages, check what's actually available before
+   promising this section -- don't guess a package name, verify it:
+   ```bash
+   pip index versions <candidate-package-name>   # confirms it's real before you rely on it
+   ```
+   `tree-sitter-language-pack` (verified on PyPI, ships pre-compiled grammars for 371 languages,
+   no per-language compiler/JDK/Go-toolchain needed) is the broadest single option. A handful of
+   languages also have lighter pure-Python parsers worth checking first (confirmed to exist at
+   time of writing: `bashlex` for shell, `javalang` for Java, `luaparser` for Lua, `sqlparse` for
+   SQL/SQLite -- weaker, it's more tokenizer than strict grammar, `dockerfile-parse` for
+   Dockerfile, `esprima` for JavaScript ES5, `solidity-parser` for Solidity). Genuinely no
+   practical ground truth exists for `cobol`, `jcl`, `fortran`, `assembly`, `agc_assembly`,
+   `abap`, `matlab`, `livecode`, `apex` -- the same legacy/esoteric languages that are GitGalaxy's
+   own reason to exist; don't force this section for them, note its absence instead.
+   Methodology once a parser is confirmed: diff function/class *names* (watch for a truncation
+   cap skewing an apparent name mismatch into a false "hallucination" reading -- confirm exact
+   vs. truncated before concluding either way), diff per-function arg counts, and cross-check at
+   least one keyword-style rule (e.g. `branch`) two ways -- against the ground-truth parser's own
+   token/node stream, AND by running the compiled rule directly against `prism`-shielded
+   `code_stream` (bypassing any recorder/aggregation layer) -- because keyword rules and
+   boundary-extraction rules can have very different accuracy profiles, and conflating them
+   produces a misleading single number. If a measured gap doesn't have an obvious cause, say so
+   plainly and file it as a confirmed-but-undiagnosed pattern (see #1184) rather than guessing at
+   a root cause you haven't verified.
 
 ## Per-language doc structure (`docs/language_status/<lang>.md`)
 
@@ -92,6 +124,11 @@ Follow `python.md`'s section order:
    real bugs found along the way vs. cross-language fixes that happened to touch this language).
 8. **Real-world evidence** -- the `gitgalaxy-raw-output` links from step 4, one line each on what
    makes that particular repo a useful data point (size, age, adversarial shape).
+9. **Measured accuracy** (only if step 5's ground-truth parser exists and you actually ran the
+   comparison) -- the methodology in one paragraph, a results table (recall/precision per signal,
+   not just one aggregate number), and any confirmed defects with links to the issues filed for
+   them. Omit this section entirely rather than writing a stub if no ground-truth parser was
+   available -- an absent §9 reads as "not attempted yet," not "verified clean."
 
 ## Process
 
@@ -100,9 +137,11 @@ Follow `python.md`'s section order:
    nothing to structurally signature-match. Those don't get a full doc; note them in the index
    table only (see `docs/language_status/README.md`'s "Data formats" section) rather than writing
    an empty prose doc for each.
-2. Gather all four source categories above for the target language before writing anything --
-   writing section-by-section from a half-gathered picture is how a doc ends up contradicting
-   itself between "what it detects" and "known limitations."
+2. Gather source categories 1-4 above for the target language before writing anything -- writing
+   section-by-section from a half-gathered picture is how a doc ends up contradicting itself
+   between "what it detects" and "known limitations." Category 5 (measured accuracy) is a
+   separate, heavier pass -- fine to ship a doc without it (sections 1-8) and add §9 later once a
+   ground-truth parser is confirmed and the comparison is actually run.
 3. Write the doc following the structure above. Keep descriptions grounded in what you actually
    read (the regex's own alternation list, the comment next to it) -- don't paraphrase the
    generic schema definition from `how_to_add_a_language.md` as if it were language-specific.
@@ -111,6 +150,9 @@ Follow `python.md`'s section order:
 5. This is documentation, not a parsing-logic change -- no `crucible_check.py` or
    `audit_check.py` needed. Normal commit/PR discipline still applies (CLAUDE.md's "Working
    autonomously" section pre-authorizes commits/PRs against `main` in this repo).
+6. If §9 surfaced confirmed defects, file them as real issues (`gh issue create` or
+   `issue-generation`) with the concrete reproduction, before or alongside the doc PR -- link the
+   issue numbers back into §9 rather than describing the bugs only in prose.
 
 ## Rolling this out across all languages
 

--- a/docs/language_status/README.md
+++ b/docs/language_status/README.md
@@ -1,0 +1,93 @@
+# Language Status
+
+One doc per language describing what GitGalaxy's structural-signature engine actually covers —
+what it detects, what it explicitly doesn't, how deep the test evidence is, which closed
+issues/PRs shaped it, and real-world scan output proving it runs on production code in that
+language. Built entirely from primary sources (`gitgalaxy/standards/language_standards.py`, the
+`tests/extraction/languages/` suite, closed GitHub issues, and the
+[`gitgalaxy-raw-output`](https://github.com/squid-protocol/gitgalaxy-raw-output) corpus) — see the
+`language-status` skill (`.claude/skills/language-status/SKILL.md`) for the exact process and
+commands used to produce each one.
+
+**These are snapshots, not a live view.** The "at a glance" numbers below were generated
+2026-08-09 against `main`. `language_standards.py`, the test suite, and issue history all keep
+moving — re-run the skill's data-gathering commands rather than trusting a stale table if the
+answer matters.
+
+## Signature-bearing languages (46)
+
+`LANGUAGE_DEFINITIONS` recognizes 59 languages/formats; these 46 have at least one non-`None`
+structural-signature rule (`func_start`/`branch`/`io`/etc.) — the ones a per-language status doc
+in this folder is actually for. "Rules" is wired-keys/total-keys in that language's `rules` dict.
+"Extraction tests" / "Strict tests" are live `pytest --collect-only` counts for
+`tests/extraction/languages/test_<lang>.py` / `test_<lang>_strict.py` — a blank extraction count
+means that language's four extraction-gauntlet cases (`func_start`/`args`/`class_start`/
+`_dependency_capture`) haven't been migrated out of the old monolithic gauntlet files yet (see
+epic #813), not that no cases exist.
+
+| Language | Status | Lexical family | Rules wired/total | Extraction tests | Strict tests | Status doc |
+|---|---|---|---|---|---|---|
+| abap | production | positional_abap | 46/48 | 42 | 87 | not written |
+| ada | production | line_exclusive_dash | 49/53 | 48 | 73 | not written |
+| agc_assembly | production | line_exclusive | 39/48 | 155 | 76 | not written |
+| apex | production | standard_block | 43/48 | 4* | 93 | not written |
+| assembly | production | line_exclusive | 42/52 | 148 | 83 | not written |
+| c | production | standard_block | 50/52 | 37 | 86 | not written |
+| cobol | production | positional_anchored | 48/52 | 62 | 82 | not written |
+| cpp | production | standard_block | 52/52 | 42 | 76 | not written |
+| csharp | production | standard_block | 51/52 | 44 | 106 | not written |
+| css | production | standard_block | 30/48 | 18 | 74 | not written |
+| dart | production | standard_block | 51/52 | 91 | 86 | not written |
+| dockerfile | production | line_exclusive | 43/52 | 34 | 86 | not written |
+| embedded_python | production | line_exclusive | 51/52 | 64 | 107 | not written |
+| fortran | production | positional_anchored | 45/52 | 33 | 101 | not written |
+| go | production | standard_block | 51/52 | 47 | 84 | not written |
+| groovy | production | standard_block | 44/48 | 53 | 91 | not written |
+| haskell | production | recursive_block_haskell | 52/52 | 48 | 97 | not written |
+| html | production | block_exclusive | 39/48 | 91 | 123 | not written |
+| java | production | standard_block | 50/52 | 67 | 91 | not written |
+| javascript | production | standard_block | 61/64 | 53 | 73 | not written |
+| jcl | production | line_exclusive | 11/24 | 41 | 51 | not written |
+| kotlin | production | standard_block | 51/52 | 42 | 90 | not written |
+| livecode | production | multi_style_live | 47/52 | 4* | 108 | not written |
+| lua | production | multi_style_dash | 50/52 | 41 | 78 | not written |
+| m4 | production | line_exclusive | 31/47 | 21 | 73 | not written |
+| makefile | production | line_exclusive | 39/52 | 55 | 73 | not written |
+| markdown | production | line_exclusive | 4/4 | — | 11 | not written |
+| matlab | production | line_exclusive | 48/52 | 45 | 70 | not written |
+| objective-c | production | standard_block | 52/52 | 95 | 83 | not written |
+| perl | production | line_exclusive | 52/52 | 32 | 69 | not written |
+| php | production | standard_block | 51/52 | 4* | 84 | not written |
+| powershell | production | embedded_syntax | 50/52 | 68 | 85 | not written |
+| **[python](python.md)** | production | line_exclusive | 61/64 | 60 | 92 | **written** |
+| ruby | production | line_exclusive | 51/52 | 4* | 66 | not written |
+| rust | production | recursive_block | 52/52 | 51 | 68 | not written |
+| scala | production | recursive_block | 51/52 | 63 | 90 | not written |
+| scheme | production | recursive_block_lisp | 40/47 | 33 | 75 | not written |
+| shell | production | line_exclusive | 44/52 | 72 | 82 | not written |
+| solidity | production | standard_block | 40/53 | 42 | 72 | not written |
+| sqlite | production | multi_style_dash | 47/52 | 63 | 96 | not written |
+| swift | production | recursive_block | 51/52 | 36 | 91 | not written |
+| tcl | production | line_exclusive | 40/48 | 40 | 65 | not written |
+| typescript | production | standard_block | 59/62 | 76 | 101 | not written |
+| yacc | production | standard_block | 31/47 | 21 | 48 | not written |
+| yaml | production | line_exclusive | 31/49 | 45 | 65 | not written |
+| zig | production | line_exclusive | 46/52 | 49 | 61 | not written |
+
+\* `apex`, `livecode`, `php`, `ruby` show only 4 migrated extraction tests each — their real
+extraction-gauntlet coverage is still in the old monolithic `test_function_extraction.py` /
+`test_args_extraction.py` / `test_class_extraction.py` / `test_dependency_extraction.py` files,
+not yet split out to a per-language file. Check those before assuming thin coverage.
+
+## Data formats (13, out of scope for a full doc)
+
+`batch`, `blp`, `csv`, `glsl`, `hlo`, `json`, `mlir`, `nix`, `pbtxt`, `plaintext`, `proto`, `td`,
+`xml` — recognized by the engine for identification/routing purposes but carry no structural
+signatures (`rules` is empty or all keys are pure boilerplate), because there's no executable
+logic to structurally signature-match. These don't get a per-language prose doc.
+
+## Writing the next one
+
+See `.claude/skills/language-status/SKILL.md`. Full rollout across all 46 is tracked as follow-on
+work (one sub-issue per language, same shape as epic #813/#1069) rather than attempted in one
+pass — `python.md` is the worked template.

--- a/docs/language_status/README.md
+++ b/docs/language_status/README.md
@@ -14,6 +14,17 @@ commands used to produce each one.
 moving — re-run the skill's data-gathering commands rather than trusting a stale table if the
 answer matters.
 
+**`python.md` also has a "Measured accuracy" section (§9)** — a real-corpus diff of GitGalaxy's
+own extraction against Python's `ast` module as ground truth, not just the isolated-snippet unit
+tests every other section describes. It found three real, now-filed defects
+([#1182](https://github.com/squid-protocol/gitgalaxy/issues/1182),
+[#1183](https://github.com/squid-protocol/gitgalaxy/issues/1183),
+[#1184](https://github.com/squid-protocol/gitgalaxy/issues/1184)) and measured function recall on
+real code well below what the unit-test suite alone would suggest — read it before assuming
+"tests pass" means "finds everything on real code." Worth repeating for other languages with an
+available AST/grammar (see §9's `tree-sitter-language-pack` note) once a language's base doc
+exists.
+
 ## Signature-bearing languages (46)
 
 `LANGUAGE_DEFINITIONS` recognizes 59 languages/formats; these 46 have at least one non-`None`

--- a/docs/language_status/python.md
+++ b/docs/language_status/python.md
@@ -20,6 +20,8 @@ old relative to `last_updated` below.
 | Extraction-gauntlet tests (`test_python.py`) | 60 |
 | Strict-signature tests (`test_python_strict.py`) | 92 |
 | Total dedicated Python test cases | 152 |
+| Real-world function recall vs. `ast` ground truth | ~63% (clean files) / ~27% (files hitting #1183) — see §9 |
+| Real-world class recall vs. `ast` ground truth | 100% — see §9 |
 
 ## 2. Identification surface
 
@@ -183,3 +185,72 @@ mid-size projects:
 Each `_galaxy_llm.md` is the human-readable architectural brief; `_galaxy_audit.json.gz` and
 `_galaxy_sbom.json.gz` in the same directory carry the raw per-file signature counts and SBOM if
 deeper inspection is needed.
+
+## 9. Measured accuracy (real-world corpus, vs. AST ground truth)
+
+Everything above describes what's *wired* and how it's *tested in isolation* — adversarial
+snippets hand-picked to probe one rule at a time. This section is different: it measures what
+the engine actually gets right on **real, unmodified production code**, using Python's own
+`ast` module as ground truth. This is empirically stronger evidence than the unit-test suite
+alone, because it exercises the segment-routing and scope-boundary machinery that sits between
+"a regex matched" and "a function got correctly recorded" — machinery the isolated per-rule
+tests don't touch.
+
+**Methodology:** regenerated a fresh self-scan of GitGalaxy's own repo
+(`python tests/tools/self_scan.py`, full precision, pinned to the exact commit scanned), giving
+228 Python files / 2,436 real functions / 61 real classes per `ast.parse()`. For each file,
+diffed `ast.walk()`'s `FunctionDef`/`AsyncFunctionDef`/`ClassDef` names (and each function's real
+parameter count) against `function_data`/`class_data` rows for that file. Cross-checked the
+`branch` keyword rule separately using Python's `tokenize` module as an independent ground truth,
+and by running the compiled `branch` regex directly against `prism`-shielded `code_stream`
+(bypassing the DB entirely) to isolate the rule's own accuracy from downstream aggregation.
+
+| Signal | Result | Read as |
+|---|---|---|
+| Class extraction (`class_start`) | **100% recall** (61/61) | Fully reliable on this corpus |
+| Function extraction (`func_start`), no confounding bug | **~63% recall** | See #1184 below |
+| Function extraction, mid-file language drift triggered | **~27% recall** | See #1183 below |
+| Function-name precision (corrected) | **~99.7%** | Engine essentially never invents a function |
+| Args-count exact match (for functions that *were* found) | **~46%** | Likely shares #1184's root cause, not separately isolated |
+| `branch` keyword rule, run directly against shielded code | **~110%** of a `tokenize`-based ground truth (catches everything, plus a few edge-case extras) | Simple keyword-alternation rules are far more reliable than boundary/entity extraction |
+
+**Three real, filed defects explain the gap** — this is not a vague "heuristics are imprecise"
+hand-wave, each has a concrete reproduction:
+
+1. **[#1182](https://github.com/squid-protocol/gitgalaxy/issues/1182) — 40-character name
+   truncation.** `detector.py`'s `_calculate_block_metrics` does `"name": name[:40]`. 984 of this
+   corpus's 2,436 functions (40%) have real names over 40 chars — this codebase's own long
+   descriptive test-naming convention routinely exceeds it. This is a naming-fidelity bug, not a
+   recall bug: it was initially mistaken for hallucinated/phantom functions during this audit
+   (a truncated name and its real counterpart look like two unrelated functions in a naive diff)
+   until corrected for — worth noting so the same false alarm isn't re-raised. Once corrected,
+   precision is genuinely ~99.7%.
+2. **[#1183](https://github.com/squid-protocol/gitgalaxy/issues/1183) — mid-file language
+   "gravity" false-triggers.** `_partition_segments` can be misled by a Python string/regex
+   literal that merely *contains* embedded-language delimiter text as data (confirmed case: a
+   dict literal in `test_prism.py` describing a `"<script>"` trigger pattern, itself test data
+   for the embedded-language detector) into permanently misrouting the rest of the file to a
+   different language's rules. Confirmed by direct inspection of `_partition_segments()`'s
+   output segments, not inferred. Affects 11/228 files in this corpus.
+3. **[#1184](https://github.com/squid-protocol/gitgalaxy/issues/1184) — scope-loss "dead
+   zones."** Contiguous ranges of real, ordinary functions (`__init__`, `main`, `cleanup`) go
+   missing in real production files (`prism.py`, `guidestar_lens.py`, `galaxyscope.py`) with no
+   language-drift trigger present — functions immediately before and after the range are found
+   correctly. This is the dominant driver of the 63% recall ceiling; root cause not yet isolated
+   (filed as a confirmed, reproducible pattern, not a diagnosed fix).
+
+**Rough estimate once fixed:** #1182 doesn't move recall (cosmetic only). #1183 affects too few
+files (~5%) to move the needle much on its own (~59% → ~63% corpus-wide). #1184 is the real
+lever — since class extraction resolves an analogous scope-boundary problem at 100% on this same
+corpus (via separately-fixed logic, #1040), and the isolated unit-test suite already proves
+`func_start`'s regex is correct in principle, function recall landing in the **high-80s to
+high-90s%** range once #1184 is fixed is a defensible estimate — not a promise, and not
+re-measured until the fix actually lands.
+
+**Scaling this beyond Python:** `ast` is stdlib-only, so this exact technique is Python-specific.
+For other languages, `tree-sitter-language-pack` (verified on PyPI, ships pre-compiled grammars
+for 371 languages, no per-language compiler toolchain required) is the most promising path to
+the same style of ground-truth diff across most of GitGalaxy's other 45 signature-bearing
+languages. Genuinely no practical AST ground truth exists for the legacy/esoteric languages
+(COBOL, JCL, Fortran, Assembly, ABAP, MATLAB, LiveCode, Apex) — the same reason GitGalaxy exists
+for them in the first place.

--- a/docs/language_status/python.md
+++ b/docs/language_status/python.md
@@ -1,0 +1,185 @@
+# Python — Structural Signature Coverage
+
+Snapshot generated 2026-08-09 against `main`. Source: `LANGUAGE_DEFINITIONS["python"]` in
+`gitgalaxy/standards/language_standards.py`, `tests/extraction/languages/test_python.py` /
+`test_python_strict.py`, closed GitHub issues, and
+[`gitgalaxy-raw-output`](https://github.com/squid-protocol/gitgalaxy-raw-output). Re-run the
+`language-status` skill's data-gathering commands before trusting these numbers if this doc looks
+old relative to `last_updated` below.
+
+## 1. At a glance
+
+| Field | Value |
+|---|---|
+| `_meta.status` | `production` |
+| `_meta.target_version` | Python 3.14 |
+| `_meta.blueprint_version` | 6.30 |
+| `_meta.last_updated` | 2026-03-11 |
+| `lexical_family` | `line_exclusive` (single `#` line comments only, no native block-comment syntax — the engine's heuristic pass handles triple-quoted-string-as-docstring separately, see §5) |
+| Structural signature keys wired | 61 / 64 (3 explicit `None`, see §4) |
+| Extraction-gauntlet tests (`test_python.py`) | 60 |
+| Strict-signature tests (`test_python_strict.py`) | 92 |
+| Total dedicated Python test cases | 152 |
+
+## 2. Identification surface
+
+- **Extensions:** `.py .py3 .py2 .pyw .pyi .pyx .pxd .pxi .pyz .pyzw .bzl .gyp .gypi .vpython .vpython3 .rpy .smk` — modern/legacy suffixes, typed stubs, Cython, and Bazel/GYP/Snakemake build-tooling dialects that are secretly Python.
+- **Exact filenames:** `setup.py`, `SConstruct`, `SConscript`, `BUCK`, `BUILD`, `wscript`, `Snakefile` — extensionless build/config scripts.
+- **Discriminators:** `.py`, `requirements.txt`, `pyproject.toml`, `Pipfile`, `Pipfile.lock`, `tox.ini`, `poetry.lock`, `setup.cfg` — ecosystem anchors used to disambiguate.
+- **Shebangs:** `python`, `python3`, `python2`, `pypy`, `pypy3`, `jython`.
+- **`embedded_python`** is a separate language entry (own status doc, not this one) for Python embedded inside another host file (e.g. Django templates, Jupyter-adjacent contexts) — don't conflate the two when reading test counts.
+
+## 3. What GitGalaxy detects
+
+Grouped by the phase headers `language_standards.py` and `how_to_add_a_language.md` use.
+Description is what Python's *actual* regex matches, not the generic cross-language definition.
+
+**Topology & structure**
+| Key | What it captures for Python |
+|---|---|
+| `branch` | `if elif else for while with try finally match case and or` |
+| `args` | `def`/`async def`/`lambda` parameter blocks, including PEP 695 (3.12+) bounded generics (`def Foo[T: Sequence[int]](x: T)`) |
+| `structural_boundaries` | `def class return import from as pass continue break await assert del global nonlocal type` |
+| `func_start` | Anchors `def`/`async def`, stepping over up to 5 decorator lines and PEP 695 generic brackets |
+| `class_start` | Anchors `class`, same decorator/generic step-over, captures class name + base-class list |
+
+**Safety & risk**
+| Key | What it captures for Python |
+|---|---|
+| `safety` | `try except except* finally assert isinstance issubclass hasattr getattr dataclass BaseModel Field TypeGuard override` |
+| `safety_bypasses` | Bare `pass`, bare/untyped `except:`/`except Exception`, wildcard `from x import *`, `# type: ignore`, `Any`/`cast`, empty `[]`/`{}` literal init |
+| `high_risk_execution` | `eval exec subprocess.call/Popen/run os.system pickle.loads yaml.unsafe_load shell=True` |
+| `io` | `open requests httpx aiohttp boto3 os. sys. pathlib socket sqlalchemy psycopg2 asyncpg` |
+| `api` | Top-level `def`/`class` without a leading underscore, `__all__ =`, FastAPI/Flask-style `@app.get/post/put/delete` route decorators (implicit-public-by-default, per Rule 1 of the engine's generation rules) |
+| `state_mutation` | `global`/`nonlocal`, `self.`/`cls.` attribute assignment, walrus operator (`:=`), list/dict mutator calls (`.append/.extend/.update/.pop/.remove/.insert/.clear`) |
+| `dead_code` | Commented-out `# def/class/import/if/for/while/try/return` |
+| `doc` | Triple-quoted docstrings, Sphinx-style `:param/:return/:raises/:type`, Google-style `Args:/Returns:/Yields:/Raises:/Attributes:` |
+| `test` | `unittest pytest TestCase fixture patch`, `def test_`, `assert`, `Mock` |
+
+**Architecture & domain sensors**
+| Key | What it captures for Python |
+|---|---|
+| `concurrency` | `async await asyncio threading multiprocessing ThreadPoolExecutor TaskGroup gather create_task` |
+| `ui_framework` | `streamlit django.shortcuts flask.render_template gradio dash fasthtml jinja2 render` |
+| `closures` | `lambda` |
+| `globals` | `os.environ sys.argv sys.path`, `globals()`, `locals()` |
+| `decorators` | Any `@`-prefixed line |
+| `generics` | `typing` generics (`List/Dict/Set/Tuple/Optional/Union/TypeVar/Generic/Any/Callable/Mapping[...]`), lowercase builtin generics (`list/dict/set/tuple/type[...]`), `->` return annotations |
+| `comprehensions` | `[...for...]` / `{...for...}` / `(...for...)` shapes, bounded to 500 chars per side (list/dict/set comprehensions and generator expressions — Python has no `.map(`/`.filter(` builtin, so it doesn't share JS's comprehensions idiom) |
+| `scientific` | `import`/`from` referencing `numpy pandas scipy matplotlib opencv cv2` |
+| `hardware_bridge` | `import`/`from` referencing `serialport usb bluetooth socket.io websocket printer webgl` |
+| `cryptography` | `import`/`from` referencing `crypto bcrypt x509 tls ssl jsonwebtoken argon2` |
+| `reflection_metaprogramming` | Dunder hooks (`__getattr__ __setattr__ __del__ __call__ __new__ ...`), `@staticmethod/@classmethod/@property`, `getattr/setattr/inspect.` |
+| `llm_api` / `llm_orchestrator` / `llm_vector_store` / `ml_traditional` / `dl_frameworks` | Shared cross-language `GLOBAL_` AI/ML SDK sensors (issue #322 moved these off a hand-pasted per-language duplicate) |
+| `import` | `from X import`, `import X`, `__import__(`, `importlib.import_module(` |
+| `_dependency_capture` | Extracts the exact dotted module path from all four import forms above (feeds the dependency DAG) |
+| `_named_token_capture` | Captures the raw name list from `from X import ...` |
+| `ownership` | `__author__ =`, `Author:`, `Created by:` |
+
+**Specialized subsystems**
+| Key | What it captures for Python |
+|---|---|
+| `planned_debt` / `fragile_debt` | Shared `GLOBAL_` TODO/FIXME-family markers |
+| `spec_exposure` | `[SPEC-123]`, `[spec ...]`, `[audit ...]` traceability tags |
+| `ssr_boundaries` | `render_template HttpResponse JSONResponse TemplateResponse WSGIApplication ASGIApplication` |
+| `events` | `Signal receiver post_save pre_save asyncio.Event EventDispatcher emit send blinker` |
+| `dependency_injection` | `Depends Provide Inject Container dependency_injector fastapi.Depends` |
+| `pointers` | `ctypes.POINTER c_void_p byref` |
+
+**Resource management & stability**
+| Key | What it captures for Python |
+|---|---|
+| `telemetry` | `logging/logger/structlog/sentry_sdk/datadog/loguru` `.info/.error/.warn/.warning/.debug/.trace/.log/.exception/.critical` |
+| `debug_prints` | `print(`, `input(` |
+| `explicit_casts` | `int str float list dict set tuple bool bytes cast(` |
+| `panics_and_aborts` | `raise quit exit sys.exit abort` |
+| `thread_sleeps` | `time.sleep asyncio.sleep Thread.join` |
+| `bitwise_ops` | `<< >> ^ ~` |
+| `sync_locks` | `Lock RLock Semaphore BoundedSemaphore Event Condition Barrier` |
+| `immutability_locks` | `Final frozenset mappingproxy immutable` |
+| `cleanup` | `close( __exit__( del( shutdown( cleanup(` |
+| `encapsulation` | Leading-underscore naming convention (Python's only privacy signal — no `private` keyword) |
+| `listeners` | `on_event add_listener subscribe callback handler` |
+| `test_skip` | `pytest.mark.skip unittest.skip mock. MagicMock` |
+
+**Advanced algorithmic / hybrid domain / AppSec sensors**
+| Key | What it captures for Python |
+|---|---|
+| `lazy_evaluation` | `yield`, `yield from`, `Generator/AsyncGenerator/Iterator/AsyncIterator` |
+| `vectorized_math` | `einsum matmul tensordot vdot bmm`, `.dot(`, the `@` matrix-multiplication operator between operands |
+| `serialization_parsing` | `pickle.loads/Unpickler marshal.loads ast.literal_eval` |
+| `regex_execution` | `re.compile/search/match/sub/findall/split` |
+| `time_date_logic` | `datetime.datetime timedelta time.sleep time.time calendar` |
+| `ipc_rpc_bridges` | `multiprocessing subprocess xmlrpc socketserver` |
+| `memory_scraping` | String-built `/proc/` paths, `/proc/<pid>/mem` |
+| `exfiltration_camouflage` | `requests.post/urllib.request/httpx.post` calls whose arguments mention `checkmarx/telemetry/metrics/audit/log` (case-insensitive — flags exfiltration traffic dressed up as observability) |
+
+## 4. What GitGalaxy explicitly does not track
+
+Three keys are hard-set to `None` in Python's `rules` dict (Rule 4 of the engine's generation
+rules: explicitly `None`, never a forced-fit regex, when a dimension doesn't exist natively):
+
+- **`macros`** — Python has no C-style preprocessor.
+- **`memory_alloc`** — memory is GC-managed; there's no manual allocation to track.
+- **`inline_asm`** — no native inline-assembly construct.
+
+## 5. Known limitations (accepted, not fixed)
+
+Two gaps are deliberately documented rather than fixed, via `known_limitation`-named tests in
+`test_python.py`:
+
+1. **No whitespace tolerance between a function name and a PEP 695 generic bracket.**
+   `def Foo[T](...)` matches; `def Foo\n[T](...)` does not. Judged not worth fixing — no real
+   formatter (`black`, `ruff format`) ever produces that exact vertical split; real-world
+   splitting happens between modifiers/parens/inside the bracket's contents, never between an
+   identifier and the generic bracket immediately following it.
+2. **`_dependency_capture` matches inside triple-quoted strings.** Unlike `func_start` (shielded
+   by Mode C's indentation-based slicing before matching), `_dependency_capture` runs against
+   fully unshielded raw file content for every language, unconditionally — an `import os`-shaped
+   line sitting at true line-start inside a Python triple-quoted string still produces a phantom
+   dependency-graph edge. This is recurring bug class 10 in
+   `tests/extraction/how_to_harden_extraction.md`, present for every language, not Python-specific
+   — documented here rather than silently worked around.
+
+## 6. Test depth
+
+- **Extraction gauntlet** (`func_start`/`args`/`class_start`/`_dependency_capture`): 60 tests in
+  `tests/extraction/languages/test_python.py` — valid/invalid/pathological cases per rule, plus
+  the PEP 695 regression tests and the two known-limitation tests above. Fully migrated to the
+  per-language file (epic #813, issue #818) — nothing left in the old monolithic gauntlet files
+  for Python.
+- **Strict signature suite** (all other wired keys): 92 tests in
+  `tests/extraction/languages/test_python_strict.py` — positive match, negative/false-positive
+  match, cross-rule ambiguity, and ReDoS-immunity checks per signature (epic #518, issue #606;
+  deepened further by issue #1072's AI/ML sensor pass, see §7).
+
+## 7. Relevant closed work
+
+**Epic-level hardening passes:**
+- [#606](https://github.com/squid-protocol/gitgalaxy/issues/606) — Strict parsing tests for Python structural signatures (epic #518).
+- [#818](https://github.com/squid-protocol/gitgalaxy/issues/818) — Extraction hardening for Python (epic #813): PEP 695 nested-bracket fixes to `args`/`func_start`/`class_start`, deepened valid/invalid/pathological case counts.
+- [#1072](https://github.com/squid-protocol/gitgalaxy/issues/1072) — Closed a real security-relevant gap: Python's entire AI/ML extension pack (`llm_api`, `llm_orchestrator`, `llm_vector_store`, `dl_frameworks`, `ml_traditional`, `vectorized_math`) plus 13 other keys (`closures`, `comprehensions`, `lazy_evaluation`, `api`, `cryptography`, `encapsulation`, `exfiltration_camouflage`, `hardware_bridge`, `import`, `memory_scraping`, `structural_boundaries`, `test`, `bitwise_ops`) had zero test coverage despite being wired and live.
+
+**Cross-language fixes that touched Python along the way:**
+- [#322](https://github.com/squid-protocol/gitgalaxy/issues/322) — Moved Python's (and JavaScript's) hand-pasted AI/LLM SDK detection onto the shared `GLOBAL_LLM_*`/`GLOBAL_ML_*`/`GLOBAL_DL_*` pattern used by every other language.
+- [#713](https://github.com/squid-protocol/gitgalaxy/issues/713) — Fixed `spec_exposure`'s unbounded `[^\]]*` ReDoS shape, copy-pasted across 28 languages including Python.
+- [#1041](https://github.com/squid-protocol/gitgalaxy/issues/1041) — Nested functions were silently dropped from extraction (affected every language routed through the same extractor path, Python included).
+
+Search performed via `gh issue list --search 'in:title "Extraction hardening: python"'` /
+`'in:title "Strict parsing tests: `python`"'` / `'in:title python'` (2026-08-09) — the last query
+also surfaces engine-wide bugs (`#1052`, `#1055`, metrics/scoring issues) that mention Python
+incidentally without changing its signature rules; excluded here as not language-coverage-specific.
+
+## 8. Real-world evidence (`gitgalaxy-raw-output`)
+
+Four repos from the `v2.4.7` batch, chosen for a size/shape spread rather than four similar
+mid-size projects:
+
+- **[`cpython`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/cpython/cpython_galaxy_llm.md)** — Python's own reference implementation (the CPython interpreter + stdlib). The most adversarial Python codebase available: decades of eras, C-extension boundary code, and every syntax generation the language has shipped. Scanned in 12.78s.
+- **[`django`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/django/django_galaxy_llm.md)** — large, long-lived production framework; heavy use of `api`/`ssr_boundaries`/`events`/`dependency_injection`-relevant patterns (signals, ORM, class-based views). Scanned in 18.06s.
+- **[`requests`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/requests/requests_galaxy_llm.md)** — small, canonical single-purpose library; a useful low-noise baseline. Scanned in 0.45s.
+- **[`black`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/black/black_galaxy_llm.md)** — a formatter that itself requires a full AST internally, scanned by an engine that has none; a pointed contrast case. Scanned in 1.12s.
+
+Each `_galaxy_llm.md` is the human-readable architectural brief; `_galaxy_audit.json.gz` and
+`_galaxy_sbom.json.gz` in the same directory carry the raw per-file signature counts and SBOM if
+deeper inspection is needed.


### PR DESCRIPTION
## Summary
- New `language-status` skill (`.claude/skills/language-status/SKILL.md`): the repeatable process + concrete commands for building a per-language coverage doc from primary sources (`language_standards.py`, the `tests/extraction/languages/` suite, closed issues, and the `gitgalaxy-raw-output` corpus), plus an optional §9/step-5 **measured-accuracy** pass (diff GitGalaxy's own extraction against an independent ground-truth parser on real code) with verified ground-truth-parser options per language tier.
- New `docs/language_status/README.md`: index table across all 46 signature-bearing languages (status, lexical family, rule keys wired/total, extraction/strict test counts), plus the 13 pure-data-format languages noted as out of scope.
- New `docs/language_status/python.md`: a fully worked example — what's detected (all 61 wired signature keys, grouped by phase), what's explicitly not tracked (3 `None` keys + why), 2 documented-but-not-fixed known limitations, test depth (152 dedicated tests), relevant closed issues/PRs (#606, #818, #1072, #322, #713, #1041), 4 cross-referenced real-world scans from `gitgalaxy-raw-output` (cpython, django, requests, black), **and a §9 real-world measured-accuracy section**: diffed GitGalaxy's own self-scan of its own 228-file Python codebase against Python's `ast` module as ground truth. Function recall on real code (~63% clean, ~27% where a mid-file language-drift bug triggers) is well below what the isolated per-rule unit tests alone suggest, while class extraction (100%) and name precision (~99.7%) hold up. Traced and filed three concrete, reproducible defects: #1182 (40-char name truncation), #1183 (mid-file language-switching false-triggered by a string merely *containing* embedded-language delimiter text as data), #1184 (contiguous scope-loss "dead zones" in real production files — root cause not yet isolated).

Full rollout across the remaining 45 languages, and re-running the measured-accuracy pass for languages with an available ground-truth parser (e.g. via `tree-sitter-language-pack`, verified on PyPI to cover 371 languages), is intentionally left as follow-on work (one sub-issue per language, same shape as epic #813/#1069) rather than attempted in this PR.

## Test plan
- [x] Docs-only change; no parsing logic touched, so no `crucible_check.py`/`audit_check.py` needed.
- [x] Table/count data in `README.md` and `python.md` generated from live `LANGUAGE_DEFINITIONS` introspection and `pytest --collect-only` counts against current `main`, not hand-typed.
- [x] Verified all linked GitHub issues (#606, #818, #1072, #322, #713, #1041, #1182, #1183, #1184) and `gitgalaxy-raw-output` repo paths (cpython/django/requests/black under `v2.4.7`) actually resolve.
- [x] The §9 measured-accuracy findings were verified empirically (fresh self-scan against current HEAD, `ast`-module diff script, direct instrumented calls to `_partition_segments()`/`splice()`/the `branch` regex) before being written up or filed as issues — not inferred from a single aggregate number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)