### PR TITLE
chore(ci): bump Muninn to v0.3.8

### DIFF
--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run Muninn
         # zizmor: ignore[github_action_from_unverified_creator_used]
-        uses: skaldlab/muninn@bf8c51b1c885725e2b82bc8ba712ac24d2e0619b # v0.3.7
+        uses: skaldlab/muninn@6426b13b68ed0331598886218414985fb28b8e2f # v0.3.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail-on: info


### PR DESCRIPTION
## Summary
- Bump `skaldlab/muninn` in `.github/workflows/muninn.yml` from **v0.3.7** to **v0.3.8** (`6426b13`).

Notable Muninn 0.3.8 changes:
- osv-scanner 2.5.0 (osv-scalibr pipeline)
- GitPython floor raised to >=3.1.58 for recent GHSAs

Release: https://github.com/skaldlab/muninn/releases/tag/v0.3.8

## Test plan
- [x] Muninn workflow runs on this PR
- [x] SARIF upload still works when a report is produced