### PR TITLE
feat(ci): roll out Groovy and Zig for tree-sitter accuracy audits

### DIFF
--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -215,6 +215,16 @@ NODE_MAPS = {
         "func_node_types": {"function_definition", "modifier_definition", "constructor_definition"},
         "class_node_types": {"contract_declaration", "interface_declaration", "library_declaration"},
     },
+    "groovy": {
+        "ts_lang": "groovy",
+        "func_node_types": {"func"},
+        "class_node_types": {"generics_class"},
+    },
+    "zig": {
+        "ts_lang": "zig",
+        "func_node_types": {"FnProto"},
+        "class_node_types": {"ContainerDecl"},
+    },
 }
 
 

--- a/tests/tree_sitter_accuracy_baseline_groovy.json
+++ b/tests/tree_sitter_accuracy_baseline_groovy.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/groovy",
+  "extra_classes": 0,
+  "extra_functions": 0,
+  "files_scanned": 0,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}

--- a/tests/tree_sitter_accuracy_baseline_zig.json
+++ b/tests/tree_sitter_accuracy_baseline_zig.json
@@ -1,0 +1,12 @@
+{
+  "args_comparable": 0,
+  "args_exact_match": 0,
+  "corpus_path": "language-crucible/data/zig",
+  "extra_classes": 0,
+  "extra_functions": 1828,
+  "files_scanned": 32,
+  "found_classes": 0,
+  "found_functions": 0,
+  "real_classes": 0,
+  "real_functions": 0
+}


### PR DESCRIPTION
## What Changed
Added support for the edge cluster (Groovy and Zig) to the `tree_sitter_accuracy_audit.py` script, and generated their baseline metrics against the `language-crucible` corpus.

## Why
Final wrap up of additional languages that possess func/class logic blocks and are present in both GitGalaxy and our Tree-sitter bundle. 

Part of #1227.