### PR TITLE
fix(tree_sitter_accuracy_audit): args ground-truth gaps for solidity/tcl/haskell/ruby

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -51,7 +51,7 @@ for the same metrics tracked over time across pushes to main.
 | Lua | N/A | N/A | N/A | N/A |
 | Makefile | 100.0% | 100.0% | N/A | N/A |
 | Matlab | 100.0% | 71.9% | N/A | N/A |
-| Objective-C | 98.7% | 98.7% | 100.0% | 100.0% |
+| Objective-C | 98.7% | 99.3% | 100.0% | 100.0% |
 | Perl | 93.2% | 99.9% | 100.0% | 100.0% |
 | Php | 100.0% | 99.9% | 100.0% | 96.6% |
 | Powershell | 100.0% | 99.1% | 100.0% | 100.0% |

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -991,6 +991,10 @@ def _get_param_count(node: Any) -> int:
         #   - "optional_parameter"/"splat_parameter"/"hash_splat_parameter"/"block_parameter":
         #     ruby's `method_parameters` (only the plain, no-default case is a bare "identifier";
         #     `y=1`, `*rest`, `**kw`, `&blk` are each their own wrapper type).
+        #   - "keyword_parameter": ruby's own keyword-argument form (#1506, follow-on gap from
+        #     this same #1339 whitelist -- missed the first time around). Covers BOTH the
+        #     optional (`k: v`) and required (`k:`, no default) forms, which tree-sitter-ruby
+        #     represents with the identical node type -- no `value`-field branching needed.
         #   - "variadic_parameter_declaration": go's `parameter_list` (`y ...string`, distinct
         #     from the plain "parameter_declaration" already counted above).
         # Confirmed via language-crucible for each: e.g. csharp's
@@ -1014,6 +1018,7 @@ def _get_param_count(node: Any) -> int:
             "hash_splat_parameter",
             "block_parameter",
             "variadic_parameter_declaration",
+            "keyword_parameter",
         )
         # #1319: rust's `function_item`/`function_signature_item` parameter list ALSO uses
         # "parameter" (now covered by the base set above) plus "self_parameter" (the receiver
@@ -1082,6 +1087,41 @@ def _get_param_count(node: Any) -> int:
         # `_count_colon_selector_segments`), manufacturing a false args-mismatch on nearly
         # every non-nullary method in the corpus.
         return sum(1 for child in node.children if child.type == "method_parameter")
+    elif node.type == "procedure":
+        # #1504: tcl's grammar exposes the parameter list under a field named "arguments", not
+        # "parameters" -- wraps one "argument" child per parameter (each wrapping a plain
+        # "simple_word"; Tcl has no destructuring/default-value/variadic-marker parameter shapes
+        # to special-case -- even the `args`-as-final-parameter convention is still just a plain
+        # argument/simple_word like any other).
+        arguments_node = node.child_by_field_name("arguments")
+        if arguments_node:
+            return sum(1 for child in arguments_node.children if child.type == "argument")
+    elif node.type == "function":
+        # #1505: haskell's grammar reuses the "function" node TYPE for two unrelated shapes,
+        # both inside func_node_types = {"function"}: an arrow-chain TYPE EXPRESSION nested
+        # inside a `signature` node (fields parameter/arrow/result, no "name" field of its own --
+        # already filtered out by _get_node_name returning None for it, so it never reaches
+        # here), and the REAL function equation (e.g. `configureCommonState a b = return ()`),
+        # whose fields are name/patterns/match. The "patterns" field wraps one child per
+        # parameter -- every named child (plain "variable", wildcard "_", a literal/constructor
+        # pattern like in `f 0 = ...`, etc.) is exactly one parameter position, so count all of
+        # them unconditionally rather than filtering by a specific pattern-node-type whitelist.
+        patterns_node = node.child_by_field_name("patterns")
+        if patterns_node:
+            return len(patterns_node.named_children)
+    elif node.type in ("function_definition", "modifier_definition", "constructor_definition"):
+        # #1503: solidity's function/modifier/constructor nodes have no "parameters" field at
+        # all -- individual "parameter" nodes are bare, unwrapped, field-less direct children,
+        # sitting alongside sibling fields like visibility/state_mutability/return_type_definition.
+        # Only reached when no `parameters` field / C-style declarator / matlab-style
+        # `function_arguments` child matched above -- the other "function_definition"-using
+        # languages (c/cpp/python/matlab/scala) already resolve via one of those and never fall
+        # through to here (shell's parameterless bash function_definition also reaches here, but
+        # has no "parameter"-typed children either way, so this is a harmless no-op for it).
+        # Direct (non-recursive) child scan only, so `return_type_definition`'s own nested
+        # "parameter" node(s) -- the `returns (...)` list -- are correctly excluded (they're
+        # grandchildren, not direct children, of the function/modifier/constructor node).
+        return sum(1 for child in node.children if child.type == "parameter")
 
     return 0
 

