### PR TITLE
Fix JavaScript func_start regex to support Flow return types (#1755)

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -724,8 +724,8 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # This allows the lookahead to safely cross vertical line breaks without
                 # resorting to an unbounded `\s*` which causes ReDoS.
                 # =====================================================================
-                r"\b[a-zA-Z_$][\w$]*(?=[ \t\n]*=[ \t\n]*(?:async\s*)?(?:function(?:\s*\*)?\b|\([^)]*\)[ \t\n]*=>|[a-zA-Z_$][\w$]*[ \t\n]*=>))|"
-                r"^[ \t]*[a-zA-Z_$][\w$]*(?=[ \t\n]*:[ \t\n]*(?:async\s*)?(?:function(?:\s*\*)?\b|\([^)]*\)[ \t\n]*=>|[a-zA-Z_$][\w$]*[ \t\n]*=>))|"
+                r"\b[a-zA-Z_$][\w$]*(?=[ \t\n]*=[ \t\n]*(?:async\s*)?(?:function(?:\s*\*)?\b|\([^)]*\)[ \t\n]*(?::[^=;]+)?[ \t\n]*=>|[a-zA-Z_$][\w$]*[ \t\n]*=>))|"
+                r"^[ \t]*[a-zA-Z_$][\w$]*(?=[ \t\n]*:[ \t\n]*(?:async\s*)?(?:function(?:\s*\*)?\b|\([^)]*\)[ \t\n]*(?::[^=;]+)?[ \t\n]*=>|[a-zA-Z_$][\w$]*[ \t\n]*=>))|"
                 # GENERATOR METHOD FIX (epic #813/#814): class/object-literal generator
                 # methods (`*foo() {}`, `async *foo() {}`, `static *foo() {}`) were
                 # completely invisible -- this branch had no allowance for the leading
@@ -756,7 +756,7 @@ LANGUAGE_DEFINITIONS: dict[str, Any] = {
                 # working the same as before; only a bare statement with
                 # neither `{` nor `=>` anywhere (e.g. `next();`) is newly
                 # rejected.
-                r"^[ \t]*(?:static[ \t\n]+)?(?:async[ \t\n]+)?(?:get\s+|set\s+)?\*?(?!(?:if|for|while|switch|catch|return|throw|new|typeof|jQuery|function)\b|\$)#?[a-zA-Z_$][\w$]*(?=[ \t\n]*\([^)(]*\)[ \t\n]*(?:=>[ \t\n]*)?\{)"
+                r"^[ \t]*(?:static[ \t\n]+)?(?:async[ \t\n]+)?(?:get\s+|set\s+)?\*?(?!(?:if|for|while|switch|catch|return|throw|new|typeof|jQuery|function)\b|\$)#?[a-zA-Z_$][\w$]*(?=[ \t\n]*\([^)(]*\)[ \t\n]*(?::[^{=;]+)?[ \t\n]*(?:=>[ \t\n]*)?\{)"
                 r")",
                 re.M,
             ),

--- a/why_we_are_better_than_tree_sitter.md
+++ b/why_we_are_better_than_tree_sitter.md
@@ -17,6 +17,10 @@ For example, functions like `export const altW: <E2, B>(that: LazyArg<Either<E2,
 By tracking depth, GitGalaxy properly counts arguments in complex TypeScript signatures where parens and brackets are nested inside function arguments.
 For example, in `export function withAsyncBody<T, E = Error>(bodyFn: (resolve: (value: T) => unknown, reject: (error: E) => unknown) => Promise<unknown>): Promise<T> {`, GitGalaxy correctly identifies this as exactly `1` argument (`bodyFn`), despite the internal commas inside the type signature. Tree-sitter and previous AST fallback methods frequently tripped over the internal `>` from `=>` when tracking depth, causing them to miscount internal commas as argument separators. GitGalaxy's counter correctly ignores `=>` when tracking angle-bracket depth, perfectly matching the true arity.
 
+## 4. Resilience Against Flow-Typed JavaScript and Error Recovery Hallucinations
+
+Tree-sitter's standard `javascript` grammar struggles with Facebook's Flow type annotations embedded inside JavaScript (commonly found in large React codebases). When tree-sitter encounters Flow-typed syntax, it enters error recovery mode. During this error recovery, tree-sitter hallucinates and incorrectly classifies other completely unrelated syntax nodes (such as `import` statements, `let` variable bindings, and object properties) as function declarations. GitGalaxy's structural extraction avoids these AST parsing panics and correctly ignores these nodes because it isn't derailed by the presence of type annotations.
+
 ## Summary of Audit Regressions Eliminated
 
 By refining the argument counting regex and the brace/arrow slicing loops, we eliminated all argument count mismatches and hallucinated bodies:


### PR DESCRIPTION
Fixes #1755.

This PR updates the JavaScript `func_start` regex to properly support optional Flow-style return types (e.g. `: void`) before the `=>` in arrow functions and before the `{` in class/object-literal methods. This prevents valid Flow-typed functions from being silently ignored.

It also updates `why_we_are_better_than_tree_sitter.md` to document GitGalaxy's superiority regarding tree-sitter error recovery hallucinations on React/Flow code (where tree-sitter incorrectly identifies `import` and `let` nodes as function declarations, while GitGalaxy gracefully handles them without parsing panic).