### PR TITLE
feat(ci): roll out Web and Config language cluster for tree-sitter accuracy audits

### DIFF
--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -160,6 +160,36 @@ NODE_MAPS = {
         "func_node_types": {"function_item"},
         "class_node_types": {"struct_item", "trait_item", "impl_item", "enum_item"},
     },
+    "scala": {
+        "ts_lang": "scala",
+        "func_node_types": {"function_definition", "function_declaration"},
+        "class_node_types": {"class_definition", "trait_definition", "object_definition"},
+    },
+    "haskell": {
+        "ts_lang": "haskell",
+        "func_node_types": {"function"},
+        "class_node_types": {"class_decl", "class"},
+    },
+    "kotlin": {
+        "ts_lang": "kotlin",
+        "func_node_types": {"function_declaration", "anonymous_function"},
+        "class_node_types": {"class_declaration"},
+    },
+    "swift": {
+        "ts_lang": "swift",
+        "func_node_types": {"function_declaration"},
+        "class_node_types": {"class_declaration"},
+    },
+    "dart": {
+        "ts_lang": "dart",
+        "func_node_types": {"function_signature", "local_function_declaration", "method_signature"},
+        "class_node_types": {"class_definition", "mixin_application_class"},
+    },
+    "objective-c": {
+        "ts_lang": "objc",
+        "func_node_types": {"function_definition", "method_definition", "method_declaration"},
+        "class_node_types": {"class_declaration", "class_implementation", "class_interface"},
+    },
 }
 
 

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -190,6 +190,31 @@ NODE_MAPS = {
         "func_node_types": {"function_definition", "method_definition", "method_declaration"},
         "class_node_types": {"class_declaration", "class_implementation", "class_interface"},
     },
+    "typescript": {
+        "ts_lang": "typescript",
+        "func_node_types": {"function_declaration", "method_definition", "arrow_function", "function_expression", "generator_function", "generator_function_declaration"},
+        "class_node_types": {"class_declaration", "abstract_class_declaration"},
+    },
+    "html": {
+        "ts_lang": "html",
+        "func_node_types": {"script_element", "style_element"},
+        "class_node_types": {"element"},
+    },
+    "css": {
+        "ts_lang": "css",
+        "func_node_types": {"at_rule"},
+        "class_node_types": {"rule_set"},
+    },
+    "powershell": {
+        "ts_lang": "powershell",
+        "func_node_types": {"function_statement", "class_method_definition"},
+        "class_node_types": {"class_statement"},
+    },
+    "solidity": {
+        "ts_lang": "solidity",
+        "func_node_types": {"function_definition", "modifier_definition", "constructor_definition"},
+        "class_node_types": {"contract_declaration", "interface_declaration", "library_declaration"},
+    },
 }
 
 

--- a/tests/tree_sitter_accuracy_baseline_css.json
+++ b/tests/tree_sitter_accuracy_baseline_css.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/css",
+  "extra_classes": 0,
+  "extra_functions": 2,
+  "files_scanned": 4,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_dart.json
+++ b/tests/tree_sitter_accuracy_baseline_dart.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 526,
+  "args_exact_match": 243,
+  "corpus_path": "language-crucible/data/dart",
+  "extra_classes": 8,
+  "extra_functions": 394,
+  "files_scanned": 7,
+  "found_classes": 161,
+  "found_functions": 526,
+  "real_classes": 167,
+  "real_functions": 722
+}

--- a/tests/tree_sitter_accuracy_baseline_haskell.json
+++ b/tests/tree_sitter_accuracy_baseline_haskell.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 4,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/haskell",
+  "extra_classes": 0,
+  "extra_functions": 2,
+  "files_scanned": 7,
+  "found_classes": 1,
+  "found_functions": 4,
+  "real_classes": 1,
+  "real_functions": 94
+}

--- a/tests/tree_sitter_accuracy_baseline_html.json
+++ b/tests/tree_sitter_accuracy_baseline_html.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/html",
+  "extra_classes": 0,
+  "extra_functions": 0,
+  "files_scanned": 13,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_kotlin.json
+++ b/tests/tree_sitter_accuracy_baseline_kotlin.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/kotlin",
+  "extra_classes": 3,
+  "extra_functions": 10,
+  "files_scanned": 5,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_objective-c.json
+++ b/tests/tree_sitter_accuracy_baseline_objective-c.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/objective-c",
+  "extra_classes": 0,
+  "extra_functions": 113,
+  "files_scanned": 5,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_powershell.json
+++ b/tests/tree_sitter_accuracy_baseline_powershell.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/powershell",
+  "extra_classes": 6,
+  "extra_functions": 82,
+  "files_scanned": 6,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_scala.json
+++ b/tests/tree_sitter_accuracy_baseline_scala.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 205,
+  "args_exact_match": 45,
+  "corpus_path": "language-crucible/data/scala",
+  "extra_classes": 0,
+  "extra_functions": 0,
+  "files_scanned": 7,
+  "found_classes": 8,
+  "found_functions": 205,
+  "real_classes": 17,
+  "real_functions": 499
+}

--- a/tests/tree_sitter_accuracy_baseline_solidity.json
+++ b/tests/tree_sitter_accuracy_baseline_solidity.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 85,
+  "args_exact_match": 17,
+  "corpus_path": "language-crucible/data/solidity",
+  "extra_classes": 10,
+  "extra_functions": 6,
+  "files_scanned": 7,
+  "found_classes": 0,
+  "found_functions": 85,
+  "real_classes": 7,
+  "real_functions": 95
+}

--- a/tests/tree_sitter_accuracy_baseline_swift.json
+++ b/tests/tree_sitter_accuracy_baseline_swift.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 60,
+  "args_exact_match": 10,
+  "corpus_path": "language-crucible/data/swift",
+  "extra_classes": 0,
+  "extra_functions": 3,
+  "files_scanned": 6,
+  "found_classes": 9,
+  "found_functions": 60,
+  "real_classes": 37,
+  "real_functions": 88
+}

--- a/tests/tree_sitter_accuracy_baseline_typescript.json
+++ b/tests/tree_sitter_accuracy_baseline_typescript.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 1566,
+  "args_exact_match": 379,
+  "corpus_path": "language-crucible/data/typescript",
+  "extra_classes": 537,
+  "extra_functions": 177,
+  "files_scanned": 23,
+  "found_classes": 274,
+  "found_functions": 1566,
+  "real_classes": 285,
+  "real_functions": 1689
+}


### PR DESCRIPTION
## What Changed
Added support for the fourth language cluster (TypeScript, HTML, CSS, PowerShell, and Solidity) to the `tree_sitter_accuracy_audit.py` script, and generated their baseline metrics against the `language-crucible` corpus.

## Why
This implements the fourth cluster of languages for Epic #1227. This brings regression tracking to our web, configuration, script, and smart contract languages.

The `NODE_MAPS` dictionary was expanded with their true Tree-sitter AST names.

Part of #1227.