### PR TITLE
fix(tools): typescript class_start ground truth was missing interface/enum (#1338)

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -63,7 +63,7 @@ for the same metrics tracked over time across pushes to main.
 | Solidity | 89.5% | 93.4% | 100.0% | 100.0% |
 | Swift | 98.9% | 100.0% | 62.2% | 100.0% |
 | Tcl | 98.6% | 98.6% | N/A | N/A |
-| Typescript | 92.7% | 89.8% | 100.0% | 34.7% |
+| Typescript | 92.7% | 89.8% | 97.6% | 100.0% |
 | Zig | 73.9% | 100.0% | 0.0% | N/A |
 <!-- TREE_SITTER_ACCURACY_TABLE:END -->
 """

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -336,7 +336,18 @@ NODE_MAPS = {
             "generator_function",
             "generator_function_declaration",
         },
-        "class_node_types": {"class_declaration", "abstract_class_declaration"},
+        # #1338: GitGalaxy's typescript class_start rule is deliberately titled "Object / Entity
+        # Declarations" (language_standards.py), not "OOP classes" -- it matches `class|enum|
+        # interface` on purpose (and `enum TargetEntity {` is an explicit "valid" test case in
+        # tests/extraction/languages/test_typescript.py's CLASS_CASES). This NODE_MAPS entry only
+        # counted `class_declaration`/`abstract_class_declaration` as "real classes", so every
+        # correctly-matched interface/enum was measured as a false-positive "extra" class -- the
+        # same ground-truth-tool-gap shape as #1314's objc `_get_node_name` fix, not a GitGalaxy
+        # regex defect. Confirmed via direct breakdown: all 537 baseline `extra_classes` traced
+        # to real `interface_declaration` (470) / `enum_declaration` (67) nodes tree-sitter itself
+        # parses, zero unexplained false matches. Added both node types here to match what
+        # class_start actually measures itself against.
+        "class_node_types": {"class_declaration", "abstract_class_declaration", "interface_declaration", "enum_declaration"},
     },
     "html": {
         "ts_lang": "html",

--- a/tests/tree_sitter_accuracy_baseline_typescript.json
+++ b/tests/tree_sitter_accuracy_baseline_typescript.json
@@ -2,11 +2,11 @@
   "args_comparable": 1566,
   "args_exact_match": 1484,
   "corpus_path": "language-crucible/data/typescript",
-  "extra_classes": 537,
+  "extra_classes": 0,
   "extra_functions": 177,
   "files_scanned": 23,
-  "found_classes": 285,
+  "found_classes": 822,
   "found_functions": 1566,
-  "real_classes": 285,
+  "real_classes": 842,
   "real_functions": 1689
 }


### PR DESCRIPTION
## Summary

- Closes #1338: `typescript class_start: 34.7% precision (537 false-positive classes against 285 real)`
- The 537 "extra" classes were never a GitGalaxy defect -- `class_start`'s own module comment
  calls it "Object / Entity Declarations" and its regex deliberately matches
  `class|enum|interface` (`enum TargetEntity {` is an explicit "valid" case in
  `tests/extraction/languages/test_typescript.py`'s `CLASS_CASES`). `tree_sitter_accuracy_audit.py`'s
  typescript `class_node_types` only counted `class_declaration`/`abstract_class_declaration` as
  ground truth, so every correctly-matched interface/enum was measured as a false positive --
  same ground-truth-tool-gap shape as #1314's objc `_get_node_name` fix, not a regex bug.
- Confirmed with a direct breakdown script: all 537 baseline `extra_classes` trace to real
  `interface_declaration` (470) and `enum_declaration` (67) nodes tree-sitter itself parses for
  those same files -- zero unexplained false matches.
- Added both node types to typescript's `class_node_types` in `tree_sitter_accuracy_audit.py`,
  regenerated the baseline (`extra_classes` 537 -> 0, `real_classes` 285 -> 842,
  `found_classes` 285 -> 822) and the summary table in `language_standards.py`'s docstring
  (class precision 34.7% -> 100%, recall 97.6%).
- Verified `--all --ci` -- all 31 other baselined languages unaffected.
- Filed #1348 for the one real gap the fixed measurement surfaced: `export`/`declare const enum`
  isn't recognized by `class_start`'s modifier group (20 of 842 real classes), which is a genuine
  parsing-logic fix deserving its own Differential Scan rather than folding into this ground-truth
  PR.

## Test plan

- [x] `python tests/tools/tree_sitter_accuracy_audit.py --lang typescript --ci` -- OK, matches
      regenerated baseline
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --all --ci` -- 31/31 languages OK, no
      regressions
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key/ast-accuracy all clean
- [x] `python -m pytest tests/extraction/languages/test_typescript.py tests/extraction/languages/test_typescript_strict.py -q` -- 177 passed
- [x] No `detector.py`/`language_standards.py` regex changes in this PR (audit-tool-only fix), so
      the Differential Scan protocol doesn't apply here

🤖 Generated with [Claude Code](https://claude.com/claude-code)