### PR TITLE
fix(testing): exclude javascript's parse-error phantom method_definition nodes from ground truth

### DIFF
--- a/docs/why_gitgalaxy_beats_ast_here.md
+++ b/docs/why_gitgalaxy_beats_ast_here.md
@@ -233,6 +233,53 @@ it still can't tell you a variable's inferred type, walk an expression tree, or 
 It's a narrower promise, and Claims 1 through 3 are exactly the places where that narrower promise
 turns out to be an advantage instead of a limitation.
 
+### Second instance (2026-08-14): javascript, where the same cascade *hallucinates* instead of going blind
+
+`#1633` found the identical root mechanism — one unparseable construct corrupting error recovery
+for unrelated real code elsewhere in the file — in `tree-sitter-javascript`, but with the opposite
+symptom shape. csharp's cascade (above) goes *blind*: the corrupted region yields zero structure,
+so GitGalaxy's real matches there look like false positives (inflated "extra"). javascript's
+cascade *hallucinates*: recovery keeps emitting structured-looking nodes in the corrupted region,
+some of which are garbage that resembles a real function definition closely enough to be counted
+as one.
+
+**The evidence:** `language-crucible/data/javascript/react/ReactFiberBeginWork.js` uses Flow type
+annotations (`function f(x: Type): ReturnType {`) that the plain (non-Flow) `tree-sitter-javascript`
+grammar can't parse — 626 separate `ERROR` nodes, the first at line 10. During recovery, the
+grammar repeatedly emits `method_definition` nodes whose "name" field resolves to a plain
+control-flow keyword: eleven separate `if (...) { ... }` statements (lines 346, 3243, 3305, 3668,
+3770, 3775, 3811, 3980, 4077, 4150, 4169) each parse as a `method_definition` literally named
+`if`, its `(...)` condition standing in for a formal parameter list. GitGalaxy, correctly, never
+reports a function named `if` — so each of these became a permanent, unfindable "missing" entry in
+`tree_sitter_accuracy_audit.py`'s ground truth, deflating measured javascript func_recall for
+something GitGalaxy was never wrong about (704 phantom-inflated "real" functions measured vs. the
+619 that remain once these are excluded, on top of a 596-vs-598-ish separate accounting of the
+already-documented "invisible Flow-typed function" gap described earlier in this doc — recall on
+this corpus moved from 85.1% to 96.6% purely from removing ground-truth garbage, GitGalaxy's own
+`found_functions`/`extra_functions`/`args_exact_match` numbers unchanged).
+
+**Why "hallucinates" needed a narrower fix than "goes blind."** csharp's cascade region has *no*
+salvageable structure at all — the fix there is a flat file+line-range exclusion. javascript's
+error recovery resyncs locally instead of staying corrupted for the rest of the file, so a first
+attempt at the equivalent fix (excluding everything past the file's detected cascade-start line
+from ground truth, mirroring csharp's fix exactly) was tried and reverted: it discarded far more
+genuinely-real, genuinely-matched functions than the handful of phantom entries it removed
+(`found_functions` dropped 599→491 while `extra_functions` went *up* — a net regression, not an
+improvement). The fix that actually worked is a targeted name+node-type filter instead of a
+region exclusion: reserved words (`if`/`for`/`while`/`switch`/`catch`/`else`/`do`) can never
+legally be a real JS identifier, but *are* legal as an object-literal property/method name written
+with an explicit `function` keyword (`catch: function(fn) { ... }`, confirmed real and common in
+`jquery/deferred.js:66`) — so the filter is scoped specifically to the ES6 shorthand-method node
+shape (`method_definition`), not the broader `function_expression`/`pair` shape that legitimate
+`catch: function(){}` uses. An earlier, broader version of the filter (any reserved-word name,
+any node type) wrongly dropped that legitimate `catch` ground-truth entry too, which then made
+GitGalaxy's own correct detection of it look like a new false positive — caught by re-running the
+audit tool after the change, not assumed correct from the diff alone.
+
+Fixed in `tests/tools/tree_sitter_accuracy_audit.py`'s `measure()` (`walk()` closure), not
+GitGalaxy's engine — this is purely a measurement-tool correction; GitGalaxy's own detected
+function set for this corpus is byte-for-byte identical before and after.
+
 ## Where Claim 3 does NOT apply
 
 - This is a grammar-*implementation* limitation (a specific parser version's bug/gap on one
@@ -247,7 +294,12 @@ turns out to be an advantage instead of a limitation.
   whole region from the line-5198 trigger to end of file), not a name list. #1427's original
   3-name exclusion was confirmed too narrow by the 2026-08-14 correction above: the real scope is
   the entire back half of the file (0 real_functions recognized past line 5198, vs. 157 before
-  it), not 3 isolated names.
+  it), not 3 isolated names. **Don't assume this generalizes to every language's cascade** — the
+  javascript instance above (`#1633`) is the counter-example: its error recovery keeps producing
+  salvageable (if occasionally garbage) structure well past the first parse error instead of going
+  fully flat, so the same region-exclusion approach actually *lost* real signal there and had to be
+  replaced with a narrower name+node-type filter. Check which shape a new instance is before
+  picking a fix, don't default to the csharp shape.
 
 ## Claim 4: counting one function once, when a grammar's node granularity is per-clause
 

