### PR TITLE
feat(ci): roll out C-Family cluster for tree-sitter accuracy audits

### DIFF
--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -130,6 +130,36 @@ NODE_MAPS = {
         "func_node_types": {"function_definition"},
         "class_node_types": set(),
     },
+    "c": {
+        "ts_lang": "c",
+        "func_node_types": {"function_definition"},
+        "class_node_types": {"struct_specifier"},
+    },
+    "cpp": {
+        "ts_lang": "cpp",
+        "func_node_types": {"function_definition", "template_function"},
+        "class_node_types": {"class_specifier", "struct_specifier"},
+    },
+    "csharp": {
+        "ts_lang": "csharp",
+        "func_node_types": {"method_declaration", "local_function_statement"},
+        "class_node_types": {"class_declaration", "struct_declaration", "interface_declaration"},
+    },
+    "java": {
+        "ts_lang": "java",
+        "func_node_types": {"method_declaration", "constructor_declaration"},
+        "class_node_types": {"class_declaration", "interface_declaration", "enum_declaration"},
+    },
+    "go": {
+        "ts_lang": "go",
+        "func_node_types": {"function_declaration", "method_declaration"},
+        "class_node_types": {"type_declaration"},
+    },
+    "rust": {
+        "ts_lang": "rust",
+        "func_node_types": {"function_item"},
+        "class_node_types": {"struct_item", "trait_item", "impl_item", "enum_item"},
+    },
 }
 
 

--- a/tests/tree_sitter_accuracy_baseline_c.json
+++ b/tests/tree_sitter_accuracy_baseline_c.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/c",
+  "extra_classes": 7,
+  "extra_functions": 1687,
+  "files_scanned": 31,
+  "found_classes": 45,
+  "found_functions": 0,
+  "real_classes": 79,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_cpp.json
+++ b/tests/tree_sitter_accuracy_baseline_cpp.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 5,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/cpp",
+  "extra_classes": 29,
+  "extra_functions": 1147,
+  "files_scanned": 29,
+  "found_classes": 138,
+  "found_functions": 5,
+  "real_classes": 140,
+  "real_functions": 87
+}

--- a/tests/tree_sitter_accuracy_baseline_csharp.json
+++ b/tests/tree_sitter_accuracy_baseline_csharp.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 553,
+  "args_exact_match": 116,
+  "corpus_path": "language-crucible/data/csharp",
+  "extra_classes": 0,
+  "extra_functions": 397,
+  "files_scanned": 6,
+  "found_classes": 0,
+  "found_functions": 553,
+  "real_classes": 19,
+  "real_functions": 558
+}

--- a/tests/tree_sitter_accuracy_baseline_go.json
+++ b/tests/tree_sitter_accuracy_baseline_go.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 817,
+  "args_exact_match": 298,
+  "corpus_path": "language-crucible/data/go",
+  "extra_classes": 0,
+  "extra_functions": 0,
+  "files_scanned": 14,
+  "found_classes": 0,
+  "found_functions": 817,
+  "real_classes": 0,
+  "real_functions": 855
+}

--- a/tests/tree_sitter_accuracy_baseline_java.json
+++ b/tests/tree_sitter_accuracy_baseline_java.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 233,
+  "args_exact_match": 81,
+  "corpus_path": "language-crucible/data/java",
+  "extra_classes": 0,
+  "extra_functions": 0,
+  "files_scanned": 7,
+  "found_classes": 9,
+  "found_functions": 233,
+  "real_classes": 35,
+  "real_functions": 266
+}

--- a/tests/tree_sitter_accuracy_baseline_rust.json
+++ b/tests/tree_sitter_accuracy_baseline_rust.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 1135,
+  "args_exact_match": 134,
+  "corpus_path": "language-crucible/data/rust",
+  "extra_classes": 10,
+  "extra_functions": 32,
+  "files_scanned": 43,
+  "found_classes": 145,
+  "found_functions": 1135,
+  "real_classes": 242,
+  "real_functions": 1457
+}


### PR DESCRIPTION
## What Changed
Added support for the C-Family cluster of languages (C, C++, C#, Java, Go, and Rust) to the `tree_sitter_accuracy_audit.py` script, and generated their baseline metrics against the `language-crucible` corpus.

## Why
This implements the second cluster of languages for Epic #1227. This introduces baseline regression tracking for our most critical systems programming languages. 

The `NODE_MAPS` dictionary was expanded with their true Tree-sitter AST names (e.g. tracking `struct_specifier` in C, `type_declaration` in Go, etc.).

Part of #1227.