### PR TITLE
fix(swift): wire swift into class_start named-entity extraction

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -361,9 +361,8 @@ class ScopeParsingRegistry:
 # risk-signal purposes, which floods the named-entity class list with
 # phantom/misattributed entries if reused here unmodified (confirmed: C's
 # found_classes 45->0 and extra_classes 7->23 on the crucible corpus when
-# tried without this gate). Swift's `class_start` captures no name at all
-# for the same reason (pure occurrence counting). Extending this set to the
-# remaining languages needs the same kind of per-language hardening pass
+# tried without this gate). Extending this set to the remaining languages
+# needs the same kind of per-language hardening pass
 # epic #813 already did for func_start/args/class_start's OWN extraction
 # gauntlets -- tracked as a follow-up (#1295), not attempted wholesale here.
 _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset(
@@ -386,6 +385,7 @@ _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset(
         "scala",
         "shell",
         "solidity",
+        "swift",
         "tcl",
         "typescript",
     }
@@ -402,7 +402,7 @@ def _resolve_class_start_match(match: re.Match, groups_count: int) -> tuple[Opti
     Fortran/Lua/ABAP-shaped patterns use alternation where the name lands in
     EITHER group 1 or group 2 depending on which branch fired, and some
     languages capture no name at all (pure occurrence-counting rules, e.g.
-    C/Swift -- see the frozenset's own comment). `name_group_idx` is `None`
+    C -- see the frozenset's own comment). `name_group_idx` is `None`
     in that last case; callers should fall back to `match.start(0)` for the
     anchor position and `"Anonymous_Class"` for the name.
 

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -61,7 +61,7 @@ for the same metrics tracked over time across pushes to main.
 | Scala | 100.0% | 100.0% | 70.6% | 100.0% |
 | Shell | 100.0% | 60.0% | N/A | N/A |
 | Solidity | 89.5% | 93.4% | 100.0% | 100.0% |
-| Swift | 98.9% | 100.0% | 62.2% | 100.0% |
+| Swift | 98.9% | 100.0% | 100.0% | 100.0% |
 | Tcl | 98.6% | 98.6% | N/A | N/A |
 | Typescript | 92.7% | 89.8% | 100.0% | 100.0% |
 | Zig | 73.9% | 100.0% | 0.0% | N/A |
@@ -4941,8 +4941,16 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 re.M,
             ),
             # 5. class_start (Object / Entity Declarations)
+            # #1295: name wrapped in a capture group so the named-entity
+            # extractor (detector.py's _CLASS_START_NAMED_EXTRACTION_LANGS)
+            # can recover real names instead of flooding class_data with one
+            # "Anonymous_Class" phantom per match. Widened to an optional
+            # dotted chain (`\.[a-zA-Z_]\w*`) so nested-type extensions
+            # (`extension AFError.ParameterEncoderFailureReason { ... }`,
+            # mainstream in real Swift error-handling code) capture their
+            # full qualified name instead of truncating at the first dot.
             "class_start": re.compile(
-                r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t]*){0,5}(?:(?:public|private|fileprivate|internal|open|package|final|distributed|indirect)[ \t]+){0,5}(?:class|struct|enum|protocol|actor|extension|macro)\s+[a-zA-Z_]\w*",
+                r"^[ \t]*(?:@[\w.]+(?:\([^)]*\))?[ \t]*){0,5}(?:(?:public|private|fileprivate|internal|open|package|final|distributed|indirect)[ \t]+){0,5}(?:class|struct|enum|protocol|actor|extension|macro)\s+([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)",
                 re.M,
             ),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---

