### PR TITLE
fix(1295-polish): powershell/scala class_start bugs, css/html shown as N/A

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -54,7 +54,7 @@ for the same metrics tracked over time across pushes to main.
 | Objective-C | 98.7% | 98.7% | 100.0% | 100.0% |
 | Perl | 70.6% | 99.9% | 100.0% | 100.0% |
 | Php | 100.0% | 99.9% | 100.0% | 96.6% |
-| Powershell | 69.1% | 92.7% | 0.0% | 0.0% |
+| Powershell | 69.1% | 92.7% | 100.0% | 100.0% |
 | Python | 99.7% | 99.2% | 99.6% | 100.0% |
 | Ruby | 100.0% | 90.7% | 100.0% | 83.3% |
 | Rust | 99.7% | 93.2% | 100.0% | 90.7% |
@@ -4028,7 +4028,12 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 re.I | re.M,
             ),
             # class_start: Object / Entity Declarations. Defines OO boundaries (Classes and Enums).
-            "class_start": re.compile(r"^[ \t]*(?:class|enum)\s+[a-zA-Z_]\w*", re.I | re.M),
+            # #1295-adjacent: no capture group around the name meant every match collapsed into
+            # "Anonymous_Class" in the named-extraction path -- powershell has been in
+            # _CLASS_START_NAMED_EXTRACTION_LANGS since #1264, but this specific gap was never
+            # caught (real_classes=5 in the corpus, found_classes=0). Purely additive change --
+            # doesn't alter which lines match or how many, only makes match.groups() richer.
+            "class_start": re.compile(r"^[ \t]*(?:class|enum)\s+([a-zA-Z_]\w*)", re.I | re.M),
             # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
             # safety: Defensive Programming. Strict mode, validation attributes, and null-conditional access (?.).
             "safety": re.compile(

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -427,7 +427,11 @@ NODE_MAPS = {
     "powershell": {
         "ts_lang": "powershell",
         "func_node_types": {"function_statement", "class_method_definition"},
-        "class_node_types": {"class_statement"},
+        # #1295: "enum_statement" was missing -- powershell's own class_start regex
+        # intentionally matches both class and enum declarations (see its comment), but only
+        # class_statement was in this set. Resolved via the existing simple_name-child branch
+        # in _get_node_name (same shape as class_statement, just a different node type).
+        "class_node_types": {"class_statement", "enum_statement"},
     },
     "solidity": {
         "ts_lang": "solidity",
@@ -762,7 +766,11 @@ def _get_node_name(node: Any) -> Optional[str]:
             if child.type == "function_name":
                 return child.text.decode("utf8")
         return None
-    if node.type in ("class_statement", "class_method_definition"):
+    # #1295: enum_statement has the identical no-name-field shape as class_statement above --
+    # powershell's own class_start regex already intentionally matches "class|enum" (its comment
+    # says "Defines OO boundaries (Classes and Enums)"), confirmed via
+    # core/packaging.psm1's MachineOSOverride/PackageManifestResultStatus enums.
+    if node.type in ("class_statement", "class_method_definition", "enum_statement"):
         for child in node.children:
             if child.type == "simple_name":
                 return child.text.decode("utf8")
@@ -1688,7 +1696,7 @@ def generate_chart_svg() -> str:
     row_h = 15
     bar_h = 9
     header_h = 34
-    top_margin = 96  # headroom for title + two-line scope note + color-scale legend
+    top_margin = 108  # headroom for title + three-line scope note + color-scale legend
     bottom_margin = 44
     left_margin = 16
     right_margin = 16
@@ -1714,9 +1722,13 @@ def generate_chart_svg() -> str:
         f"etc.), which are hardened and tested separately.</text>",
         f'<text class="scope-note" x="{left_margin}" y="64">Value labels are raw counts (found/real or '
         f"found/found+extra), not just a percentage, so each bar's sample size is visible at a glance.</text>",
-        f'<rect x="{left_margin}" y="72" width="140" height="8" rx="2" fill="url(#rainbow-legend)"/>',
-        f'<text class="legend-label" x="{left_margin}" y="88">0%</text>',
-        f'<text class="legend-label" x="{left_margin + 140}" y="88" text-anchor="end">100% (bar color = value)</text>',
+        f'<text class="scope-note" x="{left_margin}" y="76">css and html show 0% class recall/precision '
+        f"by DESIGN, not as an unfixed gap -- named class extraction was decided permanently out of "
+        f"scope for them (epic #1295): their class_start targets selectors/tags, not OOP-shaped "
+        f"entities. See tests/extraction/how_to_extend_class_start_named_extraction.md.</text>",
+        f'<rect x="{left_margin}" y="84" width="140" height="8" rx="2" fill="url(#rainbow-legend)"/>',
+        f'<text class="legend-label" x="{left_margin}" y="100">0%</text>',
+        f'<text class="legend-label" x="{left_margin + 140}" y="100" text-anchor="end">100% (bar color = value)</text>',
     ]
 
     for j, (key, title, num_field, den_field) in enumerate(_CHART_METRICS):

--- a/tests/tree_sitter_accuracy_baseline_powershell.json
+++ b/tests/tree_sitter_accuracy_baseline_powershell.json
@@ -2,11 +2,11 @@
   "args_comparable": 76,
   "args_exact_match": 71,
   "corpus_path": "language-crucible/data/powershell",
-  "extra_classes": 1,
+  "extra_classes": 0,
   "extra_functions": 6,
   "files_scanned": 6,
-  "found_classes": 0,
+  "found_classes": 7,
   "found_functions": 76,
-  "real_classes": 5,
+  "real_classes": 7,
   "real_functions": 110
 }


### PR DESCRIPTION
## Summary

Started as a fix for two things flagged in the tree-sitter accuracy graph (css showing 0%, powershell showing 0%), expanded into a full polish pass over the whole class-extraction system per request.

### PowerShell -- real bug, fixed
Been in the extraction allowlist since #1264, but its `class_start` regex never had a capture group -- every match collapsed into a nameless placeholder. Also missing `enum` from ground truth despite its own regex matching `class|enum`. `real_classes`/`found_classes` 5→7, perfect match. 69.1%/92.7%/**0.0%/0.0%** → 69.1%/92.7%/**100.0%/100.0%**.

### Scala -- real bug, found during the polish pass, fixed
Not part of the original ask, but the polish pass caught it: scala's `class_start` modifier list was missing `private`/`protected` (including the qualified `private[scope]` form) -- its own `func_start` regex right above it already handles this correctly, `class_start` just never got the same list. `real_classes`/`found_classes` 12→17, perfect match. 100.0%/100.0%/**70.6%/100.0%** → 100.0%/100.0%/**100.0%/100.0%**. Golden master re-blessed (kafka files' class counts increased as expected).

