### PR TITLE
fix(testing): dart named/factory constructor names no longer truncated

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -39,7 +39,7 @@ for the same metrics tracked over time across pushes to main.
 | Cpp | 92.3% | 95.7% | 98.6% | 92.6% |
 | Csharp | 99.2% | 99.8% | 91.7% | 73.3% |
 | Css | 100.0% | 100.0% | N/A | N/A |
-| Dart | 93.9% | 72.1% | 100.0% | 100.0% |
+| Dart | 94.5% | 72.6% | 100.0% | 100.0% |
 | Fortran | 98.4% | 88.3% | 100.0% | 100.0% |
 | Go | 95.7% | 100.0% | 100.0% | 100.0% |
 | Groovy | N/A | N/A | N/A | N/A |

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -794,6 +794,29 @@ def _get_node_name(node: Any) -> Optional[str]:
             return None
         return name_node.text.decode("utf8")
 
+    if node.type in ("constructor_signature", "constant_constructor_signature", "factory_constructor_signature"):
+        # #1569: checked first, ahead of the generic "name" field fast path below -- it would
+        # otherwise intercept `constructor_signature` first (see next paragraph) and return only
+        # the bare class name. Joins every direct "identifier"-typed child by "." instead
+        # (matching the string GitGalaxy's own func_start regex captures, e.g.
+        # "TextEditingController.fromValue", or just "TextEditingController" for the unnamed/
+        # default constructor) -- a type-based scan, not field-based, because the three dart
+        # constructor node types disagree on field tagging: `constructor_signature` tags its
+        # class-name identifier, ".", AND constructor-name identifier all with the SAME field
+        # name "name" (confirmed via field_name_for_child), while `constant_constructor_signature`
+        # and `factory_constructor_signature` tag NONE of their children with any field name at
+        # all (also confirmed directly) -- so a `children_by_field_name("name")` version works
+        # for the first node type and silently returns nothing for the other two.
+        #
+        # Why this matters: the generic fast path's `child_by_field_name("name")` only returns
+        # the FIRST field-tagged match, so for `constructor_signature` specifically it truncates
+        # every named/factory constructor down to just the bare class name -- which then collides
+        # with the class's own default constructor (both would resolve to e.g.
+        # "TextEditingController", even though GitGalaxy correctly emits the distinct
+        # "TextEditingController.fromValue" for the named one).
+        parts = [child.text.decode("utf8") for child in node.children if child.type == "identifier"]
+        return ".".join(parts) if parts else None
+
     name_node = node.child_by_field_name("name")
     if name_node:
         return name_node.text.decode("utf8")
@@ -1018,21 +1041,6 @@ def _get_node_name(node: Any) -> Optional[str]:
             if child.type == "identifier":
                 return child.text.decode("utf8")
         return None
-
-    # dart's three constructor node types have no "name" field either -- the class name (and,
-    # for a named/factory constructor, the constructor name after the dot) both sit as plainly-
-    # typed "identifier" children in source order, so joining them with "." reconstructs exactly
-    # the string GitGalaxy's own func_start regex captures (e.g. "ThemeData.dark", or just
-    # "ThemeData" for the unnamed/default constructor). factory_constructor_signature nests
-    # inside a method_signature wrapper that itself has no name field and returns None above --
-    # walk() still finds this inner node directly since it's listed in func_node_types too.
-    # Confirmed via flutter/theme_data.dart: `factory ThemeData.dark(...)` and
-    # `const ThemeData.raw(...)` were both entirely invisible to real_functions before this,
-    # scoring every real constructor as a false "extra" (a ground-truth gap, not a GitGalaxy
-    # engine defect -- same shape as #1314's csharp constructor_declaration fix).
-    if node.type in ("constructor_signature", "constant_constructor_signature", "factory_constructor_signature"):
-        parts = [child.text.decode("utf8") for child in node.children if child.type == "identifier"]
-        return ".".join(parts) if parts else None
 
     return None
 

--- a/tests/tree_sitter_accuracy_baseline_dart.json
+++ b/tests/tree_sitter_accuracy_baseline_dart.json
@@ -1,12 +1,12 @@
 {
-  "args_comparable": 1100,
-  "args_exact_match": 865,
+  "args_comparable": 1108,
+  "args_exact_match": 871,
   "corpus_path": "language-crucible/data/dart",
   "extra_classes": 0,
-  "extra_functions": 426,
+  "extra_functions": 418,
   "files_scanned": 7,
   "found_classes": 200,
-  "found_functions": 1100,
+  "found_functions": 1108,
   "real_classes": 200,
   "real_functions": 1172
 }


### PR DESCRIPTION
## Summary
- `_get_node_name`'s generic `"name"` field fast path intercepted dart's `constructor_signature` nodes before the dedicated (but unreachable) dart branch further down could run. tree-sitter-dart tags a named constructor's class-name identifier, `.`, AND constructor-name identifier all with the SAME field name `"name"` — `child_by_field_name` only returns the FIRST match, silently truncating e.g. `"TextEditingController.fromValue"` down to just `"TextEditingController"`. That collided with the class's own default constructor, making every correctly-detected named/factory constructor look like a false "extra" with no real ground-truth counterpart to pair against.
- Moved the dart constructor check to the top of `_get_node_name`, and fixed it to scan children by TYPE (`"identifier"`) rather than by field name: `constructor_signature` tags all its identifiers with field `"name"`, but `constant_constructor_signature`/`factory_constructor_signature` tag none of their children with any field name at all (confirmed directly against real parse trees) — a field-based version silently returned nothing for those two node types.
- dart: `found_functions` 1100 → 1108, `extra_functions` 426 → 418.

Fixes #1569

## Test plan
- [x] Verified all 5 constructor shapes (default, named, const-named, factory-named, and the collision case) directly against `tree_sitter_language_pack`
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --lang dart` — baseline regenerated, numbers above
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --all --ci` — all 31 languages pass
- [x] `--summary-table` regenerated (dart row only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)