### PR TITLE
chore(ci): group codeql-action Dependabot bumps, unblock #1577/#1578

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       default-days: 7
     labels:
       - "github-actions"
+    groups:
+      # init/analyze/upload-sarif are separate `uses:` lines Dependabot otherwise bumps in
+      # independent PRs, but CodeQL hard-fails if init and analyze are ever on different
+      # versions ("Loaded a configuration file for version 'X', but running version 'Y'") --
+      # see #1577/#1578. Grouping means one PR bumps every github/codeql-action/* line together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,12 +31,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- Adds a Dependabot `groups:` entry for `github/codeql-action/*` so `init`/`analyze`/`upload-sarif` bump together in one PR instead of racing across independent ones.
- Bumps `init`+`analyze` in `codeql.yml` to v4.37.6 together now, unblocking #1577/#1578.

## Why
#1577 (bumps `init` alone to v4.37.6) fails CI:
```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.37.4'
```
CodeQL's `init` and `analyze` steps must be on the same version in a given workflow run. Dependabot treats each `uses:` line as an independent dependency and opens a separate PR per line, so neither #1577 nor #1578 is mergeable alone. Grouping fixes this going forward for any repo with `codeql-action` split across multiple lines (this repo also has an `upload-sarif` usage in `gitgalaxy.yml`/`muninn.yml`, pinned to a floating `v4` tag rather than the same patch version — the group will catch that drift too next time it moves).

## Test plan
- [x] Confirmed the failure mode via `gh run view` on #1577's failed check
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — valid YAML
- [ ] CodeQL Security Scan workflow passes on this PR (init/analyze both at v4.37.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)