### CSS/HTML -- not bugs, now displayed correctly
Their 0% class recall/precision was a documented design decision (epic #1295's "permanently out of scope" call), not a gap -- but showing "0.0%" was misleading (css genuinely has 90 real classes in its ground truth; GitGalaxy just never attempts extraction there by design). Added `_CLASS_EXTRACTION_OUT_OF_SCOPE` and now both the chart panels and the markdown summary table show **N/A** on the class columns for these two specifically -- func_start numbers are untouched (that extraction IS in scope and measured for both).

### Full-system scan (the "polish" pass)
Ran `--all --ci` across all 31 baselined languages (clean) and spot-checked every remaining non-100%/non-N/A class number against `class_start_diff.py`:
- **csharp** (89.5%/56.7%) -- confirmed matches the already-documented #1264 enum precedent exactly, no new issue.
- **cpp** (98.6%/92.6%) -- found some real-looking gaps (union/scoped-enum/template-specialization naming). Did NOT fix here -- template name synthesis is genuinely complex and deserves its own dedicated investigation, not a quick fold-in to this PR. Flagging as a follow-up.
- Every other non-100% number (C, ruby, rust, zig) already traces to documented, accepted gaps from this epic's own earlier PRs.
- groovy/lua showing all-N/A is a language-crucible corpus availability issue (0 files scanned), not a code bug -- can't be fixed from this repo.
- makefile/shell (no OOP concept) and matlab (0 `classdef` files in its small corpus sample) are legitimately N/A, confirmed not measurement bugs.

## Verification

- `python tests/tools/tree_sitter_accuracy_audit.py --all --ci` -- clean across all 31 languages
- `python tests/tools/class_start_diff.py --lang powershell` / `--lang scala` -- perfect matches
- `python tests/tools/crucible_check.py` -- both modes PASS (after `--update` for scala's expected golden-master drift)
- `python tests/tools/audit_check.py --regenerate` -- clean
- `python -m pytest tests/core_engine/ tests/extraction/` -- 6585 passed, including powershell's and scala's own dedicated test suites (153 tests each)
- Chart/summary-table generators smoke-tested locally

## Test plan

- [x] `class_start_diff.py` perfect match for powershell and scala
- [x] `tree_sitter_accuracy_audit.py --all --ci` clean (all 31 languages)
- [x] `crucible_check.py` both modes clean
- [x] `audit_check.py` clean
- [x] Full `core_engine`/`extraction` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)