### PR TITLE
docs: add docs/self_scan/README.md, link it from the Tree-sitter proof item

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,15 +214,19 @@ Every "structural signature" and "AST-free" claim above is backed by three thing
 1. **[+6000 per-signature regression tests](tests/README.md).** `gitgalaxy/standards/language_standards.py` defines every regex rule the engine uses to recognize a construct — a function start, an API boundary, a safety bypass — across the 45 languages that have real structural signatures (+2000 compiled patterns total). Every one of those rules is tested for what it should match, what it should explicitly *exclude* (the false-positive check most regex-based tools skip), and that it can't be hung by an adversarial input. See **[`tests/README.md`](tests/README.md)** for the full index, and [epic #518](https://github.com/squid-protocol/gitgalaxy/issues/518) for the audit that closed it out — dozens of real regex bugs found and fixed along the way, not just theoretical coverage.
 2. **A true golden diff against real, unmodified production code.** [`language-crucible`](https://github.com/squid-protocol/language-crucible) is a pinned, tagged snapshot of ~120 real subdirectories pulled from major open-source projects — Godot's C++, the Roslyn C# compiler, curl, Kubernetes, Apollo 11's AGC flight software, and more — deliberately left disconnected and uncompilable, the same hostile state real repos are in. Every pull request that touches the parsing engine re-scans that entire corpus and diffs the output, field by field, against a checked-in snapshot (`tests/golden_master_audit.json`); a diff means the output changed on real code, and it has to be explained before it's accepted — not a smoke test, an actual golden-master comparison. See [`tests/README.md`](tests/README.md#5-golden-master-differential-testing-the-language-crucible) for exactly how this is wired into CI, and [language-crucible's own README](https://github.com/squid-protocol/language-crucible) for why that corpus is built the way it is.
 3. **[Unedited raw scan output at real-world scale](https://github.com/squid-protocol/gitgalaxy-raw-output).** Where the golden-master corpus above proves correctness on ~120 curated adversarial paradigms, this repo is the complementary evidence that the engine actually runs, unmodified, across hundreds of independently-chosen real repositories — every `_galaxy_audit.json`, `_galaxy_master.db`, and `_galaxy_llm.md` the scanner produced, kept versioned per engine release. The corpus manifest pinning exactly which repos and commits were scanned currently covers a 599-repo set.
-4. **[Measured against Tree-sitter](docs/language_status/README.md), not asserted.** [`tests/tools/tree_sitter_accuracy_audit.py`](tests/tools/tree_sitter_accuracy_audit.py) diffs GitGalaxy's extraction against real AST ground truth on the [`language-crucible`](https://github.com/squid-protocol/language-crucible) corpus, one committed baseline per language, re-measured and re-charted automatically on every push that touches the parsing engine:
+4. **[Measured against Tree-sitter](docs/self_scan/README.md), not asserted.** [`tests/tools/tree_sitter_accuracy_audit.py`](tests/tools/tree_sitter_accuracy_audit.py) diffs GitGalaxy's extraction against real AST ground truth on the [`language-crucible`](https://github.com/squid-protocol/language-crucible) corpus, one committed baseline per language, re-measured and re-charted automatically on every push that touches the parsing engine:
 
 <p align="center">
   <img src="docs/self_scan/tree_sitter_accuracy_chart.svg" alt="GitGalaxy structural extraction accuracy vs. Tree-sitter ground truth, ranked recall/precision panels by language" width="700">
 </p>
 
 31 languages baselined so far; each panel is ranked independently and "n/a" (no ground-truth
-instances) sorts to the bottom rather than scoring as 0%. Two languages have a full written
-audit behind the chart — [python](docs/language_status/python.md) and
+instances) sorts to the bottom rather than scoring as 0%. Methodology, per-column definitions,
+and the full accumulating history behind this chart are in
+[`docs/self_scan/README.md`](docs/self_scan/README.md) (raw data:
+[`tree_sitter_accuracy_history.csv`](docs/self_scan/tree_sitter_accuracy_history.csv)). Two
+languages have a full written audit one level deeper than this chart —
+[python](docs/language_status/python.md) and
 [javascript](docs/language_status/javascript.md) — which is how real defects like
 [#1193](https://github.com/squid-protocol/gitgalaxy/issues/1193) (still open) got found in
 the first place; the rest of the 31 are baseline-only so far, not yet manually audited.

--- a/docs/self_scan/README.md
+++ b/docs/self_scan/README.md
@@ -1,0 +1,87 @@
+# Self-Scan: Tree-sitter Accuracy Data
+
+This folder holds two unrelated things that happen to share a name and a path. This README is
+about the one that's committed to the repo: GitGalaxy's structural-extraction accuracy measured
+against tree-sitter. The other is `gitgalaxy_master.db` — a gitignored, locally-regenerated
+SQLite snapshot of *this repo's own* code (function/class counts, complexity, blast radius),
+produced by `tests/tools/self_scan.py` for LLM coding sessions to query cheaply (see
+`.claude/skills/self-scan-query/SKILL.md`). If you ran that script and see a `.db` file next to
+these files, that's why — it has nothing to do with tree-sitter or language accuracy.
+
+Both files below are generated, not hand-written. See
+[`tests/tools/tree_sitter_accuracy_audit.py`](../../tests/tools/tree_sitter_accuracy_audit.py)'s
+own module docstring for the authoritative methodology, corpus setup, and every known
+per-language measurement caveat — this README is the short version; that docstring is the one
+to trust if the two ever disagree.
+
+## What's measured
+
+[`tree-sitter-language-pack`](https://pypi.org/project/tree-sitter-language-pack/) parses every
+file in the pinned [`language-crucible`](https://github.com/squid-protocol/language-crucible)
+corpus (`v1.0` — ~120 real, disconnected subdirectories of production code: Godot's C++,
+Roslyn's C#, curl, tokio, and more) into a real AST, per baselined language. That AST becomes the
+reconciled ground truth for that language: real function/class names, their positions, and their
+real parameter counts. GitGalaxy's own regex-based extraction is then diffed against it —
+**recall** (did it find the real ones), **precision** (did it also report ones that aren't
+there), and **args exact-match** (of the functions it found, did it also get the parameter count
+right).
+
+Tree-sitter's own name-matching is scored against that same reconciled ground truth too (the
+`ts_*` CSV columns; the bottom bar in each chart panel). That's not tree-sitter under audit —
+it's there because the ground truth isn't simply "whatever tree-sitter's grammar happened to
+walk": occurrence pairing across same-named functions, Flow-typed JS the plain JS grammar can't
+parse, Cython scope loss, and Rust functions hidden inside macro bodies all mean tree-sitter's
+raw reading and the reconciled ground truth built from it can diverge. The audit script's SCOPE
+& LIMITATIONS section has the specific, confirmed cases (file and function names included) —
+read that before citing either side's number as more precise than the methodology supports.
+
+31 languages currently have a committed baseline
+(`tests/tree_sitter_accuracy_baseline_<lang>.json`) and appear scored here. 14 more that
+GitGalaxy extracts structural signatures from but tree-sitter has no grammar for at all (COBOL,
+JCL, assembly, and others) get a GitGalaxy-only row (`gg_only=1`) with every `ts_*` column left
+blank, not scored as a loss.
+
+## Files
+
+- **`tree_sitter_accuracy_chart.svg`** — the current snapshot: a small-multiples bar chart, five
+  metric panels (func recall/precision, class recall/precision, args exact-match), two bars per
+  language per panel — GitGalaxy on top, tree-sitter's own reading on the bottom, both against
+  the same ground truth. Regenerated from the CSV's latest batch on every push to `main` that
+  touches the parsing engine, so it always reflects one specific commit (named in the CSV), not
+  "current `main`" if you're reading this well after the fact.
+- **`tree_sitter_accuracy_history.csv`** — the full time series: one row per language per
+  measured batch, accumulating, nothing pruned or overwritten. The chart only ever renders the
+  single most recent `timestamp_utc` batch — query this file directly to see a language's
+  accuracy move over time instead.
+
+## Reproducing or updating this locally
+
+```bash
+# from the gitgalaxy repo root
+git clone --branch v1.0 --depth 1 https://github.com/squid-protocol/language-crucible.git ../language-crucible
+pip install tree-sitter-language-pack
+
+python tests/tools/tree_sitter_accuracy_audit.py --all --ci   # baseline-gated pass/fail, no writes
+python tests/tools/tree_sitter_accuracy_audit.py --history    # appends a row per language to the CSV
+python tests/tools/tree_sitter_accuracy_audit.py --chart      # re-renders the SVG from the latest CSV batch
+```
+
+`--history` is a no-op — prints a message and exits 0 without appending anything — when every
+baselined language's fresh measurement is identical to the last recorded batch, so running it
+twice with no engine change in between won't manufacture a duplicate row.
+
+## Related reading
+
+- [`docs/why_gitgalaxy_beats_ast_here.md`](../why_gitgalaxy_beats_ast_here.md) — the one
+  documented case where GitGalaxy's `args` recall structurally beats a declaration-only AST read
+  (bash, traditional-style Perl: functions with no formal parameter list at all for an AST to
+  count).
+- [`docs/language_status/README.md`](../language_status/README.md) — per-language status docs.
+  `python.md` and `javascript.md` go one level deeper than this folder's aggregate numbers, with
+  a real-corpus measurement section that found and closed several extraction defects
+  ([#1182](https://github.com/squid-protocol/gitgalaxy/issues/1182),
+  [#1183](https://github.com/squid-protocol/gitgalaxy/issues/1183),
+  [#1184](https://github.com/squid-protocol/gitgalaxy/issues/1184)) plus one still open
+  ([#1193](https://github.com/squid-protocol/gitgalaxy/issues/1193)).
+- Root [`README.md`](../../README.md#proof-not-just-claims), item 4 under "Proof, Not Just
+  Claims" — where this data is cited from.

--- a/docs/self_scan/README.md
+++ b/docs/self_scan/README.md
@@ -41,6 +41,32 @@ GitGalaxy extracts structural signatures from but tree-sitter has no grammar for
 JCL, assembly, and others) get a GitGalaxy-only row (`gg_only=1`) with every `ts_*` column left
 blank, not scored as a loss.
 
+## tree-sitter as a baseline, not as infallible ground truth
+
+Treat this tool's numbers as a well-calibrated baseline that gets corrected when it's wrong, not
+as an oracle. The confirmed cases already exist and are documented, not hypothetical: the audit
+script's SCOPE & LIMITATIONS section names specific instances (Cython scope loss across `cdef
+class` boundaries, Flow-typed JS the plain grammar can't parse, `matlab`/`shell` synthetic
+placeholder names, C++ operator-cast declarators, Rust functions hidden inside macro bodies)
+where the reconciled ground truth built from tree-sitter's parse is itself wrong, and GitGalaxy's
+own reading is the one that turned out to be right on inspection. When that happens the baseline
+gets adjusted (`--regenerate`, always reviewed, never a blind `cp`) — this is closer to "a crutch
+we lean on and periodically x-ray" than "the answer key."
+
+That said, for a *new* repository being added to `language-crucible`, comparing against
+tree-sitter remains the practical way to start: one dependency
+(`tree-sitter-language-pack`), real per-language grammars for everything already baselined, and
+a mechanism (this tool) that already exists and is wired into CI. It's a solid first check, just
+not the last word.
+
+The longer-term direction is away from treating any single tool as ground truth at all, toward
+comparing GitGalaxy against multiple independently-biased extraction tools and reconciling
+where they disagree by actually reading the source at the point of disagreement — the same
+manual-verification instinct behind the confirmed cases above, made systematic instead of
+ad hoc. A `universal-ctags`-based comparison is in progress toward that end (a separate,
+standalone tool — `tests/tools/tree_sitter_accuracy_audit.py` itself is not being modified to
+add it). This section will link to it once it exists rather than describe it ahead of time.
+
 ## Files
 
 - **`tree_sitter_accuracy_chart.svg`** — the current snapshot: a small-multiples bar chart, five


### PR DESCRIPTION
## Summary
- `docs/self_scan/` held `tree_sitter_accuracy_chart.svg` and the accumulating `tree_sitter_accuracy_history.csv` with no README explaining methodology, the CSV schema, or how to reproduce locally.
- Adds `docs/self_scan/README.md`: what's measured (tree-sitter-language-pack over the pinned `language-crucible` corpus as reconciled ground truth), what the two committed files are, reproduction commands, and related reading. Also flags that this folder separately hosts a gitignored `gitgalaxy_master.db` from the unrelated `self_scan.py` tool, so the name collision doesn't confuse anyone browsing the folder.
- `README.md`'s "Proof, Not Just Claims" item 4 previously linked its header straight to `docs/language_status/README.md` and never mentioned the CSV at all. Retargets that link to the new methodology doc and adds an explicit pointer to `tree_sitter_accuracy_history.csv`.

No engine/behavior changes — docs only.

## Test plan
- [x] Followed `docs/how_to_maintain_the_readme.md`'s five rules and status checklist against the README.md diff (link added with the claim, no new unbacked superlatives, no section reordering, existing benchmark limitation clause preserved).
- [x] Checked `docs/readme_evidence_roadmap.md` — this doesn't unlock or require a new roadmap row (already logged as Shipped 2026-08-12; this PR only adds a missing methodology doc + link, not a new claim).
- [ ] N/A: no code/test changes, so `crucible_check.py` / `tree_sitter_accuracy_audit.py` / pytest are not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)