### PR TITLE
fix(packaging): remove dead zero-trust-sbom console-script entry point (#1179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ An analytical suite for sanitizing mainframe monoliths. It safely neutralizes le
 ### [Software Supply Chain Security & Pre-Commit Firewalls](https://github.com/squid-protocol/gitgalaxy/tree/main/gitgalaxy/tools/supply_chain_security/)
 Pre-commit firewalls that scan physical file internals rather than trusting manifest files — built to block steganography, byte-level XOR decryption loops, homoglyph typosquatting, and exposed cryptographic vaults before they enter your CI/CD pipeline. **[Deploy directly via our GitHub Action](https://github.com/squid-protocol/gitgalaxy/blob/main/github-action-readme.md).**
 
-### [SBOM Generation & Dependency Auditing](https://github.com/squid-protocol/gitgalaxy/tree/main/gitgalaxy/tools/compliance/)
+### [SBOM Generation & Dependency Auditing](https://github.com/squid-protocol/gitgalaxy/blob/main/gitgalaxy/recorders/sbom_recorder.py)
 A Software Bill of Materials (SBOM) generator that doesn't blindly trust `package.json` or `requirements.txt` — it locates the physical dependencies on disk, checks their entropy and linguistic identity against what a legitimate version should look like, and generates strict CycloneDX 1.4 JSON reports.
 * **Benchmark:** Mapped and verified the physical internals of 170 unique Go modules inside the local Kubernetes repository. A single-repo result, not a claim of coverage across the Go ecosystem.
 

--- a/docs/wiki/cookbook/generate-zero-trust-sbom.md
+++ b/docs/wiki/cookbook/generate-zero-trust-sbom.md
@@ -11,10 +11,11 @@ GitGalaxy shifts this paradigm using the **Universal Zero-Trust SBOM Generator**
 The GitGalaxy generator supports NPM, Packagist (PHP), PyPI, and Cargo ecosystems. It performs a multi-stage physical audit to map the delta between what is declared and what actually exists in memory.
 
 ### 1. Execute the Generation
-Point the generator at the root directory of your project.
+Point the generator at the root directory of your project. SBOM generation is a native
+exclusive mode of the main orchestrator — there is no separate SBOM binary to install.
 
 ```bash
-python gitgalaxy/tools/sbom_generator.py /path/to/target_project
+galaxyscope /path/to/target_project --sbom-only
 ```
 
 ### 2. The Physical Integrity Audit
@@ -34,7 +35,7 @@ The engine exports a strictly formatted **CycloneDX 1.4 JSON** file, ensuring se
 ==========================================================
  Dependencies Claimed : 145
  Standard Export      : CycloneDX 1.4 JSON
- Output Location      : /path/to/target_project_bom.json
+ Output Location      : /path/to/target_project_galaxy_sbom.json
 ----------------------------------------------------------
  Verified Safe        : 142
  Missing on Disk      : 2

--- a/gitgalaxy/tools/README.md
+++ b/gitgalaxy/tools/README.md
@@ -46,7 +46,7 @@ You can trigger any of the standalone CLI tools securely in your CI/CD pipeline 
       - name: Run GitGalaxy Tool
         uses: squid-protocol/gitgalaxy@main
         with:
-          tool: 'supply-chain-firewall' # Options: vault-sentinel, zero-trust-sbom, api-network-map, etc.
+          tool: 'supply-chain-firewall' # Options: vault-sentinel, xray-inspector, api-network-map, etc.
           target: '.'
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,13 @@ blast = "gitgalaxy.galaxyscope:main"
 vault-sentinel = "gitgalaxy.tools.supply_chain_security.vault_sentinel:main"
 supply-chain-firewall = "gitgalaxy.tools.supply_chain_security.supply_chain_firewall:main"
 xray-inspector = "gitgalaxy.tools.supply_chain_security.binary_anomaly_detector:main"
-zero-trust-sbom = "gitgalaxy.tools.compliance.sbom_generator:main"
+# NOTE: there is deliberately no `zero-trust-sbom` script here. SBOM generation
+# stopped being a standalone tool in 638c8a2 (#83), which moved
+# gitgalaxy/tools/compliance/sbom_generator.py to
+# gitgalaxy/recorders/sbom_recorder.py and turned it into a passive Phase 12
+# exit stage, so the manifest is tied to the same finalized in-RAM state as the
+# forensic audits. Use `galaxyscope <target> --sbom-only`. The entry point
+# outlived the module it pointed at and shipped broken until #1179.
 pii-leak-hunter = "gitgalaxy.tools.terabyte_log_scanning.pii_leak_hunter:main"
 terabyte-log-scanner = "gitgalaxy.tools.terabyte_log_scanning.terabyte_log_scanner:main"
 api-network-map = "gitgalaxy.tools.network_auditing.full_api_network_map:main"


### PR DESCRIPTION
…t (#1179)

`zero-trust-sbom` pointed at `gitgalaxy.tools.compliance.sbom_generator:main`, a module that has not existed since 638c8a2 (#83). Anyone installing from PyPI and running the command got a failure to resolve the entry point.

That commit deliberately migrated the CycloneDX generator out of the standalone tools tree and into `gitgalaxy/recorders/sbom_recorder.py`, as a passive Phase 12 exit stage, so the manifest is tied to the same finalized in-RAM state as the forensic audits. It updated action.yml, smoke-test.yml and gitgalaxy/tools/README.md accordingly, but missed [project.scripts].

So this removes the entry rather than recreating the module: `galaxyscope <target> --sbom-only` is the supported path and re-adding a standalone binary would reverse the #83 decision. A comment records why, so the next reader doesn't "restore" it. Also fixes the three stale references left by the same incomplete migration:

- README.md linked to tree/main/gitgalaxy/tools/compliance/ (a 404) -> now points at recorders/sbom_recorder.py
- gitgalaxy/tools/README.md still listed zero-trust-sbom as a GitHub Action `tool:` option, though action.yml's own option list dropped it in #83
- the SBOM cookbook documented `python gitgalaxy/tools/sbom_generator.py`, a third dead path, and an output filename the engine never emits

Verified in a clean venv: all 19 remaining entry points import and expose a callable main() (the full-table sweep the issue asked for -- this was the only broken one), and `galaxyscope . --sbom-only` emits valid CycloneDX 1.4 with correct purls and populated gitgalaxy:trust_status properties. No Python source changed, so the parsing-logic Differential Scan does not apply.

Closes #1179
### Description of Structural Changes

None. This is a packaging and documentation fix — no Python source is touched, so no
structural signatures, regexes, or pipeline stages change. The diff is `pyproject.toml`
(one entry removed, one explanatory comment added) plus three markdown files.

### Visual Observatory Testing
- [ ] ~~I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.~~
- [ ] ~~Flexbox constraints, HUD elements, and 3D rendering remain intact.~~

**N/A** — this PR cannot affect visualization output. No engine code changes, so the
`*_galaxy_gpu.json` payload is byte-identical to `main`. Marking these unchecked rather
than ticking them, since I did not run the Observatory and nothing here would have
changed what it renders.

### The Differential Scan Acknowledgement
- [x] I understand that my PR will be subjected to a Full Differential Scan.
- [ ] ~~I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.~~ **N/A** — this is not a parsing-accuracy fix against a specific repo; there is no target repository to add to the baseline.
- [x] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
  - **Utility:** a documented-but-broken command is gone, and the three dead paths users were being pointed at now point at the real one.
  - **No regression risk:** the golden-master snapshots are unreachable from this diff, and the ruff/mypy baselines are unaffected (no `.py` files changed).