### PR TITLE
fix(tests): python's tree-sitter args-counter only measured bare identifiers

### DIFF
--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -1129,6 +1129,22 @@ def _get_param_count(node: Any, lang: str = "") -> int:
         # Confirmed via language-crucible for each: e.g. csharp's
         # `GetParseDiagnostics(CancellationToken cancellationToken = default)` measured real=0
         # against GitGalaxy's correct got=1 pre-fix.
+        #   - "typed_parameter"/"default_parameter"/"typed_default_parameter": python's own
+        #     `parameters` field wraps every non-bare parameter in one of these three (a plain
+        #     `x` is still a bare "identifier", already covered, but `x: int`, `x=1`, and
+        #     `x: int = 1` each get their own wrapper type) -- since python routes through this
+        #     branch directly (its `function_definition` has a real "parameters" field, unlike
+        #     the C-family/other grammars needing the special-cased branches below), it inherited
+        #     this same #1319/#1339-shaped gap despite predating both fixes: only bare untyped,
+        #     no-default params were ever counted, silently measuring real=2 against a true
+        #     arity of 7 for `def foo(a, b: int, c=1, d: str = "x", *args, e, **kwargs)`.
+        #   - "list_splat_pattern"/"dictionary_splat_pattern": python's `*args`/`**kwargs`,
+        #     distinct wrapper types from the three above (no default/type-annotation shape to
+        #     merge into). `positional_separator` (bare `/`) and `keyword_separator` (bare `*`
+        #     with no following name) are deliberately NOT added here -- they're arity markers,
+        #     not parameters, and GitGalaxy's own `_count_top_level_args` doesn't count them
+        #     either, so leaving them out of this whitelist keeps both counts on the same
+        #     convention.
         counted_types = (
             "identifier",
             "assignment_pattern",
@@ -1148,6 +1164,11 @@ def _get_param_count(node: Any, lang: str = "") -> int:
             "block_parameter",
             "variadic_parameter_declaration",
             "keyword_parameter",
+            "typed_parameter",
+            "default_parameter",
+            "typed_default_parameter",
+            "list_splat_pattern",
+            "dictionary_splat_pattern",
         )
         # #1319: rust's `function_item`/`function_signature_item` parameter list ALSO uses
         # "parameter" (now covered by the base set above) plus "self_parameter" (the receiver

--- a/tests/tree_sitter_accuracy_baseline_python.json
+++ b/tests/tree_sitter_accuracy_baseline_python.json
@@ -1,6 +1,6 @@
 {
   "args_comparable": 2966,
-  "args_exact_match": 1868,
+  "args_exact_match": 2926,
   "corpus_path": "language-crucible/data/python",
   "extra_classes": 0,
   "extra_functions": 24,


### PR DESCRIPTION
## Summary
- `_get_param_count()` in `tests/tools/tree_sitter_accuracy_audit.py` resolves python's
  `function_definition` parameter list directly via the generic `parameters`-field branch, but
  that branch's `counted_types` whitelist only had JS/C-family node type names — none of
  tree-sitter-python's own per-parameter wrapper types (`typed_parameter`, `default_parameter`,
  `typed_default_parameter`, `list_splat_pattern`, `dictionary_splat_pattern`). Only a fully bare
  `x` (no type, no default) was ever counted.
- Same false-defect shape as #1319/#1339, just never caught for python since it routes through the
  generic top-level branch instead of one of the special-cased fallback branches those issues
  audited.
- This is a bug in the **audit tool**, not GitGalaxy's own `args` regex (`detector.py`'s
  `_count_top_level_args` was already correct) — but it manufactured a large volume of false
  args-count mismatches on the language-crucible python corpus, where most real functions use type
  hints, defaults, or `*args`/`**kwargs`.
- `args_exact_match` rises from 63.0% (1868/2966) to 98.6% (2926/2966). No regressions on the other
  gated metrics (`found_functions`/`extra_functions`/`found_classes`/`extra_classes` untouched by
  this branch).
- Baseline regenerated via `--regenerate`.

Fixes #1524.

## Test plan
- [x] Verified fix directly against a hand-built repro (`def foo(a, b: int, c=1, d: str = "x", *args, e, **kwargs)`: measured 2 → 7; `def bar(a, /, b, *, c, **kwargs)`: measured 3 → 4)
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --lang python` — no regressions, args_exact_match 1868 → 2926
- [x] `python tests/ruff_audit.py --ci` — no new findings
- [x] `python tests/mypy_audit.py --ci` — no new errors
- [x] Not a parsing-logic change (test tooling only) — no differential scan / golden master regen needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)