### PR TITLE
ci(azure): stop running Azure Pipelines on every PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,15 @@ trigger:
     include:
       - v*
 
+# No `pr:` trigger on purpose: this pipeline previously ran on every GitHub PR
+# via the Azure Pipelines GitHub App's default PR-validation behavior (which
+# fires whenever `pr:` is unset), burning the org's Microsoft-hosted free
+# minutes across every PR in addition to `trigger:`'s push/tag runs. It's
+# also redundant -- GitHub Actions' gitgalaxy.yml already runs the same
+# --fail-on-malware scan on every PR for free. `pr: none` restricts this
+# pipeline to `trigger:`'s push-to-main/tag-push cases only.
+pr: none
+
 variables:
   GG_TOOL: 'galaxyscope'
   GG_TARGET: '.'


### PR DESCRIPTION
## Summary
- `azure-pipelines.yml` had no `pr:` section, so the Azure Pipelines GitHub App ran a full build on **every PR** (default behavior when `pr:` is unset), in addition to the `trigger:` block's push-to-main/tag runs.
- That burned through the org's free Microsoft-hosted minutes: build #20260816.20 (on PR #1735) failed instantly with "Your organization has no free minutes remaining."
- Confirmed via the branch-protection API that this check isn't required to merge, and GitHub Actions' `gitgalaxy.yml` already runs the equivalent `--fail-on-malware` scan on every PR for free — so the per-PR Azure run was pure quota burn with no unique coverage.

`pr: none` restricts this pipeline back to what `trigger:` already declares as its scope: push to `main` and tag pushes. Doesn't touch `publish.yml`'s separate `azure-sync` job (the actual git mirror to Azure Repos), which isn't metered the same way and is unaffected.

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- Not a parsing-logic change, no golden-master/crucible verification needed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>