### PR TITLE
fix(tree-sitter-audit): scope go's type_declaration ground truth to struct/interface only

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -41,7 +41,7 @@ for the same metrics tracked over time across pushes to main.
 | Css | 100.0% | 100.0% | N/A | N/A |
 | Dart | 79.8% | 71.5% | 100.0% | 100.0% |
 | Fortran | 98.3% | 88.1% | 100.0% | 100.0% |
-| Go | 95.6% | 100.0% | 82.1% | 100.0% |
+| Go | 95.6% | 100.0% | 100.0% | 100.0% |
 | Groovy | N/A | N/A | N/A | N/A |
 | Haskell | 56.4% | 65.4% | 100.0% | 100.0% |
 | Html | N/A | N/A | N/A | N/A |

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -818,9 +818,21 @@ def _get_node_name(node: Any) -> Optional[str]:
     # `type ScheduleResult struct {...}` real_classes measured 0 pre-fix despite the corpus
     # obviously containing real struct/interface declarations -- a ground-truth measurement gap,
     # not evidence GitGalaxy's own class_start regex was wrong.
+    #
+    # Only struct_type/interface_type type_specs count, though: GitGalaxy's own go class_start
+    # regex deliberately anchors on `type IDENT (struct|interface)` and never matches a plain
+    # type alias (`type gcMode int32`) or a function type (`type HandlerFunc func(...)`) --
+    # counting every type_spec here (the pre-fix behavior) treated those aliases as real classes
+    # too, scoring every one of them as a false "missing" class. Same "Class 5" ground-truth
+    # scope-mismatch shape as the csharp enum / css-html precedents. Confirmed via
+    # core/mgc.go's `type gcMode int32` and `type HandlerFunc func(...)`-shaped aliases in
+    # net/http-style corpus files -- none are matched by GitGalaxy, correctly.
     if node.type == "type_declaration":
         for child in node.children:
             if child.type == "type_spec":
+                type_node = child.child_by_field_name("type")
+                if type_node is None or type_node.type not in ("struct_type", "interface_type"):
+                    continue
                 name_node = child.child_by_field_name("name")
                 if name_node:
                     return name_node.text.decode("utf8")

--- a/tests/tree_sitter_accuracy_baseline_go.json
+++ b/tests/tree_sitter_accuracy_baseline_go.json
@@ -7,6 +7,6 @@
   "files_scanned": 14,
   "found_classes": 69,
   "found_functions": 817,
-  "real_classes": 84,
+  "real_classes": 69,
   "real_functions": 855
 }


### PR DESCRIPTION
## Summary
- Scopes `_get_node_name`'s go `type_declaration` handling to only count `type_spec` children whose `type` field is `struct_type` or `interface_type` -- matching GitGalaxy's own `class_start` regex, which only ever matches `type IDENT (struct|interface)` and never a plain alias or function type.
- Audit-tool ground-truth fix only, no engine (`gitgalaxy/`) change -- same "Class 5" scope-mismatch shape as the csharp-enum/css-html precedents documented in epic #1295.

Measured: `real_classes` 84->69 (now exactly matches `found_classes`), class_recall 82.1%->100%.

Fixes #1483.

## Test plan
- [x] `tree_sitter_accuracy_audit.py --lang go` shows class_recall now 100%, `--regenerate` blessed
- [x] `--summary-table` regenerated
- [x] `--all --ci` clean across all 31 languages