### PR TITLE
fix(core): stop truncating extracted function/method names to 40 chars

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -2473,7 +2473,7 @@ class StructuralExtractor:
         calls_out = list(set([c for c in raw_calls if c not in ignore_keywords and c != name]))[:20]
 
         sat: FunctionNode = {
-            "name": name[:40],
+            "name": name,
             "calls_out_to": calls_out,
             "texture": texture_str,
             "type_id": texture_str,

--- a/tests/golden_master_audit.json
+++ b/tests/golden_master_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-08-09T15:55:03.037278+00:00",
-            "Total Scan Duration": "28.65 seconds"
+            "Analysis ISO Timestamp": "2026-08-09T22:47:44.596493+00:00",
+            "Total Scan Duration": "30.18 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "HEAD",
@@ -198,8 +198,8 @@
         "health": {
             "avg_cognitive_load": 23.827,
             "avg_safety_score": 38.366,
-            "avg_tech_debt": 29.619,
-            "avg_documentation": 19.867
+            "avg_tech_debt": 29.576,
+            "avg_documentation": 19.865
         },
         "composition": {
             "xml": {
@@ -295,7 +295,7 @@
             "cpp": {
                 "files": 33,
                 "loc": 19443,
-                "impact": 20365.859999999993
+                "impact": 20366.859999999993
             },
             "csharp": {
                 "files": 8,
@@ -355,12 +355,12 @@
             "javascript": {
                 "files": 19,
                 "loc": 14859,
-                "impact": 16164.980000000003
+                "impact": 16162.980000000003
             },
             "typescript": {
                 "files": 24,
                 "loc": 21446,
-                "impact": 3633.2400000000002
+                "impact": 3633.14
             },
             "kotlin": {
                 "files": 5,
@@ -465,7 +465,7 @@
             "zig": {
                 "files": 32,
                 "loc": 68347,
-                "impact": 40403.04000000001
+                "impact": 40402.04000000001
             }
         },
         "ecosystem_fingerprint": {
@@ -731,13 +731,13 @@
             },
             "cpp/NVDA": {
                 "file_count": 12,
-                "total_mass": 4300.9,
+                "total_mass": 4301.9,
                 "avg_exposures": {
                     "cognitive_load": 28.17,
                     "safety_score": 43.38,
                     "tech_debt": 34.27,
                     "verification": 46.88,
-                    "api_exposure": 2.76,
+                    "api_exposure": 2.78,
                     "concurrency": 3.79,
                     "state_flux": 55.66,
                     "dead_code": 0.81,
@@ -1077,7 +1077,7 @@
                 "avg_exposures": {
                     "cognitive_load": 79.61,
                     "safety_score": 84.35,
-                    "tech_debt": 45.88,
+                    "tech_debt": 45.72,
                     "verification": 31.55,
                     "api_exposure": 12.46,
                     "concurrency": 0.0,
@@ -1229,7 +1229,7 @@
                 "avg_exposures": {
                     "cognitive_load": 13.23,
                     "safety_score": 43.05,
-                    "tech_debt": 32.53,
+                    "tech_debt": 32.47,
                     "verification": 32.18,
                     "api_exposure": 3.04,
                     "concurrency": 0.0,
@@ -1324,7 +1324,7 @@
                 "avg_exposures": {
                     "cognitive_load": 23.87,
                     "safety_score": 40.85,
-                    "tech_debt": 81.9,
+                    "tech_debt": 81.5,
                     "verification": 57.5,
                     "api_exposure": 3.59,
                     "concurrency": 19.81,
@@ -1495,7 +1495,7 @@
                 "avg_exposures": {
                     "cognitive_load": 11.69,
                     "safety_score": 56.98,
-                    "tech_debt": 75.9,
+                    "tech_debt": 75.8,
                     "verification": 50.54,
                     "api_exposure": 4.12,
                     "concurrency": 15.12,
@@ -1795,20 +1795,20 @@
             },
             "typescript/fp-ts": {
                 "file_count": 5,
-                "total_mass": 99.25,
+                "total_mass": 99.15,
                 "avg_exposures": {
                     "cognitive_load": 3.0,
                     "safety_score": 44.81,
                     "tech_debt": 52.18,
                     "verification": 48.46,
-                    "api_exposure": 10.09,
+                    "api_exposure": 10.08,
                     "concurrency": 4.28,
                     "state_flux": 0.0,
                     "dead_code": 0.0,
                     "spec_match": 80.0,
                     "stability": 40.0,
                     "churn": 0.0,
-                    "documentation": 45.35,
+                    "documentation": 45.07,
                     "secrets_risk": 0.0
                 }
             },
@@ -2008,7 +2008,7 @@
                 "avg_exposures": {
                     "cognitive_load": 31.63,
                     "safety_score": 54.87,
-                    "tech_debt": 30.11,
+                    "tech_debt": 30.05,
                     "verification": 37.47,
                     "api_exposure": 1.5,
                     "concurrency": 1.45,
@@ -2027,7 +2027,7 @@
                 "avg_exposures": {
                     "cognitive_load": 19.38,
                     "safety_score": 57.08,
-                    "tech_debt": 51.56,
+                    "tech_debt": 51.09,
                     "verification": 80.0,
                     "api_exposure": 3.09,
                     "concurrency": 31.63,
@@ -2160,7 +2160,7 @@
                 "avg_exposures": {
                     "cognitive_load": 30.26,
                     "safety_score": 57.88,
-                    "tech_debt": 29.46,
+                    "tech_debt": 28.13,
                     "verification": 44.75,
                     "api_exposure": 3.64,
                     "concurrency": 0.0,
@@ -2445,7 +2445,7 @@
                 "avg_exposures": {
                     "cognitive_load": 23.86,
                     "safety_score": 69.78,
-                    "tech_debt": 69.71,
+                    "tech_debt": 67.06,
                     "verification": 60.64,
                     "api_exposure": 2.57,
                     "concurrency": 0.0,
@@ -2517,13 +2517,13 @@
             },
             "javascript/react": {
                 "file_count": 5,
-                "total_mass": 8986.55,
+                "total_mass": 8984.55,
                 "avg_exposures": {
                     "cognitive_load": 25.71,
                     "safety_score": 29.68,
                     "tech_debt": 80.66,
                     "verification": 33.6,
-                    "api_exposure": 7.84,
+                    "api_exposure": 7.82,
                     "concurrency": 8.22,
                     "state_flux": 21.14,
                     "dead_code": 1.98,
@@ -2882,7 +2882,7 @@
                 "avg_exposures": {
                     "cognitive_load": 10.77,
                     "safety_score": 46.28,
-                    "tech_debt": 69.28,
+                    "tech_debt": 69.02,
                     "verification": 57.83,
                     "api_exposure": 3.76,
                     "concurrency": 0.0,
@@ -3186,7 +3186,7 @@
                 "avg_exposures": {
                     "cognitive_load": 30.98,
                     "safety_score": 55.18,
-                    "tech_debt": 62.58,
+                    "tech_debt": 61.25,
                     "verification": 80.0,
                     "api_exposure": 5.57,
                     "concurrency": 4.39,
@@ -3201,20 +3201,20 @@
             },
             "zig/zig": {
                 "file_count": 5,
-                "total_mass": 16999.5,
+                "total_mass": 16998.5,
                 "avg_exposures": {
                     "cognitive_load": 25.27,
                     "safety_score": 50.17,
                     "tech_debt": 39.54,
                     "verification": 80.0,
-                    "api_exposure": 3.49,
+                    "api_exposure": 3.48,
                     "concurrency": 10.28,
                     "state_flux": 14.11,
                     "dead_code": 5.11,
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 39.49,
+                    "documentation": 39.45,
                     "secrets_risk": 0.0
                 }
             },
@@ -3980,9 +3980,9 @@
                 },
                 {
                     "path": "zig/zig/Zcu.zig",
-                    "score": 495.563,
+                    "score": 492.613,
                     "pr": 14.354,
-                    "doc": 34.5244
+                    "doc": 34.3189
                 },
                 {
                     "path": "python/fastapi/fastapi/responses.py",
@@ -6697,7 +6697,7 @@
                             "End Line": 885
                         },
                         {
-                            "Function Name": "scheme_push_marks_from_lightweight_conti",
+                            "Function Name": "scheme_push_marks_from_lightweight_continuation",
                             "Structural Impact": 4.4,
                             "Lines of Code (LOC)": 28,
                             "Control Flow Branches": 2,
@@ -6717,7 +6717,7 @@
                             "End Line": 898
                         },
                         {
-                            "Function Name": "scheme_can_apply_lightweight_continuatio",
+                            "Function Name": "scheme_can_apply_lightweight_continuation",
                             "Structural Impact": 3.5,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
@@ -18578,7 +18578,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "23.87%",
                 "Error & Exception Exposure": "40.85%",
-                "Tech Debt Exposure": "81.9%",
+                "Tech Debt Exposure": "81.5%",
                 "Testing Exposure": "57.5%",
                 "API Exposure": "3.59%",
                 "Concurrency Exposure": "19.81%",
@@ -18940,7 +18940,7 @@
                             "End Line": 1706
                         },
                         {
-                            "Function Name": "AddDebugSourceDocumentsForChecksumDirect",
+                            "Function Name": "AddDebugSourceDocumentsForChecksumDirectives",
                             "Structural Impact": 20.9,
                             "Lines of Code (LOC)": 57,
                             "Control Flow Branches": 8,
@@ -19650,7 +19650,7 @@
                             "End Line": 3154
                         },
                         {
-                            "Function Name": "noMainFoundDiagnostics.DiagnosticBag.AsE",
+                            "Function Name": "noMainFoundDiagnostics.DiagnosticBag.AsEnumerable",
                             "Structural Impact": 3.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
@@ -19680,7 +19680,7 @@
                             "End Line": 581
                         },
                         {
-                            "Function Name": "CreatePreviousToCurrentSourceAssemblyMat",
+                            "Function Name": "CreatePreviousToCurrentSourceAssemblyMatcher",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -19900,7 +19900,7 @@
                             "End Line": 3065
                         },
                         {
-                            "Function Name": "IsUnreferencedAssemblyIdentityDiagnostic",
+                            "Function Name": "IsUnreferencedAssemblyIdentityDiagnosticCode",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -21319,26 +21319,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 13.345,
+                        "Repository Drift (Z-Score)": 13.343,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.839,
-                            "file_cluster_1": 14.232,
-                            "file_cluster_2": 14.207,
-                            "file_cluster_3": 14.367,
-                            "file_cluster_4": 14.134,
-                            "file_cluster_5": 14.599,
-                            "file_cluster_6": 13.898,
-                            "file_cluster_7": 13.902,
-                            "file_cluster_8": 13.771,
-                            "file_cluster_9": 14.026,
-                            "file_cluster_10": 14.682,
-                            "file_cluster_11": 13.345,
-                            "file_cluster_12": 14.29,
-                            "file_cluster_13": 13.829,
-                            "file_cluster_14": 16.381,
-                            "file_cluster_15": 13.915,
-                            "file_cluster_16": 13.893,
-                            "file_cluster_17": 13.882
+                            "file_cluster_0": 13.837,
+                            "file_cluster_1": 14.23,
+                            "file_cluster_2": 14.205,
+                            "file_cluster_3": 14.365,
+                            "file_cluster_4": 14.131,
+                            "file_cluster_5": 14.597,
+                            "file_cluster_6": 13.895,
+                            "file_cluster_7": 13.9,
+                            "file_cluster_8": 13.769,
+                            "file_cluster_9": 14.024,
+                            "file_cluster_10": 14.68,
+                            "file_cluster_11": 13.343,
+                            "file_cluster_12": 14.288,
+                            "file_cluster_13": 13.826,
+                            "file_cluster_14": 16.379,
+                            "file_cluster_15": 13.913,
+                            "file_cluster_16": 13.891,
+                            "file_cluster_17": 13.879
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -21357,7 +21357,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "63.11%",
                         "Error & Exception Exposure": "78.45%",
-                        "Tech Debt Exposure": "82.19%",
+                        "Tech Debt Exposure": "79.42%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.86%",
                         "Concurrency Exposure": "0.0%",
@@ -21731,7 +21731,7 @@
                             "End Line": 5016
                         },
                         {
-                            "Function Name": "IsPossibleDeclarationStatementFollowingN",
+                            "Function Name": "IsPossibleDeclarationStatementFollowingNullableType",
                             "Structural Impact": 45.3,
                             "Lines of Code (LOC)": 102,
                             "Control Flow Branches": 17,
@@ -21901,7 +21901,7 @@
                             "End Line": 8362
                         },
                         {
-                            "Function Name": "IsMemberDeclarationOnlyValidWithinTypeDe",
+                            "Function Name": "IsMemberDeclarationOnlyValidWithinTypeDeclaration",
                             "Structural Impact": 27.6,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 10,
@@ -22111,7 +22111,7 @@
                             "End Line": 2795
                         },
                         {
-                            "Function Name": "IsPossibleTopLevelUsingLocalDeclarationS",
+                            "Function Name": "IsPossibleTopLevelUsingLocalDeclarationStatement",
                             "Structural Impact": 20.2,
                             "Lines of Code (LOC)": 44,
                             "Control Flow Branches": 8,
@@ -22241,7 +22241,7 @@
                             "End Line": 2674
                         },
                         {
-                            "Function Name": "GetExpressionOperatorTokenKindAndExpress",
+                            "Function Name": "GetExpressionOperatorTokenKindAndExpressionKind",
                             "Structural Impact": 16.9,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 13,
@@ -22361,7 +22361,7 @@
                             "End Line": 2456
                         },
                         {
-                            "Function Name": "PointerTypeModsFollowedByRankAndDimensio",
+                            "Function Name": "PointerTypeModsFollowedByRankAndDimensionSpecifier",
                             "Structural Impact": 14.8,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 6,
@@ -22491,7 +22491,7 @@
                             "End Line": 1821
                         },
                         {
-                            "Function Name": "ScanImplicitlyTypedLambdaOrSimpleExplici",
+                            "Function Name": "ScanImplicitlyTypedLambdaOrSimpleExplicitlyTypedParenthesizedLambda",
                             "Structural Impact": 12.6,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 4,
@@ -22671,7 +22671,7 @@
                             "End Line": 5182
                         },
                         {
-                            "Function Name": "ParseErrantExpressionWhenNoCloseParenTok",
+                            "Function Name": "ParseErrantExpressionWhenNoCloseParenToken",
                             "Structural Impact": 10.4,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 3,
@@ -22961,7 +22961,7 @@
                             "End Line": 7494
                         },
                         {
-                            "Function Name": "IsCurrentTokenPartialKeywordOfPartialMem",
+                            "Function Name": "IsCurrentTokenPartialKeywordOfPartialMemberOrType",
                             "Structural Impact": 6.6,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
@@ -23101,7 +23101,7 @@
                             "End Line": 5377
                         },
                         {
-                            "Function Name": "IsPossibleFirstTypedIdentifierInLocalDec",
+                            "Function Name": "IsPossibleFirstTypedIdentifierInLocalDeclarationStatement",
                             "Structural Impact": 5.6,
                             "Lines of Code (LOC)": 22,
                             "Control Flow Branches": 1,
@@ -24251,7 +24251,7 @@
                             "End Line": 1133
                         },
                         {
-                            "Function Name": "this.IsCurrentTokenWhereOfConstraintClau",
+                            "Function Name": "this.IsCurrentTokenWhereOfConstraintClause",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -24691,7 +24691,7 @@
                             "End Line": 231
                         },
                         {
-                            "Function Name": "this.IsCurrentTokenPartialKeywordOfParti",
+                            "Function Name": "this.IsCurrentTokenPartialKeywordOfPartialMemberOrType",
                             "Structural Impact": 1.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -24761,7 +24761,7 @@
                             "End Line": 941
                         },
                         {
-                            "Function Name": "tryParseLocalDeclarationStatementFromSta",
+                            "Function Name": "tryParseLocalDeclarationStatementFromStartPoint",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -24771,7 +24771,7 @@
                             "End Line": 1304
                         },
                         {
-                            "Function Name": "tryParseLocalDeclarationStatementFromSta",
+                            "Function Name": "tryParseLocalDeclarationStatementFromStartPoint",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -24801,7 +24801,7 @@
                             "End Line": 1671
                         },
                         {
-                            "Function Name": "SyntaxFacts.IsOverloadableCompoundAssign",
+                            "Function Name": "SyntaxFacts.IsOverloadableCompoundAssignmentOperator",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -24936,7 +24936,7 @@
                         "Design Short Vars": 63,
                         "Design Long Vars": 32,
                         "Duplicate Logic": 49,
-                        "Orphaned Logic": 55,
+                        "Orphaned Logic": 47,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -25101,7 +25101,7 @@
                             "End Line": 794
                         },
                         {
-                            "Function Name": "CompileSynthesizedExplicitImplementation",
+                            "Function Name": "CompileSynthesizedExplicitImplementations",
                             "Structural Impact": 10.1,
                             "Lines of Code (LOC)": 28,
                             "Control Flow Branches": 4,
@@ -25181,7 +25181,7 @@
                             "End Line": 934
                         },
                         {
-                            "Function Name": "sourceTypeSymbol.GetSynthesizedExplicitI",
+                            "Function Name": "sourceTypeSymbol.GetSynthesizedExplicitImplementations",
                             "Structural Impact": 4.8,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 3,
@@ -25575,26 +25575,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.074,
+                        "Repository Drift (Z-Score)": 12.066,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.711,
-                            "file_cluster_1": 12.428,
-                            "file_cluster_2": 12.694,
-                            "file_cluster_3": 13.537,
-                            "file_cluster_4": 12.839,
-                            "file_cluster_5": 12.867,
-                            "file_cluster_6": 12.585,
-                            "file_cluster_7": 12.173,
-                            "file_cluster_8": 12.194,
-                            "file_cluster_9": 12.963,
-                            "file_cluster_10": 13.436,
-                            "file_cluster_11": 12.413,
-                            "file_cluster_12": 12.927,
-                            "file_cluster_13": 12.074,
-                            "file_cluster_14": 16.052,
-                            "file_cluster_15": 12.269,
-                            "file_cluster_16": 12.254,
-                            "file_cluster_17": 12.602
+                            "file_cluster_0": 12.705,
+                            "file_cluster_1": 12.421,
+                            "file_cluster_2": 12.688,
+                            "file_cluster_3": 13.53,
+                            "file_cluster_4": 12.832,
+                            "file_cluster_5": 12.86,
+                            "file_cluster_6": 12.578,
+                            "file_cluster_7": 12.166,
+                            "file_cluster_8": 12.186,
+                            "file_cluster_9": 12.956,
+                            "file_cluster_10": 13.429,
+                            "file_cluster_11": 12.406,
+                            "file_cluster_12": 12.92,
+                            "file_cluster_13": 12.066,
+                            "file_cluster_14": 16.047,
+                            "file_cluster_15": 12.262,
+                            "file_cluster_16": 12.247,
+                            "file_cluster_17": 12.595
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -25637,7 +25637,7 @@
                             "End Line": 516
                         },
                         {
-                            "Function Name": "projectChanges.GetChangedAnalyzerConfigD",
+                            "Function Name": "projectChanges.GetChangedAnalyzerConfigDocuments",
                             "Structural Impact": 59.8,
                             "Lines of Code (LOC)": 365,
                             "Control Flow Branches": 23,
@@ -25647,7 +25647,7 @@
                             "End Line": 922
                         },
                         {
-                            "Function Name": "UpdateAddedDocumentToExistingContentsInS",
+                            "Function Name": "UpdateAddedDocumentToExistingContentsInSolution",
                             "Structural Impact": 23.9,
                             "Lines of Code (LOC)": 132,
                             "Control Flow Branches": 9,
@@ -25737,7 +25737,7 @@
                             "End Line": 221
                         },
                         {
-                            "Function Name": "CheckProjectDoesNotHaveTransitiveProject",
+                            "Function Name": "CheckProjectDoesNotHaveTransitiveProjectReference",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -25827,7 +25827,7 @@
                             "End Line": 871
                         },
                         {
-                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInSoluti",
+                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInSolution",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 1,
@@ -25887,7 +25887,7 @@
                             "End Line": 783
                         },
                         {
-                            "Function Name": "CheckSolutionDoesNotHaveAnalyzerReferenc",
+                            "Function Name": "CheckSolutionDoesNotHaveAnalyzerReference",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -26087,7 +26087,7 @@
                             "End Line": 800
                         },
                         {
-                            "Function Name": "CheckAdditionalDocumentIsInCurrentSoluti",
+                            "Function Name": "CheckAdditionalDocumentIsInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26097,7 +26097,7 @@
                             "End Line": 816
                         },
                         {
-                            "Function Name": "CheckAnalyzerConfigDocumentIsInCurrentSo",
+                            "Function Name": "CheckAnalyzerConfigDocumentIsInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26107,7 +26107,7 @@
                             "End Line": 832
                         },
                         {
-                            "Function Name": "CheckAdditionalDocumentIsNotInCurrentSol",
+                            "Function Name": "CheckAdditionalDocumentIsNotInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26117,7 +26117,7 @@
                             "End Line": 861
                         },
                         {
-                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInCurren",
+                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26352,7 +26352,7 @@
                         "Design Short Vars": 6,
                         "Design Long Vars": 1,
                         "Duplicate Logic": 2,
-                        "Orphaned Logic": 43,
+                        "Orphaned Logic": 41,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -28821,7 +28821,7 @@
             }
         },
         "zig/zig": {
-            "Directory Group Magnitude": 16999.5,
+            "Directory Group Magnitude": 16998.5,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_11": "100.0%"
@@ -28831,14 +28831,14 @@
                 "Error & Exception Exposure": "50.17%",
                 "Tech Debt Exposure": "39.54%",
                 "Testing Exposure": "80.0%",
-                "API Exposure": "3.49%",
+                "API Exposure": "3.48%",
                 "Concurrency Exposure": "10.28%",
                 "State Flux Exposure": "14.11%",
                 "Commented Logic Exposure": "5.11%",
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "39.49%",
+                "Documentation Exposure": "39.45%",
                 "Hardcoded Payload Artifacts": "0.0%"
             },
             "Files": {
@@ -35644,7 +35644,7 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 13.647,
+                        "Repository Drift (Z-Score)": 13.646,
                         "Repository Fingerprint": {
                             "file_cluster_0": 14.271,
                             "file_cluster_1": 14.708,
@@ -35657,9 +35657,9 @@
                             "file_cluster_8": 14.341,
                             "file_cluster_9": 14.471,
                             "file_cluster_10": 14.89,
-                            "file_cluster_11": 13.647,
+                            "file_cluster_11": 13.646,
                             "file_cluster_12": 14.647,
-                            "file_cluster_13": 14.272,
+                            "file_cluster_13": 14.271,
                             "file_cluster_14": 15.946,
                             "file_cluster_15": 14.478,
                             "file_cluster_16": 14.42,
@@ -35671,7 +35671,7 @@
                         "Total LOC": 4802,
                         "Coding LOC": 4374,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 2619.28,
+                        "Structural Magnitude": 2618.28,
                         "Control Flow Ratio": "72.0%",
                         "Popularity Rank": 4,
                         "Raw Churn Frequency": 0.0,
@@ -35684,14 +35684,14 @@
                         "Error & Exception Exposure": "62.98%",
                         "Tech Debt Exposure": "48.16%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "3.48%",
+                        "API Exposure": "3.46%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "12.27%",
                         "Commented Logic Exposure": "5.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "34.52%",
+                        "Documentation Exposure": "34.32%",
                         "Hardcoded Payload Artifacts": "0.0%"
                     },
                     "5. Function Analysis": [
@@ -35806,7 +35806,7 @@
                             "End Line": 3059
                         },
                         {
-                            "Function Name": "markTransitiveDependersPotentiallyOutdat",
+                            "Function Name": "markTransitiveDependersPotentiallyOutdated",
                             "Structural Impact": 20.8,
                             "Lines of Code (LOC)": 35,
                             "Control Flow Branches": 10,
@@ -36437,7 +36437,7 @@
                         "Type/Safety Bypasses": 156,
                         "High-Risk Execution Commands": 76,
                         "I/O and Network Boundaries": 12,
-                        "Exposed API / Public Exports": 220,
+                        "Exposed API / Public Exports": 219,
                         "State Mutations / Variable Reassignments": 327,
                         "Commented-out Code (Dead Logic)": 3,
                         "Structured Documentation Blocks": 598,
@@ -36981,7 +36981,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "79.61%",
                 "Error & Exception Exposure": "84.35%",
-                "Tech Debt Exposure": "45.88%",
+                "Tech Debt Exposure": "45.72%",
                 "Testing Exposure": "31.55%",
                 "API Exposure": "12.46%",
                 "Concurrency Exposure": "0.0%",
@@ -37539,7 +37539,7 @@
                             "End Line": 707
                         },
                         {
-                            "Function Name": "_PyCompile_TweakInlinedComprehensionScop",
+                            "Function Name": "_PyCompile_TweakInlinedComprehensionScopes",
                             "Structural Impact": 13.9,
                             "Lines of Code (LOC)": 39,
                             "Control Flow Branches": 11,
@@ -37599,7 +37599,7 @@
                             "End Line": 640
                         },
                         {
-                            "Function Name": "_PyCompile_MaybeAddStaticAttributeToClas",
+                            "Function Name": "_PyCompile_MaybeAddStaticAttributeToClass",
                             "Structural Impact": 8.2,
                             "Lines of Code (LOC)": 25,
                             "Control Flow Branches": 6,
@@ -37891,32 +37891,32 @@
                         "Repository Drift (Z-Score)": 14.502,
                         "Repository Fingerprint": {
                             "file_cluster_0": 14.61,
-                            "file_cluster_1": 15.161,
-                            "file_cluster_2": 15.071,
-                            "file_cluster_3": 15.728,
-                            "file_cluster_4": 14.921,
+                            "file_cluster_1": 15.16,
+                            "file_cluster_2": 15.07,
+                            "file_cluster_3": 15.727,
+                            "file_cluster_4": 14.92,
                             "file_cluster_5": 15.491,
-                            "file_cluster_6": 14.769,
-                            "file_cluster_7": 14.751,
+                            "file_cluster_6": 14.768,
+                            "file_cluster_7": 14.75,
                             "file_cluster_8": 14.556,
-                            "file_cluster_9": 14.844,
-                            "file_cluster_10": 15.563,
+                            "file_cluster_9": 14.843,
+                            "file_cluster_10": 15.562,
                             "file_cluster_11": 14.502,
-                            "file_cluster_12": 14.829,
+                            "file_cluster_12": 14.828,
                             "file_cluster_13": 14.613,
-                            "file_cluster_14": 17.85,
-                            "file_cluster_15": 15.085,
-                            "file_cluster_16": 15.034,
+                            "file_cluster_14": 17.849,
+                            "file_cluster_15": 15.084,
+                            "file_cluster_16": 15.033,
                             "file_cluster_17": 14.86
                         },
                         "File Archetype": "Cluster 3: Complex Defensive Systems Logic",
-                        "File Drift (Z-Score)": 6.436,
+                        "File Drift (Z-Score)": 6.437,
                         "File Fingerprint": {
-                            "Cluster 0: Defensive Downstream Logic & Immutable State": 6.89,
+                            "Cluster 0: Defensive Downstream Logic & Immutable State": 6.891,
                             "Cluster 1: Algorithmic Bitwise & Encapsulated Core": 7.899,
                             "Cluster 2: Inert Headers & Declarative Structures": 7.697,
-                            "Cluster 3: Complex Defensive Systems Logic": 6.436,
-                            "Cluster 4: The God Headers (Documented & Defended APIs)": 11.451
+                            "Cluster 3: Complex Defensive Systems Logic": 6.437,
+                            "Cluster 4: The God Headers (Documented & Defended APIs)": 11.452
                         },
                         "Total LOC": 8326,
                         "Coding LOC": 5198,
@@ -37932,7 +37932,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "93.75%",
                         "Error & Exception Exposure": "87.43%",
-                        "Tech Debt Exposure": "31.37%",
+                        "Tech Debt Exposure": "30.14%",
                         "Testing Exposure": "2.52%",
                         "API Exposure": "13.24%",
                         "Concurrency Exposure": "0.0%",
@@ -38866,7 +38866,7 @@
                             "End Line": 660
                         },
                         {
-                            "Function Name": "_PyObject_MaterializeManagedDict_LockHel",
+                            "Function Name": "_PyObject_MaterializeManagedDict_LockHeld",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 2,
@@ -38876,7 +38876,7 @@
                             "End Line": 4820
                         },
                         {
-                            "Function Name": "replace_dict_probably_inline_materialize",
+                            "Function Name": "replace_dict_probably_inline_materialized",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 2,
@@ -39851,7 +39851,7 @@
                         "Design Short Vars": 128,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 52,
+                        "Orphaned Logic": 50,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -41566,7 +41566,7 @@
                             "End Line": 1796
                         },
                         {
-                            "Function Name": "PyUnstable_Object_IsUniqueReferencedTemp",
+                            "Function Name": "PyUnstable_Object_IsUniqueReferencedTemporary",
                             "Structural Impact": 8.3,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 6,
@@ -49085,7 +49085,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "31.63%",
                 "Error & Exception Exposure": "54.87%",
-                "Tech Debt Exposure": "30.11%",
+                "Tech Debt Exposure": "30.05%",
                 "Testing Exposure": "37.47%",
                 "API Exposure": "1.5%",
                 "Concurrency Exposure": "1.45%",
@@ -50664,26 +50664,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_7",
-                        "Repository Drift (Z-Score)": 14.877,
+                        "Repository Drift (Z-Score)": 14.876,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 15.186,
-                            "file_cluster_1": 15.192,
-                            "file_cluster_2": 15.263,
-                            "file_cluster_3": 16.005,
-                            "file_cluster_4": 15.369,
-                            "file_cluster_5": 15.513,
-                            "file_cluster_6": 15.188,
-                            "file_cluster_7": 14.877,
-                            "file_cluster_8": 14.947,
-                            "file_cluster_9": 15.376,
-                            "file_cluster_10": 15.779,
-                            "file_cluster_11": 15.024,
-                            "file_cluster_12": 15.372,
-                            "file_cluster_13": 14.941,
-                            "file_cluster_14": 18.349,
-                            "file_cluster_15": 15.255,
-                            "file_cluster_16": 15.359,
-                            "file_cluster_17": 15.31
+                            "file_cluster_0": 15.185,
+                            "file_cluster_1": 15.19,
+                            "file_cluster_2": 15.262,
+                            "file_cluster_3": 16.004,
+                            "file_cluster_4": 15.368,
+                            "file_cluster_5": 15.512,
+                            "file_cluster_6": 15.187,
+                            "file_cluster_7": 14.876,
+                            "file_cluster_8": 14.946,
+                            "file_cluster_9": 15.375,
+                            "file_cluster_10": 15.778,
+                            "file_cluster_11": 15.023,
+                            "file_cluster_12": 15.371,
+                            "file_cluster_13": 14.94,
+                            "file_cluster_14": 18.348,
+                            "file_cluster_15": 15.254,
+                            "file_cluster_16": 15.358,
+                            "file_cluster_17": 15.309
                         },
                         "File Archetype": "Cluster 1: Documented API Headers & Entity Definitions",
                         "File Drift (Z-Score)": 6.002,
@@ -50710,7 +50710,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "46.54%",
                         "Error & Exception Exposure": "95.47%",
-                        "Tech Debt Exposure": "91.73%",
+                        "Tech Debt Exposure": "91.11%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.0%",
                         "Concurrency Exposure": "0.0%",
@@ -50904,7 +50904,7 @@
                             "End Line": 523
                         },
                         {
-                            "Function Name": "MCStringCreateWithNativeCharBufferAndRel",
+                            "Function Name": "MCStringCreateWithNativeCharBufferAndRelease",
                             "Structural Impact": 19.9,
                             "Lines of Code (LOC)": 40,
                             "Control Flow Branches": 7,
@@ -51639,7 +51639,7 @@
                         "Design Short Vars": 5,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 45,
+                        "Orphaned Logic": 44,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -51782,7 +51782,7 @@
                             "End Line": 189
                         },
                         {
-                            "Function Name": "MCScriptQueryForeignHandlerParameterType",
+                            "Function Name": "MCScriptQueryForeignHandlerParameterTypeInModule",
                             "Structural Impact": 9.1,
                             "Lines of Code (LOC)": 22,
                             "Control Flow Branches": 3,
@@ -51832,7 +51832,7 @@
                             "End Line": 114
                         },
                         {
-                            "Function Name": "MCScriptQueryForeignHandlerReturnTypeInM",
+                            "Function Name": "MCScriptQueryForeignHandlerReturnTypeInModule",
                             "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 1,
@@ -51842,7 +51842,7 @@
                             "End Line": 245
                         },
                         {
-                            "Function Name": "MCScriptQueryForeignHandlerParameterCoun",
+                            "Function Name": "MCScriptQueryForeignHandlerParameterCountInModule",
                             "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 1,
@@ -52103,7 +52103,7 @@
                             "End Line": 295
                         },
                         {
-                            "Function Name": "MCScriptExecuteContext::InvokeForeignVar",
+                            "Function Name": "MCScriptExecuteContext::InvokeForeignVarArgument",
                             "Structural Impact": 59.9,
                             "Lines of Code (LOC)": 169,
                             "Control Flow Branches": 20,
@@ -57127,7 +57127,7 @@
                             "End Line": 1609
                         },
                         {
-                            "Function Name": "_entryWaitingForSubTreeDisposal.removeWh",
+                            "Function Name": "_entryWaitingForSubTreeDisposal.removeWhere",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -58567,7 +58567,7 @@
                             "End Line": 2732
                         },
                         {
-                            "Function Name": "fragment.markSiblingConfigurationConflic",
+                            "Function Name": "fragment.markSiblingConfigurationConflict",
                             "Structural Impact": 3.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
@@ -58767,7 +58767,7 @@
                             "End Line": 413
                         },
                         {
-                            "Function Name": "_RenderObjectSemantics.debugCheckForBuil",
+                            "Function Name": "_RenderObjectSemantics.debugCheckForBuilds",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 1,
@@ -66403,26 +66403,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 13.096,
+                        "Repository Drift (Z-Score)": 13.095,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.8,
-                            "file_cluster_1": 14.041,
-                            "file_cluster_2": 13.528,
-                            "file_cluster_3": 14.828,
-                            "file_cluster_4": 14.027,
-                            "file_cluster_5": 14.465,
-                            "file_cluster_6": 13.888,
-                            "file_cluster_7": 13.735,
-                            "file_cluster_8": 13.465,
-                            "file_cluster_9": 13.992,
-                            "file_cluster_10": 14.604,
-                            "file_cluster_11": 13.572,
-                            "file_cluster_12": 14.159,
-                            "file_cluster_13": 13.096,
-                            "file_cluster_14": 16.815,
-                            "file_cluster_15": 14.118,
-                            "file_cluster_16": 14.103,
-                            "file_cluster_17": 13.665
+                            "file_cluster_0": 13.799,
+                            "file_cluster_1": 14.04,
+                            "file_cluster_2": 13.527,
+                            "file_cluster_3": 14.826,
+                            "file_cluster_4": 14.025,
+                            "file_cluster_5": 14.464,
+                            "file_cluster_6": 13.887,
+                            "file_cluster_7": 13.734,
+                            "file_cluster_8": 13.464,
+                            "file_cluster_9": 13.991,
+                            "file_cluster_10": 14.602,
+                            "file_cluster_11": 13.571,
+                            "file_cluster_12": 14.157,
+                            "file_cluster_13": 13.095,
+                            "file_cluster_14": 16.814,
+                            "file_cluster_15": 14.117,
+                            "file_cluster_16": 14.102,
+                            "file_cluster_17": 13.663
                         },
                         "File Archetype": "Cluster 0: Declarative Interfaces & Inert Headers",
                         "File Drift (Z-Score)": 5.825,
@@ -66483,7 +66483,7 @@
                             "End Line": 462
                         },
                         {
-                            "Function Name": "EditorNode::_find_and_save_edited_subres",
+                            "Function Name": "EditorNode::_find_and_save_edited_subresources",
                             "Structural Impact": 36.3,
                             "Lines of Code (LOC)": 46,
                             "Control Flow Branches": 16,
@@ -67143,7 +67143,7 @@
                             "End Line": 1882
                         },
                         {
-                            "Function Name": "get_preload_modifications_reference_to_n",
+                            "Function Name": "get_preload_modifications_reference_to_nodes",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 1,
@@ -67518,7 +67518,7 @@
                         "Design Short Vars": 43,
                         "Design Long Vars": 12,
                         "Duplicate Logic": 61,
-                        "Orphaned Logic": 24,
+                        "Orphaned Logic": 23,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -70682,7 +70682,7 @@
                             "End Line": 398
                         },
                         {
-                            "Function Name": "_set_physics_interpolation_reset_request",
+                            "Function Name": "_set_physics_interpolation_reset_requested",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
@@ -70762,7 +70762,7 @@
                             "End Line": 399
                         },
                         {
-                            "Function Name": "_is_physics_interpolation_reset_requeste",
+                            "Function Name": "_is_physics_interpolation_reset_requested",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
@@ -71582,37 +71582,37 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.957,
+                        "Repository Drift (Z-Score)": 12.975,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.384,
-                            "file_cluster_1": 13.561,
-                            "file_cluster_2": 13.569,
-                            "file_cluster_3": 14.486,
-                            "file_cluster_4": 13.521,
-                            "file_cluster_5": 14.051,
-                            "file_cluster_6": 13.603,
-                            "file_cluster_7": 13.304,
-                            "file_cluster_8": 12.99,
-                            "file_cluster_9": 13.468,
-                            "file_cluster_10": 14.322,
-                            "file_cluster_11": 13.295,
-                            "file_cluster_12": 13.827,
-                            "file_cluster_13": 12.957,
-                            "file_cluster_14": 16.822,
-                            "file_cluster_15": 13.825,
-                            "file_cluster_16": 13.716,
-                            "file_cluster_17": 13.456
+                            "file_cluster_0": 13.402,
+                            "file_cluster_1": 13.573,
+                            "file_cluster_2": 13.583,
+                            "file_cluster_3": 14.499,
+                            "file_cluster_4": 13.543,
+                            "file_cluster_5": 14.063,
+                            "file_cluster_6": 13.617,
+                            "file_cluster_7": 13.317,
+                            "file_cluster_8": 13.003,
+                            "file_cluster_9": 13.485,
+                            "file_cluster_10": 14.335,
+                            "file_cluster_11": 13.31,
+                            "file_cluster_12": 13.839,
+                            "file_cluster_13": 12.975,
+                            "file_cluster_14": 16.836,
+                            "file_cluster_15": 13.837,
+                            "file_cluster_16": 13.728,
+                            "file_cluster_17": 13.476
                         },
                         "File Archetype": "Cluster 0: Declarative Interfaces & Inert Headers",
-                        "File Drift (Z-Score)": 5.943,
+                        "File Drift (Z-Score)": 5.984,
                         "File Fingerprint": {
-                            "Cluster 0: Declarative Interfaces & Inert Headers": 5.943,
-                            "Cluster 1: Documented API Headers & Entity Definitions": 7.157,
-                            "Cluster 2: Verification & Unit Testing": 7.107,
-                            "Cluster 3: Algorithmic Execution Core": 6.078,
-                            "Cluster 4: The God Headers (Universal Dependencies)": 9.151,
-                            "Cluster 5: Heavily Documented Complex Base Classes": 10.667,
-                            "Cluster 6: Generic Templates & Metaprogramming Core": 7.524
+                            "Cluster 0: Declarative Interfaces & Inert Headers": 5.984,
+                            "Cluster 1: Documented API Headers & Entity Definitions": 7.184,
+                            "Cluster 2: Verification & Unit Testing": 7.102,
+                            "Cluster 3: Algorithmic Execution Core": 6.074,
+                            "Cluster 4: The God Headers (Universal Dependencies)": 9.212,
+                            "Cluster 5: Heavily Documented Complex Base Classes": 10.709,
+                            "Cluster 6: Generic Templates & Metaprogramming Core": 7.566
                         },
                         "Total LOC": 476,
                         "Coding LOC": 330,
@@ -71628,7 +71628,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "81.37%",
                         "Error & Exception Exposure": "90.91%",
-                        "Tech Debt Exposure": "99.99%",
+                        "Tech Debt Exposure": "99.97%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.0%",
                         "Concurrency Exposure": "0.0%",
@@ -71652,7 +71652,7 @@
                             "End Line": 183
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_rendering_in",
+                            "Function Name": "RenderingServerDefault::get_rendering_info",
                             "Structural Impact": 28.7,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 15,
@@ -71692,7 +71692,7 @@
                             "End Line": 423
                         },
                         {
-                            "Function Name": "RenderingServerDefault::_run_post_draw_s",
+                            "Function Name": "RenderingServerDefault::_run_post_draw_steps",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 2,
@@ -71742,7 +71742,7 @@
                             "End Line": 244
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_maximum_view",
+                            "Function Name": "RenderingServerDefault::get_maximum_viewport_size",
                             "Structural Impact": 3.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
@@ -71792,7 +71792,7 @@
                             "End Line": 344
                         },
                         {
-                            "Function Name": "RenderingServerDefault::request_frame_dr",
+                            "Function Name": "RenderingServerDefault::request_frame_drawn_callback",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71802,7 +71802,7 @@
                             "End Line": 74
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_default_clea",
+                            "Function Name": "RenderingServerDefault::set_default_clear_color",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71812,7 +71812,7 @@
                             "End Line": 322
                         },
                         {
-                            "Function Name": "RenderingServerDefault::_call_on_render_",
+                            "Function Name": "RenderingServerDefault::_call_on_render_thread",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71822,7 +71822,7 @@
                             "End Line": 436
                         },
                         {
-                            "Function Name": "RenderingServerDefault::RenderingServerD",
+                            "Function Name": "RenderingServerDefault::RenderingServerDefault",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -71832,7 +71832,7 @@
                             "End Line": 442
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_frame_profil",
+                            "Function Name": "RenderingServerDefault::set_frame_profiling_enabled",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71852,7 +71852,7 @@
                             "End Line": 327
                         },
                         {
-                            "Function Name": "RenderingServerDefault::sdfgi_set_debug_",
+                            "Function Name": "RenderingServerDefault::sdfgi_set_debug_probe_select",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71862,7 +71862,7 @@
                             "End Line": 332
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_print_gpu_pr",
+                            "Function Name": "RenderingServerDefault::set_print_gpu_profile",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -71872,7 +71872,7 @@
                             "End Line": 337
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_debug_genera",
+                            "Function Name": "RenderingServerDefault::set_debug_generate_wireframes",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71882,7 +71882,7 @@
                             "End Line": 356
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_physics_inte",
+                            "Function Name": "RenderingServerDefault::set_physics_interpolation_enabled",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -71912,7 +71912,7 @@
                             "End Line": 428
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_frame_setup_",
+                            "Function Name": "RenderingServerDefault::get_frame_setup_time_cpu",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71932,7 +71932,7 @@
                             "End Line": 208
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_video_adapte",
+                            "Function Name": "RenderingServerDefault::get_video_adapter_type",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71942,7 +71942,7 @@
                             "End Line": 300
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_frame_profil",
+                            "Function Name": "RenderingServerDefault::get_frame_profile_frame",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71952,7 +71952,7 @@
                             "End Line": 308
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_frame_profil",
+                            "Function Name": "RenderingServerDefault::get_frame_profile",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71962,7 +71962,7 @@
                             "End Line": 312
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_default_clea",
+                            "Function Name": "RenderingServerDefault::get_default_clear_color",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -72076,8 +72076,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 3,
                         "Design Long Vars": 3,
-                        "Duplicate Logic": 2,
-                        "Orphaned Logic": 33,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 35,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -78243,7 +78243,7 @@
                             "End Line": 1594
                         },
                         {
-                            "Function Name": "nodesOverlappingIndexIncludingParseError",
+                            "Function Name": "nodesOverlappingIndexIncludingParseErrors",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
@@ -87651,36 +87651,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 12.532,
+                        "Repository Drift (Z-Score)": 12.573,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.174,
-                            "file_cluster_1": 14.295,
-                            "file_cluster_2": 14.256,
-                            "file_cluster_3": 13.167,
-                            "file_cluster_4": 14.099,
-                            "file_cluster_5": 14.535,
-                            "file_cluster_6": 13.204,
-                            "file_cluster_7": 13.939,
-                            "file_cluster_8": 13.813,
-                            "file_cluster_9": 13.737,
-                            "file_cluster_10": 14.572,
-                            "file_cluster_11": 12.532,
-                            "file_cluster_12": 14.256,
-                            "file_cluster_13": 13.028,
-                            "file_cluster_14": 14.979,
-                            "file_cluster_15": 14.196,
-                            "file_cluster_16": 13.393,
-                            "file_cluster_17": 13.712
+                            "file_cluster_0": 13.215,
+                            "file_cluster_1": 14.327,
+                            "file_cluster_2": 14.29,
+                            "file_cluster_3": 13.204,
+                            "file_cluster_4": 14.143,
+                            "file_cluster_5": 14.568,
+                            "file_cluster_6": 13.243,
+                            "file_cluster_7": 13.974,
+                            "file_cluster_8": 13.848,
+                            "file_cluster_9": 13.776,
+                            "file_cluster_10": 14.606,
+                            "file_cluster_11": 12.573,
+                            "file_cluster_12": 14.289,
+                            "file_cluster_13": 13.071,
+                            "file_cluster_14": 15.015,
+                            "file_cluster_15": 14.229,
+                            "file_cluster_16": 13.429,
+                            "file_cluster_17": 13.755
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.698,
+                        "File Drift (Z-Score)": 7.736,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 9.017,
-                            "Cluster 1: Declarative Glue & Initialization": 7.698,
-                            "Cluster 2: Async & Concurrent Testing": 9.327,
-                            "Cluster 3: Data Pipelines & I/O Operations": 8.07,
-                            "Cluster 4: Procedural Verification & Mocks": 8.546,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.349
+                            "Cluster 0: Decorated Core & Metaprogramming": 9.046,
+                            "Cluster 1: Declarative Glue & Initialization": 7.736,
+                            "Cluster 2: Async & Concurrent Testing": 9.352,
+                            "Cluster 3: Data Pipelines & I/O Operations": 8.091,
+                            "Cluster 4: Procedural Verification & Mocks": 8.558,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.469
                         },
                         "Total LOC": 133,
                         "Coding LOC": 87,
@@ -87750,7 +87750,7 @@
                             "End Line": 26
                         },
                         {
-                            "Function Name": "test_serialize_sequence_value_with_none_",
+                            "Function Name": "test_serialize_sequence_value_with_none_first_in_union",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -87760,7 +87760,7 @@
                             "End Line": 135
                         },
                         {
-                            "Function Name": "test_serialize_sequence_value_with_optio",
+                            "Function Name": "test_serialize_sequence_value_with_optional_list",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -87770,7 +87770,7 @@
                             "End Line": 108
                         },
                         {
-                            "Function Name": "test_serialize_sequence_value_with_optio",
+                            "Function Name": "test_serialize_sequence_value_with_optional_list_pipe_union",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -87894,8 +87894,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 4,
-                        "Orphaned Logic": 7,
+                        "Duplicate Logic": 2,
+                        "Orphaned Logic": 9,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -88293,7 +88293,7 @@
                             "End Line": 80
                         },
                         {
-                            "Function Name": "test_custom_middleware_exception_not_rai",
+                            "Function Name": "test_custom_middleware_exception_not_raised",
                             "Structural Impact": 6.5,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
@@ -91500,7 +91500,7 @@
                             "End Line": 20
                         },
                         {
-                            "Function Name": "test_websocket_dependency_after_yield_br",
+                            "Function Name": "test_websocket_dependency_after_yield_broken",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
@@ -93619,36 +93619,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.578,
+                        "Repository Drift (Z-Score)": 10.625,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.916,
-                            "file_cluster_1": 11.507,
-                            "file_cluster_2": 11.635,
-                            "file_cluster_3": 12.275,
-                            "file_cluster_4": 11.317,
-                            "file_cluster_5": 12.102,
-                            "file_cluster_6": 11.488,
-                            "file_cluster_7": 11.21,
-                            "file_cluster_8": 10.578,
-                            "file_cluster_9": 11.445,
-                            "file_cluster_10": 12.697,
-                            "file_cluster_11": 11.588,
-                            "file_cluster_12": 12.017,
-                            "file_cluster_13": 11.178,
-                            "file_cluster_14": 14.867,
-                            "file_cluster_15": 12.282,
-                            "file_cluster_16": 11.601,
-                            "file_cluster_17": 11.402
+                            "file_cluster_0": 10.976,
+                            "file_cluster_1": 11.549,
+                            "file_cluster_2": 11.682,
+                            "file_cluster_3": 12.319,
+                            "file_cluster_4": 11.386,
+                            "file_cluster_5": 12.144,
+                            "file_cluster_6": 11.537,
+                            "file_cluster_7": 11.256,
+                            "file_cluster_8": 10.625,
+                            "file_cluster_9": 11.501,
+                            "file_cluster_10": 12.739,
+                            "file_cluster_11": 11.637,
+                            "file_cluster_12": 12.057,
+                            "file_cluster_13": 11.237,
+                            "file_cluster_14": 14.909,
+                            "file_cluster_15": 12.322,
+                            "file_cluster_16": 11.645,
+                            "file_cluster_17": 11.468
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 5.094,
+                        "File Drift (Z-Score)": 5.19,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 7.342,
-                            "Cluster 1: Declarative Glue & Initialization": 5.094,
-                            "Cluster 2: Async & Concurrent Testing": 8.034,
-                            "Cluster 3: Data Pipelines & I/O Operations": 6.314,
-                            "Cluster 4: Procedural Verification & Mocks": 7.037,
-                            "Cluster 5: Universal Dependencies & Serialization": 8.114
+                            "Cluster 0: Decorated Core & Metaprogramming": 7.407,
+                            "Cluster 1: Declarative Glue & Initialization": 5.19,
+                            "Cluster 2: Async & Concurrent Testing": 8.097,
+                            "Cluster 3: Data Pipelines & I/O Operations": 6.37,
+                            "Cluster 4: Procedural Verification & Mocks": 7.056,
+                            "Cluster 5: Universal Dependencies & Serialization": 8.404
                         },
                         "Total LOC": 390,
                         "Coding LOC": 310,
@@ -93728,7 +93728,7 @@
                             "End Line": 231
                         },
                         {
-                            "Function Name": "test_override_with_sub__main_depends_q_f",
+                            "Function Name": "test_override_with_sub__main_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93748,7 +93748,7 @@
                             "End Line": 275
                         },
                         {
-                            "Function Name": "test_override_with_sub_decorator_depends",
+                            "Function Name": "test_override_with_sub_decorator_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93768,7 +93768,7 @@
                             "End Line": 319
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_depends_q_",
+                            "Function Name": "test_override_with_sub_router_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93778,7 +93778,7 @@
                             "End Line": 337
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_decorator_",
+                            "Function Name": "test_override_with_sub_router_decorator_depends",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93788,7 +93788,7 @@
                             "End Line": 363
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_decorator_",
+                            "Function Name": "test_override_with_sub_router_decorator_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93898,7 +93898,7 @@
                             "End Line": 72
                         },
                         {
-                            "Function Name": "test_main_depends_q_foo_skip_100_limit_2",
+                            "Function Name": "test_main_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -93918,7 +93918,7 @@
                             "End Line": 132
                         },
                         {
-                            "Function Name": "test_router_depends_q_foo_skip_100_limit",
+                            "Function Name": "test_router_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -93928,7 +93928,7 @@
                             "End Line": 141
                         },
                         {
-                            "Function Name": "test_override_with_sub_main_depends_k_ba",
+                            "Function Name": "test_override_with_sub_main_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93938,7 +93938,7 @@
                             "End Line": 257
                         },
                         {
-                            "Function Name": "test_override_with_sub_decorator_depends",
+                            "Function Name": "test_override_with_sub_decorator_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93948,7 +93948,7 @@
                             "End Line": 301
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_depends_k_",
+                            "Function Name": "test_override_with_sub_router_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93958,7 +93958,7 @@
                             "End Line": 345
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_decorator_",
+                            "Function Name": "test_override_with_sub_router_decorator_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93978,7 +93978,7 @@
                             "End Line": 102
                         },
                         {
-                            "Function Name": "test_decorator_depends_q_foo_skip_100_li",
+                            "Function Name": "test_decorator_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -93998,7 +93998,7 @@
                             "End Line": 162
                         },
                         {
-                            "Function Name": "test_router_decorator_depends_q_foo_skip",
+                            "Function Name": "test_router_decorator_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -94082,8 +94082,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 6,
-                        "Orphaned Logic": 23,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 29,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -94246,7 +94246,7 @@
                             "End Line": 48
                         },
                         {
-                            "Function Name": "test_call_get_parameterless_without_scop",
+                            "Function Name": "test_call_get_parameterless_without_scopes_for_coverage",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -94505,7 +94505,7 @@
                             "End Line": 21
                         },
                         {
-                            "Function Name": "get_partial_async_callable_gen_dependenc",
+                            "Function Name": "get_partial_async_callable_gen_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 0,
@@ -94515,7 +94515,7 @@
                             "End Line": 146
                         },
                         {
-                            "Function Name": "get_partial_synchronous_method_dependenc",
+                            "Function Name": "get_partial_synchronous_method_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 0,
@@ -94525,7 +94525,7 @@
                             "End Line": 160
                         },
                         {
-                            "Function Name": "get_partial_synchronous_method_gen_depen",
+                            "Function Name": "get_partial_synchronous_method_gen_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -94535,7 +94535,7 @@
                             "End Line": 175
                         },
                         {
-                            "Function Name": "get_partial_asynchronous_method_dependen",
+                            "Function Name": "get_partial_asynchronous_method_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -94545,7 +94545,7 @@
                             "End Line": 190
                         },
                         {
-                            "Function Name": "get_partial_asynchronous_method_gen_depe",
+                            "Function Name": "get_partial_asynchronous_method_gen_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -95334,36 +95334,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 9.529,
+                        "Repository Drift (Z-Score)": 9.537,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.529,
-                            "file_cluster_1": 10.789,
-                            "file_cluster_2": 10.987,
-                            "file_cluster_3": 11.106,
-                            "file_cluster_4": 9.631,
-                            "file_cluster_5": 11.299,
-                            "file_cluster_6": 10.697,
-                            "file_cluster_7": 10.358,
-                            "file_cluster_8": 10.356,
-                            "file_cluster_9": 10.942,
-                            "file_cluster_10": 11.649,
-                            "file_cluster_11": 10.032,
-                            "file_cluster_12": 10.298,
-                            "file_cluster_13": 10.015,
-                            "file_cluster_14": 14.188,
-                            "file_cluster_15": 11.146,
-                            "file_cluster_16": 10.388,
-                            "file_cluster_17": 10.964
+                            "file_cluster_0": 9.537,
+                            "file_cluster_1": 10.794,
+                            "file_cluster_2": 10.993,
+                            "file_cluster_3": 11.111,
+                            "file_cluster_4": 9.64,
+                            "file_cluster_5": 11.304,
+                            "file_cluster_6": 10.703,
+                            "file_cluster_7": 10.364,
+                            "file_cluster_8": 10.362,
+                            "file_cluster_9": 10.949,
+                            "file_cluster_10": 11.655,
+                            "file_cluster_11": 10.039,
+                            "file_cluster_12": 10.303,
+                            "file_cluster_13": 10.022,
+                            "file_cluster_14": 14.193,
+                            "file_cluster_15": 11.151,
+                            "file_cluster_16": 10.394,
+                            "file_cluster_17": 10.972
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.676,
+                        "File Drift (Z-Score)": 7.68,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.886,
-                            "Cluster 1: Declarative Glue & Initialization": 7.676,
-                            "Cluster 2: Async & Concurrent Testing": 9.393,
-                            "Cluster 3: Data Pipelines & I/O Operations": 8.07,
-                            "Cluster 4: Procedural Verification & Mocks": 8.807,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.256
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.889,
+                            "Cluster 1: Declarative Glue & Initialization": 7.68,
+                            "Cluster 2: Async & Concurrent Testing": 9.395,
+                            "Cluster 3: Data Pipelines & I/O Operations": 8.071,
+                            "Cluster 4: Procedural Verification & Mocks": 8.806,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.279
                         },
                         "Total LOC": 450,
                         "Coding LOC": 301,
@@ -95453,7 +95453,7 @@
                             "End Line": 227
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_async_depende",
+                            "Function Name": "get_wrapped_class_instance_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95463,7 +95463,7 @@
                             "End Line": 234
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_gen_dependenc",
+                            "Function Name": "get_wrapped_class_instance_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95473,7 +95473,7 @@
                             "End Line": 241
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_async_gen_dep",
+                            "Function Name": "get_wrapped_class_instance_async_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95493,7 +95493,7 @@
                             "End Line": 255
                         },
                         {
-                            "Function Name": "get_class_instance_wrapped_async_depende",
+                            "Function Name": "get_class_instance_wrapped_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95503,7 +95503,7 @@
                             "End Line": 262
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_depende",
+                            "Function Name": "get_class_instance_async_wrapped_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95513,7 +95513,7 @@
                             "End Line": 269
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_async_d",
+                            "Function Name": "get_class_instance_async_wrapped_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95523,7 +95523,7 @@
                             "End Line": 276
                         },
                         {
-                            "Function Name": "get_class_instance_wrapped_gen_dependenc",
+                            "Function Name": "get_class_instance_wrapped_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95533,7 +95533,7 @@
                             "End Line": 283
                         },
                         {
-                            "Function Name": "get_class_instance_wrapped_async_gen_dep",
+                            "Function Name": "get_class_instance_wrapped_async_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95543,7 +95543,7 @@
                             "End Line": 290
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_gen_dep",
+                            "Function Name": "get_class_instance_async_wrapped_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95553,7 +95553,7 @@
                             "End Line": 297
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_gen_asy",
+                            "Function Name": "get_class_instance_async_wrapped_gen_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95583,7 +95583,7 @@
                             "End Line": 358
                         },
                         {
-                            "Function Name": "get_async_wrapped_dependency_async_wrapp",
+                            "Function Name": "get_async_wrapped_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95593,7 +95593,7 @@
                             "End Line": 365
                         },
                         {
-                            "Function Name": "get_async_wrapped_gen_dependency_async_w",
+                            "Function Name": "get_async_wrapped_gen_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95603,7 +95603,7 @@
                             "End Line": 372
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_dependency_as",
+                            "Function Name": "get_wrapped_class_instance_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95613,7 +95613,7 @@
                             "End Line": 379
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_async_depende",
+                            "Function Name": "get_wrapped_class_instance_async_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95623,7 +95623,7 @@
                             "End Line": 386
                         },
                         {
-                            "Function Name": "get_wrapped_class_dependency_async_wrapp",
+                            "Function Name": "get_wrapped_class_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95773,7 +95773,7 @@
                             "End Line": 341
                         },
                         {
-                            "Function Name": "async_wrapped_gen_dependency_async_wrapp",
+                            "Function Name": "async_wrapped_gen_dependency_async_wrapper",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -96027,8 +96027,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 16,
-                        "Duplicate Logic": 16,
-                        "Orphaned Logic": 29,
+                        "Duplicate Logic": 14,
+                        "Orphaned Logic": 30,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -97743,7 +97743,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_orjson_response_emits_deprecation_w",
+                            "Function Name": "test_orjson_response_emits_deprecation_warning",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 2,
@@ -97753,7 +97753,7 @@
                             "End Line": 43
                         },
                         {
-                            "Function Name": "test_ujson_response_emits_deprecation_wa",
+                            "Function Name": "test_ujson_response_emits_deprecation_warning",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 2,
@@ -97783,7 +97783,7 @@
                             "End Line": 58
                         },
                         {
-                            "Function Name": "test_orjson_response_returns_correct_dat",
+                            "Function Name": "test_orjson_response_returns_correct_data",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 1,
@@ -98016,7 +98016,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_default_response_class_skips_json_d",
+                            "Function Name": "test_default_response_class_skips_json_dumps",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -98026,7 +98026,7 @@
                             "End Line": 39
                         },
                         {
-                            "Function Name": "test_explicit_response_class_uses_json_d",
+                            "Function Name": "test_explicit_response_class_uses_json_dumps",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -98944,7 +98944,7 @@
                             "End Line": 88
                         },
                         {
-                            "Function Name": "test_override_server_error_exception_rai",
+                            "Function Name": "test_override_server_error_exception_raises",
                             "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
@@ -98964,7 +98964,7 @@
                             "End Line": 50
                         },
                         {
-                            "Function Name": "test_override_server_error_exception_res",
+                            "Function Name": "test_override_server_error_exception_response",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -98984,7 +98984,7 @@
                             "End Line": 61
                         },
                         {
-                            "Function Name": "test_override_request_validation_excepti",
+                            "Function Name": "test_override_request_validation_exception",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -101304,7 +101304,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_router_include_overrides_generate_u",
+                            "Function Name": "test_router_include_overrides_generate_unique_id",
                             "Structural Impact": 26.4,
                             "Lines of Code (LOC)": 493,
                             "Control Flow Branches": 0,
@@ -101314,7 +101314,7 @@
                             "End Line": 944
                         },
                         {
-                            "Function Name": "test_router_path_operation_overrides_gen",
+                            "Function Name": "test_router_path_operation_overrides_generate_unique_id",
                             "Structural Impact": 23.1,
                             "Lines of Code (LOC)": 428,
                             "Control Flow Branches": 0,
@@ -101324,7 +101324,7 @@
                             "End Line": 1374
                         },
                         {
-                            "Function Name": "test_callback_override_generate_unique_i",
+                            "Function Name": "test_callback_override_generate_unique_id",
                             "Structural Impact": 23.1,
                             "Lines of Code (LOC)": 323,
                             "Control Flow Branches": 3,
@@ -104762,7 +104762,7 @@
                             "End Line": 225
                         },
                         {
-                            "Function Name": "test_encode_custom_json_encoders_model_p",
+                            "Function Name": "test_encode_custom_json_encoders_model_pydanticv2",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 0,
@@ -105853,36 +105853,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 10.008,
+                        "Repository Drift (Z-Score)": 10.045,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.008,
-                            "file_cluster_1": 10.95,
-                            "file_cluster_2": 11.098,
-                            "file_cluster_3": 10.643,
-                            "file_cluster_4": 10.449,
-                            "file_cluster_5": 11.499,
-                            "file_cluster_6": 10.887,
-                            "file_cluster_7": 10.573,
-                            "file_cluster_8": 10.193,
-                            "file_cluster_9": 11.168,
-                            "file_cluster_10": 11.724,
-                            "file_cluster_11": 10.012,
-                            "file_cluster_12": 10.264,
-                            "file_cluster_13": 10.269,
-                            "file_cluster_14": 13.626,
-                            "file_cluster_15": 11.199,
-                            "file_cluster_16": 10.977,
-                            "file_cluster_17": 11.195
+                            "file_cluster_0": 10.045,
+                            "file_cluster_1": 10.982,
+                            "file_cluster_2": 11.131,
+                            "file_cluster_3": 10.678,
+                            "file_cluster_4": 10.488,
+                            "file_cluster_5": 11.531,
+                            "file_cluster_6": 10.921,
+                            "file_cluster_7": 10.608,
+                            "file_cluster_8": 10.23,
+                            "file_cluster_9": 11.202,
+                            "file_cluster_10": 11.756,
+                            "file_cluster_11": 10.049,
+                            "file_cluster_12": 10.299,
+                            "file_cluster_13": 10.307,
+                            "file_cluster_14": 13.654,
+                            "file_cluster_15": 11.232,
+                            "file_cluster_16": 11.011,
+                            "file_cluster_17": 11.231
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.541,
+                        "File Drift (Z-Score)": 7.569,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.99,
-                            "Cluster 1: Declarative Glue & Initialization": 7.541,
-                            "Cluster 2: Async & Concurrent Testing": 9.309,
-                            "Cluster 3: Data Pipelines & I/O Operations": 8.312,
-                            "Cluster 4: Procedural Verification & Mocks": 8.68,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.465
+                            "Cluster 0: Decorated Core & Metaprogramming": 9.01,
+                            "Cluster 1: Declarative Glue & Initialization": 7.569,
+                            "Cluster 2: Async & Concurrent Testing": 9.324,
+                            "Cluster 3: Data Pipelines & I/O Operations": 8.327,
+                            "Cluster 4: Procedural Verification & Mocks": 8.696,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.503
                         },
                         "Total LOC": 150,
                         "Coding LOC": 115,
@@ -105922,7 +105922,7 @@
                             "End Line": 21
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_file_",
+                            "Function Name": "test_incorrect_multipart_installed_file_upload",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -105932,7 +105932,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_file_",
+                            "Function Name": "test_incorrect_multipart_installed_file_bytes",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -105942,7 +105942,7 @@
                             "End Line": 47
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_multi",
+                            "Function Name": "test_incorrect_multipart_installed_multi_form",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -105952,7 +105952,7 @@
                             "End Line": 60
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_form_",
+                            "Function Name": "test_incorrect_multipart_installed_form_file",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -106206,8 +106206,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 13,
-                        "Orphaned Logic": 9,
+                        "Duplicate Logic": 11,
+                        "Orphaned Logic": 11,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -106749,7 +106749,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_multiple_different_root_paths_do_no",
+                            "Function Name": "test_multiple_different_root_paths_do_not_accumulate",
                             "Structural Impact": 7.9,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 3,
@@ -106759,7 +106759,7 @@
                             "End Line": 45
                         },
                         {
-                            "Function Name": "test_root_path_does_not_persist_across_r",
+                            "Function Name": "test_root_path_does_not_persist_across_requests",
                             "Structural Impact": 6.1,
                             "Lines of Code (LOC)": 19,
                             "Control Flow Branches": 2,
@@ -111629,7 +111629,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_additio",
+                            "Function Name": "test_raises_pydantic_v1_model_in_additional_responses_model",
                             "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 1,
@@ -111639,7 +111639,7 @@
                             "End Line": 70
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_endpoin",
+                            "Function Name": "test_raises_pydantic_v1_model_in_endpoint_param",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -111649,7 +111649,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_return_",
+                            "Function Name": "test_raises_pydantic_v1_model_in_return_type",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -111659,7 +111659,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_respons",
+                            "Function Name": "test_raises_pydantic_v1_model_in_response_model",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -111679,7 +111679,7 @@
                             "End Line": 83
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_sequenc",
+                            "Function Name": "test_raises_pydantic_v1_model_in_sequence",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -112393,7 +112393,7 @@
                             "End Line": 233
                         },
                         {
-                            "Function Name": "test_query_frozenset_query_1_query_1_que",
+                            "Function Name": "test_query_frozenset_query_1_query_1_query_2",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -113391,7 +113391,7 @@
                             "End Line": 146
                         },
                         {
-                            "Function Name": "test_query_params_str_validations_item_q",
+                            "Function Name": "test_query_params_str_validations_item_query_nonregexquery",
                             "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 1,
@@ -113401,7 +113401,7 @@
                             "End Line": 60
                         },
                         {
-                            "Function Name": "test_query_params_str_validations_no_que",
+                            "Function Name": "test_query_params_str_validations_no_query",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -113411,7 +113411,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_query_params_str_validations_q_fixe",
+                            "Function Name": "test_query_params_str_validations_q_fixedquery",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -115085,7 +115085,7 @@
                             "End Line": 33
                         },
                         {
-                            "Function Name": "test_required_nonable_explicit_query_inv",
+                            "Function Name": "test_required_nonable_explicit_query_invalid",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -115095,7 +115095,7 @@
                             "End Line": 38
                         },
                         {
-                            "Function Name": "test_required_nonable_explicit_query_val",
+                            "Function Name": "test_required_nonable_explicit_query_value",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -115105,7 +115105,7 @@
                             "End Line": 44
                         },
                         {
-                            "Function Name": "test_required_nonable_body_embed_no_cont",
+                            "Function Name": "test_required_nonable_body_embed_no_content",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -116391,7 +116391,7 @@
                             "End Line": 95
                         },
                         {
-                            "Function Name": "test_background_tasks_with_depends_annot",
+                            "Function Name": "test_background_tasks_with_depends_annotated",
                             "Structural Impact": 3.0,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 0,
@@ -116401,7 +116401,7 @@
                             "End Line": 172
                         },
                         {
-                            "Function Name": "test_response_dependency_returns_differe",
+                            "Function Name": "test_response_dependency_returns_different_response_instance",
                             "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 21,
                             "Control Flow Branches": 0,
@@ -116732,36 +116732,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.382,
+                        "Repository Drift (Z-Score)": 9.53,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.65,
-                            "file_cluster_1": 10.399,
-                            "file_cluster_2": 10.608,
-                            "file_cluster_3": 11.619,
-                            "file_cluster_4": 10.785,
-                            "file_cluster_5": 11.03,
-                            "file_cluster_6": 10.484,
-                            "file_cluster_7": 10.09,
-                            "file_cluster_8": 9.382,
-                            "file_cluster_9": 10.49,
-                            "file_cluster_10": 11.726,
-                            "file_cluster_11": 10.529,
-                            "file_cluster_12": 10.936,
-                            "file_cluster_13": 10.112,
-                            "file_cluster_14": 14.595,
-                            "file_cluster_15": 11.234,
-                            "file_cluster_16": 10.0,
-                            "file_cluster_17": 10.577
+                            "file_cluster_0": 9.813,
+                            "file_cluster_1": 10.526,
+                            "file_cluster_2": 10.741,
+                            "file_cluster_3": 11.743,
+                            "file_cluster_4": 10.958,
+                            "file_cluster_5": 11.156,
+                            "file_cluster_6": 10.625,
+                            "file_cluster_7": 10.231,
+                            "file_cluster_8": 9.53,
+                            "file_cluster_9": 10.642,
+                            "file_cluster_10": 11.849,
+                            "file_cluster_11": 10.67,
+                            "file_cluster_12": 11.058,
+                            "file_cluster_13": 10.273,
+                            "file_cluster_14": 14.705,
+                            "file_cluster_15": 11.357,
+                            "file_cluster_16": 10.141,
+                            "file_cluster_17": 10.745
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 4.359,
+                        "File Drift (Z-Score)": 4.589,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 6.903,
-                            "Cluster 1: Declarative Glue & Initialization": 4.359,
-                            "Cluster 2: Async & Concurrent Testing": 7.785,
-                            "Cluster 3: Data Pipelines & I/O Operations": 5.595,
-                            "Cluster 4: Procedural Verification & Mocks": 6.672,
-                            "Cluster 5: Universal Dependencies & Serialization": 7.363
+                            "Cluster 0: Decorated Core & Metaprogramming": 7.029,
+                            "Cluster 1: Declarative Glue & Initialization": 4.589,
+                            "Cluster 2: Async & Concurrent Testing": 7.886,
+                            "Cluster 3: Data Pipelines & I/O Operations": 5.701,
+                            "Cluster 4: Procedural Verification & Mocks": 6.725,
+                            "Cluster 5: Universal Dependencies & Serialization": 7.861
                         },
                         "Total LOC": 1122,
                         "Coding LOC": 959,
@@ -116811,7 +116811,7 @@
                             "End Line": 508
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_invalid_dict",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116821,7 +116821,7 @@
                             "End Line": 281
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_invalid_model",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116831,7 +116831,7 @@
                             "End Line": 287
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_invalid_dict",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116841,7 +116841,7 @@
                             "End Line": 319
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_invalid_model",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116851,7 +116851,7 @@
                             "End Line": 325
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_invalid_dict",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116861,7 +116861,7 @@
                             "End Line": 403
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_invalid_model",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116871,7 +116871,7 @@
                             "End Line": 409
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -116881,7 +116881,7 @@
                             "End Line": 385
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_dict_with_extra_data",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 0,
@@ -116891,7 +116891,7 @@
                             "End Line": 373
                         },
                         {
-                            "Function Name": "test_response_model_list_of_model_no_ann",
+                            "Function Name": "test_response_model_list_of_model_no_annotation",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -116901,7 +116901,7 @@
                             "End Line": 442
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_list_o",
+                            "Function Name": "test_no_response_model_annotation_list_of_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -116911,7 +116911,7 @@
                             "End Line": 451
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_forwar",
+                            "Function Name": "test_no_response_model_annotation_forward_ref_list_of_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -116921,7 +116921,7 @@
                             "End Line": 460
                         },
                         {
-                            "Function Name": "response_model_list_of_model_no_annotati",
+                            "Function Name": "response_model_list_of_model_no_annotation",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -116931,7 +116931,7 @@
                             "End Line": 196
                         },
                         {
-                            "Function Name": "no_response_model_annotation_list_of_mod",
+                            "Function Name": "no_response_model_annotation_list_of_model",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -116941,7 +116941,7 @@
                             "End Line": 204
                         },
                         {
-                            "Function Name": "no_response_model_annotation_forward_ref",
+                            "Function Name": "no_response_model_annotation_forward_ref_list_of_model",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -116951,7 +116951,7 @@
                             "End Line": 212
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116961,7 +116961,7 @@
                             "End Line": 301
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116971,7 +116971,7 @@
                             "End Line": 339
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_dict_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116981,7 +116981,7 @@
                             "End Line": 417
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_submodel_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116991,7 +116991,7 @@
                             "End Line": 425
                         },
                         {
-                            "Function Name": "test_response_model_filtering_model_anno",
+                            "Function Name": "test_response_model_filtering_model_annotation_submodel_return_submodel",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -117001,7 +117001,7 @@
                             "End Line": 433
                         },
                         {
-                            "Function Name": "test_no_response_model_no_annotation_ret",
+                            "Function Name": "test_no_response_model_no_annotation_return_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117011,7 +117011,7 @@
                             "End Line": 257
                         },
                         {
-                            "Function Name": "test_no_response_model_no_annotation_ret",
+                            "Function Name": "test_no_response_model_no_annotation_return_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117021,7 +117021,7 @@
                             "End Line": 263
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117031,7 +117031,7 @@
                             "End Line": 269
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117041,7 +117041,7 @@
                             "End Line": 275
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117051,7 +117051,7 @@
                             "End Line": 293
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117061,7 +117061,7 @@
                             "End Line": 307
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117071,7 +117071,7 @@
                             "End Line": 313
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117081,7 +117081,7 @@
                             "End Line": 331
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117091,7 +117091,7 @@
                             "End Line": 345
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117101,7 +117101,7 @@
                             "End Line": 351
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_invalid_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117111,7 +117111,7 @@
                             "End Line": 357
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_invalid_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117121,7 +117121,7 @@
                             "End Line": 363
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117131,7 +117131,7 @@
                             "End Line": 391
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117141,7 +117141,7 @@
                             "End Line": 397
                         },
                         {
-                            "Function Name": "test_response_model_union_no_annotation_",
+                            "Function Name": "test_response_model_union_no_annotation_return_model1",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117151,7 +117151,7 @@
                             "End Line": 466
                         },
                         {
-                            "Function Name": "test_response_model_union_no_annotation_",
+                            "Function Name": "test_response_model_union_no_annotation_return_model2",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117161,7 +117161,7 @@
                             "End Line": 472
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_union_",
+                            "Function Name": "test_no_response_model_annotation_union_return_model1",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117171,7 +117171,7 @@
                             "End Line": 478
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_union_",
+                            "Function Name": "test_no_response_model_annotation_union_return_model2",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117181,7 +117181,7 @@
                             "End Line": 484
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_class",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117191,7 +117191,7 @@
                             "End Line": 490
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_json_r",
+                            "Function Name": "test_no_response_model_annotation_json_response_class",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117201,7 +117201,7 @@
                             "End Line": 496
                         },
                         {
-                            "Function Name": "no_response_model_no_annotation_return_m",
+                            "Function Name": "no_response_model_no_annotation_return_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117211,7 +117211,7 @@
                             "End Line": 32
                         },
                         {
-                            "Function Name": "no_response_model_no_annotation_return_d",
+                            "Function Name": "no_response_model_no_annotation_return_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117221,7 +117221,7 @@
                             "End Line": 37
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_same",
+                            "Function Name": "response_model_no_annotation_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117231,7 +117231,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_exac",
+                            "Function Name": "response_model_no_annotation_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117241,7 +117241,7 @@
                             "End Line": 47
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_inva",
+                            "Function Name": "response_model_no_annotation_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117251,7 +117251,7 @@
                             "End Line": 52
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_inva",
+                            "Function Name": "response_model_no_annotation_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117261,7 +117261,7 @@
                             "End Line": 57
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_dict",
+                            "Function Name": "response_model_no_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117271,7 +117271,7 @@
                             "End Line": 64
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_subm",
+                            "Function Name": "response_model_no_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117281,7 +117281,7 @@
                             "End Line": 71
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_same",
+                            "Function Name": "no_response_model_annotation_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117291,7 +117291,7 @@
                             "End Line": 76
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_exac",
+                            "Function Name": "no_response_model_annotation_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117301,7 +117301,7 @@
                             "End Line": 81
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_inva",
+                            "Function Name": "no_response_model_annotation_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117311,7 +117311,7 @@
                             "End Line": 86
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_inva",
+                            "Function Name": "no_response_model_annotation_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117321,7 +117321,7 @@
                             "End Line": 91
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_dict",
+                            "Function Name": "no_response_model_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117331,7 +117331,7 @@
                             "End Line": 96
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_subm",
+                            "Function Name": "no_response_model_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117341,7 +117341,7 @@
                             "End Line": 101
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_sa",
+                            "Function Name": "response_model_none_annotation_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117351,7 +117351,7 @@
                             "End Line": 106
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_ex",
+                            "Function Name": "response_model_none_annotation_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117361,7 +117361,7 @@
                             "End Line": 111
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_in",
+                            "Function Name": "response_model_none_annotation_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117371,7 +117371,7 @@
                             "End Line": 116
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_in",
+                            "Function Name": "response_model_none_annotation_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117381,7 +117381,7 @@
                             "End Line": 121
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_di",
+                            "Function Name": "response_model_none_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117391,7 +117391,7 @@
                             "End Line": 128
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_su",
+                            "Function Name": "response_model_none_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117401,7 +117401,7 @@
                             "End Line": 136
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117411,7 +117411,7 @@
                             "End Line": 143
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117421,7 +117421,7 @@
                             "End Line": 150
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117431,7 +117431,7 @@
                             "End Line": 157
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117441,7 +117441,7 @@
                             "End Line": 164
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117451,7 +117451,7 @@
                             "End Line": 172
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117461,7 +117461,7 @@
                             "End Line": 180
                         },
                         {
-                            "Function Name": "response_model_filtering_model_annotatio",
+                            "Function Name": "response_model_filtering_model_annotation_submodel_return_submodel",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117471,7 +117471,7 @@
                             "End Line": 188
                         },
                         {
-                            "Function Name": "response_model_union_no_annotation_retur",
+                            "Function Name": "response_model_union_no_annotation_return_model1",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117481,7 +117481,7 @@
                             "End Line": 220
                         },
                         {
-                            "Function Name": "response_model_union_no_annotation_retur",
+                            "Function Name": "response_model_union_no_annotation_return_model2",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117491,7 +117491,7 @@
                             "End Line": 228
                         },
                         {
-                            "Function Name": "no_response_model_annotation_union_retur",
+                            "Function Name": "no_response_model_annotation_union_return_model1",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117501,7 +117501,7 @@
                             "End Line": 233
                         },
                         {
-                            "Function Name": "no_response_model_annotation_union_retur",
+                            "Function Name": "no_response_model_annotation_union_return_model2",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117511,7 +117511,7 @@
                             "End Line": 238
                         },
                         {
-                            "Function Name": "no_response_model_annotation_response_cl",
+                            "Function Name": "no_response_model_annotation_response_class",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117521,7 +117521,7 @@
                             "End Line": 243
                         },
                         {
-                            "Function Name": "no_response_model_annotation_json_respon",
+                            "Function Name": "no_response_model_annotation_json_response_class",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117615,8 +117615,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 47,
-                        "Orphaned Logic": 28,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 75,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -118173,36 +118173,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 12.106,
+                        "Repository Drift (Z-Score)": 12.269,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.106,
-                            "file_cluster_1": 13.139,
-                            "file_cluster_2": 13.199,
-                            "file_cluster_3": 13.925,
-                            "file_cluster_4": 12.439,
-                            "file_cluster_5": 13.604,
-                            "file_cluster_6": 12.882,
-                            "file_cluster_7": 12.821,
-                            "file_cluster_8": 12.333,
-                            "file_cluster_9": 12.959,
-                            "file_cluster_10": 14.028,
-                            "file_cluster_11": 12.756,
-                            "file_cluster_12": 13.462,
-                            "file_cluster_13": 12.112,
-                            "file_cluster_14": 16.508,
-                            "file_cluster_15": 13.291,
-                            "file_cluster_16": 13.06,
-                            "file_cluster_17": 12.859
+                            "file_cluster_0": 12.269,
+                            "file_cluster_1": 13.265,
+                            "file_cluster_2": 13.335,
+                            "file_cluster_3": 14.061,
+                            "file_cluster_4": 12.643,
+                            "file_cluster_5": 13.736,
+                            "file_cluster_6": 13.032,
+                            "file_cluster_7": 12.965,
+                            "file_cluster_8": 12.48,
+                            "file_cluster_9": 13.119,
+                            "file_cluster_10": 14.162,
+                            "file_cluster_11": 12.907,
+                            "file_cluster_12": 13.585,
+                            "file_cluster_13": 12.29,
+                            "file_cluster_14": 16.635,
+                            "file_cluster_15": 13.425,
+                            "file_cluster_16": 13.202,
+                            "file_cluster_17": 13.043
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 6.758,
+                        "File Drift (Z-Score)": 6.883,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.481,
-                            "Cluster 1: Declarative Glue & Initialization": 6.758,
-                            "Cluster 2: Async & Concurrent Testing": 9.012,
-                            "Cluster 3: Data Pipelines & I/O Operations": 7.74,
-                            "Cluster 4: Procedural Verification & Mocks": 8.202,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.035
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.53,
+                            "Cluster 1: Declarative Glue & Initialization": 6.883,
+                            "Cluster 2: Async & Concurrent Testing": 9.016,
+                            "Cluster 3: Data Pipelines & I/O Operations": 7.718,
+                            "Cluster 4: Procedural Verification & Mocks": 8.164,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.5
                         },
                         "Total LOC": 48,
                         "Coding LOC": 30,
@@ -118232,7 +118232,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "response_model_has_default_factory_retur",
+                            "Function Name": "response_model_has_default_factory_return_dict",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -118242,7 +118242,7 @@
                             "End Line": 18
                         },
                         {
-                            "Function Name": "response_model_has_default_factory_retur",
+                            "Function Name": "response_model_has_default_factory_return_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -118252,7 +118252,7 @@
                             "End Line": 26
                         },
                         {
-                            "Function Name": "test_response_model_has_default_factory_",
+                            "Function Name": "test_response_model_has_default_factory_return_dict",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -118262,7 +118262,7 @@
                             "End Line": 38
                         },
                         {
-                            "Function Name": "test_response_model_has_default_factory_",
+                            "Function Name": "test_response_model_has_default_factory_return_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -118346,8 +118346,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 4,
-                        "Orphaned Logic": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 2,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -118779,7 +118779,7 @@
                             "End Line": 16
                         },
                         {
-                            "Function Name": "test_invalid_response_model_sub_type_rai",
+                            "Function Name": "test_invalid_response_model_sub_type_raises",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -118789,7 +118789,7 @@
                             "End Line": 25
                         },
                         {
-                            "Function Name": "test_invalid_response_model_in_responses",
+                            "Function Name": "test_invalid_response_model_in_responses_raises",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -118799,7 +118799,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_invalid_response_model_sub_type_in_",
+                            "Function Name": "test_invalid_response_model_sub_type_in_responses_raises",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -119962,7 +119962,7 @@
                             "End Line": 86
                         },
                         {
-                            "Function Name": "test_startup_shutdown_handlers_as_parame",
+                            "Function Name": "test_startup_shutdown_handlers_as_parameters",
                             "Structural Impact": 7.0,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 1,
@@ -120022,7 +120022,7 @@
                             "End Line": 266
                         },
                         {
-                            "Function Name": "test_router_nested_lifespan_state_overri",
+                            "Function Name": "test_router_nested_lifespan_state_overriding_by_parent",
                             "Structural Impact": 4.9,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 1,
@@ -120042,7 +120042,7 @@
                             "End Line": 242
                         },
                         {
-                            "Function Name": "test_merged_no_return_lifespans_return_n",
+                            "Function Name": "test_merged_no_return_lifespans_return_none",
                             "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 1,
@@ -124751,7 +124751,7 @@
                             "End Line": 79
                         },
                         {
-                            "Function Name": "test_security_http_basic_invalid_credent",
+                            "Function Name": "test_security_http_basic_invalid_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -124761,7 +124761,7 @@
                             "End Line": 41
                         },
                         {
-                            "Function Name": "test_security_http_basic_non_basic_crede",
+                            "Function Name": "test_security_http_basic_non_basic_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125001,7 +125001,7 @@
                             "End Line": 15
                         },
                         {
-                            "Function Name": "test_security_http_basic_invalid_credent",
+                            "Function Name": "test_security_http_basic_invalid_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125011,7 +125011,7 @@
                             "End Line": 40
                         },
                         {
-                            "Function Name": "test_security_http_basic_non_basic_crede",
+                            "Function Name": "test_security_http_basic_non_basic_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125251,7 +125251,7 @@
                             "End Line": 15
                         },
                         {
-                            "Function Name": "test_security_http_basic_invalid_credent",
+                            "Function Name": "test_security_http_basic_invalid_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125261,7 +125261,7 @@
                             "End Line": 40
                         },
                         {
-                            "Function Name": "test_security_http_basic_non_basic_crede",
+                            "Function Name": "test_security_http_basic_non_basic_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125511,7 +125511,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "test_security_http_bearer_incorrect_sche",
+                            "Function Name": "test_security_http_bearer_incorrect_scheme_credentials",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -125750,7 +125750,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "test_security_http_bearer_incorrect_sche",
+                            "Function Name": "test_security_http_bearer_incorrect_scheme_credentials",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -125999,7 +125999,7 @@
                             "End Line": 32
                         },
                         {
-                            "Function Name": "test_security_http_bearer_incorrect_sche",
+                            "Function Name": "test_security_http_bearer_incorrect_scheme_credentials",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -126218,7 +126218,7 @@
                             "End Line": 13
                         },
                         {
-                            "Function Name": "test_security_http_digest_incorrect_sche",
+                            "Function Name": "test_security_http_digest_incorrect_scheme_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -126457,7 +126457,7 @@
                             "End Line": 13
                         },
                         {
-                            "Function Name": "test_security_http_digest_incorrect_sche",
+                            "Function Name": "test_security_http_digest_incorrect_scheme_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -126696,7 +126696,7 @@
                             "End Line": 69
                         },
                         {
-                            "Function Name": "test_security_http_digest_incorrect_sche",
+                            "Function Name": "test_security_http_digest_incorrect_scheme_credentials",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -126996,7 +126996,7 @@
                             "End Line": 146
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -127016,7 +127016,7 @@
                             "End Line": 48
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128336,7 +128336,7 @@
                             "End Line": 50
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128346,7 +128346,7 @@
                             "End Line": 56
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128618,7 +128618,7 @@
                             "End Line": 105
                         },
                         {
-                            "Function Name": "test_strict_login_correct_correct_grant_",
+                            "Function Name": "test_strict_login_correct_correct_grant_type",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 0,
@@ -128638,7 +128638,7 @@
                             "End Line": 51
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128648,7 +128648,7 @@
                             "End Line": 57
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129358,7 +129358,7 @@
                             "End Line": 23
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -129378,7 +129378,7 @@
                             "End Line": 32
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129609,7 +129609,7 @@
                             "End Line": 25
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -129629,7 +129629,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129870,7 +129870,7 @@
                             "End Line": 36
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129880,7 +129880,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -130140,7 +130140,7 @@
                             "End Line": 20
                         },
                         {
-                            "Function Name": "test_security_scopes_dependency_called_o",
+                            "Function Name": "test_security_scopes_dependency_called_once",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -130658,7 +130658,7 @@
                             "End Line": 49
                         },
                         {
-                            "Function Name": "test_security_scopes_sub_dependency_cach",
+                            "Function Name": "test_security_scopes_sub_dependency_caching",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -132510,7 +132510,7 @@
                             "End Line": 36
                         },
                         {
-                            "Function Name": "test_no_body_status_code_with_detail_exc",
+                            "Function Name": "test_no_body_status_code_with_detail_exception_handlers",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -132530,7 +132530,7 @@
                             "End Line": 24
                         },
                         {
-                            "Function Name": "no_body_status_code_with_detail_exceptio",
+                            "Function Name": "no_body_status_code_with_detail_exception",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -132580,7 +132580,7 @@
                             "End Line": 58
                         },
                         {
-                            "Function Name": "test_no_body_status_code_exception_handl",
+                            "Function Name": "test_no_body_status_code_exception_handlers",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -133799,7 +133799,7 @@
                             "End Line": 17
                         },
                         {
-                            "Function Name": "test_default_strict_rejects_no_content_t",
+                            "Function Name": "test_default_strict_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -133809,7 +133809,7 @@
                             "End Line": 26
                         },
                         {
-                            "Function Name": "test_default_strict_accepts_json_content",
+                            "Function Name": "test_default_strict_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -134066,7 +134066,7 @@
                             "End Line": 64
                         },
                         {
-                            "Function Name": "test_strict_inner_on_lax_app_rejects_no_",
+                            "Function Name": "test_strict_inner_on_lax_app_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134086,7 +134086,7 @@
                             "End Line": 37
                         },
                         {
-                            "Function Name": "test_strict_inner_accepts_json_content_t",
+                            "Function Name": "test_strict_inner_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134096,7 +134096,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "test_default_inner_accepts_json_content_",
+                            "Function Name": "test_default_inner_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134106,7 +134106,7 @@
                             "End Line": 47
                         },
                         {
-                            "Function Name": "test_lax_outer_on_strict_app_accepts_no_",
+                            "Function Name": "test_lax_outer_on_strict_app_accepts_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -134116,7 +134116,7 @@
                             "End Line": 76
                         },
                         {
-                            "Function Name": "test_strict_inner_on_lax_outer_rejects_n",
+                            "Function Name": "test_strict_inner_on_lax_outer_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134136,7 +134136,7 @@
                             "End Line": 86
                         },
                         {
-                            "Function Name": "test_strict_inner_on_lax_outer_accepts_j",
+                            "Function Name": "test_strict_inner_on_lax_outer_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134363,7 +134363,7 @@
                             "End Line": 23
                         },
                         {
-                            "Function Name": "test_lax_router_on_strict_app_accepts_no",
+                            "Function Name": "test_lax_router_on_strict_app_accepts_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -134373,7 +134373,7 @@
                             "End Line": 36
                         },
                         {
-                            "Function Name": "test_strict_router_on_strict_app_rejects",
+                            "Function Name": "test_strict_router_on_strict_app_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134383,7 +134383,7 @@
                             "End Line": 41
                         },
                         {
-                            "Function Name": "test_default_router_inherits_strict_from",
+                            "Function Name": "test_default_router_inherits_strict_from_app",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134393,7 +134393,7 @@
                             "End Line": 46
                         },
                         {
-                            "Function Name": "test_lax_router_accepts_json_content_typ",
+                            "Function Name": "test_lax_router_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134403,7 +134403,7 @@
                             "End Line": 51
                         },
                         {
-                            "Function Name": "test_strict_router_accepts_json_content_",
+                            "Function Name": "test_strict_router_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134413,7 +134413,7 @@
                             "End Line": 56
                         },
                         {
-                            "Function Name": "test_default_router_accepts_json_content",
+                            "Function Name": "test_default_router_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -138189,7 +138189,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_websocket_validation_error_includes",
+                            "Function Name": "test_websocket_validation_error_includes_endpoint_context",
                             "Structural Impact": 5.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
@@ -138199,7 +138199,7 @@
                             "End Line": 124
                         },
                         {
-                            "Function Name": "test_subapp_websocket_validation_error_i",
+                            "Function Name": "test_subapp_websocket_validation_error_includes_endpoint_context",
                             "Structural Impact": 5.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
@@ -138209,7 +138209,7 @@
                             "End Line": 151
                         },
                         {
-                            "Function Name": "test_request_validation_error_includes_e",
+                            "Function Name": "test_request_validation_error_includes_endpoint_context",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -138219,7 +138219,7 @@
                             "End Line": 97
                         },
                         {
-                            "Function Name": "test_response_validation_error_includes_",
+                            "Function Name": "test_response_validation_error_includes_endpoint_context",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -138229,7 +138229,7 @@
                             "End Line": 110
                         },
                         {
-                            "Function Name": "test_subapp_request_validation_error_inc",
+                            "Function Name": "test_subapp_request_validation_error_includes_endpoint_context",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -142442,7 +142442,7 @@
             }
         },
         "javascript/react": {
-            "Directory Group Magnitude": 8986.55,
+            "Directory Group Magnitude": 8984.55,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_11": "60.0%",
@@ -142453,7 +142453,7 @@
                 "Error & Exception Exposure": "29.68%",
                 "Tech Debt Exposure": "80.66%",
                 "Testing Exposure": "33.6%",
-                "API Exposure": "7.84%",
+                "API Exposure": "7.82%",
                 "Concurrency Exposure": "8.22%",
                 "State Flux Exposure": "21.14%",
                 "Commented Logic Exposure": "1.98%",
@@ -142716,7 +142716,7 @@
                             "End Line": 1236
                         },
                         {
-                            "Function Name": "mountSuspenseFallbackAfterRetryWithoutHy",
+                            "Function Name": "mountSuspenseFallbackAfterRetryWithoutHydrating",
                             "Structural Impact": 9.9,
                             "Lines of Code (LOC)": 40,
                             "Control Flow Branches": 2,
@@ -143213,40 +143213,40 @@
                     "2. Topological Coordinates": {
                         "X": -2789.01,
                         "Y": -173.31,
-                        "Z": -3581.53
+                        "Z": -3581.51
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
                         "Repository Drift (Z-Score)": 12.023,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.655,
-                            "file_cluster_1": 13.134,
-                            "file_cluster_2": 13.046,
+                            "file_cluster_0": 12.656,
+                            "file_cluster_1": 13.133,
+                            "file_cluster_2": 13.045,
                             "file_cluster_3": 12.909,
                             "file_cluster_4": 12.977,
-                            "file_cluster_5": 13.588,
+                            "file_cluster_5": 13.587,
                             "file_cluster_6": 12.623,
-                            "file_cluster_7": 12.801,
-                            "file_cluster_8": 12.517,
+                            "file_cluster_7": 12.8,
+                            "file_cluster_8": 12.515,
                             "file_cluster_9": 12.887,
-                            "file_cluster_10": 13.677,
+                            "file_cluster_10": 13.676,
                             "file_cluster_11": 12.023,
-                            "file_cluster_12": 13.205,
+                            "file_cluster_12": 13.204,
                             "file_cluster_13": 12.373,
-                            "file_cluster_14": 15.09,
-                            "file_cluster_15": 13.013,
+                            "file_cluster_14": 15.089,
+                            "file_cluster_15": 13.012,
                             "file_cluster_16": 13.089,
-                            "file_cluster_17": 12.754
+                            "file_cluster_17": 12.753
                         },
                         "File Archetype": "Cluster 2: Procedural Core & Safety Wrappers",
-                        "File Drift (Z-Score)": 5.659,
+                        "File Drift (Z-Score)": 5.658,
                         "File Fingerprint": {
                             "Cluster 0: The God Nodes (Universal Dependencies)": 6.737,
                             "Cluster 1: Async Testing & I/O Mocks": 7.382,
-                            "Cluster 2: Procedural Core & Safety Wrappers": 5.659,
-                            "Cluster 3: Pure View Layer Components (UI)": 5.745,
+                            "Cluster 2: Procedural Core & Safety Wrappers": 5.658,
+                            "Cluster 3: Pure View Layer Components (UI)": 5.744,
                             "Cluster 4: Heavily Documented Core Functions": 6.729,
-                            "Cluster 5: I/O, UI & Routing Configuration": 6.059,
+                            "Cluster 5: I/O, UI & Routing Configuration": 6.06,
                             "Cluster 6: Documented Native Core Logic": 6.334,
                             "Cluster 7: Algorithmic Data Processing": 6.512,
                             "Cluster 8: Declarative Glue & Inert Types": 5.734,
@@ -143255,7 +143255,7 @@
                         "Total LOC": 5622,
                         "Coding LOC": 2144,
                         "Documentation LOC": 3055,
-                        "Structural Magnitude": 2299.68,
+                        "Structural Magnitude": 2297.68,
                         "Control Flow Ratio": "69.4%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -143268,7 +143268,7 @@
                         "Error & Exception Exposure": "41.08%",
                         "Tech Debt Exposure": "99.99%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "9.84%",
+                        "API Exposure": "9.77%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "23.52%",
                         "Commented Logic Exposure": "5.04%",
@@ -143480,7 +143480,7 @@
                             "End Line": 2784
                         },
                         {
-                            "Function Name": "stopProfilerTimerIfRunningAndRecordDurat",
+                            "Function Name": "stopProfilerTimerIfRunningAndRecordDuration",
                             "Structural Impact": 17.0,
                             "Lines of Code (LOC)": 40,
                             "Control Flow Branches": 14,
@@ -143590,7 +143590,7 @@
                             "End Line": 2390
                         },
                         {
-                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffect",
+                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffectsInDEV",
                             "Structural Impact": 10.0,
                             "Lines of Code (LOC)": 21,
                             "Control Flow Branches": 3,
@@ -144330,7 +144330,7 @@
                             "End Line": 2573
                         },
                         {
-                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffect",
+                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffectsInDEV",
                             "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 1,
@@ -144500,7 +144500,7 @@
                             "End Line": 1547
                         },
                         {
-                            "Function Name": "stopProfilerTimerIfRunningAndRecordIncom",
+                            "Function Name": "stopProfilerTimerIfRunningAndRecordIncompleteDuration",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -144800,7 +144800,7 @@
                             "End Line": 546
                         },
                         {
-                            "Function Name": "isInvalidExecutionContextForEventFunctio",
+                            "Function Name": "isInvalidExecutionContextForEventFunction",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -144881,7 +144881,7 @@
                         "Type/Safety Bypasses": 28,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 69,
+                        "Exposed API / Public Exports": 67,
                         "State Mutations / Variable Reassignments": 120,
                         "Commented-out Code (Dead Logic)": 4,
                         "Structured Documentation Blocks": 3,
@@ -161615,7 +161615,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "13.23%",
                 "Error & Exception Exposure": "43.05%",
-                "Tech Debt Exposure": "32.53%",
+                "Tech Debt Exposure": "32.47%",
                 "Testing Exposure": "32.18%",
                 "API Exposure": "3.04%",
                 "Concurrency Exposure": "0.0%",
@@ -162368,30 +162368,30 @@
                             "file_cluster_1": 11.398,
                             "file_cluster_2": 11.533,
                             "file_cluster_3": 12.386,
-                            "file_cluster_4": 11.892,
-                            "file_cluster_5": 11.765,
+                            "file_cluster_4": 11.891,
+                            "file_cluster_5": 11.764,
                             "file_cluster_6": 11.319,
-                            "file_cluster_7": 10.936,
+                            "file_cluster_7": 10.935,
                             "file_cluster_8": 10.971,
                             "file_cluster_9": 11.633,
-                            "file_cluster_10": 12.025,
+                            "file_cluster_10": 12.024,
                             "file_cluster_11": 11.238,
                             "file_cluster_12": 11.609,
-                            "file_cluster_13": 10.995,
-                            "file_cluster_14": 14.994,
-                            "file_cluster_15": 11.672,
-                            "file_cluster_16": 10.988,
-                            "file_cluster_17": 11.642
+                            "file_cluster_13": 10.994,
+                            "file_cluster_14": 14.993,
+                            "file_cluster_15": 11.671,
+                            "file_cluster_16": 10.987,
+                            "file_cluster_17": 11.641
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.391,
+                        "File Drift (Z-Score)": 7.393,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.615,
-                            "Cluster 1: Declarative Glue & Initialization": 7.391,
-                            "Cluster 2: Async & Concurrent Testing": 9.583,
-                            "Cluster 3: Data Pipelines & I/O Operations": 7.818,
-                            "Cluster 4: Procedural Verification & Mocks": 8.793,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.285
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.62,
+                            "Cluster 1: Declarative Glue & Initialization": 7.393,
+                            "Cluster 2: Async & Concurrent Testing": 9.591,
+                            "Cluster 3: Data Pipelines & I/O Operations": 7.826,
+                            "Cluster 4: Procedural Verification & Mocks": 8.797,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.295
                         },
                         "Total LOC": 3650,
                         "Coding LOC": 870,
@@ -162407,7 +162407,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "11.62%",
                         "Error & Exception Exposure": "51.38%",
-                        "Tech Debt Exposure": "9.86%",
+                        "Tech Debt Exposure": "8.89%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "1.37%",
                         "Concurrency Exposure": "0.0%",
@@ -162721,7 +162721,7 @@
                             "End Line": 116
                         },
                         {
-                            "Function Name": "_raise_linalgerror_eigenvalues_nonconver",
+                            "Function Name": "_raise_linalgerror_eigenvalues_nonconvergence",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -162876,7 +162876,7 @@
                         "Design Short Vars": 108,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 2,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -173651,7 +173651,7 @@
                             "End Line": 3178
                         },
                         {
-                            "Function Name": "Get-PackageVersionAsMajorMinorBuildRevis",
+                            "Function Name": "Get-PackageVersionAsMajorMinorBuildRevision",
                             "Structural Impact": 24.7,
                             "Lines of Code (LOC)": 44,
                             "Control Flow Branches": 12,
@@ -175412,7 +175412,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "30.26%",
                 "Error & Exception Exposure": "57.88%",
-                "Tech Debt Exposure": "29.46%",
+                "Tech Debt Exposure": "28.13%",
                 "Testing Exposure": "44.75%",
                 "API Exposure": "3.64%",
                 "Concurrency Exposure": "0.0%",
@@ -178110,23 +178110,23 @@
                         "Repository Archetype": "file_cluster_11",
                         "Repository Drift (Z-Score)": 11.382,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.024,
+                            "file_cluster_0": 12.026,
                             "file_cluster_1": 12.152,
                             "file_cluster_2": 12.239,
                             "file_cluster_3": 11.622,
                             "file_cluster_4": 12.593,
-                            "file_cluster_5": 12.577,
+                            "file_cluster_5": 12.576,
                             "file_cluster_6": 11.997,
-                            "file_cluster_7": 11.772,
-                            "file_cluster_8": 11.503,
-                            "file_cluster_9": 12.173,
-                            "file_cluster_10": 12.756,
+                            "file_cluster_7": 11.771,
+                            "file_cluster_8": 11.501,
+                            "file_cluster_9": 12.174,
+                            "file_cluster_10": 12.755,
                             "file_cluster_11": 11.382,
                             "file_cluster_12": 12.296,
                             "file_cluster_13": 11.968,
                             "file_cluster_14": 13.919,
-                            "file_cluster_15": 12.235,
-                            "file_cluster_16": 12.149,
+                            "file_cluster_15": 12.234,
+                            "file_cluster_16": 12.148,
                             "file_cluster_17": 12.253
                         },
                         "File Archetype": null,
@@ -178146,7 +178146,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "12.62%",
                         "Error & Exception Exposure": "54.89%",
-                        "Tech Debt Exposure": "43.76%",
+                        "Tech Debt Exposure": "29.19%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.82%",
                         "Concurrency Exposure": "0.0%",
@@ -178440,7 +178440,7 @@
                             "End Line": 5043
                         },
                         {
-                            "Function Name": "prefetch_create_transfers_callback_trans",
+                            "Function Name": "prefetch_create_transfers_callback_transfers",
                             "Structural Impact": 16.2,
                             "Lines of Code (LOC)": 47,
                             "Control Flow Branches": 7,
@@ -178640,7 +178640,7 @@
                             "End Line": 3208
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_accoun",
+                            "Function Name": "prefetch_expire_pending_transfers_accounts",
                             "Structural Impact": 8.9,
                             "Lines of Code (LOC)": 39,
                             "Control Flow Branches": 3,
@@ -178900,7 +178900,7 @@
                             "End Line": 4360
                         },
                         {
-                            "Function Name": "prefetch_get_account_transfers_scan_call",
+                            "Function Name": "prefetch_get_account_transfers_scan_callback",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 1,
@@ -178910,7 +178910,7 @@
                             "End Line": 1490
                         },
                         {
-                            "Function Name": "prefetch_get_account_balances_scan_callb",
+                            "Function Name": "prefetch_get_account_balances_scan_callback",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 1,
@@ -179140,7 +179140,7 @@
                             "End Line": 4982
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_scan_c",
+                            "Function Name": "prefetch_expire_pending_transfers_scan_callback",
                             "Structural Impact": 3.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 0,
@@ -179180,7 +179180,7 @@
                             "End Line": 1176
                         },
                         {
-                            "Function Name": "prefetch_create_transfers_callback_accou",
+                            "Function Name": "prefetch_create_transfers_callback_accounts",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 0,
@@ -179190,7 +179190,7 @@
                             "End Line": 1331
                         },
                         {
-                            "Function Name": "prefetch_get_account_balances_lookup_acc",
+                            "Function Name": "prefetch_get_account_balances_lookup_account_callback",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 0,
@@ -179210,7 +179210,7 @@
                             "End Line": 2062
                         },
                         {
-                            "Function Name": "prefetch_get_change_events_callback_acco",
+                            "Function Name": "prefetch_get_change_events_callback_accounts",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -179220,7 +179220,7 @@
                             "End Line": 2285
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_callba",
+                            "Function Name": "prefetch_expire_pending_transfers_callback_accounts",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -179230,7 +179230,7 @@
                             "End Line": 2467
                         },
                         {
-                            "Function Name": "prefetch_create_accounts_transfers_callb",
+                            "Function Name": "prefetch_create_accounts_transfers_callback",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -179240,7 +179240,7 @@
                             "End Line": 1242
                         },
                         {
-                            "Function Name": "prefetch_create_transfers_callback_trans",
+                            "Function Name": "prefetch_create_transfers_callback_transfers_pending",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -179340,7 +179340,7 @@
                             "End Line": 2131
                         },
                         {
-                            "Function Name": "prefetch_get_change_events_callback_tran",
+                            "Function Name": "prefetch_get_change_events_callback_transfers",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -179350,7 +179350,7 @@
                             "End Line": 2296
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_callba",
+                            "Function Name": "prefetch_expire_pending_transfers_callback_transfers_pending",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -179514,8 +179514,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 17,
                         "Design Long Vars": 2,
-                        "Duplicate Logic": 18,
-                        "Orphaned Logic": 13,
+                        "Duplicate Logic": 14,
+                        "Orphaned Logic": 4,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -193835,7 +193835,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "30.98%",
                 "Error & Exception Exposure": "55.18%",
-                "Tech Debt Exposure": "62.58%",
+                "Tech Debt Exposure": "61.25%",
                 "Testing Exposure": "80.0%",
                 "API Exposure": "5.57%",
                 "Concurrency Exposure": "4.39%",
@@ -195090,26 +195090,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 12.886,
+                        "Repository Drift (Z-Score)": 12.887,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.258,
-                            "file_cluster_1": 13.728,
-                            "file_cluster_2": 13.731,
-                            "file_cluster_3": 13.532,
-                            "file_cluster_4": 13.63,
-                            "file_cluster_5": 14.047,
-                            "file_cluster_6": 13.303,
-                            "file_cluster_7": 13.294,
-                            "file_cluster_8": 13.178,
-                            "file_cluster_9": 13.501,
-                            "file_cluster_10": 14.107,
-                            "file_cluster_11": 12.886,
+                            "file_cluster_0": 13.259,
+                            "file_cluster_1": 13.729,
+                            "file_cluster_2": 13.732,
+                            "file_cluster_3": 13.533,
+                            "file_cluster_4": 13.632,
+                            "file_cluster_5": 14.048,
+                            "file_cluster_6": 13.304,
+                            "file_cluster_7": 13.295,
+                            "file_cluster_8": 13.179,
+                            "file_cluster_9": 13.502,
+                            "file_cluster_10": 14.108,
+                            "file_cluster_11": 12.887,
                             "file_cluster_12": 13.72,
-                            "file_cluster_13": 13.323,
-                            "file_cluster_14": 15.774,
-                            "file_cluster_15": 13.648,
-                            "file_cluster_16": 13.606,
-                            "file_cluster_17": 13.564
+                            "file_cluster_13": 13.325,
+                            "file_cluster_14": 15.775,
+                            "file_cluster_15": 13.649,
+                            "file_cluster_16": 13.607,
+                            "file_cluster_17": 13.566
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -195128,7 +195128,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "15.5%",
                         "Error & Exception Exposure": "49.64%",
-                        "Tech Debt Exposure": "73.32%",
+                        "Tech Debt Exposure": "68.02%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "13.64%",
                         "Concurrency Exposure": "0.0%",
@@ -196122,7 +196122,7 @@
                             "End Line": 720
                         },
                         {
-                            "Function Name": "napi_internal_suppress_crash_on_abort_if",
+                            "Function Name": "napi_internal_suppress_crash_on_abort_if_desired",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
@@ -196312,7 +196312,7 @@
                             "End Line": 67
                         },
                         {
-                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
+                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEEEmNSt3__18functionIFNS_10MaybeLocalINS_5ValueEEEvEEE",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -196322,7 +196322,7 @@
                             "End Line": 2008
                         },
                         {
-                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
+                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEEEmSt8functionIFNS_10MaybeLocalINS_5ValueEEEvEE",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -196406,8 +196406,8 @@
                         "Design Upper Case": 2,
                         "Design Short Vars": 12,
                         "Design Long Vars": 13,
-                        "Duplicate Logic": 15,
-                        "Orphaned Logic": 10,
+                        "Duplicate Logic": 13,
+                        "Orphaned Logic": 11,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -202603,7 +202603,7 @@
             }
         },
         "cpp/NVDA": {
-            "Directory Group Magnitude": 4300.9,
+            "Directory Group Magnitude": 4301.9,
             "File Count": 12,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_13": "41.7%",
@@ -202617,7 +202617,7 @@
                 "Error & Exception Exposure": "43.38%",
                 "Tech Debt Exposure": "34.27%",
                 "Testing Exposure": "46.88%",
-                "API Exposure": "2.76%",
+                "API Exposure": "2.78%",
                 "Concurrency Exposure": "3.79%",
                 "State Flux Exposure": "55.66%",
                 "Commented Logic Exposure": "0.81%",
@@ -206624,7 +206624,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "nvdaControllerInternal_displayModelTextC",
+                            "Function Name": "nvdaControllerInternal_displayModelTextChangeNotify",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206634,7 +206634,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_drawFocusRectNoti",
+                            "Function Name": "nvdaControllerInternal_drawFocusRectNotify",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206644,7 +206644,7 @@
                             "End Line": 69
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputCompositionU",
+                            "Function Name": "nvdaControllerInternal_inputCompositionUpdate",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206654,7 +206654,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_requestRegistrati",
+                            "Function Name": "nvdaControllerInternal_requestRegistration",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206664,7 +206664,7 @@
                             "End Line": 8
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputLangChangeNo",
+                            "Function Name": "nvdaControllerInternal_inputLangChangeNotify",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206674,7 +206674,7 @@
                             "End Line": 13
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_typedCharacterNot",
+                            "Function Name": "nvdaControllerInternal_typedCharacterNotify",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206694,7 +206694,7 @@
                             "End Line": 24
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputCandidateLis",
+                            "Function Name": "nvdaControllerInternal_inputCandidateListUpdate",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206704,7 +206704,7 @@
                             "End Line": 39
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_IMEOpenStatusUpda",
+                            "Function Name": "nvdaControllerInternal_IMEOpenStatusUpdate",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206714,7 +206714,7 @@
                             "End Line": 44
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputConversionMo",
+                            "Function Name": "nvdaControllerInternal_inputConversionModeUpdate",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206724,7 +206724,7 @@
                             "End Line": 49
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_installAddonPacka",
+                            "Function Name": "nvdaControllerInternal_installAddonPackageFromPath",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206764,7 +206764,7 @@
                             "End Line": 74
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_openConfigDirecto",
+                            "Function Name": "nvdaControllerInternal_openConfigDirectory",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206895,48 +206895,48 @@
                         "Identity Proof": "Single Indicator (Ext: .cpp)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3707.99,
+                        "X": -3707.97,
                         "Y": -40.37,
-                        "Z": -1331.9
+                        "Z": -1331.87
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 13.729,
+                        "Repository Drift (Z-Score)": 13.731,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.346,
-                            "file_cluster_1": 14.609,
-                            "file_cluster_2": 14.598,
-                            "file_cluster_3": 15.367,
-                            "file_cluster_4": 14.361,
-                            "file_cluster_5": 15.015,
-                            "file_cluster_6": 14.557,
-                            "file_cluster_7": 14.291,
-                            "file_cluster_8": 14.129,
-                            "file_cluster_9": 14.541,
-                            "file_cluster_10": 15.21,
-                            "file_cluster_11": 14.193,
-                            "file_cluster_12": 14.766,
-                            "file_cluster_13": 13.729,
-                            "file_cluster_14": 17.678,
-                            "file_cluster_15": 14.641,
-                            "file_cluster_16": 14.573,
-                            "file_cluster_17": 14.464
+                            "file_cluster_0": 14.347,
+                            "file_cluster_1": 14.614,
+                            "file_cluster_2": 14.603,
+                            "file_cluster_3": 15.369,
+                            "file_cluster_4": 14.362,
+                            "file_cluster_5": 15.019,
+                            "file_cluster_6": 14.558,
+                            "file_cluster_7": 14.294,
+                            "file_cluster_8": 14.134,
+                            "file_cluster_9": 14.543,
+                            "file_cluster_10": 15.212,
+                            "file_cluster_11": 14.195,
+                            "file_cluster_12": 14.768,
+                            "file_cluster_13": 13.731,
+                            "file_cluster_14": 17.682,
+                            "file_cluster_15": 14.643,
+                            "file_cluster_16": 14.575,
+                            "file_cluster_17": 14.468
                         },
                         "File Archetype": "Cluster 0: Declarative Interfaces & Inert Headers",
-                        "File Drift (Z-Score)": 6.878,
+                        "File Drift (Z-Score)": 6.898,
                         "File Fingerprint": {
-                            "Cluster 0: Declarative Interfaces & Inert Headers": 6.878,
-                            "Cluster 1: Documented API Headers & Entity Definitions": 7.732,
-                            "Cluster 2: Verification & Unit Testing": 7.876,
-                            "Cluster 3: Algorithmic Execution Core": 7.024,
-                            "Cluster 4: The God Headers (Universal Dependencies)": 9.833,
-                            "Cluster 5: Heavily Documented Complex Base Classes": 11.057,
-                            "Cluster 6: Generic Templates & Metaprogramming Core": 8.361
+                            "Cluster 0: Declarative Interfaces & Inert Headers": 6.898,
+                            "Cluster 1: Documented API Headers & Entity Definitions": 7.749,
+                            "Cluster 2: Verification & Unit Testing": 7.893,
+                            "Cluster 3: Algorithmic Execution Core": 7.043,
+                            "Cluster 4: The God Headers (Universal Dependencies)": 9.846,
+                            "Cluster 5: Heavily Documented Complex Base Classes": 11.069,
+                            "Cluster 6: Generic Templates & Metaprogramming Core": 8.376
                         },
                         "Total LOC": 1247,
                         "Coding LOC": 220,
                         "Documentation LOC": 957,
-                        "Structural Magnitude": 371.5,
+                        "Structural Magnitude": 372.5,
                         "Control Flow Ratio": "72.9%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -206949,7 +206949,7 @@
                         "Error & Exception Exposure": "97.77%",
                         "Tech Debt Exposure": "0.0%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "6.97%",
+                        "API Exposure": "7.2%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "100.0%",
                         "Commented Logic Exposure": "0.0%",
@@ -206971,7 +206971,7 @@
                             "End Line": 112
                         },
                         {
-                            "Function Name": "VBufStorage_fieldNode_t::locateTextField",
+                            "Function Name": "VBufStorage_fieldNode_t::locateTextFieldNodeAtOffset",
                             "Structural Impact": 25.5,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 12,
@@ -207001,7 +207001,7 @@
                             "End Line": 137
                         },
                         {
-                            "Function Name": "VBufStorage_fieldNode_t::disassociateFro",
+                            "Function Name": "VBufStorage_fieldNode_t::disassociateFromBuffer",
                             "Structural Impact": 9.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 4,
@@ -207011,7 +207011,7 @@
                             "End Line": 236
                         },
                         {
-                            "Function Name": "VBufStorage_fieldNode_t::calculateOffset",
+                            "Function Name": "VBufStorage_fieldNode_t::calculateOffsetInTree",
                             "Structural Impact": 8.6,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 2,
@@ -207051,7 +207051,7 @@
                             "End Line": 41
                         },
                         {
-                            "Function Name": "VBufStorage_textFieldNode_t::VBufStorage",
+                            "Function Name": "VBufStorage_textFieldNode_t::VBufStorage_textFieldNode_t",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -207061,7 +207061,7 @@
                             "End Line": 240
                         },
                         {
-                            "Function Name": "VBufStorage_buffer_t::forgetControlField",
+                            "Function Name": "VBufStorage_buffer_t::forgetControlFieldNode",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -207071,7 +207071,7 @@
                             "End Line": 253
                         },
                         {
-                            "Function Name": "VBufStorage_controlFieldNodeIdentifier_t",
+                            "Function Name": "VBufStorage_controlFieldNodeIdentifier_t::VBufStorage_controlFieldNodeIdentifier_t",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -207081,7 +207081,7 @@
                             "End Line": 25
                         },
                         {
-                            "Function Name": "VBufStorage_textFieldNode_t::getDebugInf",
+                            "Function Name": "VBufStorage_textFieldNode_t::getDebugInfo",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -207102,7 +207102,7 @@
                         "Type/Safety Bypasses": 0,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 11,
+                        "Exposed API / Public Exports": 12,
                         "State Mutations / Variable Reassignments": 203,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 4,
@@ -225490,7 +225490,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "10.77%",
                 "Error & Exception Exposure": "46.28%",
-                "Tech Debt Exposure": "69.28%",
+                "Tech Debt Exposure": "69.02%",
                 "Testing Exposure": "57.83%",
                 "API Exposure": "3.76%",
                 "Concurrency Exposure": "0.0%",
@@ -226822,26 +226822,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 11.896,
+                        "Repository Drift (Z-Score)": 11.894,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.052,
-                            "file_cluster_1": 13.574,
-                            "file_cluster_2": 13.575,
-                            "file_cluster_3": 12.11,
-                            "file_cluster_4": 13.568,
-                            "file_cluster_5": 13.9,
-                            "file_cluster_6": 13.395,
-                            "file_cluster_7": 13.23,
-                            "file_cluster_8": 13.175,
-                            "file_cluster_9": 13.545,
-                            "file_cluster_10": 13.811,
-                            "file_cluster_11": 11.896,
-                            "file_cluster_12": 13.471,
-                            "file_cluster_13": 13.237,
-                            "file_cluster_14": 13.7,
-                            "file_cluster_15": 12.519,
-                            "file_cluster_16": 12.885,
-                            "file_cluster_17": 13.129
+                            "file_cluster_0": 13.051,
+                            "file_cluster_1": 13.573,
+                            "file_cluster_2": 13.573,
+                            "file_cluster_3": 12.108,
+                            "file_cluster_4": 13.566,
+                            "file_cluster_5": 13.898,
+                            "file_cluster_6": 13.394,
+                            "file_cluster_7": 13.228,
+                            "file_cluster_8": 13.173,
+                            "file_cluster_9": 13.544,
+                            "file_cluster_10": 13.809,
+                            "file_cluster_11": 11.894,
+                            "file_cluster_12": 13.469,
+                            "file_cluster_13": 13.236,
+                            "file_cluster_14": 13.698,
+                            "file_cluster_15": 12.518,
+                            "file_cluster_16": 12.883,
+                            "file_cluster_17": 13.127
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -226860,7 +226860,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "15.26%",
                         "Error & Exception Exposure": "62.88%",
-                        "Tech Debt Exposure": "35.14%",
+                        "Tech Debt Exposure": "33.31%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "4.87%",
                         "Concurrency Exposure": "0.0%",
@@ -227214,7 +227214,7 @@
                             "End Line": 405
                         },
                         {
-                            "Function Name": "maybeTruncateCleanerCheckpointToActiveSe",
+                            "Function Name": "maybeTruncateCleanerCheckpointToActiveSegmentBaseOffset",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
@@ -227509,7 +227509,7 @@
                         "Design Short Vars": 3,
                         "Design Long Vars": 14,
                         "Duplicate Logic": 4,
-                        "Orphaned Logic": 12,
+                        "Orphaned Logic": 11,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -228519,7 +228519,7 @@
                             "End Line": 337
                         },
                         {
-                            "Function Name": "completeDelayedOperationsWhenNotPartitio",
+                            "Function Name": "completeDelayedOperationsWhenNotPartitionLeader",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 1,
@@ -234139,7 +234139,7 @@
                             "End Line": 1639
                         },
                         {
-                            "Function Name": "test_partially_untagged_internally_tagge",
+                            "Function Name": "test_partially_untagged_internally_tagged_enum",
                             "Structural Impact": 3.2,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 0,
@@ -234279,7 +234279,7 @@
                             "End Line": 2573
                         },
                         {
-                            "Function Name": "test_expecting_message_externally_tagged",
+                            "Function Name": "test_expecting_message_externally_tagged_enum",
                             "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 19,
                             "Control Flow Branches": 0,
@@ -239109,7 +239109,7 @@
                             "End Line": 21
                         },
                         {
-                            "Function Name": "websocket_request_validation_exception_h",
+                            "Function Name": "websocket_request_validation_exception_handler",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -242503,7 +242503,7 @@
                             "End Line": 2049
                         },
                         {
-                            "Function Name": "Translator::CreateFlexBuilderWithNodeAtt",
+                            "Function Name": "Translator::CreateFlexBuilderWithNodeAttrs",
                             "Structural Impact": 52.0,
                             "Lines of Code (LOC)": 70,
                             "Control Flow Branches": 27,
@@ -242613,7 +242613,7 @@
                             "End Line": 342
                         },
                         {
-                            "Function Name": "Translator::GetOperatorDebugMetadataInde",
+                            "Function Name": "Translator::GetOperatorDebugMetadataIndex",
                             "Structural Impact": 7.6,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 3,
@@ -242623,7 +242623,7 @@
                             "End Line": 777
                         },
                         {
-                            "Function Name": "Translator::GetQuantizationForQuantStats",
+                            "Function Name": "Translator::GetQuantizationForQuantStatsOpOutput",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 5,
@@ -242733,7 +242733,7 @@
                             "End Line": 1166
                         },
                         {
-                            "Function Name": "Translator::BuildStablehloOperatorwithou",
+                            "Function Name": "Translator::BuildStablehloOperatorwithoutOptions",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 0,
@@ -242773,7 +242773,7 @@
                             "End Line": 423
                         },
                         {
-                            "Function Name": "Translator::BuildStablehloPrecisionConfi",
+                            "Function Name": "Translator::BuildStablehloPrecisionConfig",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -243457,7 +243457,7 @@
                             "End Line": 149
                         },
                         {
-                            "Function Name": "MlirV1CompatOptimizationPassRegistry::Gl",
+                            "Function Name": "MlirV1CompatOptimizationPassRegistry::Global",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -244294,7 +244294,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "19.38%",
                 "Error & Exception Exposure": "57.08%",
-                "Tech Debt Exposure": "51.56%",
+                "Tech Debt Exposure": "51.09%",
                 "Testing Exposure": "80.0%",
                 "API Exposure": "3.09%",
                 "Concurrency Exposure": "31.63%",
@@ -245596,9 +245596,9 @@
                         "Repository Archetype": "file_cluster_11",
                         "Repository Drift (Z-Score)": 11.284,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.765,
-                            "file_cluster_1": 11.976,
-                            "file_cluster_2": 12.085,
+                            "file_cluster_0": 11.766,
+                            "file_cluster_1": 11.977,
+                            "file_cluster_2": 12.086,
                             "file_cluster_3": 12.149,
                             "file_cluster_4": 12.384,
                             "file_cluster_5": 12.392,
@@ -245606,24 +245606,24 @@
                             "file_cluster_7": 11.644,
                             "file_cluster_8": 11.548,
                             "file_cluster_9": 12.196,
-                            "file_cluster_10": 12.683,
+                            "file_cluster_10": 12.684,
                             "file_cluster_11": 11.284,
-                            "file_cluster_12": 12.089,
+                            "file_cluster_12": 12.09,
                             "file_cluster_13": 11.4,
                             "file_cluster_14": 14.452,
                             "file_cluster_15": 12.121,
-                            "file_cluster_16": 11.603,
+                            "file_cluster_16": 11.602,
                             "file_cluster_17": 11.833
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 6.193,
+                        "File Drift (Z-Score)": 6.196,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.288,
-                            "Cluster 1: Declarative Glue & Initialization": 6.193,
-                            "Cluster 2: Async & Concurrent Testing": 9.061,
-                            "Cluster 3: Data Pipelines & I/O Operations": 6.96,
-                            "Cluster 4: Procedural Verification & Mocks": 8.158,
-                            "Cluster 5: Universal Dependencies & Serialization": 8.96
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.292,
+                            "Cluster 1: Declarative Glue & Initialization": 6.196,
+                            "Cluster 2: Async & Concurrent Testing": 9.068,
+                            "Cluster 3: Data Pipelines & I/O Operations": 6.967,
+                            "Cluster 4: Procedural Verification & Mocks": 8.162,
+                            "Cluster 5: Universal Dependencies & Serialization": 8.969
                         },
                         "Total LOC": 3261,
                         "Coding LOC": 2380,
@@ -245639,7 +245639,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "11.71%",
                         "Error & Exception Exposure": "54.91%",
-                        "Tech Debt Exposure": "13.73%",
+                        "Tech Debt Exposure": "12.3%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.2%",
                         "Concurrency Exposure": "15.36%",
@@ -245753,7 +245753,7 @@
                             "End Line": 883
                         },
                         {
-                            "Function Name": "_find_and_purge_task_instances_without_h",
+                            "Function Name": "_find_and_purge_task_instances_without_heartbeats",
                             "Structural Impact": 5.7,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 2,
@@ -245863,7 +245863,7 @@
                             "End Line": 2103
                         },
                         {
-                            "Function Name": "_enqueue_task_instances_with_queued_stat",
+                            "Function Name": "_enqueue_task_instances_with_queued_state",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -245958,7 +245958,7 @@
                         "Design Short Vars": 15,
                         "Design Long Vars": 13,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 3,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -249967,7 +249967,7 @@
                             "End Line": 733
                         },
                         {
-                            "Function Name": "mut_to_immut_query_methods_have_immut_it",
+                            "Function Name": "mut_to_immut_query_methods_have_immut_item",
                             "Structural Impact": 3.5,
                             "Lines of Code (LOC)": 35,
                             "Control Flow Branches": 0,
@@ -252592,7 +252592,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "11.69%",
                 "Error & Exception Exposure": "56.98%",
-                "Tech Debt Exposure": "75.9%",
+                "Tech Debt Exposure": "75.8%",
                 "Testing Exposure": "50.54%",
                 "API Exposure": "4.12%",
                 "Concurrency Exposure": "15.12%",
@@ -254825,26 +254825,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.797,
+                        "Repository Drift (Z-Score)": 12.792,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.223,
-                            "file_cluster_1": 13.694,
-                            "file_cluster_2": 13.836,
-                            "file_cluster_3": 14.543,
-                            "file_cluster_4": 13.2,
-                            "file_cluster_5": 14.083,
-                            "file_cluster_6": 13.698,
-                            "file_cluster_7": 13.463,
-                            "file_cluster_8": 13.51,
-                            "file_cluster_9": 13.625,
-                            "file_cluster_10": 14.439,
-                            "file_cluster_11": 13.176,
-                            "file_cluster_12": 13.885,
-                            "file_cluster_13": 12.797,
-                            "file_cluster_14": 16.971,
-                            "file_cluster_15": 13.609,
-                            "file_cluster_16": 13.163,
-                            "file_cluster_17": 13.55
+                            "file_cluster_0": 13.218,
+                            "file_cluster_1": 13.69,
+                            "file_cluster_2": 13.831,
+                            "file_cluster_3": 14.538,
+                            "file_cluster_4": 13.194,
+                            "file_cluster_5": 14.078,
+                            "file_cluster_6": 13.693,
+                            "file_cluster_7": 13.458,
+                            "file_cluster_8": 13.504,
+                            "file_cluster_9": 13.62,
+                            "file_cluster_10": 14.434,
+                            "file_cluster_11": 13.171,
+                            "file_cluster_12": 13.88,
+                            "file_cluster_13": 12.792,
+                            "file_cluster_14": 16.967,
+                            "file_cluster_15": 13.604,
+                            "file_cluster_16": 13.158,
+                            "file_cluster_17": 13.545
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -255057,7 +255057,7 @@
                             "End Line": 787
                         },
                         {
-                            "Function Name": "getExitCodeFromExitCodeGeneratorExceptio",
+                            "Function Name": "getExitCodeFromExitCodeGeneratorException",
                             "Structural Impact": 7.8,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
@@ -255877,7 +255877,7 @@
                             "End Line": 812
                         },
                         {
-                            "Function Name": "PropertySourceOrderingBeanFactoryPostPro",
+                            "Function Name": "PropertySourceOrderingBeanFactoryPostProcessor",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -256092,7 +256092,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 4,
                         "Duplicate Logic": 40,
-                        "Orphaned Logic": 20,
+                        "Orphaned Logic": 18,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -256233,26 +256233,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 10.7,
+                        "Repository Drift (Z-Score)": 10.695,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.898,
-                            "file_cluster_1": 12.102,
-                            "file_cluster_2": 12.137,
-                            "file_cluster_3": 12.963,
-                            "file_cluster_4": 11.831,
-                            "file_cluster_5": 12.558,
-                            "file_cluster_6": 12.028,
-                            "file_cluster_7": 11.772,
-                            "file_cluster_8": 11.5,
-                            "file_cluster_9": 11.846,
-                            "file_cluster_10": 12.877,
-                            "file_cluster_11": 11.282,
-                            "file_cluster_12": 12.308,
-                            "file_cluster_13": 10.7,
-                            "file_cluster_14": 15.54,
-                            "file_cluster_15": 11.843,
-                            "file_cluster_16": 11.582,
-                            "file_cluster_17": 11.727
+                            "file_cluster_0": 10.893,
+                            "file_cluster_1": 12.098,
+                            "file_cluster_2": 12.133,
+                            "file_cluster_3": 12.958,
+                            "file_cluster_4": 11.826,
+                            "file_cluster_5": 12.554,
+                            "file_cluster_6": 12.023,
+                            "file_cluster_7": 11.767,
+                            "file_cluster_8": 11.495,
+                            "file_cluster_9": 11.842,
+                            "file_cluster_10": 12.873,
+                            "file_cluster_11": 11.277,
+                            "file_cluster_12": 12.304,
+                            "file_cluster_13": 10.695,
+                            "file_cluster_14": 15.536,
+                            "file_cluster_15": 11.838,
+                            "file_cluster_16": 11.577,
+                            "file_cluster_17": 11.723
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -256271,7 +256271,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "17.59%",
                         "Error & Exception Exposure": "77.3%",
-                        "Tech Debt Exposure": "95.17%",
+                        "Tech Debt Exposure": "94.35%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "5.95%",
                         "Concurrency Exposure": "0.0%",
@@ -256685,7 +256685,7 @@
                             "End Line": 340
                         },
                         {
-                            "Function Name": "ResourceChainResourceHandlerRegistration",
+                            "Function Name": "ResourceChainResourceHandlerRegistrationCustomizer",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -256810,7 +256810,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 1,
                         "Duplicate Logic": 6,
-                        "Orphaned Logic": 18,
+                        "Orphaned Logic": 17,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -266597,7 +266597,7 @@
                             "End Line": 151
                         },
                         {
-                            "Function Name": "incomplete_partial_read_followed_by_writ",
+                            "Function Name": "incomplete_partial_read_followed_by_write",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 43,
                             "Control Flow Branches": 0,
@@ -309104,7 +309104,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "23.86%",
                 "Error & Exception Exposure": "69.78%",
-                "Tech Debt Exposure": "69.71%",
+                "Tech Debt Exposure": "67.06%",
                 "Testing Exposure": "60.64%",
                 "API Exposure": "2.57%",
                 "Concurrency Exposure": "0.0%",
@@ -309137,26 +309137,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 9.878,
+                        "Repository Drift (Z-Score)": 9.871,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.878,
-                            "file_cluster_1": 10.888,
-                            "file_cluster_2": 10.949,
-                            "file_cluster_3": 11.88,
-                            "file_cluster_4": 10.642,
-                            "file_cluster_5": 11.447,
-                            "file_cluster_6": 10.606,
-                            "file_cluster_7": 10.506,
-                            "file_cluster_8": 10.118,
-                            "file_cluster_9": 10.535,
-                            "file_cluster_10": 11.848,
-                            "file_cluster_11": 10.51,
-                            "file_cluster_12": 11.221,
-                            "file_cluster_13": 9.894,
-                            "file_cluster_14": 14.682,
-                            "file_cluster_15": 11.3,
-                            "file_cluster_16": 10.893,
-                            "file_cluster_17": 10.577
+                            "file_cluster_0": 9.871,
+                            "file_cluster_1": 10.879,
+                            "file_cluster_2": 10.94,
+                            "file_cluster_3": 11.87,
+                            "file_cluster_4": 10.631,
+                            "file_cluster_5": 11.437,
+                            "file_cluster_6": 10.595,
+                            "file_cluster_7": 10.495,
+                            "file_cluster_8": 10.106,
+                            "file_cluster_9": 10.526,
+                            "file_cluster_10": 11.839,
+                            "file_cluster_11": 10.5,
+                            "file_cluster_12": 11.213,
+                            "file_cluster_13": 9.883,
+                            "file_cluster_14": 14.674,
+                            "file_cluster_15": 11.29,
+                            "file_cluster_16": 10.882,
+                            "file_cluster_17": 10.567
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -309175,7 +309175,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "11.62%",
                         "Error & Exception Exposure": "52.91%",
-                        "Tech Debt Exposure": "64.19%",
+                        "Tech Debt Exposure": "53.57%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "2.61%",
                         "Concurrency Exposure": "0.0%",
@@ -309309,7 +309309,7 @@
                             "End Line": 255
                         },
                         {
-                            "Function Name": "replaceObjectExpressionWithCurrentClosur",
+                            "Function Name": "replaceObjectExpressionWithCurrentClosure",
                             "Structural Impact": 4.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -309494,7 +309494,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 2,
-                        "Orphaned Logic": 2,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -315462,7 +315462,7 @@
                             "End Line": 1199
                         },
                         {
-                            "Function Name": "nonStallingRawEvaluateInExistingMainCont",
+                            "Function Name": "nonStallingRawEvaluateInExistingMainContext",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 1,
@@ -315722,7 +315722,7 @@
                             "End Line": 1188
                         },
                         {
-                            "Function Name": "rafrafTimeoutScreenshotElementWithProgre",
+                            "Function Name": "rafrafTimeoutScreenshotElementWithProgress",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -317530,7 +317530,7 @@
                             "End Line": 1076
                         },
                         {
-                            "Function Name": "getStrictModeBlockScopeFunctionDeclarati",
+                            "Function Name": "getStrictModeBlockScopeFunctionDeclarationMessage",
                             "Structural Impact": 5.2,
                             "Lines of Code (LOC)": 23,
                             "Control Flow Branches": 1,
@@ -322392,7 +322392,7 @@
                             "End Line": 60
                         },
                         {
-                            "Function Name": "testUpdateAccountNameNegativeMinAccessPr",
+                            "Function Name": "testUpdateAccountNameNegativeMinAccessProfile",
                             "Structural Impact": 7.9,
                             "Lines of Code (LOC)": 23,
                             "Control Flow Branches": 2,
@@ -323053,7 +323053,7 @@
                             "End Line": 360
                         },
                         {
-                            "Function Name": "testQueryWithFilterNegativeNoPermsToAcco",
+                            "Function Name": "testQueryWithFilterNegativeNoPermsToAccountNegative",
                             "Structural Impact": 13.1,
                             "Lines of Code (LOC)": 39,
                             "Control Flow Branches": 4,
@@ -323093,7 +323093,7 @@
                             "End Line": 300
                         },
                         {
-                            "Function Name": "testPermSetGrantsAccessToAccountNamePosi",
+                            "Function Name": "testPermSetGrantsAccessToAccountNamePositve",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 30,
                             "Control Flow Branches": 0,
@@ -323113,7 +323113,7 @@
                             "End Line": 213
                         },
                         {
-                            "Function Name": "testgetDetailsFromBothParentRecordsPosit",
+                            "Function Name": "testgetDetailsFromBothParentRecordsPositive",
                             "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 28,
                             "Control Flow Branches": 0,
@@ -323123,7 +323123,7 @@
                             "End Line": 416
                         },
                         {
-                            "Function Name": "testGetAccountInfoWhenQueryingContactPos",
+                            "Function Name": "testGetAccountInfoWhenQueryingContactPositive",
                             "Structural Impact": 3.5,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 0,
@@ -323153,7 +323153,7 @@
                             "End Line": 105
                         },
                         {
-                            "Function Name": "testQueryWithFilterWithNoMatchingAcctsPo",
+                            "Function Name": "testQueryWithFilterWithNoMatchingAcctsPositive",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 0,
@@ -323173,7 +323173,7 @@
                             "End Line": 182
                         },
                         {
-                            "Function Name": "testLimitClauseLessThan10AccountsPositiv",
+                            "Function Name": "testLimitClauseLessThan10AccountsPositive",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 0,
@@ -323193,7 +323193,7 @@
                             "End Line": 317
                         },
                         {
-                            "Function Name": "testLimitClauseMoreThan10AccountsPositiv",
+                            "Function Name": "testLimitClauseMoreThan10AccountsPositive",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 0,
@@ -323213,7 +323213,7 @@
                             "End Line": 274
                         },
                         {
-                            "Function Name": "testComplexFilterOmnibusPositiveNoResult",
+                            "Function Name": "testComplexFilterOmnibusPositiveNoResults",
                             "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -327632,7 +327632,7 @@
                             "End Line": 133
                         },
                         {
-                            "Function Name": "getBulkFLSAccessibleWithAccountPositiveW",
+                            "Function Name": "getBulkFLSAccessibleWithAccountPositiveWithNegativeResults",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 0,
@@ -327642,7 +327642,7 @@
                             "End Line": 118
                         },
                         {
-                            "Function Name": "getBulkFLSUpdatableWithAccountPositiveWi",
+                            "Function Name": "getBulkFLSUpdatableWithAccountPositiveWithNegativeResults",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 0,
@@ -327652,7 +327652,7 @@
                             "End Line": 152
                         },
                         {
-                            "Function Name": "memoizedFLSMDCcomparesAccesibleToUpdatab",
+                            "Function Name": "memoizedFLSMDCcomparesAccesibleToUpdatable",
                             "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -327939,7 +327939,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "testIterableApiClientRecipeNegativeWhenR",
+                            "Function Name": "testIterableApiClientRecipeNegativeWhenRecordPageRequestFails",
                             "Structural Impact": 11.1,
                             "Lines of Code (LOC)": 27,
                             "Control Flow Branches": 3,
@@ -328176,7 +328176,7 @@
                             "End Line": 61
                         },
                         {
-                            "Function Name": "testSortAccountsByShippingCountryInDesce",
+                            "Function Name": "testSortAccountsByShippingCountryInDescending",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 0,
@@ -330733,7 +330733,7 @@
             }
         },
         "typescript/fp-ts": {
-            "Directory Group Magnitude": 99.25,
+            "Directory Group Magnitude": 99.15,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_16": "80.0%",
@@ -330744,14 +330744,14 @@
                 "Error & Exception Exposure": "44.81%",
                 "Tech Debt Exposure": "52.18%",
                 "Testing Exposure": "48.46%",
-                "API Exposure": "10.09%",
+                "API Exposure": "10.08%",
                 "Concurrency Exposure": "4.28%",
                 "State Flux Exposure": "0.0%",
                 "Commented Logic Exposure": "0.0%",
                 "Specification Exposure": "80.0%",
                 "Instability Exposure": "40.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "45.35%",
+                "Documentation Exposure": "45.07%",
                 "Hardcoded Payload Artifacts": "0.0%"
             },
             "Files": {
@@ -331569,32 +331569,32 @@
                         "Identity Proof": "Single Indicator (Ext: .ts)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 6259.06,
-                        "Y": 228.82,
-                        "Z": -1035.38
+                        "X": 6259.09,
+                        "Y": 228.81,
+                        "Z": -1035.4
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 11.959,
+                        "Repository Drift (Z-Score)": 11.958,
                         "Repository Fingerprint": {
                             "file_cluster_0": 13.193,
-                            "file_cluster_1": 13.369,
-                            "file_cluster_2": 12.308,
+                            "file_cluster_1": 13.368,
+                            "file_cluster_2": 12.307,
                             "file_cluster_3": 13.868,
                             "file_cluster_4": 13.428,
-                            "file_cluster_5": 13.691,
+                            "file_cluster_5": 13.69,
                             "file_cluster_6": 13.401,
-                            "file_cluster_7": 13.061,
-                            "file_cluster_8": 12.992,
-                            "file_cluster_9": 13.475,
-                            "file_cluster_10": 14.089,
+                            "file_cluster_7": 13.06,
+                            "file_cluster_8": 12.991,
+                            "file_cluster_9": 13.474,
+                            "file_cluster_10": 14.088,
                             "file_cluster_11": 12.839,
-                            "file_cluster_12": 13.493,
-                            "file_cluster_13": 12.453,
-                            "file_cluster_14": 15.628,
+                            "file_cluster_12": 13.492,
+                            "file_cluster_13": 12.452,
+                            "file_cluster_14": 15.627,
                             "file_cluster_15": 13.251,
-                            "file_cluster_16": 11.959,
-                            "file_cluster_17": 12.82
+                            "file_cluster_16": 11.958,
+                            "file_cluster_17": 12.819
                         },
                         "File Archetype": "Cluster 8: Algorithmic Data Processing",
                         "File Drift (Z-Score)": 6.958,
@@ -331603,7 +331603,7 @@
                             "Cluster 1: Async Scripting & I/O Automation": 8.067,
                             "Cluster 2: Type Definitions & Bypasses": 7.952,
                             "Cluster 3: UI Frameworks & View Layers": 7.511,
-                            "Cluster 4: Heavily Documented Core Classes": 7.461,
+                            "Cluster 4: Heavily Documented Core Classes": 7.46,
                             "Cluster 5: Declarative Glue & Inert Types": 7.55,
                             "Cluster 6: Async Testing & Verification": 9.104,
                             "Cluster 7: Highly Concurrent State Management": 8.517,
@@ -331612,7 +331612,7 @@
                         "Total LOC": 1882,
                         "Coding LOC": 662,
                         "Documentation LOC": 1053,
-                        "Structural Magnitude": 24.36,
+                        "Structural Magnitude": 24.26,
                         "Control Flow Ratio": "2.5%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -331625,14 +331625,14 @@
                         "Error & Exception Exposure": "33.76%",
                         "Tech Debt Exposure": "71.07%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "13.31%",
+                        "API Exposure": "13.29%",
                         "Concurrency Exposure": "21.39%",
                         "State Flux Exposure": "0.0%",
                         "Commented Logic Exposure": "0.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "42.04%",
+                        "Documentation Exposure": "40.62%",
                         "Hardcoded Payload Artifacts": "0.0%"
                     },
                     "5. Function Analysis": [
@@ -331647,7 +331647,7 @@
                             "End Line": 152
                         },
                         {
-                            "Function Name": "traverseReadonlyNonEmptyArrayWithIndexSe",
+                            "Function Name": "traverseReadonlyNonEmptyArrayWithIndexSeq",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 2,
@@ -331868,7 +331868,7 @@
                         "Type/Safety Bypasses": 16,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 155,
+                        "Exposed API / Public Exports": 154,
                         "State Mutations / Variable Reassignments": 5,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 158,

--- a/tests/golden_master_zero_dep_audit.json
+++ b/tests/golden_master_zero_dep_audit.json
@@ -12,8 +12,8 @@
             },
             "Target Root Name": "data",
             "Absolute Project Path": "/home/joe/nyx_projects/language-crucible/data",
