### PR TITLE
fix(tree-sitter-audit): add dart's 3 constructor node types to ground truth

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -39,7 +39,7 @@ for the same metrics tracked over time across pushes to main.
 | Cpp | 93.4% | 95.4% | 98.6% | 92.6% |
 | Csharp | 99.5% | 65.0% | 91.7% | 73.3% |
 | Css | 100.0% | 100.0% | N/A | N/A |
-| Dart | 93.8% | 68.7% | 100.0% | 100.0% |
+| Dart | 79.8% | 71.5% | 100.0% | 100.0% |
 | Fortran | 98.3% | 88.1% | 100.0% | 100.0% |
 | Go | 95.6% | 100.0% | 82.1% | 100.0% |
 | Groovy | N/A | N/A | N/A | N/A |

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -366,7 +366,18 @@ NODE_MAPS = {
     },
     "dart": {
         "ts_lang": "dart",
-        "func_node_types": {"function_signature", "local_function_declaration", "method_signature"},
+        # constructor_signature/constant_constructor_signature/factory_constructor_signature: dart
+        # constructors (`Foo()`, `const Foo.raw()`, `factory Foo.create()`) get their own node
+        # types, distinct from function_signature/method_signature -- see _get_node_name's dart
+        # constructor branch for why they were entirely invisible to real_functions before this.
+        "func_node_types": {
+            "function_signature",
+            "local_function_declaration",
+            "method_signature",
+            "constructor_signature",
+            "constant_constructor_signature",
+            "factory_constructor_signature",
+        },
         # #1295: dart's `mixin` declarations get their own `mixin_declaration` node type, and
         # `enum` declarations get `enum_declaration` -- distinct from `class_definition`, real
         # named class-like entities GitGalaxy's own class_start regex intentionally matches,
@@ -852,6 +863,21 @@ def _get_node_name(node: Any) -> Optional[str]:
             if child.type == "identifier":
                 return child.text.decode("utf8")
         return None
+
+    # dart's three constructor node types have no "name" field either -- the class name (and,
+    # for a named/factory constructor, the constructor name after the dot) both sit as plainly-
+    # typed "identifier" children in source order, so joining them with "." reconstructs exactly
+    # the string GitGalaxy's own func_start regex captures (e.g. "ThemeData.dark", or just
+    # "ThemeData" for the unnamed/default constructor). factory_constructor_signature nests
+    # inside a method_signature wrapper that itself has no name field and returns None above --
+    # walk() still finds this inner node directly since it's listed in func_node_types too.
+    # Confirmed via flutter/theme_data.dart: `factory ThemeData.dark(...)` and
+    # `const ThemeData.raw(...)` were both entirely invisible to real_functions before this,
+    # scoring every real constructor as a false "extra" (a ground-truth gap, not a GitGalaxy
+    # engine defect -- same shape as #1314's csharp constructor_declaration fix).
+    if node.type in ("constructor_signature", "constant_constructor_signature", "factory_constructor_signature"):
+        parts = [child.text.decode("utf8") for child in node.children if child.type == "identifier"]
+        return ".".join(parts) if parts else None
 
     return None
 

--- a/tests/tree_sitter_accuracy_baseline_dart.json
+++ b/tests/tree_sitter_accuracy_baseline_dart.json
@@ -1,12 +1,12 @@
 {
-  "args_comparable": 677,
-  "args_exact_match": 608,
+  "args_comparable": 705,
+  "args_exact_match": 618,
   "corpus_path": "language-crucible/data/dart",
   "extra_classes": 0,
-  "extra_functions": 309,
+  "extra_functions": 281,
   "files_scanned": 7,
   "found_classes": 200,
-  "found_functions": 677,
+  "found_functions": 705,
   "real_classes": 200,
-  "real_functions": 722
+  "real_functions": 884
 }


### PR DESCRIPTION
## Summary
- Adds `constructor_signature`/`constant_constructor_signature`/`factory_constructor_signature` to dart's `NODE_MAPS["dart"]["func_node_types"]`, plus a `_get_node_name` branch that composes the dotted `ClassName.constructorName` string (or bare `ClassName` for the unnamed constructor) from their plainly-typed `identifier` children.
- Audit-tool ground-truth fix only, no engine (`gitgalaxy/`) change -- same shape as #1314's csharp `constructor_declaration` fix.

Measured: `found_functions` 677->705, `extra_functions` 309->281, `real_functions` 722->884 (class_precision unaffected, `extra_classes` stayed 0).

Fixes #1477.

## Test plan
- [x] `tree_sitter_accuracy_audit.py --lang dart` shows the numbers above, `--regenerate` blessed
- [x] `--summary-table` regenerated
- [x] `--all --ci` clean across all 31 languages (no shared-helper ripple -- this only touches the dart-specific NODE_MAPS entry and a dart-gated `_get_node_name` branch)