### PR TITLE
fix(testing): collapse haskell multi-clause equations in tree_sitter_accuracy_audit ground truth

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -43,7 +43,7 @@ for the same metrics tracked over time across pushes to main.
 | Fortran | 98.4% | 88.3% | 100.0% | 100.0% |
 | Go | 95.7% | 100.0% | 100.0% | 100.0% |
 | Groovy | N/A | N/A | N/A | N/A |
-| Haskell | 47.3% | 94.9% | 100.0% | 100.0% |
+| Haskell | 95.2% | 98.6% | 100.0% | 100.0% |
 | Html | N/A | N/A | N/A | N/A |
 | Java | 99.1% | 100.0% | 100.0% | 100.0% |
 | Javascript | 85.1% | 98.2% | 100.0% | 100.0% |

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -1610,7 +1610,7 @@ def measure(lang: str, verbose: bool = False) -> dict:
                 real_funcs: dict[str, list[tuple[int, int]]] = {}
                 real_classes: set[str] = set()
 
-                def walk(node):
+                def walk(node, is_continuation_clause=False):
                     if node.type in func_node_types:
                         # #1608: perl's `subroutine_declaration_statement`/
                         # `method_declaration_statement` node types cover BOTH a real
@@ -1633,6 +1633,31 @@ def measure(lang: str, verbose: bool = False) -> dict:
                         # body-bearing occurrence is ever in GitGalaxy's own output.
                         if lang == "perl" and node.child_by_field_name("body") is None:
                             pass
+                        # #1614: haskell represents each pattern-matched EQUATION CLAUSE
+                        # of a single function as its own separate node (`deNote (Note _)
+                        # = ...` and `deNote x = ...` are two sibling `function` nodes
+                        # under the same `declarations`/`local_binds` parent, confirmed by
+                        # direct tree_sitter_language_pack parse) -- there is no single
+                        # grammar node representing "deNote, the function" as one unit.
+                        # GitGalaxy's own `_slice_by_indentation` (detector.py) already
+                        # merges every clause of one function into ONE reported
+                        # FunctionNode by design (#1442's own comment: "clauses 2..N would
+                        # otherwise each spawn their own duplicate, overlapping
+                        # FunctionNode"), so counting each clause as its own real
+                        # occurrence here compares GitGalaxy's correct, merged output
+                        # against an artificially inflated ground truth -- every
+                        # multi-clause function loses (clauses - 1) "real" credit it never
+                        # actually lacked. `is_continuation_clause` (set by the sibling
+                        # loop below, which is the only thing that can determine
+                        # adjacency) marks exactly this case; skip re-counting it as a
+                        # distinct occurrence, matching GitGalaxy's own semantics instead
+                        # of the grammar's raw per-clause node granularity. Measured
+                        # impact on language-crucible/data/haskell/pandoc: recall
+                        # 50.5% (275 real/139 found) -> 95.2% (146 real/139 found), same
+                        # GitGalaxy output, same alignment algorithm. See
+                        # docs/why_gitgalaxy_beats_ast_here.md Claim 4.
+                        elif lang == "haskell" and is_continuation_clause:
+                            pass
                         else:
                             name = _get_node_name(node)
                             if name:
@@ -1646,8 +1671,30 @@ def measure(lang: str, verbose: bool = False) -> dict:
                             name = _get_node_name(node)
                             if name:
                                 real_classes.add(name)
+
+                    # #1614: track the most recently seen func-type sibling's name so a
+                    # consecutive same-name clause (haskell only) can be recognized as a
+                    # continuation rather than a new function. `comment` siblings are
+                    # skipped without resetting this -- real corpus code routinely
+                    # interleaves a trailing-line comment between two equation clauses
+                    # (e.g. Shared.hs's `go (RawInline ...) = " " -- see #2105` followed
+                    # by `go LineBreak = " "`), and tree-sitter emits that comment as its
+                    # own sibling node in between, which would otherwise wrongly split one
+                    # real clause-group into two.
+                    last_clause_name: Optional[str] = None
                     for child in node.children:
-                        walk(child)
+                        if lang == "haskell" and child.type == "comment":
+                            walk(child)
+                            continue
+                        child_is_continuation = False
+                        if lang == "haskell" and child.type in func_node_types:
+                            child_name = _get_node_name(child)
+                            if child_name is not None and child_name == last_clause_name:
+                                child_is_continuation = True
+                            last_clause_name = child_name
+                        else:
+                            last_clause_name = None
+                        walk(child, is_continuation_clause=child_is_continuation)
 
                 walk(tree.root_node)
 

--- a/tests/tree_sitter_accuracy_baseline_haskell.json
+++ b/tests/tree_sitter_accuracy_baseline_haskell.json
@@ -1,12 +1,12 @@
 {
-  "args_comparable": 130,
-  "args_exact_match": 120,
+  "args_comparable": 139,
+  "args_exact_match": 129,
   "corpus_path": "language-crucible/data/haskell",
   "extra_classes": 0,
-  "extra_functions": 7,
+  "extra_functions": 2,
   "files_scanned": 7,
   "found_classes": 16,
-  "found_functions": 130,
+  "found_functions": 139,
   "real_classes": 16,
-  "real_functions": 275
+  "real_functions": 146
 }


### PR DESCRIPTION
## Summary
Fixes #1614. `tests/tools/tree_sitter_accuracy_audit.py`'s haskell ground truth counted each pattern-matched equation *clause* of a multi-clause function as its own separate real function (tree-sitter-haskell gives each clause its own `function` node), while GitGalaxy's `detector.py` deliberately merges all clauses of one function into a single reported `FunctionNode` (#1442). This made every idiomatic multi-clause Haskell function score as a partial "miss."

- Threads an `is_continuation_clause` flag through `measure()`'s `walk()` recursion, set by tracking the previous func-type sibling's name per parent — gated strictly to `lang == "haskell"`.
- Comment nodes interleaved between two equation clauses (a real corpus shape — e.g. a trailing `-- see #2105` between two `go` equations in pandoc's `Shared.hs`) are skipped without breaking consecutiveness, so they don't wrongly split one real clause-group into two.
- Regenerated `tests/tree_sitter_accuracy_baseline_haskell.json` and the summary table embedded in `gitgalaxy/standards/language_standards.py`'s docstring.

## Measured impact
On `language-crucible/data/haskell/pandoc` (the pinned corpus): recall **50.5% (275 real / 139 found) → 95.2% (146 real / 139 found)**, same GitGalaxy output, same `_align_occurrences_by_line` alignment algorithm — this is purely a ground-truth counting-semantics fix, not a GitGalaxy behavior change.

The remaining 7 real misses (`ensureNl`, `adjustNum`, `go`, `isAllowedPunct`, `matchTags`, `rejectBadYear`, `stripBeginSpace`) are genuine, smaller gaps tracked separately as #1615 and #1616.

## Test plan
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --all --ci` — all 31 baselined languages pass, confirming zero behavior change outside haskell.
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --lang haskell --regenerate` — new baseline committed.
- [x] `python tests/tools/tree_sitter_accuracy_audit.py --summary-table` — `language_standards.py` docstring table regenerated and committed.
- [x] `python tests/ruff_audit.py --ci` / `python tests/mypy_audit.py --ci` — no new findings (both scoped to `gitgalaxy/`, this change is `tests/`-only).
- [x] No changes to `detector.py`/`prism.py`/`language_standards.py` rule logic — this is a measurement-tool fix only, so the Differential Scan protocol doesn't apply.