-            "Analysis ISO Timestamp": "2026-08-09T15:55:54.457956+00:00",
-            "Total Scan Duration": "26.86 seconds"
+            "Analysis ISO Timestamp": "2026-08-09T22:48:44.019291+00:00",
+            "Total Scan Duration": "28.73 seconds"
         },
         "Source Control Footprint (Immutable Anchor)": {
             "Active Branch": "HEAD",
@@ -198,8 +198,8 @@
         "health": {
             "avg_cognitive_load": 23.827,
             "avg_safety_score": 38.366,
-            "avg_tech_debt": 29.619,
-            "avg_documentation": 19.867
+            "avg_tech_debt": 29.576,
+            "avg_documentation": 19.865
         },
         "composition": {
             "xml": {
@@ -295,7 +295,7 @@
             "cpp": {
                 "files": 33,
                 "loc": 19443,
-                "impact": 20365.859999999993
+                "impact": 20366.859999999993
             },
             "csharp": {
                 "files": 8,
@@ -355,12 +355,12 @@
             "javascript": {
                 "files": 19,
                 "loc": 14859,
-                "impact": 16164.980000000003
+                "impact": 16162.980000000003
             },
             "typescript": {
                 "files": 24,
                 "loc": 21446,
-                "impact": 3633.2400000000002
+                "impact": 3633.14
             },
             "kotlin": {
                 "files": 5,
@@ -465,7 +465,7 @@
             "zig": {
                 "files": 32,
                 "loc": 68347,
-                "impact": 40403.04000000001
+                "impact": 40402.04000000001
             }
         },
         "ecosystem_fingerprint": {
@@ -731,13 +731,13 @@
             },
             "cpp/NVDA": {
                 "file_count": 12,
-                "total_mass": 4300.9,
+                "total_mass": 4301.9,
                 "avg_exposures": {
                     "cognitive_load": 28.17,
                     "safety_score": 43.38,
                     "tech_debt": 34.27,
                     "verification": 46.88,
-                    "api_exposure": 2.76,
+                    "api_exposure": 2.78,
                     "concurrency": 3.79,
                     "state_flux": 55.66,
                     "dead_code": 0.81,
@@ -1077,7 +1077,7 @@
                 "avg_exposures": {
                     "cognitive_load": 79.61,
                     "safety_score": 84.35,
-                    "tech_debt": 45.88,
+                    "tech_debt": 45.72,
                     "verification": 31.55,
                     "api_exposure": 12.46,
                     "concurrency": 0.0,
@@ -1229,7 +1229,7 @@
                 "avg_exposures": {
                     "cognitive_load": 13.23,
                     "safety_score": 43.05,
-                    "tech_debt": 32.53,
+                    "tech_debt": 32.47,
                     "verification": 32.18,
                     "api_exposure": 3.04,
                     "concurrency": 0.0,
@@ -1324,7 +1324,7 @@
                 "avg_exposures": {
                     "cognitive_load": 23.87,
                     "safety_score": 40.85,
-                    "tech_debt": 81.9,
+                    "tech_debt": 81.5,
                     "verification": 57.5,
                     "api_exposure": 3.59,
                     "concurrency": 19.81,
@@ -1495,7 +1495,7 @@
                 "avg_exposures": {
                     "cognitive_load": 11.69,
                     "safety_score": 56.98,
-                    "tech_debt": 75.9,
+                    "tech_debt": 75.8,
                     "verification": 50.54,
                     "api_exposure": 4.12,
                     "concurrency": 15.12,
@@ -1795,20 +1795,20 @@
             },
             "typescript/fp-ts": {
                 "file_count": 5,
-                "total_mass": 99.25,
+                "total_mass": 99.15,
                 "avg_exposures": {
                     "cognitive_load": 3.0,
                     "safety_score": 44.81,
                     "tech_debt": 52.18,
                     "verification": 48.46,
-                    "api_exposure": 10.09,
+                    "api_exposure": 10.08,
                     "concurrency": 4.28,
                     "state_flux": 0.0,
                     "dead_code": 0.0,
                     "spec_match": 80.0,
                     "stability": 40.0,
                     "churn": 0.0,
-                    "documentation": 45.35,
+                    "documentation": 45.07,
                     "secrets_risk": 0.0
                 }
             },
@@ -2008,7 +2008,7 @@
                 "avg_exposures": {
                     "cognitive_load": 31.63,
                     "safety_score": 54.87,
-                    "tech_debt": 30.11,
+                    "tech_debt": 30.05,
                     "verification": 37.47,
                     "api_exposure": 1.5,
                     "concurrency": 1.45,
@@ -2027,7 +2027,7 @@
                 "avg_exposures": {
                     "cognitive_load": 19.38,
                     "safety_score": 57.08,
-                    "tech_debt": 51.56,
+                    "tech_debt": 51.09,
                     "verification": 80.0,
                     "api_exposure": 3.09,
                     "concurrency": 31.63,
@@ -2160,7 +2160,7 @@
                 "avg_exposures": {
                     "cognitive_load": 30.26,
                     "safety_score": 57.88,
-                    "tech_debt": 29.46,
+                    "tech_debt": 28.13,
                     "verification": 44.75,
                     "api_exposure": 3.64,
                     "concurrency": 0.0,
@@ -2445,7 +2445,7 @@
                 "avg_exposures": {
                     "cognitive_load": 23.86,
                     "safety_score": 69.78,
-                    "tech_debt": 69.71,
+                    "tech_debt": 67.06,
                     "verification": 60.64,
                     "api_exposure": 2.57,
                     "concurrency": 0.0,
@@ -2517,13 +2517,13 @@
             },
             "javascript/react": {
                 "file_count": 5,
-                "total_mass": 8986.55,
+                "total_mass": 8984.55,
                 "avg_exposures": {
                     "cognitive_load": 25.71,
                     "safety_score": 29.68,
                     "tech_debt": 80.66,
                     "verification": 33.6,
-                    "api_exposure": 7.84,
+                    "api_exposure": 7.82,
                     "concurrency": 8.22,
                     "state_flux": 21.14,
                     "dead_code": 1.98,
@@ -2882,7 +2882,7 @@
                 "avg_exposures": {
                     "cognitive_load": 10.77,
                     "safety_score": 46.28,
-                    "tech_debt": 69.28,
+                    "tech_debt": 69.02,
                     "verification": 57.83,
                     "api_exposure": 3.76,
                     "concurrency": 0.0,
@@ -3186,7 +3186,7 @@
                 "avg_exposures": {
                     "cognitive_load": 30.98,
                     "safety_score": 55.18,
-                    "tech_debt": 62.58,
+                    "tech_debt": 61.25,
                     "verification": 80.0,
                     "api_exposure": 5.57,
                     "concurrency": 4.39,
@@ -3201,20 +3201,20 @@
             },
             "zig/zig": {
                 "file_count": 5,
-                "total_mass": 16999.5,
+                "total_mass": 16998.5,
                 "avg_exposures": {
                     "cognitive_load": 25.27,
                     "safety_score": 50.17,
                     "tech_debt": 39.54,
                     "verification": 80.0,
-                    "api_exposure": 3.49,
+                    "api_exposure": 3.48,
                     "concurrency": 10.28,
                     "state_flux": 14.11,
                     "dead_code": 5.11,
                     "spec_match": 100.0,
                     "stability": 50.0,
                     "churn": 0.0,
-                    "documentation": 39.49,
+                    "documentation": 39.45,
                     "secrets_risk": 0.0
                 }
             },
@@ -6697,7 +6697,7 @@
                             "End Line": 885
                         },
                         {
-                            "Function Name": "scheme_push_marks_from_lightweight_conti",
+                            "Function Name": "scheme_push_marks_from_lightweight_continuation",
                             "Structural Impact": 4.4,
                             "Lines of Code (LOC)": 28,
                             "Control Flow Branches": 2,
@@ -6717,7 +6717,7 @@
                             "End Line": 898
                         },
                         {
-                            "Function Name": "scheme_can_apply_lightweight_continuatio",
+                            "Function Name": "scheme_can_apply_lightweight_continuation",
                             "Structural Impact": 3.5,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
@@ -18578,7 +18578,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "23.87%",
                 "Error & Exception Exposure": "40.85%",
-                "Tech Debt Exposure": "81.9%",
+                "Tech Debt Exposure": "81.5%",
                 "Testing Exposure": "57.5%",
                 "API Exposure": "3.59%",
                 "Concurrency Exposure": "19.81%",
@@ -18940,7 +18940,7 @@
                             "End Line": 1706
                         },
                         {
-                            "Function Name": "AddDebugSourceDocumentsForChecksumDirect",
+                            "Function Name": "AddDebugSourceDocumentsForChecksumDirectives",
                             "Structural Impact": 20.9,
                             "Lines of Code (LOC)": 57,
                             "Control Flow Branches": 8,
@@ -19650,7 +19650,7 @@
                             "End Line": 3154
                         },
                         {
-                            "Function Name": "noMainFoundDiagnostics.DiagnosticBag.AsE",
+                            "Function Name": "noMainFoundDiagnostics.DiagnosticBag.AsEnumerable",
                             "Structural Impact": 3.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
@@ -19680,7 +19680,7 @@
                             "End Line": 581
                         },
                         {
-                            "Function Name": "CreatePreviousToCurrentSourceAssemblyMat",
+                            "Function Name": "CreatePreviousToCurrentSourceAssemblyMatcher",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -19900,7 +19900,7 @@
                             "End Line": 3065
                         },
                         {
-                            "Function Name": "IsUnreferencedAssemblyIdentityDiagnostic",
+                            "Function Name": "IsUnreferencedAssemblyIdentityDiagnosticCode",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -21319,26 +21319,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 13.345,
+                        "Repository Drift (Z-Score)": 13.343,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.839,
-                            "file_cluster_1": 14.232,
-                            "file_cluster_2": 14.207,
-                            "file_cluster_3": 14.367,
-                            "file_cluster_4": 14.134,
-                            "file_cluster_5": 14.599,
-                            "file_cluster_6": 13.898,
-                            "file_cluster_7": 13.902,
-                            "file_cluster_8": 13.771,
-                            "file_cluster_9": 14.026,
-                            "file_cluster_10": 14.682,
-                            "file_cluster_11": 13.345,
-                            "file_cluster_12": 14.29,
-                            "file_cluster_13": 13.829,
-                            "file_cluster_14": 16.381,
-                            "file_cluster_15": 13.915,
-                            "file_cluster_16": 13.893,
-                            "file_cluster_17": 13.882
+                            "file_cluster_0": 13.837,
+                            "file_cluster_1": 14.23,
+                            "file_cluster_2": 14.205,
+                            "file_cluster_3": 14.365,
+                            "file_cluster_4": 14.131,
+                            "file_cluster_5": 14.597,
+                            "file_cluster_6": 13.895,
+                            "file_cluster_7": 13.9,
+                            "file_cluster_8": 13.769,
+                            "file_cluster_9": 14.024,
+                            "file_cluster_10": 14.68,
+                            "file_cluster_11": 13.343,
+                            "file_cluster_12": 14.288,
+                            "file_cluster_13": 13.826,
+                            "file_cluster_14": 16.379,
+                            "file_cluster_15": 13.913,
+                            "file_cluster_16": 13.891,
+                            "file_cluster_17": 13.879
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -21357,7 +21357,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "63.11%",
                         "Error & Exception Exposure": "78.45%",
-                        "Tech Debt Exposure": "82.19%",
+                        "Tech Debt Exposure": "79.42%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.86%",
                         "Concurrency Exposure": "0.0%",
@@ -21731,7 +21731,7 @@
                             "End Line": 5016
                         },
                         {
-                            "Function Name": "IsPossibleDeclarationStatementFollowingN",
+                            "Function Name": "IsPossibleDeclarationStatementFollowingNullableType",
                             "Structural Impact": 45.3,
                             "Lines of Code (LOC)": 102,
                             "Control Flow Branches": 17,
@@ -21901,7 +21901,7 @@
                             "End Line": 8362
                         },
                         {
-                            "Function Name": "IsMemberDeclarationOnlyValidWithinTypeDe",
+                            "Function Name": "IsMemberDeclarationOnlyValidWithinTypeDeclaration",
                             "Structural Impact": 27.6,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 10,
@@ -22111,7 +22111,7 @@
                             "End Line": 2795
                         },
                         {
-                            "Function Name": "IsPossibleTopLevelUsingLocalDeclarationS",
+                            "Function Name": "IsPossibleTopLevelUsingLocalDeclarationStatement",
                             "Structural Impact": 20.2,
                             "Lines of Code (LOC)": 44,
                             "Control Flow Branches": 8,
@@ -22241,7 +22241,7 @@
                             "End Line": 2674
                         },
                         {
-                            "Function Name": "GetExpressionOperatorTokenKindAndExpress",
+                            "Function Name": "GetExpressionOperatorTokenKindAndExpressionKind",
                             "Structural Impact": 16.9,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 13,
@@ -22361,7 +22361,7 @@
                             "End Line": 2456
                         },
                         {
-                            "Function Name": "PointerTypeModsFollowedByRankAndDimensio",
+                            "Function Name": "PointerTypeModsFollowedByRankAndDimensionSpecifier",
                             "Structural Impact": 14.8,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 6,
@@ -22491,7 +22491,7 @@
                             "End Line": 1821
                         },
                         {
-                            "Function Name": "ScanImplicitlyTypedLambdaOrSimpleExplici",
+                            "Function Name": "ScanImplicitlyTypedLambdaOrSimpleExplicitlyTypedParenthesizedLambda",
                             "Structural Impact": 12.6,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 4,
@@ -22671,7 +22671,7 @@
                             "End Line": 5182
                         },
                         {
-                            "Function Name": "ParseErrantExpressionWhenNoCloseParenTok",
+                            "Function Name": "ParseErrantExpressionWhenNoCloseParenToken",
                             "Structural Impact": 10.4,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 3,
@@ -22961,7 +22961,7 @@
                             "End Line": 7494
                         },
                         {
-                            "Function Name": "IsCurrentTokenPartialKeywordOfPartialMem",
+                            "Function Name": "IsCurrentTokenPartialKeywordOfPartialMemberOrType",
                             "Structural Impact": 6.6,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
@@ -23101,7 +23101,7 @@
                             "End Line": 5377
                         },
                         {
-                            "Function Name": "IsPossibleFirstTypedIdentifierInLocalDec",
+                            "Function Name": "IsPossibleFirstTypedIdentifierInLocalDeclarationStatement",
                             "Structural Impact": 5.6,
                             "Lines of Code (LOC)": 22,
                             "Control Flow Branches": 1,
@@ -24251,7 +24251,7 @@
                             "End Line": 1133
                         },
                         {
-                            "Function Name": "this.IsCurrentTokenWhereOfConstraintClau",
+                            "Function Name": "this.IsCurrentTokenWhereOfConstraintClause",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -24691,7 +24691,7 @@
                             "End Line": 231
                         },
                         {
-                            "Function Name": "this.IsCurrentTokenPartialKeywordOfParti",
+                            "Function Name": "this.IsCurrentTokenPartialKeywordOfPartialMemberOrType",
                             "Structural Impact": 1.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -24761,7 +24761,7 @@
                             "End Line": 941
                         },
                         {
-                            "Function Name": "tryParseLocalDeclarationStatementFromSta",
+                            "Function Name": "tryParseLocalDeclarationStatementFromStartPoint",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -24771,7 +24771,7 @@
                             "End Line": 1304
                         },
                         {
-                            "Function Name": "tryParseLocalDeclarationStatementFromSta",
+                            "Function Name": "tryParseLocalDeclarationStatementFromStartPoint",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -24801,7 +24801,7 @@
                             "End Line": 1671
                         },
                         {
-                            "Function Name": "SyntaxFacts.IsOverloadableCompoundAssign",
+                            "Function Name": "SyntaxFacts.IsOverloadableCompoundAssignmentOperator",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -24936,7 +24936,7 @@
                         "Design Short Vars": 63,
                         "Design Long Vars": 32,
                         "Duplicate Logic": 49,
-                        "Orphaned Logic": 55,
+                        "Orphaned Logic": 47,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -25101,7 +25101,7 @@
                             "End Line": 794
                         },
                         {
-                            "Function Name": "CompileSynthesizedExplicitImplementation",
+                            "Function Name": "CompileSynthesizedExplicitImplementations",
                             "Structural Impact": 10.1,
                             "Lines of Code (LOC)": 28,
                             "Control Flow Branches": 4,
@@ -25181,7 +25181,7 @@
                             "End Line": 934
                         },
                         {
-                            "Function Name": "sourceTypeSymbol.GetSynthesizedExplicitI",
+                            "Function Name": "sourceTypeSymbol.GetSynthesizedExplicitImplementations",
                             "Structural Impact": 4.8,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 3,
@@ -25575,26 +25575,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.074,
+                        "Repository Drift (Z-Score)": 12.066,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.711,
-                            "file_cluster_1": 12.428,
-                            "file_cluster_2": 12.694,
-                            "file_cluster_3": 13.537,
-                            "file_cluster_4": 12.839,
-                            "file_cluster_5": 12.867,
-                            "file_cluster_6": 12.585,
-                            "file_cluster_7": 12.173,
-                            "file_cluster_8": 12.194,
-                            "file_cluster_9": 12.963,
-                            "file_cluster_10": 13.436,
-                            "file_cluster_11": 12.413,
-                            "file_cluster_12": 12.927,
-                            "file_cluster_13": 12.074,
-                            "file_cluster_14": 16.052,
-                            "file_cluster_15": 12.269,
-                            "file_cluster_16": 12.254,
-                            "file_cluster_17": 12.602
+                            "file_cluster_0": 12.705,
+                            "file_cluster_1": 12.421,
+                            "file_cluster_2": 12.688,
+                            "file_cluster_3": 13.53,
+                            "file_cluster_4": 12.832,
+                            "file_cluster_5": 12.86,
+                            "file_cluster_6": 12.578,
+                            "file_cluster_7": 12.166,
+                            "file_cluster_8": 12.186,
+                            "file_cluster_9": 12.956,
+                            "file_cluster_10": 13.429,
+                            "file_cluster_11": 12.406,
+                            "file_cluster_12": 12.92,
+                            "file_cluster_13": 12.066,
+                            "file_cluster_14": 16.047,
+                            "file_cluster_15": 12.262,
+                            "file_cluster_16": 12.247,
+                            "file_cluster_17": 12.595
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -25637,7 +25637,7 @@
                             "End Line": 516
                         },
                         {
-                            "Function Name": "projectChanges.GetChangedAnalyzerConfigD",
+                            "Function Name": "projectChanges.GetChangedAnalyzerConfigDocuments",
                             "Structural Impact": 59.8,
                             "Lines of Code (LOC)": 365,
                             "Control Flow Branches": 23,
@@ -25647,7 +25647,7 @@
                             "End Line": 922
                         },
                         {
-                            "Function Name": "UpdateAddedDocumentToExistingContentsInS",
+                            "Function Name": "UpdateAddedDocumentToExistingContentsInSolution",
                             "Structural Impact": 23.9,
                             "Lines of Code (LOC)": 132,
                             "Control Flow Branches": 9,
@@ -25737,7 +25737,7 @@
                             "End Line": 221
                         },
                         {
-                            "Function Name": "CheckProjectDoesNotHaveTransitiveProject",
+                            "Function Name": "CheckProjectDoesNotHaveTransitiveProjectReference",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -25827,7 +25827,7 @@
                             "End Line": 871
                         },
                         {
-                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInSoluti",
+                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInSolution",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 1,
@@ -25887,7 +25887,7 @@
                             "End Line": 783
                         },
                         {
-                            "Function Name": "CheckSolutionDoesNotHaveAnalyzerReferenc",
+                            "Function Name": "CheckSolutionDoesNotHaveAnalyzerReference",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -26087,7 +26087,7 @@
                             "End Line": 800
                         },
                         {
-                            "Function Name": "CheckAdditionalDocumentIsInCurrentSoluti",
+                            "Function Name": "CheckAdditionalDocumentIsInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26097,7 +26097,7 @@
                             "End Line": 816
                         },
                         {
-                            "Function Name": "CheckAnalyzerConfigDocumentIsInCurrentSo",
+                            "Function Name": "CheckAnalyzerConfigDocumentIsInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26107,7 +26107,7 @@
                             "End Line": 832
                         },
                         {
-                            "Function Name": "CheckAdditionalDocumentIsNotInCurrentSol",
+                            "Function Name": "CheckAdditionalDocumentIsNotInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26117,7 +26117,7 @@
                             "End Line": 861
                         },
                         {
-                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInCurren",
+                            "Function Name": "CheckAnalyzerConfigDocumentIsNotInCurrentSolution",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -26352,7 +26352,7 @@
                         "Design Short Vars": 6,
                         "Design Long Vars": 1,
                         "Duplicate Logic": 2,
-                        "Orphaned Logic": 43,
+                        "Orphaned Logic": 41,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -28821,7 +28821,7 @@
             }
         },
         "zig/zig": {
-            "Directory Group Magnitude": 16999.5,
+            "Directory Group Magnitude": 16998.5,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_11": "100.0%"
@@ -28831,14 +28831,14 @@
                 "Error & Exception Exposure": "50.17%",
                 "Tech Debt Exposure": "39.54%",
                 "Testing Exposure": "80.0%",
-                "API Exposure": "3.49%",
+                "API Exposure": "3.48%",
                 "Concurrency Exposure": "10.28%",
                 "State Flux Exposure": "14.11%",
                 "Commented Logic Exposure": "5.11%",
                 "Specification Exposure": "100.0%",
                 "Instability Exposure": "50.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "39.49%",
+                "Documentation Exposure": "39.45%",
                 "Hardcoded Payload Artifacts": "0.0%"
             },
             "Files": {
@@ -35644,7 +35644,7 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 13.647,
+                        "Repository Drift (Z-Score)": 13.646,
                         "Repository Fingerprint": {
                             "file_cluster_0": 14.271,
                             "file_cluster_1": 14.708,
@@ -35657,9 +35657,9 @@
                             "file_cluster_8": 14.341,
                             "file_cluster_9": 14.471,
                             "file_cluster_10": 14.89,
-                            "file_cluster_11": 13.647,
+                            "file_cluster_11": 13.646,
                             "file_cluster_12": 14.647,
-                            "file_cluster_13": 14.272,
+                            "file_cluster_13": 14.271,
                             "file_cluster_14": 15.946,
                             "file_cluster_15": 14.478,
                             "file_cluster_16": 14.42,
@@ -35671,7 +35671,7 @@
                         "Total LOC": 4802,
                         "Coding LOC": 4374,
                         "Documentation LOC": 0,
-                        "Structural Magnitude": 2619.28,
+                        "Structural Magnitude": 2618.28,
                         "Control Flow Ratio": "72.0%",
                         "Popularity Rank": 4,
                         "Raw Churn Frequency": 0.0,
@@ -35684,14 +35684,14 @@
                         "Error & Exception Exposure": "62.98%",
                         "Tech Debt Exposure": "48.16%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "3.48%",
+                        "API Exposure": "3.46%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "12.27%",
                         "Commented Logic Exposure": "5.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "34.52%",
+                        "Documentation Exposure": "34.32%",
                         "Hardcoded Payload Artifacts": "0.0%"
                     },
                     "5. Function Analysis": [
@@ -35806,7 +35806,7 @@
                             "End Line": 3059
                         },
                         {
-                            "Function Name": "markTransitiveDependersPotentiallyOutdat",
+                            "Function Name": "markTransitiveDependersPotentiallyOutdated",
                             "Structural Impact": 20.8,
                             "Lines of Code (LOC)": 35,
                             "Control Flow Branches": 10,
@@ -36437,7 +36437,7 @@
                         "Type/Safety Bypasses": 156,
                         "High-Risk Execution Commands": 76,
                         "I/O and Network Boundaries": 12,
-                        "Exposed API / Public Exports": 220,
+                        "Exposed API / Public Exports": 219,
                         "State Mutations / Variable Reassignments": 327,
                         "Commented-out Code (Dead Logic)": 3,
                         "Structured Documentation Blocks": 598,
@@ -36981,7 +36981,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "79.61%",
                 "Error & Exception Exposure": "84.35%",
-                "Tech Debt Exposure": "45.88%",
+                "Tech Debt Exposure": "45.72%",
                 "Testing Exposure": "31.55%",
                 "API Exposure": "12.46%",
                 "Concurrency Exposure": "0.0%",
@@ -37539,7 +37539,7 @@
                             "End Line": 707
                         },
                         {
-                            "Function Name": "_PyCompile_TweakInlinedComprehensionScop",
+                            "Function Name": "_PyCompile_TweakInlinedComprehensionScopes",
                             "Structural Impact": 13.9,
                             "Lines of Code (LOC)": 39,
                             "Control Flow Branches": 11,
@@ -37599,7 +37599,7 @@
                             "End Line": 640
                         },
                         {
-                            "Function Name": "_PyCompile_MaybeAddStaticAttributeToClas",
+                            "Function Name": "_PyCompile_MaybeAddStaticAttributeToClass",
                             "Structural Impact": 8.2,
                             "Lines of Code (LOC)": 25,
                             "Control Flow Branches": 6,
@@ -37891,32 +37891,32 @@
                         "Repository Drift (Z-Score)": 14.502,
                         "Repository Fingerprint": {
                             "file_cluster_0": 14.61,
-                            "file_cluster_1": 15.161,
-                            "file_cluster_2": 15.071,
-                            "file_cluster_3": 15.728,
-                            "file_cluster_4": 14.921,
+                            "file_cluster_1": 15.16,
+                            "file_cluster_2": 15.07,
+                            "file_cluster_3": 15.727,
+                            "file_cluster_4": 14.92,
                             "file_cluster_5": 15.491,
-                            "file_cluster_6": 14.769,
-                            "file_cluster_7": 14.751,
+                            "file_cluster_6": 14.768,
+                            "file_cluster_7": 14.75,
                             "file_cluster_8": 14.556,
-                            "file_cluster_9": 14.844,
-                            "file_cluster_10": 15.563,
+                            "file_cluster_9": 14.843,
+                            "file_cluster_10": 15.562,
                             "file_cluster_11": 14.502,
-                            "file_cluster_12": 14.829,
+                            "file_cluster_12": 14.828,
                             "file_cluster_13": 14.613,
-                            "file_cluster_14": 17.85,
-                            "file_cluster_15": 15.085,
-                            "file_cluster_16": 15.034,
+                            "file_cluster_14": 17.849,
+                            "file_cluster_15": 15.084,
+                            "file_cluster_16": 15.033,
                             "file_cluster_17": 14.86
                         },
                         "File Archetype": "Cluster 3: Complex Defensive Systems Logic",
-                        "File Drift (Z-Score)": 6.436,
+                        "File Drift (Z-Score)": 6.437,
                         "File Fingerprint": {
-                            "Cluster 0: Defensive Downstream Logic & Immutable State": 6.89,
+                            "Cluster 0: Defensive Downstream Logic & Immutable State": 6.891,
                             "Cluster 1: Algorithmic Bitwise & Encapsulated Core": 7.899,
                             "Cluster 2: Inert Headers & Declarative Structures": 7.697,
-                            "Cluster 3: Complex Defensive Systems Logic": 6.436,
-                            "Cluster 4: The God Headers (Documented & Defended APIs)": 11.451
+                            "Cluster 3: Complex Defensive Systems Logic": 6.437,
+                            "Cluster 4: The God Headers (Documented & Defended APIs)": 11.452
                         },
                         "Total LOC": 8326,
                         "Coding LOC": 5198,
@@ -37932,7 +37932,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "93.75%",
                         "Error & Exception Exposure": "87.43%",
-                        "Tech Debt Exposure": "31.37%",
+                        "Tech Debt Exposure": "30.14%",
                         "Testing Exposure": "2.52%",
                         "API Exposure": "13.24%",
                         "Concurrency Exposure": "0.0%",
@@ -38866,7 +38866,7 @@
                             "End Line": 660
                         },
                         {
-                            "Function Name": "_PyObject_MaterializeManagedDict_LockHel",
+                            "Function Name": "_PyObject_MaterializeManagedDict_LockHeld",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 2,
@@ -38876,7 +38876,7 @@
                             "End Line": 4820
                         },
                         {
-                            "Function Name": "replace_dict_probably_inline_materialize",
+                            "Function Name": "replace_dict_probably_inline_materialized",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 2,
@@ -39851,7 +39851,7 @@
                         "Design Short Vars": 128,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 52,
+                        "Orphaned Logic": 50,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -41566,7 +41566,7 @@
                             "End Line": 1796
                         },
                         {
-                            "Function Name": "PyUnstable_Object_IsUniqueReferencedTemp",
+                            "Function Name": "PyUnstable_Object_IsUniqueReferencedTemporary",
                             "Structural Impact": 8.3,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 6,
@@ -49085,7 +49085,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "31.63%",
                 "Error & Exception Exposure": "54.87%",
-                "Tech Debt Exposure": "30.11%",
+                "Tech Debt Exposure": "30.05%",
                 "Testing Exposure": "37.47%",
                 "API Exposure": "1.5%",
                 "Concurrency Exposure": "1.45%",
@@ -50664,26 +50664,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_7",
-                        "Repository Drift (Z-Score)": 14.877,
+                        "Repository Drift (Z-Score)": 14.876,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 15.186,
-                            "file_cluster_1": 15.192,
-                            "file_cluster_2": 15.263,
-                            "file_cluster_3": 16.005,
-                            "file_cluster_4": 15.369,
-                            "file_cluster_5": 15.513,
-                            "file_cluster_6": 15.188,
-                            "file_cluster_7": 14.877,
-                            "file_cluster_8": 14.947,
-                            "file_cluster_9": 15.376,
-                            "file_cluster_10": 15.779,
-                            "file_cluster_11": 15.024,
-                            "file_cluster_12": 15.372,
-                            "file_cluster_13": 14.941,
-                            "file_cluster_14": 18.349,
-                            "file_cluster_15": 15.255,
-                            "file_cluster_16": 15.359,
-                            "file_cluster_17": 15.31
+                            "file_cluster_0": 15.185,
+                            "file_cluster_1": 15.19,
+                            "file_cluster_2": 15.262,
+                            "file_cluster_3": 16.004,
+                            "file_cluster_4": 15.368,
+                            "file_cluster_5": 15.512,
+                            "file_cluster_6": 15.187,
+                            "file_cluster_7": 14.876,
+                            "file_cluster_8": 14.946,
+                            "file_cluster_9": 15.375,
+                            "file_cluster_10": 15.778,
+                            "file_cluster_11": 15.023,
+                            "file_cluster_12": 15.371,
+                            "file_cluster_13": 14.94,
+                            "file_cluster_14": 18.348,
+                            "file_cluster_15": 15.254,
+                            "file_cluster_16": 15.358,
+                            "file_cluster_17": 15.309
                         },
                         "File Archetype": "Cluster 1: Documented API Headers & Entity Definitions",
                         "File Drift (Z-Score)": 6.002,
@@ -50710,7 +50710,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "46.54%",
                         "Error & Exception Exposure": "95.47%",
-                        "Tech Debt Exposure": "91.73%",
+                        "Tech Debt Exposure": "91.11%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.0%",
                         "Concurrency Exposure": "0.0%",
@@ -50904,7 +50904,7 @@
                             "End Line": 523
                         },
                         {
-                            "Function Name": "MCStringCreateWithNativeCharBufferAndRel",
+                            "Function Name": "MCStringCreateWithNativeCharBufferAndRelease",
                             "Structural Impact": 19.9,
                             "Lines of Code (LOC)": 40,
                             "Control Flow Branches": 7,
@@ -51639,7 +51639,7 @@
                         "Design Short Vars": 5,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 45,
+                        "Orphaned Logic": 44,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -51782,7 +51782,7 @@
                             "End Line": 189
                         },
                         {
-                            "Function Name": "MCScriptQueryForeignHandlerParameterType",
+                            "Function Name": "MCScriptQueryForeignHandlerParameterTypeInModule",
                             "Structural Impact": 9.1,
                             "Lines of Code (LOC)": 22,
                             "Control Flow Branches": 3,
@@ -51832,7 +51832,7 @@
                             "End Line": 114
                         },
                         {
-                            "Function Name": "MCScriptQueryForeignHandlerReturnTypeInM",
+                            "Function Name": "MCScriptQueryForeignHandlerReturnTypeInModule",
                             "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 1,
@@ -51842,7 +51842,7 @@
                             "End Line": 245
                         },
                         {
-                            "Function Name": "MCScriptQueryForeignHandlerParameterCoun",
+                            "Function Name": "MCScriptQueryForeignHandlerParameterCountInModule",
                             "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 1,
@@ -52103,7 +52103,7 @@
                             "End Line": 295
                         },
                         {
-                            "Function Name": "MCScriptExecuteContext::InvokeForeignVar",
+                            "Function Name": "MCScriptExecuteContext::InvokeForeignVarArgument",
                             "Structural Impact": 59.9,
                             "Lines of Code (LOC)": 169,
                             "Control Flow Branches": 20,
@@ -57127,7 +57127,7 @@
                             "End Line": 1609
                         },
                         {
-                            "Function Name": "_entryWaitingForSubTreeDisposal.removeWh",
+                            "Function Name": "_entryWaitingForSubTreeDisposal.removeWhere",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -58567,7 +58567,7 @@
                             "End Line": 2732
                         },
                         {
-                            "Function Name": "fragment.markSiblingConfigurationConflic",
+                            "Function Name": "fragment.markSiblingConfigurationConflict",
                             "Structural Impact": 3.2,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 2,
@@ -58767,7 +58767,7 @@
                             "End Line": 413
                         },
                         {
-                            "Function Name": "_RenderObjectSemantics.debugCheckForBuil",
+                            "Function Name": "_RenderObjectSemantics.debugCheckForBuilds",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 1,
@@ -66403,26 +66403,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 13.096,
+                        "Repository Drift (Z-Score)": 13.095,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.8,
-                            "file_cluster_1": 14.041,
-                            "file_cluster_2": 13.528,
-                            "file_cluster_3": 14.828,
-                            "file_cluster_4": 14.027,
-                            "file_cluster_5": 14.465,
-                            "file_cluster_6": 13.888,
-                            "file_cluster_7": 13.735,
-                            "file_cluster_8": 13.465,
-                            "file_cluster_9": 13.992,
-                            "file_cluster_10": 14.604,
-                            "file_cluster_11": 13.572,
-                            "file_cluster_12": 14.159,
-                            "file_cluster_13": 13.096,
-                            "file_cluster_14": 16.815,
-                            "file_cluster_15": 14.118,
-                            "file_cluster_16": 14.103,
-                            "file_cluster_17": 13.665
+                            "file_cluster_0": 13.799,
+                            "file_cluster_1": 14.04,
+                            "file_cluster_2": 13.527,
+                            "file_cluster_3": 14.826,
+                            "file_cluster_4": 14.025,
+                            "file_cluster_5": 14.464,
+                            "file_cluster_6": 13.887,
+                            "file_cluster_7": 13.734,
+                            "file_cluster_8": 13.464,
+                            "file_cluster_9": 13.991,
+                            "file_cluster_10": 14.602,
+                            "file_cluster_11": 13.571,
+                            "file_cluster_12": 14.157,
+                            "file_cluster_13": 13.095,
+                            "file_cluster_14": 16.814,
+                            "file_cluster_15": 14.117,
+                            "file_cluster_16": 14.102,
+                            "file_cluster_17": 13.663
                         },
                         "File Archetype": "Cluster 0: Declarative Interfaces & Inert Headers",
                         "File Drift (Z-Score)": 5.825,
@@ -66483,7 +66483,7 @@
                             "End Line": 462
                         },
                         {
-                            "Function Name": "EditorNode::_find_and_save_edited_subres",
+                            "Function Name": "EditorNode::_find_and_save_edited_subresources",
                             "Structural Impact": 36.3,
                             "Lines of Code (LOC)": 46,
                             "Control Flow Branches": 16,
@@ -67143,7 +67143,7 @@
                             "End Line": 1882
                         },
                         {
-                            "Function Name": "get_preload_modifications_reference_to_n",
+                            "Function Name": "get_preload_modifications_reference_to_nodes",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 1,
@@ -67518,7 +67518,7 @@
                         "Design Short Vars": 43,
                         "Design Long Vars": 12,
                         "Duplicate Logic": 61,
-                        "Orphaned Logic": 24,
+                        "Orphaned Logic": 23,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -70682,7 +70682,7 @@
                             "End Line": 398
                         },
                         {
-                            "Function Name": "_set_physics_interpolation_reset_request",
+                            "Function Name": "_set_physics_interpolation_reset_requested",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
@@ -70762,7 +70762,7 @@
                             "End Line": 399
                         },
                         {
-                            "Function Name": "_is_physics_interpolation_reset_requeste",
+                            "Function Name": "_is_physics_interpolation_reset_requested",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
@@ -71582,37 +71582,37 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.957,
+                        "Repository Drift (Z-Score)": 12.975,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.384,
-                            "file_cluster_1": 13.561,
-                            "file_cluster_2": 13.569,
-                            "file_cluster_3": 14.486,
-                            "file_cluster_4": 13.521,
-                            "file_cluster_5": 14.051,
-                            "file_cluster_6": 13.603,
-                            "file_cluster_7": 13.304,
-                            "file_cluster_8": 12.99,
-                            "file_cluster_9": 13.468,
-                            "file_cluster_10": 14.322,
-                            "file_cluster_11": 13.295,
-                            "file_cluster_12": 13.827,
-                            "file_cluster_13": 12.957,
-                            "file_cluster_14": 16.822,
-                            "file_cluster_15": 13.825,
-                            "file_cluster_16": 13.716,
-                            "file_cluster_17": 13.456
+                            "file_cluster_0": 13.402,
+                            "file_cluster_1": 13.573,
+                            "file_cluster_2": 13.583,
+                            "file_cluster_3": 14.499,
+                            "file_cluster_4": 13.543,
+                            "file_cluster_5": 14.063,
+                            "file_cluster_6": 13.617,
+                            "file_cluster_7": 13.317,
+                            "file_cluster_8": 13.003,
+                            "file_cluster_9": 13.485,
+                            "file_cluster_10": 14.335,
+                            "file_cluster_11": 13.31,
+                            "file_cluster_12": 13.839,
+                            "file_cluster_13": 12.975,
+                            "file_cluster_14": 16.836,
+                            "file_cluster_15": 13.837,
+                            "file_cluster_16": 13.728,
+                            "file_cluster_17": 13.476
                         },
                         "File Archetype": "Cluster 0: Declarative Interfaces & Inert Headers",
-                        "File Drift (Z-Score)": 5.943,
+                        "File Drift (Z-Score)": 5.984,
                         "File Fingerprint": {
-                            "Cluster 0: Declarative Interfaces & Inert Headers": 5.943,
-                            "Cluster 1: Documented API Headers & Entity Definitions": 7.157,
-                            "Cluster 2: Verification & Unit Testing": 7.107,
-                            "Cluster 3: Algorithmic Execution Core": 6.078,
-                            "Cluster 4: The God Headers (Universal Dependencies)": 9.151,
-                            "Cluster 5: Heavily Documented Complex Base Classes": 10.667,
-                            "Cluster 6: Generic Templates & Metaprogramming Core": 7.524
+                            "Cluster 0: Declarative Interfaces & Inert Headers": 5.984,
+                            "Cluster 1: Documented API Headers & Entity Definitions": 7.184,
+                            "Cluster 2: Verification & Unit Testing": 7.102,
+                            "Cluster 3: Algorithmic Execution Core": 6.074,
+                            "Cluster 4: The God Headers (Universal Dependencies)": 9.212,
+                            "Cluster 5: Heavily Documented Complex Base Classes": 10.709,
+                            "Cluster 6: Generic Templates & Metaprogramming Core": 7.566
                         },
                         "Total LOC": 476,
                         "Coding LOC": 330,
@@ -71628,7 +71628,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "81.37%",
                         "Error & Exception Exposure": "90.91%",
-                        "Tech Debt Exposure": "99.99%",
+                        "Tech Debt Exposure": "99.97%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.0%",
                         "Concurrency Exposure": "0.0%",
@@ -71652,7 +71652,7 @@
                             "End Line": 183
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_rendering_in",
+                            "Function Name": "RenderingServerDefault::get_rendering_info",
                             "Structural Impact": 28.7,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 15,
@@ -71692,7 +71692,7 @@
                             "End Line": 423
                         },
                         {
-                            "Function Name": "RenderingServerDefault::_run_post_draw_s",
+                            "Function Name": "RenderingServerDefault::_run_post_draw_steps",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 2,
@@ -71742,7 +71742,7 @@
                             "End Line": 244
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_maximum_view",
+                            "Function Name": "RenderingServerDefault::get_maximum_viewport_size",
                             "Structural Impact": 3.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 2,
@@ -71792,7 +71792,7 @@
                             "End Line": 344
                         },
                         {
-                            "Function Name": "RenderingServerDefault::request_frame_dr",
+                            "Function Name": "RenderingServerDefault::request_frame_drawn_callback",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71802,7 +71802,7 @@
                             "End Line": 74
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_default_clea",
+                            "Function Name": "RenderingServerDefault::set_default_clear_color",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71812,7 +71812,7 @@
                             "End Line": 322
                         },
                         {
-                            "Function Name": "RenderingServerDefault::_call_on_render_",
+                            "Function Name": "RenderingServerDefault::_call_on_render_thread",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71822,7 +71822,7 @@
                             "End Line": 436
                         },
                         {
-                            "Function Name": "RenderingServerDefault::RenderingServerD",
+                            "Function Name": "RenderingServerDefault::RenderingServerDefault",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -71832,7 +71832,7 @@
                             "End Line": 442
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_frame_profil",
+                            "Function Name": "RenderingServerDefault::set_frame_profiling_enabled",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71852,7 +71852,7 @@
                             "End Line": 327
                         },
                         {
-                            "Function Name": "RenderingServerDefault::sdfgi_set_debug_",
+                            "Function Name": "RenderingServerDefault::sdfgi_set_debug_probe_select",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71862,7 +71862,7 @@
                             "End Line": 332
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_print_gpu_pr",
+                            "Function Name": "RenderingServerDefault::set_print_gpu_profile",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -71872,7 +71872,7 @@
                             "End Line": 337
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_debug_genera",
+                            "Function Name": "RenderingServerDefault::set_debug_generate_wireframes",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71882,7 +71882,7 @@
                             "End Line": 356
                         },
                         {
-                            "Function Name": "RenderingServerDefault::set_physics_inte",
+                            "Function Name": "RenderingServerDefault::set_physics_interpolation_enabled",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -71912,7 +71912,7 @@
                             "End Line": 428
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_frame_setup_",
+                            "Function Name": "RenderingServerDefault::get_frame_setup_time_cpu",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71932,7 +71932,7 @@
                             "End Line": 208
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_video_adapte",
+                            "Function Name": "RenderingServerDefault::get_video_adapter_type",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71942,7 +71942,7 @@
                             "End Line": 300
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_frame_profil",
+                            "Function Name": "RenderingServerDefault::get_frame_profile_frame",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71952,7 +71952,7 @@
                             "End Line": 308
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_frame_profil",
+                            "Function Name": "RenderingServerDefault::get_frame_profile",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -71962,7 +71962,7 @@
                             "End Line": 312
                         },
                         {
-                            "Function Name": "RenderingServerDefault::get_default_clea",
+                            "Function Name": "RenderingServerDefault::get_default_clear_color",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -72076,8 +72076,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 3,
                         "Design Long Vars": 3,
-                        "Duplicate Logic": 2,
-                        "Orphaned Logic": 33,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 35,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -78243,7 +78243,7 @@
                             "End Line": 1594
                         },
                         {
-                            "Function Name": "nodesOverlappingIndexIncludingParseError",
+                            "Function Name": "nodesOverlappingIndexIncludingParseErrors",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 1,
                             "Control Flow Branches": 0,
@@ -87651,36 +87651,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 12.532,
+                        "Repository Drift (Z-Score)": 12.573,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.174,
-                            "file_cluster_1": 14.295,
-                            "file_cluster_2": 14.256,
-                            "file_cluster_3": 13.167,
-                            "file_cluster_4": 14.099,
-                            "file_cluster_5": 14.535,
-                            "file_cluster_6": 13.204,
-                            "file_cluster_7": 13.939,
-                            "file_cluster_8": 13.813,
-                            "file_cluster_9": 13.737,
-                            "file_cluster_10": 14.572,
-                            "file_cluster_11": 12.532,
-                            "file_cluster_12": 14.256,
-                            "file_cluster_13": 13.028,
-                            "file_cluster_14": 14.979,
-                            "file_cluster_15": 14.196,
-                            "file_cluster_16": 13.393,
-                            "file_cluster_17": 13.712
+                            "file_cluster_0": 13.215,
+                            "file_cluster_1": 14.327,
+                            "file_cluster_2": 14.29,
+                            "file_cluster_3": 13.204,
+                            "file_cluster_4": 14.143,
+                            "file_cluster_5": 14.568,
+                            "file_cluster_6": 13.243,
+                            "file_cluster_7": 13.974,
+                            "file_cluster_8": 13.848,
+                            "file_cluster_9": 13.776,
+                            "file_cluster_10": 14.606,
+                            "file_cluster_11": 12.573,
+                            "file_cluster_12": 14.289,
+                            "file_cluster_13": 13.071,
+                            "file_cluster_14": 15.015,
+                            "file_cluster_15": 14.229,
+                            "file_cluster_16": 13.429,
+                            "file_cluster_17": 13.755
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.698,
+                        "File Drift (Z-Score)": 7.736,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 9.017,
-                            "Cluster 1: Declarative Glue & Initialization": 7.698,
-                            "Cluster 2: Async & Concurrent Testing": 9.327,
-                            "Cluster 3: Data Pipelines & I/O Operations": 8.07,
-                            "Cluster 4: Procedural Verification & Mocks": 8.546,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.349
+                            "Cluster 0: Decorated Core & Metaprogramming": 9.046,
+                            "Cluster 1: Declarative Glue & Initialization": 7.736,
+                            "Cluster 2: Async & Concurrent Testing": 9.352,
+                            "Cluster 3: Data Pipelines & I/O Operations": 8.091,
+                            "Cluster 4: Procedural Verification & Mocks": 8.558,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.469
                         },
                         "Total LOC": 133,
                         "Coding LOC": 87,
@@ -87750,7 +87750,7 @@
                             "End Line": 26
                         },
                         {
-                            "Function Name": "test_serialize_sequence_value_with_none_",
+                            "Function Name": "test_serialize_sequence_value_with_none_first_in_union",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -87760,7 +87760,7 @@
                             "End Line": 135
                         },
                         {
-                            "Function Name": "test_serialize_sequence_value_with_optio",
+                            "Function Name": "test_serialize_sequence_value_with_optional_list",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -87770,7 +87770,7 @@
                             "End Line": 108
                         },
                         {
-                            "Function Name": "test_serialize_sequence_value_with_optio",
+                            "Function Name": "test_serialize_sequence_value_with_optional_list_pipe_union",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -87894,8 +87894,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 4,
-                        "Orphaned Logic": 7,
+                        "Duplicate Logic": 2,
+                        "Orphaned Logic": 9,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -88293,7 +88293,7 @@
                             "End Line": 80
                         },
                         {
-                            "Function Name": "test_custom_middleware_exception_not_rai",
+                            "Function Name": "test_custom_middleware_exception_not_raised",
                             "Structural Impact": 6.5,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
@@ -91500,7 +91500,7 @@
                             "End Line": 20
                         },
                         {
-                            "Function Name": "test_websocket_dependency_after_yield_br",
+                            "Function Name": "test_websocket_dependency_after_yield_broken",
                             "Structural Impact": 7.1,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 3,
@@ -93619,36 +93619,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 10.578,
+                        "Repository Drift (Z-Score)": 10.625,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.916,
-                            "file_cluster_1": 11.507,
-                            "file_cluster_2": 11.635,
-                            "file_cluster_3": 12.275,
-                            "file_cluster_4": 11.317,
-                            "file_cluster_5": 12.102,
-                            "file_cluster_6": 11.488,
-                            "file_cluster_7": 11.21,
-                            "file_cluster_8": 10.578,
-                            "file_cluster_9": 11.445,
-                            "file_cluster_10": 12.697,
-                            "file_cluster_11": 11.588,
-                            "file_cluster_12": 12.017,
-                            "file_cluster_13": 11.178,
-                            "file_cluster_14": 14.867,
-                            "file_cluster_15": 12.282,
-                            "file_cluster_16": 11.601,
-                            "file_cluster_17": 11.402
+                            "file_cluster_0": 10.976,
+                            "file_cluster_1": 11.549,
+                            "file_cluster_2": 11.682,
+                            "file_cluster_3": 12.319,
+                            "file_cluster_4": 11.386,
+                            "file_cluster_5": 12.144,
+                            "file_cluster_6": 11.537,
+                            "file_cluster_7": 11.256,
+                            "file_cluster_8": 10.625,
+                            "file_cluster_9": 11.501,
+                            "file_cluster_10": 12.739,
+                            "file_cluster_11": 11.637,
+                            "file_cluster_12": 12.057,
+                            "file_cluster_13": 11.237,
+                            "file_cluster_14": 14.909,
+                            "file_cluster_15": 12.322,
+                            "file_cluster_16": 11.645,
+                            "file_cluster_17": 11.468
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 5.094,
+                        "File Drift (Z-Score)": 5.19,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 7.342,
-                            "Cluster 1: Declarative Glue & Initialization": 5.094,
-                            "Cluster 2: Async & Concurrent Testing": 8.034,
-                            "Cluster 3: Data Pipelines & I/O Operations": 6.314,
-                            "Cluster 4: Procedural Verification & Mocks": 7.037,
-                            "Cluster 5: Universal Dependencies & Serialization": 8.114
+                            "Cluster 0: Decorated Core & Metaprogramming": 7.407,
+                            "Cluster 1: Declarative Glue & Initialization": 5.19,
+                            "Cluster 2: Async & Concurrent Testing": 8.097,
+                            "Cluster 3: Data Pipelines & I/O Operations": 6.37,
+                            "Cluster 4: Procedural Verification & Mocks": 7.056,
+                            "Cluster 5: Universal Dependencies & Serialization": 8.404
                         },
                         "Total LOC": 390,
                         "Coding LOC": 310,
@@ -93728,7 +93728,7 @@
                             "End Line": 231
                         },
                         {
-                            "Function Name": "test_override_with_sub__main_depends_q_f",
+                            "Function Name": "test_override_with_sub__main_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93748,7 +93748,7 @@
                             "End Line": 275
                         },
                         {
-                            "Function Name": "test_override_with_sub_decorator_depends",
+                            "Function Name": "test_override_with_sub_decorator_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93768,7 +93768,7 @@
                             "End Line": 319
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_depends_q_",
+                            "Function Name": "test_override_with_sub_router_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93778,7 +93778,7 @@
                             "End Line": 337
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_decorator_",
+                            "Function Name": "test_override_with_sub_router_decorator_depends",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93788,7 +93788,7 @@
                             "End Line": 363
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_decorator_",
+                            "Function Name": "test_override_with_sub_router_decorator_depends_q_foo",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 0,
@@ -93898,7 +93898,7 @@
                             "End Line": 72
                         },
                         {
-                            "Function Name": "test_main_depends_q_foo_skip_100_limit_2",
+                            "Function Name": "test_main_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -93918,7 +93918,7 @@
                             "End Line": 132
                         },
                         {
-                            "Function Name": "test_router_depends_q_foo_skip_100_limit",
+                            "Function Name": "test_router_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -93928,7 +93928,7 @@
                             "End Line": 141
                         },
                         {
-                            "Function Name": "test_override_with_sub_main_depends_k_ba",
+                            "Function Name": "test_override_with_sub_main_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93938,7 +93938,7 @@
                             "End Line": 257
                         },
                         {
-                            "Function Name": "test_override_with_sub_decorator_depends",
+                            "Function Name": "test_override_with_sub_decorator_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93948,7 +93948,7 @@
                             "End Line": 301
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_depends_k_",
+                            "Function Name": "test_override_with_sub_router_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93958,7 +93958,7 @@
                             "End Line": 345
                         },
                         {
-                            "Function Name": "test_override_with_sub_router_decorator_",
+                            "Function Name": "test_override_with_sub_router_decorator_depends_k_bar",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -93978,7 +93978,7 @@
                             "End Line": 102
                         },
                         {
-                            "Function Name": "test_decorator_depends_q_foo_skip_100_li",
+                            "Function Name": "test_decorator_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -93998,7 +93998,7 @@
                             "End Line": 162
                         },
                         {
-                            "Function Name": "test_router_decorator_depends_q_foo_skip",
+                            "Function Name": "test_router_decorator_depends_q_foo_skip_100_limit_200",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -94082,8 +94082,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 6,
-                        "Orphaned Logic": 23,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 29,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -94246,7 +94246,7 @@
                             "End Line": 48
                         },
                         {
-                            "Function Name": "test_call_get_parameterless_without_scop",
+                            "Function Name": "test_call_get_parameterless_without_scopes_for_coverage",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -94505,7 +94505,7 @@
                             "End Line": 21
                         },
                         {
-                            "Function Name": "get_partial_async_callable_gen_dependenc",
+                            "Function Name": "get_partial_async_callable_gen_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 0,
@@ -94515,7 +94515,7 @@
                             "End Line": 146
                         },
                         {
-                            "Function Name": "get_partial_synchronous_method_dependenc",
+                            "Function Name": "get_partial_synchronous_method_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 0,
@@ -94525,7 +94525,7 @@
                             "End Line": 160
                         },
                         {
-                            "Function Name": "get_partial_synchronous_method_gen_depen",
+                            "Function Name": "get_partial_synchronous_method_gen_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -94535,7 +94535,7 @@
                             "End Line": 175
                         },
                         {
-                            "Function Name": "get_partial_asynchronous_method_dependen",
+                            "Function Name": "get_partial_asynchronous_method_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -94545,7 +94545,7 @@
                             "End Line": 190
                         },
                         {
-                            "Function Name": "get_partial_asynchronous_method_gen_depe",
+                            "Function Name": "get_partial_asynchronous_method_gen_dependency",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -95334,36 +95334,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 9.529,
+                        "Repository Drift (Z-Score)": 9.537,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.529,
-                            "file_cluster_1": 10.789,
-                            "file_cluster_2": 10.987,
-                            "file_cluster_3": 11.106,
-                            "file_cluster_4": 9.631,
-                            "file_cluster_5": 11.299,
-                            "file_cluster_6": 10.697,
-                            "file_cluster_7": 10.358,
-                            "file_cluster_8": 10.356,
-                            "file_cluster_9": 10.942,
-                            "file_cluster_10": 11.649,
-                            "file_cluster_11": 10.032,
-                            "file_cluster_12": 10.298,
-                            "file_cluster_13": 10.015,
-                            "file_cluster_14": 14.188,
-                            "file_cluster_15": 11.146,
-                            "file_cluster_16": 10.388,
-                            "file_cluster_17": 10.964
+                            "file_cluster_0": 9.537,
+                            "file_cluster_1": 10.794,
+                            "file_cluster_2": 10.993,
+                            "file_cluster_3": 11.111,
+                            "file_cluster_4": 9.64,
+                            "file_cluster_5": 11.304,
+                            "file_cluster_6": 10.703,
+                            "file_cluster_7": 10.364,
+                            "file_cluster_8": 10.362,
+                            "file_cluster_9": 10.949,
+                            "file_cluster_10": 11.655,
+                            "file_cluster_11": 10.039,
+                            "file_cluster_12": 10.303,
+                            "file_cluster_13": 10.022,
+                            "file_cluster_14": 14.193,
+                            "file_cluster_15": 11.151,
+                            "file_cluster_16": 10.394,
+                            "file_cluster_17": 10.972
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.676,
+                        "File Drift (Z-Score)": 7.68,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.886,
-                            "Cluster 1: Declarative Glue & Initialization": 7.676,
-                            "Cluster 2: Async & Concurrent Testing": 9.393,
-                            "Cluster 3: Data Pipelines & I/O Operations": 8.07,
-                            "Cluster 4: Procedural Verification & Mocks": 8.807,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.256
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.889,
+                            "Cluster 1: Declarative Glue & Initialization": 7.68,
+                            "Cluster 2: Async & Concurrent Testing": 9.395,
+                            "Cluster 3: Data Pipelines & I/O Operations": 8.071,
+                            "Cluster 4: Procedural Verification & Mocks": 8.806,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.279
                         },
                         "Total LOC": 450,
                         "Coding LOC": 301,
@@ -95453,7 +95453,7 @@
                             "End Line": 227
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_async_depende",
+                            "Function Name": "get_wrapped_class_instance_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95463,7 +95463,7 @@
                             "End Line": 234
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_gen_dependenc",
+                            "Function Name": "get_wrapped_class_instance_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95473,7 +95473,7 @@
                             "End Line": 241
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_async_gen_dep",
+                            "Function Name": "get_wrapped_class_instance_async_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95493,7 +95493,7 @@
                             "End Line": 255
                         },
                         {
-                            "Function Name": "get_class_instance_wrapped_async_depende",
+                            "Function Name": "get_class_instance_wrapped_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95503,7 +95503,7 @@
                             "End Line": 262
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_depende",
+                            "Function Name": "get_class_instance_async_wrapped_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95513,7 +95513,7 @@
                             "End Line": 269
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_async_d",
+                            "Function Name": "get_class_instance_async_wrapped_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95523,7 +95523,7 @@
                             "End Line": 276
                         },
                         {
-                            "Function Name": "get_class_instance_wrapped_gen_dependenc",
+                            "Function Name": "get_class_instance_wrapped_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95533,7 +95533,7 @@
                             "End Line": 283
                         },
                         {
-                            "Function Name": "get_class_instance_wrapped_async_gen_dep",
+                            "Function Name": "get_class_instance_wrapped_async_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95543,7 +95543,7 @@
                             "End Line": 290
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_gen_dep",
+                            "Function Name": "get_class_instance_async_wrapped_gen_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95553,7 +95553,7 @@
                             "End Line": 297
                         },
                         {
-                            "Function Name": "get_class_instance_async_wrapped_gen_asy",
+                            "Function Name": "get_class_instance_async_wrapped_gen_async_dependency",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95583,7 +95583,7 @@
                             "End Line": 358
                         },
                         {
-                            "Function Name": "get_async_wrapped_dependency_async_wrapp",
+                            "Function Name": "get_async_wrapped_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95593,7 +95593,7 @@
                             "End Line": 365
                         },
                         {
-                            "Function Name": "get_async_wrapped_gen_dependency_async_w",
+                            "Function Name": "get_async_wrapped_gen_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95603,7 +95603,7 @@
                             "End Line": 372
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_dependency_as",
+                            "Function Name": "get_wrapped_class_instance_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95613,7 +95613,7 @@
                             "End Line": 379
                         },
                         {
-                            "Function Name": "get_wrapped_class_instance_async_depende",
+                            "Function Name": "get_wrapped_class_instance_async_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95623,7 +95623,7 @@
                             "End Line": 386
                         },
                         {
-                            "Function Name": "get_wrapped_class_dependency_async_wrapp",
+                            "Function Name": "get_wrapped_class_dependency_async_wrapper",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -95773,7 +95773,7 @@
                             "End Line": 341
                         },
                         {
-                            "Function Name": "async_wrapped_gen_dependency_async_wrapp",
+                            "Function Name": "async_wrapped_gen_dependency_async_wrapper",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -96027,8 +96027,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 16,
-                        "Duplicate Logic": 16,
-                        "Orphaned Logic": 29,
+                        "Duplicate Logic": 14,
+                        "Orphaned Logic": 30,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -97743,7 +97743,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_orjson_response_emits_deprecation_w",
+                            "Function Name": "test_orjson_response_emits_deprecation_warning",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 2,
@@ -97753,7 +97753,7 @@
                             "End Line": 43
                         },
                         {
-                            "Function Name": "test_ujson_response_emits_deprecation_wa",
+                            "Function Name": "test_ujson_response_emits_deprecation_warning",
                             "Structural Impact": 5.3,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 2,
@@ -97783,7 +97783,7 @@
                             "End Line": 58
                         },
                         {
-                            "Function Name": "test_orjson_response_returns_correct_dat",
+                            "Function Name": "test_orjson_response_returns_correct_data",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 1,
@@ -98016,7 +98016,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_default_response_class_skips_json_d",
+                            "Function Name": "test_default_response_class_skips_json_dumps",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -98026,7 +98026,7 @@
                             "End Line": 39
                         },
                         {
-                            "Function Name": "test_explicit_response_class_uses_json_d",
+                            "Function Name": "test_explicit_response_class_uses_json_dumps",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -98944,7 +98944,7 @@
                             "End Line": 88
                         },
                         {
-                            "Function Name": "test_override_server_error_exception_rai",
+                            "Function Name": "test_override_server_error_exception_raises",
                             "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 1,
@@ -98964,7 +98964,7 @@
                             "End Line": 50
                         },
                         {
-                            "Function Name": "test_override_server_error_exception_res",
+                            "Function Name": "test_override_server_error_exception_response",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -98984,7 +98984,7 @@
                             "End Line": 61
                         },
                         {
-                            "Function Name": "test_override_request_validation_excepti",
+                            "Function Name": "test_override_request_validation_exception",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -101304,7 +101304,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_router_include_overrides_generate_u",
+                            "Function Name": "test_router_include_overrides_generate_unique_id",
                             "Structural Impact": 26.4,
                             "Lines of Code (LOC)": 493,
                             "Control Flow Branches": 0,
@@ -101314,7 +101314,7 @@
                             "End Line": 944
                         },
                         {
-                            "Function Name": "test_router_path_operation_overrides_gen",
+                            "Function Name": "test_router_path_operation_overrides_generate_unique_id",
                             "Structural Impact": 23.1,
                             "Lines of Code (LOC)": 428,
                             "Control Flow Branches": 0,
@@ -101324,7 +101324,7 @@
                             "End Line": 1374
                         },
                         {
-                            "Function Name": "test_callback_override_generate_unique_i",
+                            "Function Name": "test_callback_override_generate_unique_id",
                             "Structural Impact": 23.1,
                             "Lines of Code (LOC)": 323,
                             "Control Flow Branches": 3,
@@ -104762,7 +104762,7 @@
                             "End Line": 225
                         },
                         {
-                            "Function Name": "test_encode_custom_json_encoders_model_p",
+                            "Function Name": "test_encode_custom_json_encoders_model_pydanticv2",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 0,
@@ -105853,36 +105853,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 10.008,
+                        "Repository Drift (Z-Score)": 10.045,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.008,
-                            "file_cluster_1": 10.95,
-                            "file_cluster_2": 11.098,
-                            "file_cluster_3": 10.643,
-                            "file_cluster_4": 10.449,
-                            "file_cluster_5": 11.499,
-                            "file_cluster_6": 10.887,
-                            "file_cluster_7": 10.573,
-                            "file_cluster_8": 10.193,
-                            "file_cluster_9": 11.168,
-                            "file_cluster_10": 11.724,
-                            "file_cluster_11": 10.012,
-                            "file_cluster_12": 10.264,
-                            "file_cluster_13": 10.269,
-                            "file_cluster_14": 13.626,
-                            "file_cluster_15": 11.199,
-                            "file_cluster_16": 10.977,
-                            "file_cluster_17": 11.195
+                            "file_cluster_0": 10.045,
+                            "file_cluster_1": 10.982,
+                            "file_cluster_2": 11.131,
+                            "file_cluster_3": 10.678,
+                            "file_cluster_4": 10.488,
+                            "file_cluster_5": 11.531,
+                            "file_cluster_6": 10.921,
+                            "file_cluster_7": 10.608,
+                            "file_cluster_8": 10.23,
+                            "file_cluster_9": 11.202,
+                            "file_cluster_10": 11.756,
+                            "file_cluster_11": 10.049,
+                            "file_cluster_12": 10.299,
+                            "file_cluster_13": 10.307,
+                            "file_cluster_14": 13.654,
+                            "file_cluster_15": 11.232,
+                            "file_cluster_16": 11.011,
+                            "file_cluster_17": 11.231
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.541,
+                        "File Drift (Z-Score)": 7.569,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.99,
-                            "Cluster 1: Declarative Glue & Initialization": 7.541,
-                            "Cluster 2: Async & Concurrent Testing": 9.309,
-                            "Cluster 3: Data Pipelines & I/O Operations": 8.312,
-                            "Cluster 4: Procedural Verification & Mocks": 8.68,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.465
+                            "Cluster 0: Decorated Core & Metaprogramming": 9.01,
+                            "Cluster 1: Declarative Glue & Initialization": 7.569,
+                            "Cluster 2: Async & Concurrent Testing": 9.324,
+                            "Cluster 3: Data Pipelines & I/O Operations": 8.327,
+                            "Cluster 4: Procedural Verification & Mocks": 8.696,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.503
                         },
                         "Total LOC": 150,
                         "Coding LOC": 115,
@@ -105922,7 +105922,7 @@
                             "End Line": 21
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_file_",
+                            "Function Name": "test_incorrect_multipart_installed_file_upload",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -105932,7 +105932,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_file_",
+                            "Function Name": "test_incorrect_multipart_installed_file_bytes",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -105942,7 +105942,7 @@
                             "End Line": 47
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_multi",
+                            "Function Name": "test_incorrect_multipart_installed_multi_form",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -105952,7 +105952,7 @@
                             "End Line": 60
                         },
                         {
-                            "Function Name": "test_incorrect_multipart_installed_form_",
+                            "Function Name": "test_incorrect_multipart_installed_form_file",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 3,
@@ -106206,8 +106206,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 13,
-                        "Orphaned Logic": 9,
+                        "Duplicate Logic": 11,
+                        "Orphaned Logic": 11,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -106749,7 +106749,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_multiple_different_root_paths_do_no",
+                            "Function Name": "test_multiple_different_root_paths_do_not_accumulate",
                             "Structural Impact": 7.9,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 3,
@@ -106759,7 +106759,7 @@
                             "End Line": 45
                         },
                         {
-                            "Function Name": "test_root_path_does_not_persist_across_r",
+                            "Function Name": "test_root_path_does_not_persist_across_requests",
                             "Structural Impact": 6.1,
                             "Lines of Code (LOC)": 19,
                             "Control Flow Branches": 2,
@@ -111629,7 +111629,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_additio",
+                            "Function Name": "test_raises_pydantic_v1_model_in_additional_responses_model",
                             "Structural Impact": 4.1,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 1,
@@ -111639,7 +111639,7 @@
                             "End Line": 70
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_endpoin",
+                            "Function Name": "test_raises_pydantic_v1_model_in_endpoint_param",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -111649,7 +111649,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_return_",
+                            "Function Name": "test_raises_pydantic_v1_model_in_return_type",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -111659,7 +111659,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_respons",
+                            "Function Name": "test_raises_pydantic_v1_model_in_response_model",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -111679,7 +111679,7 @@
                             "End Line": 83
                         },
                         {
-                            "Function Name": "test_raises_pydantic_v1_model_in_sequenc",
+                            "Function Name": "test_raises_pydantic_v1_model_in_sequence",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -112393,7 +112393,7 @@
                             "End Line": 233
                         },
                         {
-                            "Function Name": "test_query_frozenset_query_1_query_1_que",
+                            "Function Name": "test_query_frozenset_query_1_query_1_query_2",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -113391,7 +113391,7 @@
                             "End Line": 146
                         },
                         {
-                            "Function Name": "test_query_params_str_validations_item_q",
+                            "Function Name": "test_query_params_str_validations_item_query_nonregexquery",
                             "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 1,
@@ -113401,7 +113401,7 @@
                             "End Line": 60
                         },
                         {
-                            "Function Name": "test_query_params_str_validations_no_que",
+                            "Function Name": "test_query_params_str_validations_no_query",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -113411,7 +113411,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_query_params_str_validations_q_fixe",
+                            "Function Name": "test_query_params_str_validations_q_fixedquery",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -115085,7 +115085,7 @@
                             "End Line": 33
                         },
                         {
-                            "Function Name": "test_required_nonable_explicit_query_inv",
+                            "Function Name": "test_required_nonable_explicit_query_invalid",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -115095,7 +115095,7 @@
                             "End Line": 38
                         },
                         {
-                            "Function Name": "test_required_nonable_explicit_query_val",
+                            "Function Name": "test_required_nonable_explicit_query_value",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -115105,7 +115105,7 @@
                             "End Line": 44
                         },
                         {
-                            "Function Name": "test_required_nonable_body_embed_no_cont",
+                            "Function Name": "test_required_nonable_body_embed_no_content",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -116391,7 +116391,7 @@
                             "End Line": 95
                         },
                         {
-                            "Function Name": "test_background_tasks_with_depends_annot",
+                            "Function Name": "test_background_tasks_with_depends_annotated",
                             "Structural Impact": 3.0,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 0,
@@ -116401,7 +116401,7 @@
                             "End Line": 172
                         },
                         {
-                            "Function Name": "test_response_dependency_returns_differe",
+                            "Function Name": "test_response_dependency_returns_different_response_instance",
                             "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 21,
                             "Control Flow Branches": 0,
@@ -116732,36 +116732,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_8",
-                        "Repository Drift (Z-Score)": 9.382,
+                        "Repository Drift (Z-Score)": 9.53,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.65,
-                            "file_cluster_1": 10.399,
-                            "file_cluster_2": 10.608,
-                            "file_cluster_3": 11.619,
-                            "file_cluster_4": 10.785,
-                            "file_cluster_5": 11.03,
-                            "file_cluster_6": 10.484,
-                            "file_cluster_7": 10.09,
-                            "file_cluster_8": 9.382,
-                            "file_cluster_9": 10.49,
-                            "file_cluster_10": 11.726,
-                            "file_cluster_11": 10.529,
-                            "file_cluster_12": 10.936,
-                            "file_cluster_13": 10.112,
-                            "file_cluster_14": 14.595,
-                            "file_cluster_15": 11.234,
-                            "file_cluster_16": 10.0,
-                            "file_cluster_17": 10.577
+                            "file_cluster_0": 9.813,
+                            "file_cluster_1": 10.526,
+                            "file_cluster_2": 10.741,
+                            "file_cluster_3": 11.743,
+                            "file_cluster_4": 10.958,
+                            "file_cluster_5": 11.156,
+                            "file_cluster_6": 10.625,
+                            "file_cluster_7": 10.231,
+                            "file_cluster_8": 9.53,
+                            "file_cluster_9": 10.642,
+                            "file_cluster_10": 11.849,
+                            "file_cluster_11": 10.67,
+                            "file_cluster_12": 11.058,
+                            "file_cluster_13": 10.273,
+                            "file_cluster_14": 14.705,
+                            "file_cluster_15": 11.357,
+                            "file_cluster_16": 10.141,
+                            "file_cluster_17": 10.745
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 4.359,
+                        "File Drift (Z-Score)": 4.589,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 6.903,
-                            "Cluster 1: Declarative Glue & Initialization": 4.359,
-                            "Cluster 2: Async & Concurrent Testing": 7.785,
-                            "Cluster 3: Data Pipelines & I/O Operations": 5.595,
-                            "Cluster 4: Procedural Verification & Mocks": 6.672,
-                            "Cluster 5: Universal Dependencies & Serialization": 7.363
+                            "Cluster 0: Decorated Core & Metaprogramming": 7.029,
+                            "Cluster 1: Declarative Glue & Initialization": 4.589,
+                            "Cluster 2: Async & Concurrent Testing": 7.886,
+                            "Cluster 3: Data Pipelines & I/O Operations": 5.701,
+                            "Cluster 4: Procedural Verification & Mocks": 6.725,
+                            "Cluster 5: Universal Dependencies & Serialization": 7.861
                         },
                         "Total LOC": 1122,
                         "Coding LOC": 959,
@@ -116811,7 +116811,7 @@
                             "End Line": 508
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_invalid_dict",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116821,7 +116821,7 @@
                             "End Line": 281
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_invalid_model",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116831,7 +116831,7 @@
                             "End Line": 287
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_invalid_dict",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116841,7 +116841,7 @@
                             "End Line": 319
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_invalid_model",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116851,7 +116851,7 @@
                             "End Line": 325
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_invalid_dict",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116861,7 +116861,7 @@
                             "End Line": 403
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_invalid_model",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -116871,7 +116871,7 @@
                             "End Line": 409
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -116881,7 +116881,7 @@
                             "End Line": 385
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_dict_with_extra_data",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 0,
@@ -116891,7 +116891,7 @@
                             "End Line": 373
                         },
                         {
-                            "Function Name": "test_response_model_list_of_model_no_ann",
+                            "Function Name": "test_response_model_list_of_model_no_annotation",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -116901,7 +116901,7 @@
                             "End Line": 442
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_list_o",
+                            "Function Name": "test_no_response_model_annotation_list_of_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -116911,7 +116911,7 @@
                             "End Line": 451
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_forwar",
+                            "Function Name": "test_no_response_model_annotation_forward_ref_list_of_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -116921,7 +116921,7 @@
                             "End Line": 460
                         },
                         {
-                            "Function Name": "response_model_list_of_model_no_annotati",
+                            "Function Name": "response_model_list_of_model_no_annotation",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -116931,7 +116931,7 @@
                             "End Line": 196
                         },
                         {
-                            "Function Name": "no_response_model_annotation_list_of_mod",
+                            "Function Name": "no_response_model_annotation_list_of_model",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -116941,7 +116941,7 @@
                             "End Line": 204
                         },
                         {
-                            "Function Name": "no_response_model_annotation_forward_ref",
+                            "Function Name": "no_response_model_annotation_forward_ref_list_of_model",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -116951,7 +116951,7 @@
                             "End Line": 212
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116961,7 +116961,7 @@
                             "End Line": 301
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116971,7 +116971,7 @@
                             "End Line": 339
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_dict_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116981,7 +116981,7 @@
                             "End Line": 417
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_submodel_with_extra_data",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -116991,7 +116991,7 @@
                             "End Line": 425
                         },
                         {
-                            "Function Name": "test_response_model_filtering_model_anno",
+                            "Function Name": "test_response_model_filtering_model_annotation_submodel_return_submodel",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -117001,7 +117001,7 @@
                             "End Line": 433
                         },
                         {
-                            "Function Name": "test_no_response_model_no_annotation_ret",
+                            "Function Name": "test_no_response_model_no_annotation_return_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117011,7 +117011,7 @@
                             "End Line": 257
                         },
                         {
-                            "Function Name": "test_no_response_model_no_annotation_ret",
+                            "Function Name": "test_no_response_model_no_annotation_return_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117021,7 +117021,7 @@
                             "End Line": 263
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117031,7 +117031,7 @@
                             "End Line": 269
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117041,7 +117041,7 @@
                             "End Line": 275
                         },
                         {
-                            "Function Name": "test_response_model_no_annotation_return",
+                            "Function Name": "test_response_model_no_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117051,7 +117051,7 @@
                             "End Line": 293
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117061,7 +117061,7 @@
                             "End Line": 307
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117071,7 +117071,7 @@
                             "End Line": 313
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117081,7 +117081,7 @@
                             "End Line": 331
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117091,7 +117091,7 @@
                             "End Line": 345
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117101,7 +117101,7 @@
                             "End Line": 351
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_invalid_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117111,7 +117111,7 @@
                             "End Line": 357
                         },
                         {
-                            "Function Name": "test_response_model_none_annotation_retu",
+                            "Function Name": "test_response_model_none_annotation_return_invalid_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117121,7 +117121,7 @@
                             "End Line": 363
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_same_model",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117131,7 +117131,7 @@
                             "End Line": 391
                         },
                         {
-                            "Function Name": "test_response_model_model1_annotation_mo",
+                            "Function Name": "test_response_model_model1_annotation_model2_return_exact_dict",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117141,7 +117141,7 @@
                             "End Line": 397
                         },
                         {
-                            "Function Name": "test_response_model_union_no_annotation_",
+                            "Function Name": "test_response_model_union_no_annotation_return_model1",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117151,7 +117151,7 @@
                             "End Line": 466
                         },
                         {
-                            "Function Name": "test_response_model_union_no_annotation_",
+                            "Function Name": "test_response_model_union_no_annotation_return_model2",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117161,7 +117161,7 @@
                             "End Line": 472
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_union_",
+                            "Function Name": "test_no_response_model_annotation_union_return_model1",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117171,7 +117171,7 @@
                             "End Line": 478
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_union_",
+                            "Function Name": "test_no_response_model_annotation_union_return_model2",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117181,7 +117181,7 @@
                             "End Line": 484
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_return",
+                            "Function Name": "test_no_response_model_annotation_return_class",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117191,7 +117191,7 @@
                             "End Line": 490
                         },
                         {
-                            "Function Name": "test_no_response_model_annotation_json_r",
+                            "Function Name": "test_no_response_model_annotation_json_response_class",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -117201,7 +117201,7 @@
                             "End Line": 496
                         },
                         {
-                            "Function Name": "no_response_model_no_annotation_return_m",
+                            "Function Name": "no_response_model_no_annotation_return_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117211,7 +117211,7 @@
                             "End Line": 32
                         },
                         {
-                            "Function Name": "no_response_model_no_annotation_return_d",
+                            "Function Name": "no_response_model_no_annotation_return_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117221,7 +117221,7 @@
                             "End Line": 37
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_same",
+                            "Function Name": "response_model_no_annotation_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117231,7 +117231,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_exac",
+                            "Function Name": "response_model_no_annotation_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117241,7 +117241,7 @@
                             "End Line": 47
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_inva",
+                            "Function Name": "response_model_no_annotation_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117251,7 +117251,7 @@
                             "End Line": 52
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_inva",
+                            "Function Name": "response_model_no_annotation_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117261,7 +117261,7 @@
                             "End Line": 57
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_dict",
+                            "Function Name": "response_model_no_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117271,7 +117271,7 @@
                             "End Line": 64
                         },
                         {
-                            "Function Name": "response_model_no_annotation_return_subm",
+                            "Function Name": "response_model_no_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117281,7 +117281,7 @@
                             "End Line": 71
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_same",
+                            "Function Name": "no_response_model_annotation_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117291,7 +117291,7 @@
                             "End Line": 76
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_exac",
+                            "Function Name": "no_response_model_annotation_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117301,7 +117301,7 @@
                             "End Line": 81
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_inva",
+                            "Function Name": "no_response_model_annotation_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117311,7 +117311,7 @@
                             "End Line": 86
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_inva",
+                            "Function Name": "no_response_model_annotation_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117321,7 +117321,7 @@
                             "End Line": 91
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_dict",
+                            "Function Name": "no_response_model_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117331,7 +117331,7 @@
                             "End Line": 96
                         },
                         {
-                            "Function Name": "no_response_model_annotation_return_subm",
+                            "Function Name": "no_response_model_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117341,7 +117341,7 @@
                             "End Line": 101
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_sa",
+                            "Function Name": "response_model_none_annotation_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117351,7 +117351,7 @@
                             "End Line": 106
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_ex",
+                            "Function Name": "response_model_none_annotation_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117361,7 +117361,7 @@
                             "End Line": 111
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_in",
+                            "Function Name": "response_model_none_annotation_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117371,7 +117371,7 @@
                             "End Line": 116
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_in",
+                            "Function Name": "response_model_none_annotation_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117381,7 +117381,7 @@
                             "End Line": 121
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_di",
+                            "Function Name": "response_model_none_annotation_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117391,7 +117391,7 @@
                             "End Line": 128
                         },
                         {
-                            "Function Name": "response_model_none_annotation_return_su",
+                            "Function Name": "response_model_none_annotation_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117401,7 +117401,7 @@
                             "End Line": 136
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_same_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117411,7 +117411,7 @@
                             "End Line": 143
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_exact_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117421,7 +117421,7 @@
                             "End Line": 150
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_invalid_dict",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117431,7 +117431,7 @@
                             "End Line": 157
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_invalid_model",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117441,7 +117441,7 @@
                             "End Line": 164
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_dict_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117451,7 +117451,7 @@
                             "End Line": 172
                         },
                         {
-                            "Function Name": "response_model_model1_annotation_model2_",
+                            "Function Name": "response_model_model1_annotation_model2_return_submodel_with_extra_data",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117461,7 +117461,7 @@
                             "End Line": 180
                         },
                         {
-                            "Function Name": "response_model_filtering_model_annotatio",
+                            "Function Name": "response_model_filtering_model_annotation_submodel_return_submodel",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117471,7 +117471,7 @@
                             "End Line": 188
                         },
                         {
-                            "Function Name": "response_model_union_no_annotation_retur",
+                            "Function Name": "response_model_union_no_annotation_return_model1",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117481,7 +117481,7 @@
                             "End Line": 220
                         },
                         {
-                            "Function Name": "response_model_union_no_annotation_retur",
+                            "Function Name": "response_model_union_no_annotation_return_model2",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117491,7 +117491,7 @@
                             "End Line": 228
                         },
                         {
-                            "Function Name": "no_response_model_annotation_union_retur",
+                            "Function Name": "no_response_model_annotation_union_return_model1",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117501,7 +117501,7 @@
                             "End Line": 233
                         },
                         {
-                            "Function Name": "no_response_model_annotation_union_retur",
+                            "Function Name": "no_response_model_annotation_union_return_model2",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117511,7 +117511,7 @@
                             "End Line": 238
                         },
                         {
-                            "Function Name": "no_response_model_annotation_response_cl",
+                            "Function Name": "no_response_model_annotation_response_class",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117521,7 +117521,7 @@
                             "End Line": 243
                         },
                         {
-                            "Function Name": "no_response_model_annotation_json_respon",
+                            "Function Name": "no_response_model_annotation_json_response_class",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -117615,8 +117615,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 47,
-                        "Orphaned Logic": 28,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 75,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -118173,36 +118173,36 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 12.106,
+                        "Repository Drift (Z-Score)": 12.269,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.106,
-                            "file_cluster_1": 13.139,
-                            "file_cluster_2": 13.199,
-                            "file_cluster_3": 13.925,
-                            "file_cluster_4": 12.439,
-                            "file_cluster_5": 13.604,
-                            "file_cluster_6": 12.882,
-                            "file_cluster_7": 12.821,
-                            "file_cluster_8": 12.333,
-                            "file_cluster_9": 12.959,
-                            "file_cluster_10": 14.028,
-                            "file_cluster_11": 12.756,
-                            "file_cluster_12": 13.462,
-                            "file_cluster_13": 12.112,
-                            "file_cluster_14": 16.508,
-                            "file_cluster_15": 13.291,
-                            "file_cluster_16": 13.06,
-                            "file_cluster_17": 12.859
+                            "file_cluster_0": 12.269,
+                            "file_cluster_1": 13.265,
+                            "file_cluster_2": 13.335,
+                            "file_cluster_3": 14.061,
+                            "file_cluster_4": 12.643,
+                            "file_cluster_5": 13.736,
+                            "file_cluster_6": 13.032,
+                            "file_cluster_7": 12.965,
+                            "file_cluster_8": 12.48,
+                            "file_cluster_9": 13.119,
+                            "file_cluster_10": 14.162,
+                            "file_cluster_11": 12.907,
+                            "file_cluster_12": 13.585,
+                            "file_cluster_13": 12.29,
+                            "file_cluster_14": 16.635,
+                            "file_cluster_15": 13.425,
+                            "file_cluster_16": 13.202,
+                            "file_cluster_17": 13.043
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 6.758,
+                        "File Drift (Z-Score)": 6.883,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.481,
-                            "Cluster 1: Declarative Glue & Initialization": 6.758,
-                            "Cluster 2: Async & Concurrent Testing": 9.012,
-                            "Cluster 3: Data Pipelines & I/O Operations": 7.74,
-                            "Cluster 4: Procedural Verification & Mocks": 8.202,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.035
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.53,
+                            "Cluster 1: Declarative Glue & Initialization": 6.883,
+                            "Cluster 2: Async & Concurrent Testing": 9.016,
+                            "Cluster 3: Data Pipelines & I/O Operations": 7.718,
+                            "Cluster 4: Procedural Verification & Mocks": 8.164,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.5
                         },
                         "Total LOC": 48,
                         "Coding LOC": 30,
@@ -118232,7 +118232,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "response_model_has_default_factory_retur",
+                            "Function Name": "response_model_has_default_factory_return_dict",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -118242,7 +118242,7 @@
                             "End Line": 18
                         },
                         {
-                            "Function Name": "response_model_has_default_factory_retur",
+                            "Function Name": "response_model_has_default_factory_return_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -118252,7 +118252,7 @@
                             "End Line": 26
                         },
                         {
-                            "Function Name": "test_response_model_has_default_factory_",
+                            "Function Name": "test_response_model_has_default_factory_return_dict",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -118262,7 +118262,7 @@
                             "End Line": 38
                         },
                         {
-                            "Function Name": "test_response_model_has_default_factory_",
+                            "Function Name": "test_response_model_has_default_factory_return_model",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -118346,8 +118346,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
-                        "Duplicate Logic": 4,
-                        "Orphaned Logic": 0,
+                        "Duplicate Logic": 0,
+                        "Orphaned Logic": 2,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -118779,7 +118779,7 @@
                             "End Line": 16
                         },
                         {
-                            "Function Name": "test_invalid_response_model_sub_type_rai",
+                            "Function Name": "test_invalid_response_model_sub_type_raises",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -118789,7 +118789,7 @@
                             "End Line": 25
                         },
                         {
-                            "Function Name": "test_invalid_response_model_in_responses",
+                            "Function Name": "test_invalid_response_model_in_responses_raises",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -118799,7 +118799,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_invalid_response_model_sub_type_in_",
+                            "Function Name": "test_invalid_response_model_sub_type_in_responses_raises",
                             "Structural Impact": 3.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -119962,7 +119962,7 @@
                             "End Line": 86
                         },
                         {
-                            "Function Name": "test_startup_shutdown_handlers_as_parame",
+                            "Function Name": "test_startup_shutdown_handlers_as_parameters",
                             "Structural Impact": 7.0,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 1,
@@ -120022,7 +120022,7 @@
                             "End Line": 266
                         },
                         {
-                            "Function Name": "test_router_nested_lifespan_state_overri",
+                            "Function Name": "test_router_nested_lifespan_state_overriding_by_parent",
                             "Structural Impact": 4.9,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 1,
@@ -120042,7 +120042,7 @@
                             "End Line": 242
                         },
                         {
-                            "Function Name": "test_merged_no_return_lifespans_return_n",
+                            "Function Name": "test_merged_no_return_lifespans_return_none",
                             "Structural Impact": 4.2,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 1,
@@ -124751,7 +124751,7 @@
                             "End Line": 79
                         },
                         {
-                            "Function Name": "test_security_http_basic_invalid_credent",
+                            "Function Name": "test_security_http_basic_invalid_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -124761,7 +124761,7 @@
                             "End Line": 41
                         },
                         {
-                            "Function Name": "test_security_http_basic_non_basic_crede",
+                            "Function Name": "test_security_http_basic_non_basic_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125001,7 +125001,7 @@
                             "End Line": 15
                         },
                         {
-                            "Function Name": "test_security_http_basic_invalid_credent",
+                            "Function Name": "test_security_http_basic_invalid_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125011,7 +125011,7 @@
                             "End Line": 40
                         },
                         {
-                            "Function Name": "test_security_http_basic_non_basic_crede",
+                            "Function Name": "test_security_http_basic_non_basic_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125251,7 +125251,7 @@
                             "End Line": 15
                         },
                         {
-                            "Function Name": "test_security_http_basic_invalid_credent",
+                            "Function Name": "test_security_http_basic_invalid_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125261,7 +125261,7 @@
                             "End Line": 40
                         },
                         {
-                            "Function Name": "test_security_http_basic_non_basic_crede",
+                            "Function Name": "test_security_http_basic_non_basic_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -125511,7 +125511,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "test_security_http_bearer_incorrect_sche",
+                            "Function Name": "test_security_http_bearer_incorrect_scheme_credentials",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -125750,7 +125750,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "test_security_http_bearer_incorrect_sche",
+                            "Function Name": "test_security_http_bearer_incorrect_scheme_credentials",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -125999,7 +125999,7 @@
                             "End Line": 32
                         },
                         {
-                            "Function Name": "test_security_http_bearer_incorrect_sche",
+                            "Function Name": "test_security_http_bearer_incorrect_scheme_credentials",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -126218,7 +126218,7 @@
                             "End Line": 13
                         },
                         {
-                            "Function Name": "test_security_http_digest_incorrect_sche",
+                            "Function Name": "test_security_http_digest_incorrect_scheme_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -126457,7 +126457,7 @@
                             "End Line": 13
                         },
                         {
-                            "Function Name": "test_security_http_digest_incorrect_sche",
+                            "Function Name": "test_security_http_digest_incorrect_scheme_credentials",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 0,
@@ -126696,7 +126696,7 @@
                             "End Line": 69
                         },
                         {
-                            "Function Name": "test_security_http_digest_incorrect_sche",
+                            "Function Name": "test_security_http_digest_incorrect_scheme_credentials",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -126996,7 +126996,7 @@
                             "End Line": 146
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -127016,7 +127016,7 @@
                             "End Line": 48
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128336,7 +128336,7 @@
                             "End Line": 50
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128346,7 +128346,7 @@
                             "End Line": 56
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128618,7 +128618,7 @@
                             "End Line": 105
                         },
                         {
-                            "Function Name": "test_strict_login_correct_correct_grant_",
+                            "Function Name": "test_strict_login_correct_correct_grant_type",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 0,
@@ -128638,7 +128638,7 @@
                             "End Line": 51
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -128648,7 +128648,7 @@
                             "End Line": 57
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129358,7 +129358,7 @@
                             "End Line": 23
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -129378,7 +129378,7 @@
                             "End Line": 32
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129609,7 +129609,7 @@
                             "End Line": 25
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 2.0,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -129629,7 +129629,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129870,7 +129870,7 @@
                             "End Line": 36
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_other_head",
+                            "Function Name": "test_security_oauth2_password_other_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -129880,7 +129880,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "test_security_oauth2_password_bearer_no_",
+                            "Function Name": "test_security_oauth2_password_bearer_no_header",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -130140,7 +130140,7 @@
                             "End Line": 20
                         },
                         {
-                            "Function Name": "test_security_scopes_dependency_called_o",
+                            "Function Name": "test_security_scopes_dependency_called_once",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -130658,7 +130658,7 @@
                             "End Line": 49
                         },
                         {
-                            "Function Name": "test_security_scopes_sub_dependency_cach",
+                            "Function Name": "test_security_scopes_sub_dependency_caching",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -132510,7 +132510,7 @@
                             "End Line": 36
                         },
                         {
-                            "Function Name": "test_no_body_status_code_with_detail_exc",
+                            "Function Name": "test_no_body_status_code_with_detail_exception_handlers",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 1,
@@ -132530,7 +132530,7 @@
                             "End Line": 24
                         },
                         {
-                            "Function Name": "no_body_status_code_with_detail_exceptio",
+                            "Function Name": "no_body_status_code_with_detail_exception",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -132580,7 +132580,7 @@
                             "End Line": 58
                         },
                         {
-                            "Function Name": "test_no_body_status_code_exception_handl",
+                            "Function Name": "test_no_body_status_code_exception_handlers",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -133799,7 +133799,7 @@
                             "End Line": 17
                         },
                         {
-                            "Function Name": "test_default_strict_rejects_no_content_t",
+                            "Function Name": "test_default_strict_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -133809,7 +133809,7 @@
                             "End Line": 26
                         },
                         {
-                            "Function Name": "test_default_strict_accepts_json_content",
+                            "Function Name": "test_default_strict_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -134066,7 +134066,7 @@
                             "End Line": 64
                         },
                         {
-                            "Function Name": "test_strict_inner_on_lax_app_rejects_no_",
+                            "Function Name": "test_strict_inner_on_lax_app_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134086,7 +134086,7 @@
                             "End Line": 37
                         },
                         {
-                            "Function Name": "test_strict_inner_accepts_json_content_t",
+                            "Function Name": "test_strict_inner_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134096,7 +134096,7 @@
                             "End Line": 42
                         },
                         {
-                            "Function Name": "test_default_inner_accepts_json_content_",
+                            "Function Name": "test_default_inner_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134106,7 +134106,7 @@
                             "End Line": 47
                         },
                         {
-                            "Function Name": "test_lax_outer_on_strict_app_accepts_no_",
+                            "Function Name": "test_lax_outer_on_strict_app_accepts_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -134116,7 +134116,7 @@
                             "End Line": 76
                         },
                         {
-                            "Function Name": "test_strict_inner_on_lax_outer_rejects_n",
+                            "Function Name": "test_strict_inner_on_lax_outer_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134136,7 +134136,7 @@
                             "End Line": 86
                         },
                         {
-                            "Function Name": "test_strict_inner_on_lax_outer_accepts_j",
+                            "Function Name": "test_strict_inner_on_lax_outer_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134363,7 +134363,7 @@
                             "End Line": 23
                         },
                         {
-                            "Function Name": "test_lax_router_on_strict_app_accepts_no",
+                            "Function Name": "test_lax_router_on_strict_app_accepts_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -134373,7 +134373,7 @@
                             "End Line": 36
                         },
                         {
-                            "Function Name": "test_strict_router_on_strict_app_rejects",
+                            "Function Name": "test_strict_router_on_strict_app_rejects_no_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134383,7 +134383,7 @@
                             "End Line": 41
                         },
                         {
-                            "Function Name": "test_default_router_inherits_strict_from",
+                            "Function Name": "test_default_router_inherits_strict_from_app",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134393,7 +134393,7 @@
                             "End Line": 46
                         },
                         {
-                            "Function Name": "test_lax_router_accepts_json_content_typ",
+                            "Function Name": "test_lax_router_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134403,7 +134403,7 @@
                             "End Line": 51
                         },
                         {
-                            "Function Name": "test_strict_router_accepts_json_content_",
+                            "Function Name": "test_strict_router_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -134413,7 +134413,7 @@
                             "End Line": 56
                         },
                         {
-                            "Function Name": "test_default_router_accepts_json_content",
+                            "Function Name": "test_default_router_accepts_json_content_type",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -138189,7 +138189,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "test_websocket_validation_error_includes",
+                            "Function Name": "test_websocket_validation_error_includes_endpoint_context",
                             "Structural Impact": 5.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
@@ -138199,7 +138199,7 @@
                             "End Line": 124
                         },
                         {
-                            "Function Name": "test_subapp_websocket_validation_error_i",
+                            "Function Name": "test_subapp_websocket_validation_error_includes_endpoint_context",
                             "Structural Impact": 5.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 2,
@@ -138209,7 +138209,7 @@
                             "End Line": 151
                         },
                         {
-                            "Function Name": "test_request_validation_error_includes_e",
+                            "Function Name": "test_request_validation_error_includes_endpoint_context",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -138219,7 +138219,7 @@
                             "End Line": 97
                         },
                         {
-                            "Function Name": "test_response_validation_error_includes_",
+                            "Function Name": "test_response_validation_error_includes_endpoint_context",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -138229,7 +138229,7 @@
                             "End Line": 110
                         },
                         {
-                            "Function Name": "test_subapp_request_validation_error_inc",
+                            "Function Name": "test_subapp_request_validation_error_includes_endpoint_context",
                             "Structural Impact": 4.0,
                             "Lines of Code (LOC)": 11,
                             "Control Flow Branches": 1,
@@ -142442,7 +142442,7 @@
             }
         },
         "javascript/react": {
-            "Directory Group Magnitude": 8986.55,
+            "Directory Group Magnitude": 8984.55,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_11": "60.0%",
@@ -142453,7 +142453,7 @@
                 "Error & Exception Exposure": "29.68%",
                 "Tech Debt Exposure": "80.66%",
                 "Testing Exposure": "33.6%",
-                "API Exposure": "7.84%",
+                "API Exposure": "7.82%",
                 "Concurrency Exposure": "8.22%",
                 "State Flux Exposure": "21.14%",
                 "Commented Logic Exposure": "1.98%",
@@ -142716,7 +142716,7 @@
                             "End Line": 1236
                         },
                         {
-                            "Function Name": "mountSuspenseFallbackAfterRetryWithoutHy",
+                            "Function Name": "mountSuspenseFallbackAfterRetryWithoutHydrating",
                             "Structural Impact": 9.9,
                             "Lines of Code (LOC)": 40,
                             "Control Flow Branches": 2,
@@ -143213,40 +143213,40 @@
                     "2. Topological Coordinates": {
                         "X": -2789.01,
                         "Y": -173.31,
-                        "Z": -3581.53
+                        "Z": -3581.51
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
                         "Repository Drift (Z-Score)": 12.023,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.655,
-                            "file_cluster_1": 13.134,
-                            "file_cluster_2": 13.046,
+                            "file_cluster_0": 12.656,
+                            "file_cluster_1": 13.133,
+                            "file_cluster_2": 13.045,
                             "file_cluster_3": 12.909,
                             "file_cluster_4": 12.977,
-                            "file_cluster_5": 13.588,
+                            "file_cluster_5": 13.587,
                             "file_cluster_6": 12.623,
-                            "file_cluster_7": 12.801,
-                            "file_cluster_8": 12.517,
+                            "file_cluster_7": 12.8,
+                            "file_cluster_8": 12.515,
                             "file_cluster_9": 12.887,
-                            "file_cluster_10": 13.677,
+                            "file_cluster_10": 13.676,
                             "file_cluster_11": 12.023,
-                            "file_cluster_12": 13.205,
+                            "file_cluster_12": 13.204,
                             "file_cluster_13": 12.373,
-                            "file_cluster_14": 15.09,
-                            "file_cluster_15": 13.013,
+                            "file_cluster_14": 15.089,
+                            "file_cluster_15": 13.012,
                             "file_cluster_16": 13.089,
-                            "file_cluster_17": 12.754
+                            "file_cluster_17": 12.753
                         },
                         "File Archetype": "Cluster 2: Procedural Core & Safety Wrappers",
-                        "File Drift (Z-Score)": 5.659,
+                        "File Drift (Z-Score)": 5.658,
                         "File Fingerprint": {
                             "Cluster 0: The God Nodes (Universal Dependencies)": 6.737,
                             "Cluster 1: Async Testing & I/O Mocks": 7.382,
-                            "Cluster 2: Procedural Core & Safety Wrappers": 5.659,
-                            "Cluster 3: Pure View Layer Components (UI)": 5.745,
+                            "Cluster 2: Procedural Core & Safety Wrappers": 5.658,
+                            "Cluster 3: Pure View Layer Components (UI)": 5.744,
                             "Cluster 4: Heavily Documented Core Functions": 6.729,
-                            "Cluster 5: I/O, UI & Routing Configuration": 6.059,
+                            "Cluster 5: I/O, UI & Routing Configuration": 6.06,
                             "Cluster 6: Documented Native Core Logic": 6.334,
                             "Cluster 7: Algorithmic Data Processing": 6.512,
                             "Cluster 8: Declarative Glue & Inert Types": 5.734,
@@ -143255,7 +143255,7 @@
                         "Total LOC": 5622,
                         "Coding LOC": 2144,
                         "Documentation LOC": 3055,
-                        "Structural Magnitude": 2299.68,
+                        "Structural Magnitude": 2297.68,
                         "Control Flow Ratio": "69.4%",
                         "Popularity Rank": 1,
                         "Raw Churn Frequency": 0.0,
@@ -143268,7 +143268,7 @@
                         "Error & Exception Exposure": "41.08%",
                         "Tech Debt Exposure": "99.99%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "9.84%",
+                        "API Exposure": "9.77%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "23.52%",
                         "Commented Logic Exposure": "5.04%",
@@ -143480,7 +143480,7 @@
                             "End Line": 2784
                         },
                         {
-                            "Function Name": "stopProfilerTimerIfRunningAndRecordDurat",
+                            "Function Name": "stopProfilerTimerIfRunningAndRecordDuration",
                             "Structural Impact": 17.0,
                             "Lines of Code (LOC)": 40,
                             "Control Flow Branches": 14,
@@ -143590,7 +143590,7 @@
                             "End Line": 2390
                         },
                         {
-                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffect",
+                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffectsInDEV",
                             "Structural Impact": 10.0,
                             "Lines of Code (LOC)": 21,
                             "Control Flow Branches": 3,
@@ -144330,7 +144330,7 @@
                             "End Line": 2573
                         },
                         {
-                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffect",
+                            "Function Name": "recursivelyTraverseAndDoubleInvokeEffectsInDEV",
                             "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 1,
@@ -144500,7 +144500,7 @@
                             "End Line": 1547
                         },
                         {
-                            "Function Name": "stopProfilerTimerIfRunningAndRecordIncom",
+                            "Function Name": "stopProfilerTimerIfRunningAndRecordIncompleteDuration",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -144800,7 +144800,7 @@
                             "End Line": 546
                         },
                         {
-                            "Function Name": "isInvalidExecutionContextForEventFunctio",
+                            "Function Name": "isInvalidExecutionContextForEventFunction",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -144881,7 +144881,7 @@
                         "Type/Safety Bypasses": 28,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 69,
+                        "Exposed API / Public Exports": 67,
                         "State Mutations / Variable Reassignments": 120,
                         "Commented-out Code (Dead Logic)": 4,
                         "Structured Documentation Blocks": 3,
@@ -161615,7 +161615,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "13.23%",
                 "Error & Exception Exposure": "43.05%",
-                "Tech Debt Exposure": "32.53%",
+                "Tech Debt Exposure": "32.47%",
                 "Testing Exposure": "32.18%",
                 "API Exposure": "3.04%",
                 "Concurrency Exposure": "0.0%",
@@ -162368,30 +162368,30 @@
                             "file_cluster_1": 11.398,
                             "file_cluster_2": 11.533,
                             "file_cluster_3": 12.386,
-                            "file_cluster_4": 11.892,
-                            "file_cluster_5": 11.765,
+                            "file_cluster_4": 11.891,
+                            "file_cluster_5": 11.764,
                             "file_cluster_6": 11.319,
-                            "file_cluster_7": 10.936,
+                            "file_cluster_7": 10.935,
                             "file_cluster_8": 10.971,
                             "file_cluster_9": 11.633,
-                            "file_cluster_10": 12.025,
+                            "file_cluster_10": 12.024,
                             "file_cluster_11": 11.238,
                             "file_cluster_12": 11.609,
-                            "file_cluster_13": 10.995,
-                            "file_cluster_14": 14.994,
-                            "file_cluster_15": 11.672,
-                            "file_cluster_16": 10.988,
-                            "file_cluster_17": 11.642
+                            "file_cluster_13": 10.994,
+                            "file_cluster_14": 14.993,
+                            "file_cluster_15": 11.671,
+                            "file_cluster_16": 10.987,
+                            "file_cluster_17": 11.641
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 7.391,
+                        "File Drift (Z-Score)": 7.393,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.615,
-                            "Cluster 1: Declarative Glue & Initialization": 7.391,
-                            "Cluster 2: Async & Concurrent Testing": 9.583,
-                            "Cluster 3: Data Pipelines & I/O Operations": 7.818,
-                            "Cluster 4: Procedural Verification & Mocks": 8.793,
-                            "Cluster 5: Universal Dependencies & Serialization": 9.285
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.62,
+                            "Cluster 1: Declarative Glue & Initialization": 7.393,
+                            "Cluster 2: Async & Concurrent Testing": 9.591,
+                            "Cluster 3: Data Pipelines & I/O Operations": 7.826,
+                            "Cluster 4: Procedural Verification & Mocks": 8.797,
+                            "Cluster 5: Universal Dependencies & Serialization": 9.295
                         },
                         "Total LOC": 3650,
                         "Coding LOC": 870,
@@ -162407,7 +162407,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "11.62%",
                         "Error & Exception Exposure": "51.38%",
-                        "Tech Debt Exposure": "9.86%",
+                        "Tech Debt Exposure": "8.89%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "1.37%",
                         "Concurrency Exposure": "0.0%",
@@ -162721,7 +162721,7 @@
                             "End Line": 116
                         },
                         {
-                            "Function Name": "_raise_linalgerror_eigenvalues_nonconver",
+                            "Function Name": "_raise_linalgerror_eigenvalues_nonconvergence",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -162876,7 +162876,7 @@
                         "Design Short Vars": 108,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 2,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -173651,7 +173651,7 @@
                             "End Line": 3178
                         },
                         {
-                            "Function Name": "Get-PackageVersionAsMajorMinorBuildRevis",
+                            "Function Name": "Get-PackageVersionAsMajorMinorBuildRevision",
                             "Structural Impact": 24.7,
                             "Lines of Code (LOC)": 44,
                             "Control Flow Branches": 12,
@@ -175412,7 +175412,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "30.26%",
                 "Error & Exception Exposure": "57.88%",
-                "Tech Debt Exposure": "29.46%",
+                "Tech Debt Exposure": "28.13%",
                 "Testing Exposure": "44.75%",
                 "API Exposure": "3.64%",
                 "Concurrency Exposure": "0.0%",
@@ -178110,23 +178110,23 @@
                         "Repository Archetype": "file_cluster_11",
                         "Repository Drift (Z-Score)": 11.382,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 12.024,
+                            "file_cluster_0": 12.026,
                             "file_cluster_1": 12.152,
                             "file_cluster_2": 12.239,
                             "file_cluster_3": 11.622,
                             "file_cluster_4": 12.593,
-                            "file_cluster_5": 12.577,
+                            "file_cluster_5": 12.576,
                             "file_cluster_6": 11.997,
-                            "file_cluster_7": 11.772,
-                            "file_cluster_8": 11.503,
-                            "file_cluster_9": 12.173,
-                            "file_cluster_10": 12.756,
+                            "file_cluster_7": 11.771,
+                            "file_cluster_8": 11.501,
+                            "file_cluster_9": 12.174,
+                            "file_cluster_10": 12.755,
                             "file_cluster_11": 11.382,
                             "file_cluster_12": 12.296,
                             "file_cluster_13": 11.968,
                             "file_cluster_14": 13.919,
-                            "file_cluster_15": 12.235,
-                            "file_cluster_16": 12.149,
+                            "file_cluster_15": 12.234,
+                            "file_cluster_16": 12.148,
                             "file_cluster_17": 12.253
                         },
                         "File Archetype": null,
@@ -178146,7 +178146,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "12.62%",
                         "Error & Exception Exposure": "54.89%",
-                        "Tech Debt Exposure": "43.76%",
+                        "Tech Debt Exposure": "29.19%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.82%",
                         "Concurrency Exposure": "0.0%",
@@ -178440,7 +178440,7 @@
                             "End Line": 5043
                         },
                         {
-                            "Function Name": "prefetch_create_transfers_callback_trans",
+                            "Function Name": "prefetch_create_transfers_callback_transfers",
                             "Structural Impact": 16.2,
                             "Lines of Code (LOC)": 47,
                             "Control Flow Branches": 7,
@@ -178640,7 +178640,7 @@
                             "End Line": 3208
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_accoun",
+                            "Function Name": "prefetch_expire_pending_transfers_accounts",
                             "Structural Impact": 8.9,
                             "Lines of Code (LOC)": 39,
                             "Control Flow Branches": 3,
@@ -178900,7 +178900,7 @@
                             "End Line": 4360
                         },
                         {
-                            "Function Name": "prefetch_get_account_transfers_scan_call",
+                            "Function Name": "prefetch_get_account_transfers_scan_callback",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 1,
@@ -178910,7 +178910,7 @@
                             "End Line": 1490
                         },
                         {
-                            "Function Name": "prefetch_get_account_balances_scan_callb",
+                            "Function Name": "prefetch_get_account_balances_scan_callback",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 1,
@@ -179140,7 +179140,7 @@
                             "End Line": 4982
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_scan_c",
+                            "Function Name": "prefetch_expire_pending_transfers_scan_callback",
                             "Structural Impact": 3.0,
                             "Lines of Code (LOC)": 20,
                             "Control Flow Branches": 0,
@@ -179180,7 +179180,7 @@
                             "End Line": 1176
                         },
                         {
-                            "Function Name": "prefetch_create_transfers_callback_accou",
+                            "Function Name": "prefetch_create_transfers_callback_accounts",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 0,
@@ -179190,7 +179190,7 @@
                             "End Line": 1331
                         },
                         {
-                            "Function Name": "prefetch_get_account_balances_lookup_acc",
+                            "Function Name": "prefetch_get_account_balances_lookup_account_callback",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 15,
                             "Control Flow Branches": 0,
@@ -179210,7 +179210,7 @@
                             "End Line": 2062
                         },
                         {
-                            "Function Name": "prefetch_get_change_events_callback_acco",
+                            "Function Name": "prefetch_get_change_events_callback_accounts",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -179220,7 +179220,7 @@
                             "End Line": 2285
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_callba",
+                            "Function Name": "prefetch_expire_pending_transfers_callback_accounts",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 0,
@@ -179230,7 +179230,7 @@
                             "End Line": 2467
                         },
                         {
-                            "Function Name": "prefetch_create_accounts_transfers_callb",
+                            "Function Name": "prefetch_create_accounts_transfers_callback",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -179240,7 +179240,7 @@
                             "End Line": 1242
                         },
                         {
-                            "Function Name": "prefetch_create_transfers_callback_trans",
+                            "Function Name": "prefetch_create_transfers_callback_transfers_pending",
                             "Structural Impact": 2.3,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -179340,7 +179340,7 @@
                             "End Line": 2131
                         },
                         {
-                            "Function Name": "prefetch_get_change_events_callback_tran",
+                            "Function Name": "prefetch_get_change_events_callback_transfers",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -179350,7 +179350,7 @@
                             "End Line": 2296
                         },
                         {
-                            "Function Name": "prefetch_expire_pending_transfers_callba",
+                            "Function Name": "prefetch_expire_pending_transfers_callback_transfers_pending",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 0,
@@ -179514,8 +179514,8 @@
                         "Design Upper Case": 0,
                         "Design Short Vars": 17,
                         "Design Long Vars": 2,
-                        "Duplicate Logic": 18,
-                        "Orphaned Logic": 13,
+                        "Duplicate Logic": 14,
+                        "Orphaned Logic": 4,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -193835,7 +193835,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "30.98%",
                 "Error & Exception Exposure": "55.18%",
-                "Tech Debt Exposure": "62.58%",
+                "Tech Debt Exposure": "61.25%",
                 "Testing Exposure": "80.0%",
                 "API Exposure": "5.57%",
                 "Concurrency Exposure": "4.39%",
@@ -195090,26 +195090,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 12.886,
+                        "Repository Drift (Z-Score)": 12.887,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.258,
-                            "file_cluster_1": 13.728,
-                            "file_cluster_2": 13.731,
-                            "file_cluster_3": 13.532,
-                            "file_cluster_4": 13.63,
-                            "file_cluster_5": 14.047,
-                            "file_cluster_6": 13.303,
-                            "file_cluster_7": 13.294,
-                            "file_cluster_8": 13.178,
-                            "file_cluster_9": 13.501,
-                            "file_cluster_10": 14.107,
-                            "file_cluster_11": 12.886,
+                            "file_cluster_0": 13.259,
+                            "file_cluster_1": 13.729,
+                            "file_cluster_2": 13.732,
+                            "file_cluster_3": 13.533,
+                            "file_cluster_4": 13.632,
+                            "file_cluster_5": 14.048,
+                            "file_cluster_6": 13.304,
+                            "file_cluster_7": 13.295,
+                            "file_cluster_8": 13.179,
+                            "file_cluster_9": 13.502,
+                            "file_cluster_10": 14.108,
+                            "file_cluster_11": 12.887,
                             "file_cluster_12": 13.72,
-                            "file_cluster_13": 13.323,
-                            "file_cluster_14": 15.774,
-                            "file_cluster_15": 13.648,
-                            "file_cluster_16": 13.606,
-                            "file_cluster_17": 13.564
+                            "file_cluster_13": 13.325,
+                            "file_cluster_14": 15.775,
+                            "file_cluster_15": 13.649,
+                            "file_cluster_16": 13.607,
+                            "file_cluster_17": 13.566
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -195128,7 +195128,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "15.5%",
                         "Error & Exception Exposure": "49.64%",
-                        "Tech Debt Exposure": "73.32%",
+                        "Tech Debt Exposure": "68.02%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "13.64%",
                         "Concurrency Exposure": "0.0%",
@@ -196122,7 +196122,7 @@
                             "End Line": 720
                         },
                         {
-                            "Function Name": "napi_internal_suppress_crash_on_abort_if",
+                            "Function Name": "napi_internal_suppress_crash_on_abort_if_desired",
                             "Structural Impact": 2.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
@@ -196312,7 +196312,7 @@
                             "End Line": 67
                         },
                         {
-                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
+                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEEEmNSt3__18functionIFNS_10MaybeLocalINS_5ValueEEEvEEE",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -196322,7 +196322,7 @@
                             "End Line": 2008
                         },
                         {
-                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEE",
+                            "Function Name": "_ZN2v85Array3NewENS_5LocalINS_7ContextEEEmSt8functionIFNS_10MaybeLocalINS_5ValueEEEvEE",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -196406,8 +196406,8 @@
                         "Design Upper Case": 2,
                         "Design Short Vars": 12,
                         "Design Long Vars": 13,
-                        "Duplicate Logic": 15,
-                        "Orphaned Logic": 10,
+                        "Duplicate Logic": 13,
+                        "Orphaned Logic": 11,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -202603,7 +202603,7 @@
             }
         },
         "cpp/NVDA": {
-            "Directory Group Magnitude": 4300.9,
+            "Directory Group Magnitude": 4301.9,
             "File Count": 12,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_13": "41.7%",
@@ -202617,7 +202617,7 @@
                 "Error & Exception Exposure": "43.38%",
                 "Tech Debt Exposure": "34.27%",
                 "Testing Exposure": "46.88%",
-                "API Exposure": "2.76%",
+                "API Exposure": "2.78%",
                 "Concurrency Exposure": "3.79%",
                 "State Flux Exposure": "55.66%",
                 "Commented Logic Exposure": "0.81%",
@@ -206624,7 +206624,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "nvdaControllerInternal_displayModelTextC",
+                            "Function Name": "nvdaControllerInternal_displayModelTextChangeNotify",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206634,7 +206634,7 @@
                             "End Line": 29
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_drawFocusRectNoti",
+                            "Function Name": "nvdaControllerInternal_drawFocusRectNotify",
                             "Structural Impact": 2.6,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206644,7 +206644,7 @@
                             "End Line": 69
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputCompositionU",
+                            "Function Name": "nvdaControllerInternal_inputCompositionUpdate",
                             "Structural Impact": 2.4,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206654,7 +206654,7 @@
                             "End Line": 34
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_requestRegistrati",
+                            "Function Name": "nvdaControllerInternal_requestRegistration",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206664,7 +206664,7 @@
                             "End Line": 8
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputLangChangeNo",
+                            "Function Name": "nvdaControllerInternal_inputLangChangeNotify",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206674,7 +206674,7 @@
                             "End Line": 13
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_typedCharacterNot",
+                            "Function Name": "nvdaControllerInternal_typedCharacterNotify",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206694,7 +206694,7 @@
                             "End Line": 24
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputCandidateLis",
+                            "Function Name": "nvdaControllerInternal_inputCandidateListUpdate",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206704,7 +206704,7 @@
                             "End Line": 39
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_IMEOpenStatusUpda",
+                            "Function Name": "nvdaControllerInternal_IMEOpenStatusUpdate",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206714,7 +206714,7 @@
                             "End Line": 44
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_inputConversionMo",
+                            "Function Name": "nvdaControllerInternal_inputConversionModeUpdate",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206724,7 +206724,7 @@
                             "End Line": 49
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_installAddonPacka",
+                            "Function Name": "nvdaControllerInternal_installAddonPackageFromPath",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206764,7 +206764,7 @@
                             "End Line": 74
                         },
                         {
-                            "Function Name": "nvdaControllerInternal_openConfigDirecto",
+                            "Function Name": "nvdaControllerInternal_openConfigDirectory",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -206895,48 +206895,48 @@
                         "Identity Proof": "Single Indicator (Ext: .cpp)"
                     },
                     "2. Topological Coordinates": {
-                        "X": -3707.99,
+                        "X": -3707.97,
                         "Y": -40.37,
-                        "Z": -1331.9
+                        "Z": -1331.87
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 13.729,
+                        "Repository Drift (Z-Score)": 13.731,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 14.346,
-                            "file_cluster_1": 14.609,
-                            "file_cluster_2": 14.598,
-                            "file_cluster_3": 15.367,
-                            "file_cluster_4": 14.361,
-                            "file_cluster_5": 15.015,
-                            "file_cluster_6": 14.557,
-                            "file_cluster_7": 14.291,
-                            "file_cluster_8": 14.129,
-                            "file_cluster_9": 14.541,
-                            "file_cluster_10": 15.21,
-                            "file_cluster_11": 14.193,
-                            "file_cluster_12": 14.766,
-                            "file_cluster_13": 13.729,
-                            "file_cluster_14": 17.678,
-                            "file_cluster_15": 14.641,
-                            "file_cluster_16": 14.573,
-                            "file_cluster_17": 14.464
+                            "file_cluster_0": 14.347,
+                            "file_cluster_1": 14.614,
+                            "file_cluster_2": 14.603,
+                            "file_cluster_3": 15.369,
+                            "file_cluster_4": 14.362,
+                            "file_cluster_5": 15.019,
+                            "file_cluster_6": 14.558,
+                            "file_cluster_7": 14.294,
+                            "file_cluster_8": 14.134,
+                            "file_cluster_9": 14.543,
+                            "file_cluster_10": 15.212,
+                            "file_cluster_11": 14.195,
+                            "file_cluster_12": 14.768,
+                            "file_cluster_13": 13.731,
+                            "file_cluster_14": 17.682,
+                            "file_cluster_15": 14.643,
+                            "file_cluster_16": 14.575,
+                            "file_cluster_17": 14.468
                         },
                         "File Archetype": "Cluster 0: Declarative Interfaces & Inert Headers",
-                        "File Drift (Z-Score)": 6.878,
+                        "File Drift (Z-Score)": 6.898,
                         "File Fingerprint": {
-                            "Cluster 0: Declarative Interfaces & Inert Headers": 6.878,
-                            "Cluster 1: Documented API Headers & Entity Definitions": 7.732,
-                            "Cluster 2: Verification & Unit Testing": 7.876,
-                            "Cluster 3: Algorithmic Execution Core": 7.024,
-                            "Cluster 4: The God Headers (Universal Dependencies)": 9.833,
-                            "Cluster 5: Heavily Documented Complex Base Classes": 11.057,
-                            "Cluster 6: Generic Templates & Metaprogramming Core": 8.361
+                            "Cluster 0: Declarative Interfaces & Inert Headers": 6.898,
+                            "Cluster 1: Documented API Headers & Entity Definitions": 7.749,
+                            "Cluster 2: Verification & Unit Testing": 7.893,
+                            "Cluster 3: Algorithmic Execution Core": 7.043,
+                            "Cluster 4: The God Headers (Universal Dependencies)": 9.846,
+                            "Cluster 5: Heavily Documented Complex Base Classes": 11.069,
+                            "Cluster 6: Generic Templates & Metaprogramming Core": 8.376
                         },
                         "Total LOC": 1247,
                         "Coding LOC": 220,
                         "Documentation LOC": 957,
-                        "Structural Magnitude": 371.5,
+                        "Structural Magnitude": 372.5,
                         "Control Flow Ratio": "72.9%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -206949,7 +206949,7 @@
                         "Error & Exception Exposure": "97.77%",
                         "Tech Debt Exposure": "0.0%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "6.97%",
+                        "API Exposure": "7.2%",
                         "Concurrency Exposure": "0.0%",
                         "State Flux Exposure": "100.0%",
                         "Commented Logic Exposure": "0.0%",
@@ -206971,7 +206971,7 @@
                             "End Line": 112
                         },
                         {
-                            "Function Name": "VBufStorage_fieldNode_t::locateTextField",
+                            "Function Name": "VBufStorage_fieldNode_t::locateTextFieldNodeAtOffset",
                             "Structural Impact": 25.5,
                             "Lines of Code (LOC)": 59,
                             "Control Flow Branches": 12,
@@ -207001,7 +207001,7 @@
                             "End Line": 137
                         },
                         {
-                            "Function Name": "VBufStorage_fieldNode_t::disassociateFro",
+                            "Function Name": "VBufStorage_fieldNode_t::disassociateFromBuffer",
                             "Structural Impact": 9.5,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 4,
@@ -207011,7 +207011,7 @@
                             "End Line": 236
                         },
                         {
-                            "Function Name": "VBufStorage_fieldNode_t::calculateOffset",
+                            "Function Name": "VBufStorage_fieldNode_t::calculateOffsetInTree",
                             "Structural Impact": 8.6,
                             "Lines of Code (LOC)": 13,
                             "Control Flow Branches": 2,
@@ -207051,7 +207051,7 @@
                             "End Line": 41
                         },
                         {
-                            "Function Name": "VBufStorage_textFieldNode_t::VBufStorage",
+                            "Function Name": "VBufStorage_textFieldNode_t::VBufStorage_textFieldNode_t",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -207061,7 +207061,7 @@
                             "End Line": 240
                         },
                         {
-                            "Function Name": "VBufStorage_buffer_t::forgetControlField",
+                            "Function Name": "VBufStorage_buffer_t::forgetControlFieldNode",
                             "Structural Impact": 1.9,
                             "Lines of Code (LOC)": 4,
                             "Control Flow Branches": 0,
@@ -207071,7 +207071,7 @@
                             "End Line": 253
                         },
                         {
-                            "Function Name": "VBufStorage_controlFieldNodeIdentifier_t",
+                            "Function Name": "VBufStorage_controlFieldNodeIdentifier_t::VBufStorage_controlFieldNodeIdentifier_t",
                             "Structural Impact": 1.8,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -207081,7 +207081,7 @@
                             "End Line": 25
                         },
                         {
-                            "Function Name": "VBufStorage_textFieldNode_t::getDebugInf",
+                            "Function Name": "VBufStorage_textFieldNode_t::getDebugInfo",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -207102,7 +207102,7 @@
                         "Type/Safety Bypasses": 0,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 11,
+                        "Exposed API / Public Exports": 12,
                         "State Mutations / Variable Reassignments": 203,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 4,
@@ -225490,7 +225490,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "10.77%",
                 "Error & Exception Exposure": "46.28%",
-                "Tech Debt Exposure": "69.28%",
+                "Tech Debt Exposure": "69.02%",
                 "Testing Exposure": "57.83%",
                 "API Exposure": "3.76%",
                 "Concurrency Exposure": "0.0%",
@@ -226822,26 +226822,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_11",
-                        "Repository Drift (Z-Score)": 11.896,
+                        "Repository Drift (Z-Score)": 11.894,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.052,
-                            "file_cluster_1": 13.574,
-                            "file_cluster_2": 13.575,
-                            "file_cluster_3": 12.11,
-                            "file_cluster_4": 13.568,
-                            "file_cluster_5": 13.9,
-                            "file_cluster_6": 13.395,
-                            "file_cluster_7": 13.23,
-                            "file_cluster_8": 13.175,
-                            "file_cluster_9": 13.545,
-                            "file_cluster_10": 13.811,
-                            "file_cluster_11": 11.896,
-                            "file_cluster_12": 13.471,
-                            "file_cluster_13": 13.237,
-                            "file_cluster_14": 13.7,
-                            "file_cluster_15": 12.519,
-                            "file_cluster_16": 12.885,
-                            "file_cluster_17": 13.129
+                            "file_cluster_0": 13.051,
+                            "file_cluster_1": 13.573,
+                            "file_cluster_2": 13.573,
+                            "file_cluster_3": 12.108,
+                            "file_cluster_4": 13.566,
+                            "file_cluster_5": 13.898,
+                            "file_cluster_6": 13.394,
+                            "file_cluster_7": 13.228,
+                            "file_cluster_8": 13.173,
+                            "file_cluster_9": 13.544,
+                            "file_cluster_10": 13.809,
+                            "file_cluster_11": 11.894,
+                            "file_cluster_12": 13.469,
+                            "file_cluster_13": 13.236,
+                            "file_cluster_14": 13.698,
+                            "file_cluster_15": 12.518,
+                            "file_cluster_16": 12.883,
+                            "file_cluster_17": 13.127
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -226860,7 +226860,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "15.26%",
                         "Error & Exception Exposure": "62.88%",
-                        "Tech Debt Exposure": "35.14%",
+                        "Tech Debt Exposure": "33.31%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "4.87%",
                         "Concurrency Exposure": "0.0%",
@@ -227214,7 +227214,7 @@
                             "End Line": 405
                         },
                         {
-                            "Function Name": "maybeTruncateCleanerCheckpointToActiveSe",
+                            "Function Name": "maybeTruncateCleanerCheckpointToActiveSegmentBaseOffset",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 1,
@@ -227509,7 +227509,7 @@
                         "Design Short Vars": 3,
                         "Design Long Vars": 14,
                         "Duplicate Logic": 4,
-                        "Orphaned Logic": 12,
+                        "Orphaned Logic": 11,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -228519,7 +228519,7 @@
                             "End Line": 337
                         },
                         {
-                            "Function Name": "completeDelayedOperationsWhenNotPartitio",
+                            "Function Name": "completeDelayedOperationsWhenNotPartitionLeader",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 1,
@@ -234139,7 +234139,7 @@
                             "End Line": 1639
                         },
                         {
-                            "Function Name": "test_partially_untagged_internally_tagge",
+                            "Function Name": "test_partially_untagged_internally_tagged_enum",
                             "Structural Impact": 3.2,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 0,
@@ -234279,7 +234279,7 @@
                             "End Line": 2573
                         },
                         {
-                            "Function Name": "test_expecting_message_externally_tagged",
+                            "Function Name": "test_expecting_message_externally_tagged_enum",
                             "Structural Impact": 2.7,
                             "Lines of Code (LOC)": 19,
                             "Control Flow Branches": 0,
@@ -239109,7 +239109,7 @@
                             "End Line": 21
                         },
                         {
-                            "Function Name": "websocket_request_validation_exception_h",
+                            "Function Name": "websocket_request_validation_exception_handler",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -242503,7 +242503,7 @@
                             "End Line": 2049
                         },
                         {
-                            "Function Name": "Translator::CreateFlexBuilderWithNodeAtt",
+                            "Function Name": "Translator::CreateFlexBuilderWithNodeAttrs",
                             "Structural Impact": 52.0,
                             "Lines of Code (LOC)": 70,
                             "Control Flow Branches": 27,
@@ -242613,7 +242613,7 @@
                             "End Line": 342
                         },
                         {
-                            "Function Name": "Translator::GetOperatorDebugMetadataInde",
+                            "Function Name": "Translator::GetOperatorDebugMetadataIndex",
                             "Structural Impact": 7.6,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 3,
@@ -242623,7 +242623,7 @@
                             "End Line": 777
                         },
                         {
-                            "Function Name": "Translator::GetQuantizationForQuantStats",
+                            "Function Name": "Translator::GetQuantizationForQuantStatsOpOutput",
                             "Structural Impact": 7.5,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 5,
@@ -242733,7 +242733,7 @@
                             "End Line": 1166
                         },
                         {
-                            "Function Name": "Translator::BuildStablehloOperatorwithou",
+                            "Function Name": "Translator::BuildStablehloOperatorwithoutOptions",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 0,
@@ -242773,7 +242773,7 @@
                             "End Line": 423
                         },
                         {
-                            "Function Name": "Translator::BuildStablehloPrecisionConfi",
+                            "Function Name": "Translator::BuildStablehloPrecisionConfig",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 1,
@@ -243457,7 +243457,7 @@
                             "End Line": 149
                         },
                         {
-                            "Function Name": "MlirV1CompatOptimizationPassRegistry::Gl",
+                            "Function Name": "MlirV1CompatOptimizationPassRegistry::Global",
                             "Structural Impact": 1.2,
                             "Lines of Code (LOC)": 5,
                             "Control Flow Branches": 0,
@@ -244294,7 +244294,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "19.38%",
                 "Error & Exception Exposure": "57.08%",
-                "Tech Debt Exposure": "51.56%",
+                "Tech Debt Exposure": "51.09%",
                 "Testing Exposure": "80.0%",
                 "API Exposure": "3.09%",
                 "Concurrency Exposure": "31.63%",
@@ -245596,9 +245596,9 @@
                         "Repository Archetype": "file_cluster_11",
                         "Repository Drift (Z-Score)": 11.284,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 11.765,
-                            "file_cluster_1": 11.976,
-                            "file_cluster_2": 12.085,
+                            "file_cluster_0": 11.766,
+                            "file_cluster_1": 11.977,
+                            "file_cluster_2": 12.086,
                             "file_cluster_3": 12.149,
                             "file_cluster_4": 12.384,
                             "file_cluster_5": 12.392,
@@ -245606,24 +245606,24 @@
                             "file_cluster_7": 11.644,
                             "file_cluster_8": 11.548,
                             "file_cluster_9": 12.196,
-                            "file_cluster_10": 12.683,
+                            "file_cluster_10": 12.684,
                             "file_cluster_11": 11.284,
-                            "file_cluster_12": 12.089,
+                            "file_cluster_12": 12.09,
                             "file_cluster_13": 11.4,
                             "file_cluster_14": 14.452,
                             "file_cluster_15": 12.121,
-                            "file_cluster_16": 11.603,
+                            "file_cluster_16": 11.602,
                             "file_cluster_17": 11.833
                         },
                         "File Archetype": "Cluster 1: Declarative Glue & Initialization",
-                        "File Drift (Z-Score)": 6.193,
+                        "File Drift (Z-Score)": 6.196,
                         "File Fingerprint": {
-                            "Cluster 0: Decorated Core & Metaprogramming": 8.288,
-                            "Cluster 1: Declarative Glue & Initialization": 6.193,
-                            "Cluster 2: Async & Concurrent Testing": 9.061,
-                            "Cluster 3: Data Pipelines & I/O Operations": 6.96,
-                            "Cluster 4: Procedural Verification & Mocks": 8.158,
-                            "Cluster 5: Universal Dependencies & Serialization": 8.96
+                            "Cluster 0: Decorated Core & Metaprogramming": 8.292,
+                            "Cluster 1: Declarative Glue & Initialization": 6.196,
+                            "Cluster 2: Async & Concurrent Testing": 9.068,
+                            "Cluster 3: Data Pipelines & I/O Operations": 6.967,
+                            "Cluster 4: Procedural Verification & Mocks": 8.162,
+                            "Cluster 5: Universal Dependencies & Serialization": 8.969
                         },
                         "Total LOC": 3261,
                         "Coding LOC": 2380,
@@ -245639,7 +245639,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "11.71%",
                         "Error & Exception Exposure": "54.91%",
-                        "Tech Debt Exposure": "13.73%",
+                        "Tech Debt Exposure": "12.3%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "0.2%",
                         "Concurrency Exposure": "15.36%",
@@ -245753,7 +245753,7 @@
                             "End Line": 883
                         },
                         {
-                            "Function Name": "_find_and_purge_task_instances_without_h",
+                            "Function Name": "_find_and_purge_task_instances_without_heartbeats",
                             "Structural Impact": 5.7,
                             "Lines of Code (LOC)": 10,
                             "Control Flow Branches": 2,
@@ -245863,7 +245863,7 @@
                             "End Line": 2103
                         },
                         {
-                            "Function Name": "_enqueue_task_instances_with_queued_stat",
+                            "Function Name": "_enqueue_task_instances_with_queued_state",
                             "Structural Impact": 1.1,
                             "Lines of Code (LOC)": 2,
                             "Control Flow Branches": 0,
@@ -245958,7 +245958,7 @@
                         "Design Short Vars": 15,
                         "Design Long Vars": 13,
                         "Duplicate Logic": 0,
-                        "Orphaned Logic": 3,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -249967,7 +249967,7 @@
                             "End Line": 733
                         },
                         {
-                            "Function Name": "mut_to_immut_query_methods_have_immut_it",
+                            "Function Name": "mut_to_immut_query_methods_have_immut_item",
                             "Structural Impact": 3.5,
                             "Lines of Code (LOC)": 35,
                             "Control Flow Branches": 0,
@@ -252592,7 +252592,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "11.69%",
                 "Error & Exception Exposure": "56.98%",
-                "Tech Debt Exposure": "75.9%",
+                "Tech Debt Exposure": "75.8%",
                 "Testing Exposure": "50.54%",
                 "API Exposure": "4.12%",
                 "Concurrency Exposure": "15.12%",
@@ -254825,26 +254825,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 12.797,
+                        "Repository Drift (Z-Score)": 12.792,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 13.223,
-                            "file_cluster_1": 13.694,
-                            "file_cluster_2": 13.836,
-                            "file_cluster_3": 14.543,
-                            "file_cluster_4": 13.2,
-                            "file_cluster_5": 14.083,
-                            "file_cluster_6": 13.698,
-                            "file_cluster_7": 13.463,
-                            "file_cluster_8": 13.51,
-                            "file_cluster_9": 13.625,
-                            "file_cluster_10": 14.439,
-                            "file_cluster_11": 13.176,
-                            "file_cluster_12": 13.885,
-                            "file_cluster_13": 12.797,
-                            "file_cluster_14": 16.971,
-                            "file_cluster_15": 13.609,
-                            "file_cluster_16": 13.163,
-                            "file_cluster_17": 13.55
+                            "file_cluster_0": 13.218,
+                            "file_cluster_1": 13.69,
+                            "file_cluster_2": 13.831,
+                            "file_cluster_3": 14.538,
+                            "file_cluster_4": 13.194,
+                            "file_cluster_5": 14.078,
+                            "file_cluster_6": 13.693,
+                            "file_cluster_7": 13.458,
+                            "file_cluster_8": 13.504,
+                            "file_cluster_9": 13.62,
+                            "file_cluster_10": 14.434,
+                            "file_cluster_11": 13.171,
+                            "file_cluster_12": 13.88,
+                            "file_cluster_13": 12.792,
+                            "file_cluster_14": 16.967,
+                            "file_cluster_15": 13.604,
+                            "file_cluster_16": 13.158,
+                            "file_cluster_17": 13.545
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -255057,7 +255057,7 @@
                             "End Line": 787
                         },
                         {
-                            "Function Name": "getExitCodeFromExitCodeGeneratorExceptio",
+                            "Function Name": "getExitCodeFromExitCodeGeneratorException",
                             "Structural Impact": 7.8,
                             "Lines of Code (LOC)": 9,
                             "Control Flow Branches": 2,
@@ -255877,7 +255877,7 @@
                             "End Line": 812
                         },
                         {
-                            "Function Name": "PropertySourceOrderingBeanFactoryPostPro",
+                            "Function Name": "PropertySourceOrderingBeanFactoryPostProcessor",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -256092,7 +256092,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 4,
                         "Duplicate Logic": 40,
-                        "Orphaned Logic": 20,
+                        "Orphaned Logic": 18,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -256233,26 +256233,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_13",
-                        "Repository Drift (Z-Score)": 10.7,
+                        "Repository Drift (Z-Score)": 10.695,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 10.898,
-                            "file_cluster_1": 12.102,
-                            "file_cluster_2": 12.137,
-                            "file_cluster_3": 12.963,
-                            "file_cluster_4": 11.831,
-                            "file_cluster_5": 12.558,
-                            "file_cluster_6": 12.028,
-                            "file_cluster_7": 11.772,
-                            "file_cluster_8": 11.5,
-                            "file_cluster_9": 11.846,
-                            "file_cluster_10": 12.877,
-                            "file_cluster_11": 11.282,
-                            "file_cluster_12": 12.308,
-                            "file_cluster_13": 10.7,
-                            "file_cluster_14": 15.54,
-                            "file_cluster_15": 11.843,
-                            "file_cluster_16": 11.582,
-                            "file_cluster_17": 11.727
+                            "file_cluster_0": 10.893,
+                            "file_cluster_1": 12.098,
+                            "file_cluster_2": 12.133,
+                            "file_cluster_3": 12.958,
+                            "file_cluster_4": 11.826,
+                            "file_cluster_5": 12.554,
+                            "file_cluster_6": 12.023,
+                            "file_cluster_7": 11.767,
+                            "file_cluster_8": 11.495,
+                            "file_cluster_9": 11.842,
+                            "file_cluster_10": 12.873,
+                            "file_cluster_11": 11.277,
+                            "file_cluster_12": 12.304,
+                            "file_cluster_13": 10.695,
+                            "file_cluster_14": 15.536,
+                            "file_cluster_15": 11.838,
+                            "file_cluster_16": 11.577,
+                            "file_cluster_17": 11.723
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -256271,7 +256271,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "17.59%",
                         "Error & Exception Exposure": "77.3%",
-                        "Tech Debt Exposure": "95.17%",
+                        "Tech Debt Exposure": "94.35%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "5.95%",
                         "Concurrency Exposure": "0.0%",
@@ -256685,7 +256685,7 @@
                             "End Line": 340
                         },
                         {
-                            "Function Name": "ResourceChainResourceHandlerRegistration",
+                            "Function Name": "ResourceChainResourceHandlerRegistrationCustomizer",
                             "Structural Impact": 2.1,
                             "Lines of Code (LOC)": 3,
                             "Control Flow Branches": 0,
@@ -256810,7 +256810,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 1,
                         "Duplicate Logic": 6,
-                        "Orphaned Logic": 18,
+                        "Orphaned Logic": 17,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -266597,7 +266597,7 @@
                             "End Line": 151
                         },
                         {
-                            "Function Name": "incomplete_partial_read_followed_by_writ",
+                            "Function Name": "incomplete_partial_read_followed_by_write",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 43,
                             "Control Flow Branches": 0,
@@ -309104,7 +309104,7 @@
             "Average Risk Exposures": {
                 "Cognitive Load Exposure": "23.86%",
                 "Error & Exception Exposure": "69.78%",
-                "Tech Debt Exposure": "69.71%",
+                "Tech Debt Exposure": "67.06%",
                 "Testing Exposure": "60.64%",
                 "API Exposure": "2.57%",
                 "Concurrency Exposure": "0.0%",
@@ -309137,26 +309137,26 @@
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_0",
-                        "Repository Drift (Z-Score)": 9.878,
+                        "Repository Drift (Z-Score)": 9.871,
                         "Repository Fingerprint": {
-                            "file_cluster_0": 9.878,
-                            "file_cluster_1": 10.888,
-                            "file_cluster_2": 10.949,
-                            "file_cluster_3": 11.88,
-                            "file_cluster_4": 10.642,
-                            "file_cluster_5": 11.447,
-                            "file_cluster_6": 10.606,
-                            "file_cluster_7": 10.506,
-                            "file_cluster_8": 10.118,
-                            "file_cluster_9": 10.535,
-                            "file_cluster_10": 11.848,
-                            "file_cluster_11": 10.51,
-                            "file_cluster_12": 11.221,
-                            "file_cluster_13": 9.894,
-                            "file_cluster_14": 14.682,
-                            "file_cluster_15": 11.3,
-                            "file_cluster_16": 10.893,
-                            "file_cluster_17": 10.577
+                            "file_cluster_0": 9.871,
+                            "file_cluster_1": 10.879,
+                            "file_cluster_2": 10.94,
+                            "file_cluster_3": 11.87,
+                            "file_cluster_4": 10.631,
+                            "file_cluster_5": 11.437,
+                            "file_cluster_6": 10.595,
+                            "file_cluster_7": 10.495,
+                            "file_cluster_8": 10.106,
+                            "file_cluster_9": 10.526,
+                            "file_cluster_10": 11.839,
+                            "file_cluster_11": 10.5,
+                            "file_cluster_12": 11.213,
+                            "file_cluster_13": 9.883,
+                            "file_cluster_14": 14.674,
+                            "file_cluster_15": 11.29,
+                            "file_cluster_16": 10.882,
+                            "file_cluster_17": 10.567
                         },
                         "File Archetype": null,
                         "File Drift (Z-Score)": 0.0,
@@ -309175,7 +309175,7 @@
                     "4. Vulnerability & Risk Exposures": {
                         "Cognitive Load Exposure": "11.62%",
                         "Error & Exception Exposure": "52.91%",
-                        "Tech Debt Exposure": "64.19%",
+                        "Tech Debt Exposure": "53.57%",
                         "Testing Exposure": "80.0%",
                         "API Exposure": "2.61%",
                         "Concurrency Exposure": "0.0%",
@@ -309309,7 +309309,7 @@
                             "End Line": 255
                         },
                         {
-                            "Function Name": "replaceObjectExpressionWithCurrentClosur",
+                            "Function Name": "replaceObjectExpressionWithCurrentClosure",
                             "Structural Impact": 4.8,
                             "Lines of Code (LOC)": 7,
                             "Control Flow Branches": 1,
@@ -309494,7 +309494,7 @@
                         "Design Short Vars": 0,
                         "Design Long Vars": 0,
                         "Duplicate Logic": 2,
-                        "Orphaned Logic": 2,
+                        "Orphaned Logic": 1,
                         "Instructional Code Examples": 0,
                         "Architectural Diagrams (Mermaid/PlantUML)": 0,
                         "Structured Literature Headers": 0,
@@ -315462,7 +315462,7 @@
                             "End Line": 1199
                         },
                         {
-                            "Function Name": "nonStallingRawEvaluateInExistingMainCont",
+                            "Function Name": "nonStallingRawEvaluateInExistingMainContext",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 8,
                             "Control Flow Branches": 1,
@@ -315722,7 +315722,7 @@
                             "End Line": 1188
                         },
                         {
-                            "Function Name": "rafrafTimeoutScreenshotElementWithProgre",
+                            "Function Name": "rafrafTimeoutScreenshotElementWithProgress",
                             "Structural Impact": 2.5,
                             "Lines of Code (LOC)": 6,
                             "Control Flow Branches": 0,
@@ -317530,7 +317530,7 @@
                             "End Line": 1076
                         },
                         {
-                            "Function Name": "getStrictModeBlockScopeFunctionDeclarati",
+                            "Function Name": "getStrictModeBlockScopeFunctionDeclarationMessage",
                             "Structural Impact": 5.2,
                             "Lines of Code (LOC)": 23,
                             "Control Flow Branches": 1,
@@ -322392,7 +322392,7 @@
                             "End Line": 60
                         },
                         {
-                            "Function Name": "testUpdateAccountNameNegativeMinAccessPr",
+                            "Function Name": "testUpdateAccountNameNegativeMinAccessProfile",
                             "Structural Impact": 7.9,
                             "Lines of Code (LOC)": 23,
                             "Control Flow Branches": 2,
@@ -323053,7 +323053,7 @@
                             "End Line": 360
                         },
                         {
-                            "Function Name": "testQueryWithFilterNegativeNoPermsToAcco",
+                            "Function Name": "testQueryWithFilterNegativeNoPermsToAccountNegative",
                             "Structural Impact": 13.1,
                             "Lines of Code (LOC)": 39,
                             "Control Flow Branches": 4,
@@ -323093,7 +323093,7 @@
                             "End Line": 300
                         },
                         {
-                            "Function Name": "testPermSetGrantsAccessToAccountNamePosi",
+                            "Function Name": "testPermSetGrantsAccessToAccountNamePositve",
                             "Structural Impact": 3.7,
                             "Lines of Code (LOC)": 30,
                             "Control Flow Branches": 0,
@@ -323113,7 +323113,7 @@
                             "End Line": 213
                         },
                         {
-                            "Function Name": "testgetDetailsFromBothParentRecordsPosit",
+                            "Function Name": "testgetDetailsFromBothParentRecordsPositive",
                             "Structural Impact": 3.6,
                             "Lines of Code (LOC)": 28,
                             "Control Flow Branches": 0,
@@ -323123,7 +323123,7 @@
                             "End Line": 416
                         },
                         {
-                            "Function Name": "testGetAccountInfoWhenQueryingContactPos",
+                            "Function Name": "testGetAccountInfoWhenQueryingContactPositive",
                             "Structural Impact": 3.5,
                             "Lines of Code (LOC)": 26,
                             "Control Flow Branches": 0,
@@ -323153,7 +323153,7 @@
                             "End Line": 105
                         },
                         {
-                            "Function Name": "testQueryWithFilterWithNoMatchingAcctsPo",
+                            "Function Name": "testQueryWithFilterWithNoMatchingAcctsPositive",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 0,
@@ -323173,7 +323173,7 @@
                             "End Line": 182
                         },
                         {
-                            "Function Name": "testLimitClauseLessThan10AccountsPositiv",
+                            "Function Name": "testLimitClauseLessThan10AccountsPositive",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 17,
                             "Control Flow Branches": 0,
@@ -323193,7 +323193,7 @@
                             "End Line": 317
                         },
                         {
-                            "Function Name": "testLimitClauseMoreThan10AccountsPositiv",
+                            "Function Name": "testLimitClauseMoreThan10AccountsPositive",
                             "Structural Impact": 2.9,
                             "Lines of Code (LOC)": 14,
                             "Control Flow Branches": 0,
@@ -323213,7 +323213,7 @@
                             "End Line": 274
                         },
                         {
-                            "Function Name": "testComplexFilterOmnibusPositiveNoResult",
+                            "Function Name": "testComplexFilterOmnibusPositiveNoResults",
                             "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -327632,7 +327632,7 @@
                             "End Line": 133
                         },
                         {
-                            "Function Name": "getBulkFLSAccessibleWithAccountPositiveW",
+                            "Function Name": "getBulkFLSAccessibleWithAccountPositiveWithNegativeResults",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 0,
@@ -327642,7 +327642,7 @@
                             "End Line": 118
                         },
                         {
-                            "Function Name": "getBulkFLSUpdatableWithAccountPositiveWi",
+                            "Function Name": "getBulkFLSUpdatableWithAccountPositiveWithNegativeResults",
                             "Structural Impact": 3.1,
                             "Lines of Code (LOC)": 18,
                             "Control Flow Branches": 0,
@@ -327652,7 +327652,7 @@
                             "End Line": 152
                         },
                         {
-                            "Function Name": "memoizedFLSMDCcomparesAccesibleToUpdatab",
+                            "Function Name": "memoizedFLSMDCcomparesAccesibleToUpdatable",
                             "Structural Impact": 2.8,
                             "Lines of Code (LOC)": 12,
                             "Control Flow Branches": 0,
@@ -327939,7 +327939,7 @@
                     },
                     "5. Function Analysis": [
                         {
-                            "Function Name": "testIterableApiClientRecipeNegativeWhenR",
+                            "Function Name": "testIterableApiClientRecipeNegativeWhenRecordPageRequestFails",
                             "Structural Impact": 11.1,
                             "Lines of Code (LOC)": 27,
                             "Control Flow Branches": 3,
@@ -328176,7 +328176,7 @@
                             "End Line": 61
                         },
                         {
-                            "Function Name": "testSortAccountsByShippingCountryInDesce",
+                            "Function Name": "testSortAccountsByShippingCountryInDescending",
                             "Structural Impact": 3.9,
                             "Lines of Code (LOC)": 29,
                             "Control Flow Branches": 0,
@@ -330733,7 +330733,7 @@
             }
         },
         "typescript/fp-ts": {
-            "Directory Group Magnitude": 99.25,
+            "Directory Group Magnitude": 99.15,
             "File Count": 5,
             "Ecosystem Fingerprint (Archetypes)": {
                 "file_cluster_16": "80.0%",
@@ -330744,14 +330744,14 @@
                 "Error & Exception Exposure": "44.81%",
                 "Tech Debt Exposure": "52.18%",
                 "Testing Exposure": "48.46%",
-                "API Exposure": "10.09%",
+                "API Exposure": "10.08%",
                 "Concurrency Exposure": "4.28%",
                 "State Flux Exposure": "0.0%",
                 "Commented Logic Exposure": "0.0%",
                 "Specification Exposure": "80.0%",
                 "Instability Exposure": "40.0%",
                 "Volatility Exposure": "0.0%",
-                "Documentation Exposure": "45.35%",
+                "Documentation Exposure": "45.07%",
                 "Hardcoded Payload Artifacts": "0.0%"
             },
             "Files": {
@@ -331569,32 +331569,32 @@
                         "Identity Proof": "Single Indicator (Ext: .ts)"
                     },
                     "2. Topological Coordinates": {
-                        "X": 6259.06,
-                        "Y": 228.82,
-                        "Z": -1035.38
+                        "X": 6259.09,
+                        "Y": 228.81,
+                        "Z": -1035.4
                     },
                     "3. Architectural Profile": {
                         "Repository Archetype": "file_cluster_16",
-                        "Repository Drift (Z-Score)": 11.959,
+                        "Repository Drift (Z-Score)": 11.958,
                         "Repository Fingerprint": {
                             "file_cluster_0": 13.193,
-                            "file_cluster_1": 13.369,
-                            "file_cluster_2": 12.308,
+                            "file_cluster_1": 13.368,
+                            "file_cluster_2": 12.307,
                             "file_cluster_3": 13.868,
                             "file_cluster_4": 13.428,
-                            "file_cluster_5": 13.691,
+                            "file_cluster_5": 13.69,
                             "file_cluster_6": 13.401,
-                            "file_cluster_7": 13.061,
-                            "file_cluster_8": 12.992,
-                            "file_cluster_9": 13.475,
-                            "file_cluster_10": 14.089,
+                            "file_cluster_7": 13.06,
+                            "file_cluster_8": 12.991,
+                            "file_cluster_9": 13.474,
+                            "file_cluster_10": 14.088,
                             "file_cluster_11": 12.839,
-                            "file_cluster_12": 13.493,
-                            "file_cluster_13": 12.453,
-                            "file_cluster_14": 15.628,
+                            "file_cluster_12": 13.492,
+                            "file_cluster_13": 12.452,
+                            "file_cluster_14": 15.627,
                             "file_cluster_15": 13.251,
-                            "file_cluster_16": 11.959,
-                            "file_cluster_17": 12.82
+                            "file_cluster_16": 11.958,
+                            "file_cluster_17": 12.819
                         },
                         "File Archetype": "Cluster 8: Algorithmic Data Processing",
                         "File Drift (Z-Score)": 6.958,
@@ -331603,7 +331603,7 @@
                             "Cluster 1: Async Scripting & I/O Automation": 8.067,
                             "Cluster 2: Type Definitions & Bypasses": 7.952,
                             "Cluster 3: UI Frameworks & View Layers": 7.511,
-                            "Cluster 4: Heavily Documented Core Classes": 7.461,
+                            "Cluster 4: Heavily Documented Core Classes": 7.46,
                             "Cluster 5: Declarative Glue & Inert Types": 7.55,
                             "Cluster 6: Async Testing & Verification": 9.104,
                             "Cluster 7: Highly Concurrent State Management": 8.517,
@@ -331612,7 +331612,7 @@
                         "Total LOC": 1882,
                         "Coding LOC": 662,
                         "Documentation LOC": 1053,
-                        "Structural Magnitude": 24.36,
+                        "Structural Magnitude": 24.26,
                         "Control Flow Ratio": "2.5%",
                         "Popularity Rank": 0,
                         "Raw Churn Frequency": 0.0,
@@ -331625,14 +331625,14 @@
                         "Error & Exception Exposure": "33.76%",
                         "Tech Debt Exposure": "71.07%",
                         "Testing Exposure": "80.0%",
-                        "API Exposure": "13.31%",
+                        "API Exposure": "13.29%",
                         "Concurrency Exposure": "21.39%",
                         "State Flux Exposure": "0.0%",
                         "Commented Logic Exposure": "0.0%",
                         "Specification Exposure": "100.0%",
                         "Instability Exposure": "50.0%",
                         "Volatility Exposure": "0.0%",
-                        "Documentation Exposure": "42.04%",
+                        "Documentation Exposure": "40.62%",
                         "Hardcoded Payload Artifacts": "0.0%"
                     },
                     "5. Function Analysis": [
@@ -331647,7 +331647,7 @@
                             "End Line": 152
                         },
                         {
-                            "Function Name": "traverseReadonlyNonEmptyArrayWithIndexSe",
+                            "Function Name": "traverseReadonlyNonEmptyArrayWithIndexSeq",
                             "Structural Impact": 5.0,
                             "Lines of Code (LOC)": 16,
                             "Control Flow Branches": 2,
@@ -331868,7 +331868,7 @@
                         "Type/Safety Bypasses": 16,
                         "High-Risk Execution Commands": 0,
                         "I/O and Network Boundaries": 0,
-                        "Exposed API / Public Exports": 155,
+                        "Exposed API / Public Exports": 154,
                         "State Mutations / Variable Reassignments": 5,
                         "Commented-out Code (Dead Logic)": 0,
                         "Structured Documentation Blocks": 158,


### PR DESCRIPTION
## Summary
- `detector.py:_calculate_block_metrics` (`gitgalaxy/core/detector.py:2476`) hard-truncated every extracted function/method name to 40 characters before storing it on the `FunctionNode`, silently corrupting names in the SQLite recorder, SARIF/SBOM output, the LLM-optimized architectural brief, and risk-scoring hotspot output.
- Across GitGalaxy's own 228-file/2,436-function Python codebase, 984 functions (40%) exceed 40 characters (this repo's own long, descriptive `test_*` naming convention routinely does).
- Removed the truncation at the extraction layer per the issue's suggested fix — no format currently truncates at its own serialization boundary, so the cap should live there if one is ever needed again, not baked into the shared structural extraction result.

## Golden master regeneration
Per the Differential Scan protocol, regenerated both `tests/golden_master_audit.json` (full-precision) and `tests/golden_master_zero_dep_audit.json` (zero-dependency) via `tests/tools/update_golden_master.py`. The diff is more than cosmetic name-length changes: `_calculate_block_metrics`'s orphan/duplicate detector token-matches each function's `name` against the surrounding source text to flag unused/duplicate logic, so untruncated names change some `orphaned_logic`/`duplicate_logic` signal counts, which ripple into a handful of `tech_debt`/`impact` scores across the corpus. `tests/tools/crucible_check.py` passes clean (`full_precision: PASS`, `zero_dependency: PASS`) against the regenerated fixtures.

Fixes #1182

## Test plan
- [x] `python -m pytest tests/` — 6787 passed, 2 skipped, 11 xfailed, 3 xpassed
- [x] `python tests/tools/audit_check.py` — ruff/mypy/dead-key all clean against baseline
- [x] `python tests/tools/crucible_check.py` — full_precision PASS, zero_dependency PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)