--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -46,7 +46,7 @@ for the same metrics tracked over time across pushes to main.
 | Haskell | 95.2% | 98.6% | 100.0% | 100.0% |
 | Html | N/A | N/A | N/A | N/A |
 | Java | 99.1% | 100.0% | 100.0% | 100.0% |
-| Javascript | 85.1% | 98.2% | 100.0% | 100.0% |
+| Javascript | 96.6% | 98.2% | 100.0% | 100.0% |
 | Kotlin | 100.0% | 96.4% | 100.0% | 100.0% |
 | Lua | N/A | N/A | N/A | N/A |
 | Makefile | 100.0% | 100.0% | N/A | N/A |

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -1501,6 +1501,25 @@ _SKIP_PENALTY = 1_000_000  # bigger than any real file's line count -- see docst
 # of literal `main` functions.
 _SYNTHETIC_GG_FUNC_NAMES = frozenset({"Anonymous_Block", "__global_context__"})
 
+# #1633: when a grammar's error recovery corrupts a downstream region (Claim 3's mechanism --
+# see docs/why_gitgalaxy_beats_ast_here.md), tree-sitter-javascript doesn't just go blind, it can
+# actively hallucinate a control-flow statement AS a `method_definition` node whose "name" field
+# resolves to the keyword itself. Confirmed via language-crucible/data/javascript/react/
+# ReactFiberBeginWork.js (626 ERROR nodes, first at line 10, from Flow-typed syntax the plain JS
+# grammar can't parse): eleven separate `if (...) { ... }` statements each produced a
+# `method_definition` node with `_get_node_name() == "if"`. Deliberately scoped to
+# `method_definition` only where this filter is applied (see the `walk()` call site) -- a reserved
+# word IS a completely valid `pair`-shaped object-literal method name when written with an
+# explicit `function` keyword (`catch: function(fn) { ... }`, confirmed real in
+# jquery/deferred.js:66), so this can't be a blanket "reserved word => never real" rule. These
+# phantom `method_definition` nodes aren't confined to one contiguous trailing region either (the
+# earliest confirmed instance, line 346, sits well before this file's own detected cascade start
+# at line 3221), and a cascade-region exclusion was tried and reverted (see the `walk()` comment
+# at the actual filter site): it discarded far more genuinely-real, genuinely-matched ground truth
+# than the phantom entries it removed, since javascript's error recovery resyncs locally rather
+# than going permanently blind for the rest of the file.
+_JS_RESERVED_STATEMENT_KEYWORDS = frozenset({"if", "for", "while", "switch", "catch", "else", "do"})
+
 
 def _align_occurrences_by_line(
     real: list[tuple[int, int]], gg: list[tuple[int, int]]
@@ -1692,7 +1711,31 @@ def measure(lang: str, verbose: bool = False) -> dict:
                             pass
                         else:
                             name = _get_node_name(node)
-                            if name:
+                            # #1633: error recovery in a Flow-typed javascript file (Claim 3's
+                            # mechanism -- see docs/why_gitgalaxy_beats_ast_here.md) can
+                            # misparse a plain control-flow statement (`if (...) { ... }`)
+                            # itself AS a `method_definition` node, with the keyword resolving
+                            # as the "name". Scoped to `method_definition` specifically (ES6
+                            # shorthand-method syntax, `name(...) { ... }`), NOT the broader
+                            # `func_node_types` set: a reserved word is completely valid as a
+                            # `pair`-shaped object-literal method name written with an explicit
+                            # `function` keyword (`catch: function(fn) { ... }`, confirmed real
+                            # and common in jquery/deferred.js:66) -- an earlier, broader version
+                            # of this filter wrongly dropped that real ground-truth entry too,
+                            # which then made GitGalaxy's own correct detection of it show up as
+                            # a false "extra". A cascade-region exclusion (excluding everything
+                            # past `trailing_error_start` instead of name-filtering) was also
+                            # tried and reverted: javascript's error recovery resyncs locally
+                            # rather than going permanently blind like csharp's #1427/#1567
+                            # cascade, so it discarded far more genuinely-real, genuinely-matched
+                            # ground truth than the handful of phantom entries it removed
+                            # (confirmed empirically: found_functions dropped 599->491 while
+                            # extra_functions went UP, a net regression).
+                            if name and not (
+                                lang == "javascript"
+                                and node.type == "method_definition"
+                                and name in _JS_RESERVED_STATEMENT_KEYWORDS
+                            ):
                                 real_funcs.setdefault(name, []).append(
                                     (node.start_point[0] + 1, _get_param_count(node, lang))
                                 )

--- a/tests/tree_sitter_accuracy_baseline_javascript.json
+++ b/tests/tree_sitter_accuracy_baseline_javascript.json
@@ -8,5 +8,5 @@
   "found_classes": 29,
   "found_functions": 599,
   "real_classes": 29,
-  "real_functions": 704
+  "real_functions": 620
 }