--- a/tests/extraction/how_to_extend_class_start_named_extraction.md
+++ b/tests/extraction/how_to_extend_class_start_named_extraction.md
@@ -20,8 +20,8 @@ _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset({
 13 more languages regressed when tried the same way and were left on the legacy fallback:
 **c, css, dart, go, haskell, html, kotlin, objective-c, perl, ruby, rust, swift, zig**. Extending
 the allowlist to them -- one at a time, with real verification -- is what epic #1295 tracks, and
-what this doc + `tests/tools/class_start_diff.py` exist to make cheap. **go and objective-c are
-done** (flipped into the allowlist, see the table below); 11 remain.
+what this doc + `tests/tools/class_start_diff.py` exist to make cheap. **go, objective-c, and
+swift are done** (flipped into the allowlist, see the table below); 10 remain.
 
 Read `_resolve_class_start_match` in `gitgalaxy/core/detector.py` before touching anything --
 it's the exact name-resolution algorithm the live pipeline uses (prefer capture group 1, fall
@@ -43,8 +43,9 @@ during #1295's scaffolding pass -- do not re-derive this, just apply the fixes b
 |---|---|
 | **go** | Fixed (#1295 PR): `type_declaration` has no `name` field, but its `type_spec` child does. Flipped into `_CLASS_START_NAMED_EXTRACTION_LANGS`: `found_classes` 0→69, `extra_classes` 0→0. The 15 tree-sitter-only "missing" are all plain type aliases (`type WaitStatus uint32`) that go's own `class_start` intentionally excludes (requires `struct`/`interface` to follow) -- a scope mismatch, not a recall bug, documented in the baseline commit. |
 | **objective-c** | Fixed (#1295 PR): `class_interface`/`class_implementation`/`class_declaration` have no `name` field; first positional `identifier` child is the class name (second is the superclass for `class_interface` only). Flipped into the allowlist: `found_classes` 0→5, `extra_classes` 0→0, a perfect match. |
-| **kotlin** | Ground truth already fixed as a side effect of #1313's function-extraction work (`class_declaration` branch in `_get_node_name` returns the first `type_identifier` child) -- `real_classes` now reads 4, not 0. **Not yet flipped into the allowlist**: `found_classes` is still 0, `extra_classes` is 5, all `"Anonymous_Class"` -- kotlin's `class_start` regex has no capture group (same shape as C/Swift below), so this needs the regex workflow, not more measurement-tool work. Moved to the "ground truth already works" list below. |
+| **kotlin** | Ground truth already fixed as a side effect of #1313's function-extraction work (`class_declaration` branch in `_get_node_name` returns the first `type_identifier` child) -- `real_classes` now reads 4, not 0. **Not yet flipped into the allowlist**: `found_classes` is still 0, `extra_classes` is 5, all `"Anonymous_Class"` -- kotlin's `class_start` regex has no capture group (same shape as C below), so this needs the regex workflow, not more measurement-tool work. Moved to the "ground truth already works" list below. |
 | **zig** | Ground truth already fixed (`ContainerDecl` resolves via `_get_zig_container_name`, walking up to the enclosing `VarDecl`) -- `real_classes` reads 642. **Not yet flipped into the allowlist**: `extra_classes` is 10, `missing_classes` is 23 -- a real per-file diff is needed before concluding whether `class_start` over/under-matches zig's `const X = struct {...}` idiom. Moved to the "ground truth already works" list below.
+| **swift** | Fixed (PR #1361): `class_start` had a capture group added (name only had an unparenthesized `[a-zA-Z_]\w*` before), widened to an optional dotted chain for nested-type extensions (`extension AFError.ParameterEncoderFailureReason`). Also hit the ground-truth measurement gap: tree-sitter-swift's protocols are a separate `protocol_declaration` node type, not `class_declaration` -- added to `NODE_MAPS["swift"]["class_node_types"]`. `real_classes` 37→38, `found_classes` 23→38, `extra_classes` stays 0. Flipped into the allowlist. |
 
 ### Needs a judgment call, not a quick field-name fix
 
@@ -62,10 +63,11 @@ each fix as its own small commit/PR (it changes a shared measurement file, not
 
 ### Languages where ground truth already works -- go straight to the regex workflow below
 
-**c** (real_classes=79), **swift** (37), **rust** (242), **dart** (167), **ruby** (9),
+**c** (real_classes=79), **rust** (242), **dart** (167), **ruby** (9),
 **haskell** (1, small corpus), **kotlin** (4 -- but `class_start` has no capture group, expect
-`"Anonymous_Class"` flooding same as C/Swift), **zig** (642, but `extra_classes`=10/
+`"Anonymous_Class"` flooding same as C), **zig** (642, but `extra_classes`=10/
 `missing_classes`=23 needs a real per-file diff before concluding what's over/under-matching).
+(**swift** done -- see the "Done" table above.)
 
 ## Per-language workflow (once ground truth is trustworthy)
 
@@ -76,7 +78,7 @@ each fix as its own small commit/PR (it changes a shared measurement file, not
 2. **Classify every `extra` entry** against the recurring-cause list below. A failing name is a
    finding to triage, not an automatic regex change.
 3. **If it's `"Anonymous_Class"` flooding** (the count next to it, not a single line): the
-   language's `class_start` has no/optional capture group around the name (same as C/Swift).
+   language's `class_start` has no/optional capture group around the name (same as C/kotlin).
    Decide whether the name is realistically recoverable (a capture group can be added around an
    existing optional span) or whether the rule was only ever meant for numeric counting and
    should stay off the allowlist.
@@ -112,7 +114,8 @@ each fix as its own small commit/PR (it changes a shared measurement file, not
 
 1. **No capture group at all** -- the rule was written purely for numeric signal-counting
    (`class_start` feeding `equations`/`counts`, same tier as `branch`/`io`) and never needed a
-   name. Confirmed: C, Swift, Kotlin, Groovy, PowerShell, assembly. Every match becomes
+   name. Confirmed: C, Kotlin, Groovy, PowerShell, assembly (Swift was in this class too --
+   fixed by adding a capture group, PR #1361, no other blocker). Every match becomes
    `"Anonymous_Class"`, which floods `class_data` with one phantom entry per file that has any
    match at all -- `class_start_diff.py` surfaces this explicitly (`N unnamed match(es)`), don't
    let it get filtered out of a triage pass.

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -314,7 +314,13 @@ NODE_MAPS = {
         # so every `init` scored as a false "extra" (all 5 language-crucible/data/swift/alamofire
         # samples at the time of investigation were plain `init` methods, not a GitGalaxy defect).
         "func_node_types": {"function_declaration", "init_declaration"},
-        "class_node_types": {"class_declaration"},
+        # #1295: tree-sitter-swift gives protocols their own `protocol_declaration` node type,
+        # distinct from `class_declaration` -- a real, named class-like entity that GitGalaxy's
+        # own class_start regex intentionally matches (`class|struct|enum|protocol|actor|
+        # extension|macro`), but was invisible to real_classes here (e.g. alamofire's
+        # `RequestDelegate` protocol, which has no corresponding `extension RequestDelegate`
+        # elsewhere in the corpus to accidentally surface its name via a class_declaration node).
+        "class_node_types": {"class_declaration", "protocol_declaration"},
     },
     "dart": {
         "ts_lang": "dart",

--- a/tests/tree_sitter_accuracy_baseline_swift.json
+++ b/tests/tree_sitter_accuracy_baseline_swift.json
@@ -5,8 +5,8 @@
   "extra_classes": 0,
   "extra_functions": 0,
   "files_scanned": 6,
-  "found_classes": 23,
+  "found_classes": 38,
   "found_functions": 92,
-  "real_classes": 37,
+  "real_classes": 38,
   "real_functions": 93
 }


### PR DESCRIPTION
## Summary

Extends #1264's per-language `class_start` named-entity extraction to Swift, per epic #1295's checklist (`tests/extraction/how_to_extend_class_start_named_extraction.md`). Swift was one of the 8 languages listed as ready for the regex workflow (ground truth already trustworthy), and was called out in #1295's body as "likely the simplest fix in this list."

Two fixes were needed, not one:

1. **`gitgalaxy/standards/language_standards.py`**: swift's `class_start` regex matched `class|struct|enum|protocol|actor|extension|macro` declarations but never captured the name -- every match collapsed into a phantom `"Anonymous_Class"` entry in `class_data`. Wrapped the name in a capture group, widened to an optional dotted chain (`\.[a-zA-Z_]\w*`) so nested-type extensions (`extension AFError.ParameterEncoderFailureReason { ... }`, common in Alamofire's error-handling code) capture their full qualified name instead of truncating at the first dot.

2. **`tests/tools/tree_sitter_accuracy_audit.py`**: found a class-#6-shaped ground-truth gap (same shape as go/kotlin/objective-c/zig in #1295's earlier passes) -- tree-sitter-swift gives protocols their own `protocol_declaration` node type, separate from `class_declaration`, which `NODE_MAPS["swift"]` didn't include. This undercounted `real_classes` by exactly the protocols with no same-named `extension` elsewhere in the corpus to accidentally surface them (e.g. Alamofire's `RequestDelegate`). Added `protocol_declaration` alongside `class_declaration`.

## Result

`tests/tree_sitter_accuracy_baseline_swift.json`: `found_classes` 23→38, `real_classes` 37→38, `extra_classes` stays 0 -- a perfect match (verified via `class_start_diff.py` before regenerating the baseline). `swift` added to `detector.py`'s `_CLASS_START_NAMED_EXTRACTION_LANGS`.

## Test plan

- [x] `python tests/tools/class_start_diff.py --lang swift` -- 0 extra/missing after both fixes
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --lang swift --regenerate`
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --summary-table`
- [x] `python tests/tools/crucible_check.py` (both full_precision and zero_dependency) -- clean, zero diff
- [x] `python -m pytest tests/core_engine/ tests/extraction/` -- 6584 passed, 2 skipped, 11 xfailed, 3 xpassed
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key/ast-accuracy all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)