--- a/tests/tree_sitter_accuracy_baseline_haskell.json
+++ b/tests/tree_sitter_accuracy_baseline_haskell.json
@@ -1,6 +1,6 @@
 {
   "args_comparable": 81,
-  "args_exact_match": 31,
+  "args_exact_match": 43,
   "corpus_path": "language-crucible/data/haskell",
   "extra_classes": 0,
   "extra_functions": 29,

--- a/tests/tree_sitter_accuracy_baseline_objective-c.json
+++ b/tests/tree_sitter_accuracy_baseline_objective-c.json
@@ -1,9 +1,9 @@
 {
   "args_comparable": 149,
-  "args_exact_match": 110,
+  "args_exact_match": 148,
   "corpus_path": "language-crucible/data/objective-c",
   "extra_classes": 0,
-  "extra_functions": 2,
+  "extra_functions": 1,
   "files_scanned": 5,
   "found_classes": 5,
   "found_functions": 149,

--- a/tests/tree_sitter_accuracy_baseline_ruby.json
+++ b/tests/tree_sitter_accuracy_baseline_ruby.json
@@ -1,6 +1,6 @@
 {
   "args_comparable": 117,
-  "args_exact_match": 89,
+  "args_exact_match": 106,
   "corpus_path": "language-crucible/data/ruby",
   "extra_classes": 0,
   "extra_functions": 12,

--- a/tests/tree_sitter_accuracy_baseline_solidity.json
+++ b/tests/tree_sitter_accuracy_baseline_solidity.json
@@ -1,6 +1,6 @@
 {
   "args_comparable": 95,
-  "args_exact_match": 22,
+  "args_exact_match": 95,
   "corpus_path": "language-crucible/data/solidity",
   "extra_classes": 0,
   "extra_functions": 6,

--- a/tests/tree_sitter_accuracy_baseline_tcl.json
+++ b/tests/tree_sitter_accuracy_baseline_tcl.json
@@ -1,6 +1,6 @@
 {
   "args_comparable": 141,
-  "args_exact_match": 42,
+  "args_exact_match": 118,
   "corpus_path": "language-crucible/data/tcl",
   "extra_classes": 0,
   "extra_functions": 2,


### PR DESCRIPTION
## Summary

`_get_param_count()` in `tests/tools/tree_sitter_accuracy_audit.py` (the args-counting *ground truth*, not GitGalaxy's actual engine) only knew how to find a parameter list via a `parameters` field or a C-style declarator. Four real per-language shapes fell through and silently measured `0` real params regardless of true arity:

- **solidity** (#1503): `function_definition`/`modifier_definition`/`constructor_definition` have no `parameters` field -- params are bare, field-less `parameter` children. `args_exact_match`: 22/95 → **95/95**.
- **tcl** (#1504): `procedure`'s param-list field is named `arguments`, not `parameters`. `args_exact_match`: 42/141 → **118/141**.
- **haskell** (#1505): the real function-equation `function` node's params live in a `patterns` field (distinct from the same-named arrow-chain type-expression node inside a `signature`, which has no `name` field and was already correctly excluded from `real_funcs`). `args_exact_match`: 31/81 → **43/81**.
- **ruby** (#1506): `keyword_parameter` was missing from the `counted_types` whitelist -- a follow-on gap from #1339 (which added ruby's other parameter wrapper types but missed this one). `args_exact_match`: 89/117 → **106/117**.

**Bonus**: the solidity fix's fallback branch is gated on the shared node type `function_definition`, which objective-c also uses for its C-style plain functions -- some objc functions whose declarator-based extraction failed also now resolve correctly via the same fallback: `args_exact_match` 110/149 → **148/149**.

## Process note

All 4 were originally scoped as separate issues for a 4-way parallel Gemini dispatch (this repo's usual pattern for independent per-language fixes), but since all 4 land in the exact same function and I'd already fully root-caused each one, implementing them directly was faster and avoided guaranteed same-function merge conflicts across 4 PRs -- so this is one PR covering all 4 issues plus the objc bonus.

## Remaining gaps (filed separately, not fixed here)

Fixing the ground truth surfaced two genuine GitGalaxy *engine*-side bugs that were previously masked by the ground truth itself under-measuring:
- haskell: `let`/`where`-local functions with no `::` type signature (e.g. `isPandocCiteproc`) measure `real=1 got=0` -- GitGalaxy's args regex relies on arrow-counting a `::` signature that doesn't exist for these.
- tcl: default-value braced parameters (e.g. `proc foo {{db db}}`) measure `real=1 got=2` -- GitGalaxy's args regex appears to split on whitespace inside the default-value braces instead of treating `{db db}` as one parameter.

Out of scope for this PR (ground-truth-only fix); will file follow-ups.

## Verification

```
tree_sitter_accuracy_audit --lang solidity/tcl/haskell/ruby/objective-c --regenerate   # each bcommitted
tree_sitter_accuracy_audit --all --ci     # all 31 baselined languages clean, no cross-language regressions
tree_sitter_accuracy_audit --summary-table  # docstring table refreshed
tests/tools/audit_check.py --ci           # ruff/mypy/dead-key/ast-accuracy all clean (pre-existing baseline only)
```

No `crucible_check.py`/golden-master diffing needed -- this only touches the accuracy-measurement tool itself, not GitGalaxy's parsing engine.

Fixes #1503, #1504, #1505, #1506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)