### PR DESCRIPTION
## Summary

Fixes #1633. `tests/tools/tree_sitter_accuracy_audit.py --lang javascript` measured func recall
at 85.1%, most of which was a ground-truth measurement artifact, not a GitGalaxy defect.

Flow-typed syntax in `react/*.js` corpus files breaks `tree-sitter-javascript`'s parse (626
`ERROR` nodes in `ReactFiberBeginWork.js`, first at line 10). During error recovery the grammar
occasionally emits a `method_definition` node whose "name" resolves to a plain control-flow
keyword — 11 confirmed instances of `if (...) { ... }` parsed as a method literally named `if`.
GitGalaxy correctly never reports a function named `if`, so these became permanent "missing"
entries, deflating measured recall for something GitGalaxy was never wrong about.

- Excludes reserved-keyword-named `method_definition` nodes from javascript's ground truth
  (`_JS_RESERVED_STATEMENT_KEYWORDS`, scoped to that node type specifically — a reserved word IS
  legitimate as a `pair`-shaped object-literal method name written with an explicit `function`
  keyword, e.g. `catch: function(fn) { ... }` in `jquery/deferred.js:66`, confirmed real code. An
  earlier, broader version of this filter wrongly dropped that legitimate entry too, which then
  made GitGalaxy's own correct detection of it look like a new false positive.)
- A cascade-region exclusion (mirroring csharp's `#1567` fix — exclude everything past the
  detected cascade-start line) was tried and reverted: javascript's error recovery resyncs
  locally rather than staying corrupted for the rest of the file, so it discarded far more real,
  correctly-matched ground truth than the phantom entries it removed (`found_functions` dropped
  599→491, `extra_functions` went *up* — a net regression, confirmed empirically before
  reverting).
- Documented as a second confirmed instance of Claim 3 in `docs/why_gitgalaxy_beats_ast_here.md`
  — csharp's cascade goes *blind* (zero structure in the corrupted region); javascript's instead
  *hallucinates* phantom structure, which needed a different fix shape.

**Result:** javascript func_recall 85.1% → 96.6%. GitGalaxy's own `found_functions`/
`extra_functions`/`args_exact_match` are byte-for-byte unchanged — this is purely a ground-truth
measurement correction in test tooling, not an engine change.

## Test plan

- [x] `tree_sitter_accuracy_audit.py --lang javascript` — no regressions, recall 85.1% → 96.6%
- [x] `tree_sitter_accuracy_audit.py --all --ci` — 31 languages checked, all OK (confirms the
      javascript-gated guard has zero cross-language ripple)
- [x] `tree_sitter_accuracy_audit.py --regenerate` / `--summary-table` — baseline + docstring
      table updated
- [x] `audit_check.py --ci` — ruff/mypy/dead-key/ast-accuracy all clean, no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)