### PR TITLE
chore: redesign PR template around actual CI gates, not vibes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,32 @@
-### Description of Structural Changes
-### Visual Observatory Testing
-- [ ] I tested the output JSON on **GitGalaxy.io** OR the **Airgap Observatory**.
-- [ ] Flexbox constraints, HUD elements, and 3D rendering remain intact.
+## Summary
 
-### The Differential Scan Acknowledgement
-- [ ] I understand that my PR will be subjected to a Full Differential Scan.
-- [ ] I have provided the link to the specific repository this PR addresses so it can be tested alongside the 80-repo calibrated baseline.
-- [ ] I believe these changes will measurably improve the engine's Accuracy, Speed, Utility, or Ethos without causing regressions.
+<!-- What does this change and why? Link the issue it closes, e.g. "Fixes #488." -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / language support
+- [ ] Parsing or engine logic (`gitgalaxy/core/detector.py`, `language_standards.py`, `prism.py`, or a per-language rule)
+- [ ] Docs, tooling, or CI only
+- [ ] Other (describe above)
+
+## CI checklist
+
+Check only what applies to your change — CI enforces the rest, but running it locally first saves a review round-trip.
+
+- [ ] `python tests/tools/audit_check.py` passes (bundles the ruff/mypy/dead-key baseline-gated audits + `ruff format --check`)
+- [ ] `python -m pytest tests/` passes, or the specific test file(s) for this change (list them below)
+- [ ] **Touches parsing/engine logic (see above)?** `python tests/tools/crucible_check.py` passes — this is the Differential Scan against the ~80-repo calibrated baseline (see `CONTRIBUTING.md`)
+- [ ] **Changes the CLI's output JSON schema?** Verified on [GitGalaxy.io](https://gitgalaxy.io) or the local Airgap Observatory that 3D rendering still works
+
+## Differential Scan target
+
+<!-- Parsing/engine changes only: link the specific repo this PR is meant to fix or improve, so it runs
+alongside the 80-repo baseline. Leave blank if not applicable. -->
+
+## Verification
+
+<!-- Paste the actual commands you ran and their result, e.g.:
+$ python tests/tools/audit_check.py            -- clean
+$ pytest tests/tools_recorders/test_llm_recorder.py -q   -- 12 passed
+-->


### PR DESCRIPTION
## Summary
- The old template's "5-step checklist" mandated Visual Observatory testing and a self-graded "Ethos" acknowledgement for *every* PR, even ones (docs, tooling, lint cleanup) that touch neither the 3D output contract nor the parsing engine.
- Replaces it with a checklist tied to what CI actually enforces: `tests/tools/audit_check.py` (ruff/mypy/dead-key baselines + format), `pytest`, and `tests/tools/crucible_check.py` (the Differential Scan) -- the last two only flagged as relevant when the PR touches parsing/engine logic or the output JSON schema.
- Motivated by an uptick in first-time external contributor PRs (e.g. #1201) where a generic vibe-check template gives neither the contributor nor reviewers useful signal about what's actually going to fail in CI.

## Verification
Rendered the new markdown locally and cross-checked every command/script referenced (`audit_check.py`, `crucible_check.py`) against CLAUDE.md/CONTRIBUTING.md to confirm they're current and real.