### PR TITLE
test(perl): lock in args-summing behavior from PR #1520

### DIFF
--- a/tests/extraction/languages/test_perl.py
+++ b/tests/extraction/languages/test_perl.py
@@ -207,3 +207,60 @@ def test_perl_qr_brace_shield_does_not_desync_brace_slicing():
     ext = StructuralExtractor("perl", LANGUAGE_DEFINITIONS)
     safe_code = ext._build_brace_safe_stream(code, "perl")
     assert safe_code.count("{") == safe_code.count("}")
+
+# ==============================================================================
+# PERL ARGS SUMMING (Root Causes 2, 3, 4)
+# ==============================================================================
+def test_perl_args_summing():
+    from gitgalaxy.core.detector import StructuralExtractor
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    extractor = StructuralExtractor("perl", LANGUAGE_DEFINITIONS)
+    rules = LANGUAGE_DEFINITIONS["perl"]["rules"]
+
+    def _get_args_count(code: str) -> int:
+        sat, _ = extractor._calculate_block_metrics(
+            name="test_sub",
+            block=code,
+            loc=code.count("\n") + 1,
+            start_line=1,
+            end_line=code.count("\n") + 1,
+            rules=rules,
+            start_idx=0,
+            end_idx=len(code),
+            spatial_map={},
+        )
+        return sat.get("args_count", 0)
+
+    # 1. Traditional prototype: skipped by signature capture, falls through to sum the body.
+    # Should sum to 2 (two shifts), even though prototype is ($$).
+    code_proto = """sub foo($$) {
+        my $x = shift;
+        my $y = shift;
+    }"""
+    assert _get_args_count(code_proto) == 2
+
+    # 2. Multiple separate shift/my-unpacking statements.
+    code_multiple = """sub ValidateDependencies {
+        my $self = shift;
+        my $pkg = shift;
+        my $deps = shift;
+    }"""
+    assert _get_args_count(code_multiple) == 3
+
+    # 3. Bare shift (not shifting an explicitly named array).
+    # Also verify it doesn't overcount `shift @other_array`.
+    code_bare_shift = """sub process {
+        my $x = shift;
+        shift;
+        shift @other_queue;
+        my $y = shift || 0;
+    }"""
+    assert _get_args_count(code_bare_shift) == 3
+
+    # 4. Bare catch-all array assignment.
+    code_catch_all = """sub finalize {
+        my $class = shift;
+        my @rest = @_;
+    }"""
+    assert _get_args_count(code_catch_all) == 2


### PR DESCRIPTION
## Summary

Was dispatched to fix #1519, but investigation found it was already fixed by
PR #1520 (merged 2026-08-14) -- that PR's body said "Fixes #1518, #1519" but
GitHub only auto-linked #1518, so #1519 never closed despite being resolved.
Closed #1519 directly with a pointer to PR #1520 and the current measured
number (`args_exact_match` 923/938 = 98.4%).

This PR is the one genuinely missing piece: PR #1520 shipped without
dedicated regression tests for its own specific behaviors (multi-statement
shift/my-unpacking summing, bare-shift-vs-shift-@array disambiguation, bare
catch-all `@_` assignment). Adding them now so a future regex change can't
silently regress this without a test failing.

## Verification

```
$ venv/bin/pytest tests/extraction/languages/test_perl.py tests/extraction/languages/test_perl_strict.py -q
111 passed
```

No engine changes -- test-only PR, no golden master / accuracy baseline impact.

## Type of change

- [ ] Bug fix
- [x] Docs, tooling, or CI only (test coverage)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>