### PR TITLE
feat: tri-comparison recall/precision split + chart redesign (follow-up to #1859)

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -1,675 +1,1153 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 668 1632" width="668" height="1632" font-family="system-ui, -apple-system, Segoe UI, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 812 2248" width="812" height="2248" font-family="system-ui, -apple-system, Segoe UI, sans-serif">
 <style>
   .surface { fill: #fcfcfb; }
   .title { font-size: 15px; font-weight: 600; fill: #0b0b0b; }
   .subtitle { font-size: 11px; fill: #52514e; }
   .scope-note { font-size: 10px; fill: #706f6a; }
-  .panel-title { font-size: 11px; font-weight: 600; fill: #0b0b0b; text-anchor: middle; }
-  .lang-label { font-size: 10.5px; fill: #0b0b0b; }
-  .value-label { font-size: 8.5px; fill: #52514e; }
+  .panel-title { font-size: 10.5px; font-weight: 600; fill: #0b0b0b; text-anchor: middle; }
+  .summary-title { font-size: 10.5px; font-weight: 600; fill: #0b0b0b; text-anchor: start; }
+  .lang-label { font-size: 13px; font-weight: 700; fill: #0b0b0b; }
+  .bar-value-label { font-size: 8px; fill: #ffffff; text-anchor: middle; font-weight: 600; }
   .legend-label { font-size: 10px; fill: #0b0b0b; }
   .stripe { fill: #f0efec; }
   .awaiting { font-size: 9.5px; fill: #9a9a95; font-style: italic; }
   .bar-track { fill: #eeede9; }
+  .badge-label { font-size: 8.5px; font-weight: 700; fill: #ffffff; text-anchor: middle; }
 </style>
-<rect class="surface" x="0" y="0" width="668" height="1632"/>
+<rect class="surface" x="0" y="0" width="812" height="2248"/>
 <text class="title" x="16" y="20">GitGalaxy Structural Extraction: Tri-Comparison vs. Tree-sitter and ctags</text>
 <text class="subtitle" x="16" y="36">2026-08-18 &#183; source: tests/tools/tri_comparison_chart.py &#183; ledger: docs/self_scan/tri_comparison_ledger.json</text>
-<text class="scope-note" x="16" y="52">No tool is ground truth -- each bar is that tool's own agreement rate vs. everything anyone found.</text>
-<text class="scope-note" x="16" y="64">Bar groups vary 1-3 by language's tool coverage -- order is always GitGalaxy, tree-sitter, ctags.</text>
-<text class="scope-note" x="16" y="76">GitGalaxy's bar is GRAY when beaten and unaudited, colored when tied or validated.</text>
-<text class="scope-note" x="16" y="88">See docs/self_scan/how_to_investigate_a_discrepancy.md for what an unaudited gap means.</text>
+<text class="scope-note" x="16" y="52">No tool is ground truth -- recall is vs. everything anyone found, precision is vs. what each tool itself claimed.</text>
+<text class="scope-note" x="16" y="64">Bar groups vary 1-3 by language's tool coverage -- order is always GitGalaxy, tree-sitter, ctags. css/html class panels are out of scope by design (selectors, not OOP classes).</text>
+<text class="scope-note" x="16" y="76">GitGalaxy's bar is always blue; `*` marks an unaudited loss to another tool, not a verdict. Badge = the tool that scored strictly highest (blank on a tie).</text>
+<text class="scope-note" x="16" y="88">See docs/self_scan/how_to_investigate_a_discrepancy.md for what `*` is asking for.</text>
 <rect x="16" y="100" width="14" height="8" rx="2" fill="#2a78d6"/>
 <text class="legend-label" x="34" y="108">GitGalaxy</text>
 <rect x="135" y="100" width="14" height="8" rx="2" fill="#eb6834"/>
 <text class="legend-label" x="153" y="108">tree-sitter</text>
 <rect x="272" y="100" width="14" height="8" rx="2" fill="#1baf7a"/>
 <text class="legend-label" x="290" y="108">ctags</text>
-<rect x="355" y="100" width="14" height="8" rx="2" fill="#9a9a95"/>
-<text class="legend-label" x="373" y="108">GitGalaxy, unaudited gap</text>
-<text class="panel-title" x="213.0" y="144">Function Existence</text>
-<text class="panel-title" x="393.0" y="144">Class Existence</text>
-<text class="panel-title" x="573.0" y="144">Args Exact-Match</text>
-<rect class="stripe" x="16" y="148" width="636" height="32"/>
-<text class="lang-label" x="20" y="167.5">abap</text>
-<rect class="bar-track" x="134" y="153" width="92" height="22" rx="2"/>
-<rect x="134" y="153" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="158.5">16/16</text>
-<rect class="bar-track" x="314" y="153" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="153" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="199.5">ada</text>
-<text class="awaiting" x="134" y="199.5">awaiting language-crucible corpus</text>
-<rect class="stripe" x="16" y="212" width="636" height="32"/>
-<text class="lang-label" x="20" y="231.5">agc_assembly</text>
-<rect class="bar-track" x="134" y="217" width="92" height="22" rx="2"/>
-<rect x="134" y="217" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="222.5">760/760</text>
-<rect x="134" y="225" width="2.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="230.5">0/760</text>
-<rect class="bar-track" x="314" y="217" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="217" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="263.5">apex</text>
-<rect class="bar-track" x="134" y="249" width="92" height="22" rx="2"/>
-<rect x="134" y="249" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="254.5">40/40</text>
-<rect x="134" y="257" width="87.4" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="262.5">38/40</text>
-<rect class="bar-track" x="314" y="249" width="92" height="22" rx="2"/>
-<rect x="314" y="249" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="254.5">4/4</text>
-<rect x="314" y="257" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="262.5">4/4</text>
-<rect class="bar-track" x="494" y="249" width="92" height="22" rx="2"/>
-<rect x="494" y="249" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="254.5">38/38</text>
-<rect x="494" y="257" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="262.5">38/38</text>
-<rect class="stripe" x="16" y="276" width="636" height="32"/>
-<text class="lang-label" x="20" y="295.5">assembly</text>
-<rect class="bar-track" x="134" y="281" width="92" height="22" rx="2"/>
-<rect x="134" y="281" width="87.4" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="286.5">132/139</text>
-<rect x="134" y="289" width="57.6" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="294.5">87/139</text>
-<rect class="bar-track" x="314" y="281" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="281" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="327.5">c</text>
-<rect class="bar-track" x="134" y="313" width="92" height="22" rx="2"/>
-<rect x="134" y="313" width="87.7" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="318.5">1730/1814</text>
-<rect x="134" y="321" width="90.8" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="326.5">1790/1814</text>
-<rect x="134" y="329" width="87.6" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="334.5">1728/1814</text>
-<rect class="bar-track" x="314" y="313" width="92" height="22" rx="2"/>
-<rect x="314" y="313" width="9.2" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="318.5">61/609</text>
-<rect x="314" y="321" width="88.5" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="326.5">586/609</text>
-<rect x="314" y="329" width="11.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="334.5">75/609</text>
-<rect class="bar-track" x="494" y="313" width="92" height="22" rx="2"/>
-<rect x="494" y="313" width="86.3" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="318.5">1600/1705</text>
-<rect x="494" y="321" width="86.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="326.5">1600/1705</text>
-<rect x="494" y="329" width="86.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="334.5">1600/1705</text>
-<rect class="stripe" x="16" y="340" width="636" height="32"/>
-<text class="lang-label" x="20" y="359.5">cobol</text>
-<rect class="bar-track" x="134" y="345" width="92" height="22" rx="2"/>
-<rect x="134" y="345" width="44.8" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="350.5">126/259</text>
-<rect x="134" y="353" width="85.6" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="358.5">241/259</text>
-<rect class="bar-track" x="314" y="345" width="92" height="22" rx="2"/>
-<rect x="314" y="345" width="2.0" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="350.5">0/19</text>
-<rect x="314" y="353" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="358.5">19/19</text>
-<rect class="bar-track" x="494" y="345" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="391.5">cpp</text>
-<rect class="bar-track" x="134" y="377" width="92" height="22" rx="2"/>
-<rect x="134" y="377" width="51.3" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="382.5">1462/2622</text>
-<rect x="134" y="385" width="52.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="390.5">1491/2622</text>
-<rect x="134" y="393" width="41.5" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="398.5">1184/2622</text>
-<rect class="bar-track" x="314" y="377" width="92" height="22" rx="2"/>
-<rect x="314" y="377" width="79.2" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="382.5">149/173</text>
-<rect x="314" y="385" width="90.9" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="390.5">171/173</text>
-<rect x="314" y="393" width="16.5" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="398.5">31/173</text>
-<rect class="bar-track" x="494" y="377" width="92" height="22" rx="2"/>
-<rect x="494" y="377" width="70.1" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="590" y="382.5">93/122</text>
-<rect x="494" y="385" width="70.1" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="390.5">93/122</text>
-<rect x="494" y="393" width="70.1" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="398.5">93/122</text>
-<rect class="stripe" x="16" y="404" width="636" height="32"/>
-<text class="lang-label" x="20" y="423.5">csharp</text>
-<rect class="bar-track" x="134" y="409" width="92" height="22" rx="2"/>
-<rect x="134" y="409" width="91.5" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="414.5">961/966</text>
-<rect x="134" y="417" width="61.6" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="422.5">647/966</text>
-<rect x="134" y="425" width="77.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="430.5">809/966</text>
-<rect class="bar-track" x="314" y="409" width="92" height="22" rx="2"/>
-<rect x="314" y="409" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="414.5">33/33</text>
-<rect x="314" y="417" width="66.9" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="422.5">24/33</text>
-<rect x="314" y="425" width="61.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="430.5">22/33</text>
-<rect class="bar-track" x="494" y="409" width="92" height="22" rx="2"/>
-<rect x="494" y="409" width="89.8" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="590" y="414.5">521/534</text>
-<rect x="494" y="417" width="89.8" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="422.5">521/534</text>
-<rect x="494" y="425" width="89.8" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="430.5">521/534</text>
-<text class="lang-label" x="20" y="455.5">css</text>
-<rect class="bar-track" x="134" y="441" width="92" height="22" rx="2"/>
-<rect x="134" y="441" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="446.5">3/3</text>
-<rect x="134" y="449" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="454.5">3/3</text>
-<rect x="134" y="457" width="2.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="462.5">0/3</text>
-<rect class="bar-track" x="314" y="441" width="92" height="22" rx="2"/>
-<rect x="314" y="441" width="54.6" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="446.5">124/209</text>
-<rect x="314" y="449" width="54.6" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="454.5">124/209</text>
-<rect x="314" y="457" width="42.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="462.5">97/209</text>
-<rect class="bar-track" x="494" y="441" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="468" width="636" height="32"/>
-<text class="lang-label" x="20" y="487.5">dart</text>
-<rect class="bar-track" x="134" y="473" width="92" height="22" rx="2"/>
-<rect x="134" y="473" width="91.1" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="478.5">1767/1785</text>
-<rect x="134" y="481" width="90.1" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="486.5">1748/1785</text>
-<rect class="bar-track" x="314" y="473" width="92" height="22" rx="2"/>
-<rect x="314" y="473" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="478.5">200/200</text>
-<rect x="314" y="481" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="486.5">200/200</text>
-<rect class="bar-track" x="494" y="473" width="92" height="22" rx="2"/>
-<rect x="494" y="473" width="80.5" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="478.5">1514/1730</text>
-<rect x="494" y="481" width="80.5" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="486.5">1514/1730</text>
-<text class="lang-label" x="20" y="519.5">dockerfile</text>
-<rect class="bar-track" x="134" y="505" width="92" height="22" rx="2"/>
-<rect x="134" y="505" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="510.5">17/17</text>
-<rect class="bar-track" x="314" y="505" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="505" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="532" width="636" height="32"/>
-<text class="lang-label" x="20" y="551.5">embedded_python</text>
-<text class="awaiting" x="134" y="551.5">awaiting language-crucible corpus</text>
-<text class="lang-label" x="20" y="583.5">fortran</text>
-<rect class="bar-track" x="134" y="569" width="92" height="22" rx="2"/>
-<rect x="134" y="569" width="90.7" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="574.5">137/139</text>
-<rect x="134" y="577" width="81.4" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="582.5">123/139</text>
-<rect x="134" y="585" width="90.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="590.5">137/139</text>
-<rect class="bar-track" x="314" y="569" width="92" height="22" rx="2"/>
-<rect x="314" y="569" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="574.5">11/11</text>
-<rect x="314" y="577" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="582.5">11/11</text>
-<rect x="314" y="585" width="25.1" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="590.5">3/11</text>
-<rect class="bar-track" x="494" y="569" width="92" height="22" rx="2"/>
-<rect x="494" y="569" width="91.2" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="590" y="574.5">120/121</text>
-<rect x="494" y="577" width="91.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="582.5">120/121</text>
-<rect x="494" y="585" width="91.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="590.5">94/95</text>
-<rect class="stripe" x="16" y="596" width="636" height="32"/>
-<text class="lang-label" x="20" y="615.5">go</text>
-<rect class="bar-track" x="134" y="601" width="92" height="22" rx="2"/>
-<rect x="134" y="601" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="606.5">897/897</text>
-<rect x="134" y="609" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="614.5">897/897</text>
-<rect x="134" y="617" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="622.5">897/897</text>
-<rect class="bar-track" x="314" y="601" width="92" height="22" rx="2"/>
-<rect x="314" y="601" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="606.5">69/69</text>
-<rect x="314" y="609" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="614.5">69/69</text>
-<rect x="314" y="617" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="622.5">69/69</text>
-<rect class="bar-track" x="494" y="601" width="92" height="22" rx="2"/>
-<rect x="494" y="601" width="84.3" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="606.5">822/897</text>
-<rect x="494" y="609" width="84.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="614.5">822/897</text>
-<rect x="494" y="617" width="84.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="622.5">819/894</text>
-<text class="lang-label" x="20" y="647.5">groovy</text>
-<rect class="bar-track" x="134" y="633" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="633" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="633" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="660" width="636" height="32"/>
-<text class="lang-label" x="20" y="679.5">haskell</text>
-<rect class="bar-track" x="134" y="665" width="92" height="22" rx="2"/>
-<rect x="134" y="665" width="39.9" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="670.5">148/341</text>
-<rect x="134" y="673" width="74.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="678.5">275/341</text>
-<rect x="134" y="681" width="48.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="686.5">179/341</text>
-<rect class="bar-track" x="314" y="665" width="92" height="22" rx="2"/>
-<rect x="314" y="665" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="670.5">16/16</text>
-<rect x="314" y="673" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="678.5">16/16</text>
-<rect x="314" y="681" width="2.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="686.5">0/16</text>
-<rect class="bar-track" x="494" y="665" width="92" height="22" rx="2"/>
-<rect x="494" y="665" width="81.2" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="670.5">68/77</text>
-<rect x="494" y="673" width="81.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="678.5">68/77</text>
-<text class="lang-label" x="20" y="711.5">html</text>
-<rect class="bar-track" x="134" y="697" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="697" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="697" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="724" width="636" height="32"/>
-<text class="lang-label" x="20" y="743.5">java</text>
-<rect class="bar-track" x="134" y="729" width="92" height="22" rx="2"/>
-<rect x="134" y="729" width="91.1" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="734.5">315/318</text>
-<rect x="134" y="737" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="742.5">318/318</text>
-<rect x="134" y="745" width="2.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="750.5">0/318</text>
-<rect class="bar-track" x="314" y="729" width="92" height="22" rx="2"/>
-<rect x="314" y="729" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="734.5">35/35</text>
-<rect x="314" y="737" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="742.5">35/35</text>
-<rect x="314" y="745" width="18.4" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="750.5">7/35</text>
-<rect class="bar-track" x="494" y="729" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="775.5">javascript</text>
-<rect class="bar-track" x="134" y="761" width="92" height="22" rx="2"/>
-<rect x="134" y="761" width="80.6" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="766.5">793/905</text>
-<rect x="134" y="769" width="71.6" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="774.5">704/905</text>
-<rect x="134" y="777" width="9.1" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="782.5">90/905</text>
-<rect class="bar-track" x="314" y="761" width="92" height="22" rx="2"/>
-<rect x="314" y="761" width="76.2" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="766.5">29/35</text>
-<rect x="314" y="769" width="76.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="774.5">29/35</text>
-<rect x="314" y="777" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="782.5">35/35</text>
-<rect class="bar-track" x="494" y="761" width="92" height="22" rx="2"/>
-<rect x="494" y="761" width="82.9" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="766.5">64/71</text>
-<rect x="494" y="769" width="82.9" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="774.5">64/71</text>
-<rect x="494" y="777" width="82.9" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="782.5">64/71</text>
-<rect class="stripe" x="16" y="788" width="636" height="32"/>
-<text class="lang-label" x="20" y="807.5">jcl</text>
-<rect class="bar-track" x="134" y="793" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="793" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="793" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="839.5">kotlin</text>
-<rect class="bar-track" x="134" y="825" width="92" height="22" rx="2"/>
-<rect x="134" y="825" width="59.9" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="830.5">28/43</text>
-<rect x="134" y="833" width="57.8" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="838.5">27/43</text>
-<rect x="134" y="841" width="89.9" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="846.5">42/43</text>
-<rect class="bar-track" x="314" y="825" width="92" height="22" rx="2"/>
-<rect x="314" y="825" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="830.5">7/7</text>
-<rect x="314" y="833" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="838.5">7/7</text>
-<rect x="314" y="841" width="52.6" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="846.5">4/7</text>
-<rect class="bar-track" x="494" y="825" width="92" height="22" rx="2"/>
-<rect x="494" y="825" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="830.5">27/27</text>
-<rect x="494" y="833" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="838.5">27/27</text>
-<rect class="stripe" x="16" y="852" width="636" height="32"/>
-<text class="lang-label" x="20" y="871.5">livecode</text>
-<rect class="bar-track" x="134" y="857" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="857" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="857" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="903.5">lua</text>
-<rect class="bar-track" x="134" y="889" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="889" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="889" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="916" width="636" height="32"/>
-<text class="lang-label" x="20" y="935.5">m4</text>
-<rect class="bar-track" x="134" y="921" width="92" height="22" rx="2"/>
-<rect x="134" y="921" width="2.0" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="926.5">1/148</text>
-<rect x="134" y="929" width="91.4" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="934.5">147/148</text>
-<rect class="bar-track" x="314" y="921" width="92" height="22" rx="2"/>
-<rect x="314" y="921" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="926.5">4/4</text>
-<rect x="314" y="929" width="2.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="934.5">0/4</text>
-<rect class="bar-track" x="494" y="921" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="967.5">makefile</text>
-<rect class="bar-track" x="134" y="953" width="92" height="22" rx="2"/>
-<rect x="134" y="953" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="958.5">1/1</text>
-<rect x="134" y="961" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="966.5">1/1</text>
-<rect x="134" y="969" width="2.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="974.5">0/1</text>
-<rect class="bar-track" x="314" y="953" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="953" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="980" width="636" height="32"/>
-<text class="lang-label" x="20" y="999.5">matlab</text>
-<rect class="bar-track" x="134" y="985" width="92" height="22" rx="2"/>
-<rect x="134" y="985" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="990.5">23/23</text>
-<rect x="134" y="993" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="998.5">23/23</text>
-<rect x="134" y="1001" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1006.5">23/23</text>
-<rect class="bar-track" x="314" y="985" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="985" width="92" height="22" rx="2"/>
-<rect x="494" y="985" width="88.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="990.5">22/23</text>
-<rect x="494" y="993" width="88.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="998.5">22/23</text>
-<text class="lang-label" x="20" y="1031.5">objective-c</text>
-<rect class="bar-track" x="134" y="1017" width="92" height="22" rx="2"/>
-<rect x="134" y="1017" width="62.4" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1022.5">152/224</text>
-<rect x="134" y="1025" width="62.8" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1030.5">153/224</text>
-<rect x="134" y="1033" width="41.5" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1038.5">101/224</text>
-<rect class="bar-track" x="314" y="1017" width="92" height="22" rx="2"/>
-<rect x="314" y="1017" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1022.5">5/5</text>
-<rect x="314" y="1025" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1030.5">5/5</text>
-<rect x="314" y="1033" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1038.5">5/5</text>
-<rect class="bar-track" x="494" y="1017" width="92" height="22" rx="2"/>
-<rect x="494" y="1017" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1022.5">31/31</text>
-<rect x="494" y="1025" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1030.5">31/31</text>
-<rect x="494" y="1033" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="1038.5">31/31</text>
-<rect class="stripe" x="16" y="1044" width="636" height="32"/>
-<text class="lang-label" x="20" y="1063.5">perl</text>
-<rect class="bar-track" x="134" y="1049" width="92" height="22" rx="2"/>
-<rect x="134" y="1049" width="80.9" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1054.5">942/1071</text>
-<rect x="134" y="1057" width="91.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1062.5">1063/1071</text>
-<rect x="134" y="1065" width="80.8" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1070.5">941/1071</text>
-<rect class="bar-track" x="314" y="1049" width="92" height="22" rx="2"/>
-<rect x="314" y="1049" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1054.5">21/21</text>
-<rect x="314" y="1057" width="87.6" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1062.5">20/21</text>
-<rect x="314" y="1065" width="87.6" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1070.5">20/21</text>
-<rect class="bar-track" x="494" y="1049" width="92" height="22" rx="2"/>
-<rect x="494" y="1049" width="85.7" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1054.5">870/934</text>
-<rect x="494" y="1057" width="85.7" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1062.5">870/934</text>
-<text class="lang-label" x="20" y="1095.5">php</text>
-<rect class="bar-track" x="134" y="1081" width="92" height="22" rx="2"/>
-<rect x="134" y="1081" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1086.5">1703/1703</text>
-<rect x="134" y="1089" width="91.9" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1094.5">1702/1703</text>
-<rect x="134" y="1097" width="88.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1102.5">1635/1703</text>
-<rect class="bar-track" x="314" y="1081" width="92" height="22" rx="2"/>
-<rect x="314" y="1081" width="88.9" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="1086.5">29/30</text>
-<rect x="314" y="1089" width="88.9" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1094.5">29/30</text>
-<rect x="314" y="1097" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1102.5">30/30</text>
-<rect class="bar-track" x="494" y="1081" width="92" height="22" rx="2"/>
-<rect x="494" y="1081" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1086.5">1634/1634</text>
-<rect x="494" y="1089" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1094.5">1634/1634</text>
-<rect x="494" y="1097" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="1102.5">1634/1634</text>
-<rect class="stripe" x="16" y="1108" width="636" height="32"/>
-<text class="lang-label" x="20" y="1127.5">powershell</text>
-<rect class="bar-track" x="134" y="1113" width="92" height="22" rx="2"/>
-<rect x="134" y="1113" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1118.5">111/111</text>
-<rect x="134" y="1121" width="91.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1126.5">110/111</text>
-<rect x="134" y="1129" width="88.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1134.5">107/111</text>
-<rect class="bar-track" x="314" y="1113" width="92" height="22" rx="2"/>
-<rect x="314" y="1113" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1118.5">7/7</text>
-<rect x="314" y="1121" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1126.5">7/7</text>
-<rect x="314" y="1129" width="65.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1134.5">5/7</text>
-<rect class="bar-track" x="494" y="1113" width="92" height="22" rx="2"/>
-<rect x="494" y="1113" width="87.7" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1118.5">101/106</text>
-<rect x="494" y="1121" width="87.7" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1126.5">101/106</text>
-<rect x="494" y="1129" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="1134.5">2/2</text>
-<text class="lang-label" x="20" y="1159.5">python</text>
-<rect class="bar-track" x="134" y="1145" width="92" height="22" rx="2"/>
-<rect x="134" y="1145" width="90.3" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1150.5">3657/3725</text>
-<rect x="134" y="1153" width="89.5" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1158.5">3625/3725</text>
-<rect x="134" y="1161" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1166.5">3725/3725</text>
-<rect class="bar-track" x="314" y="1145" width="92" height="22" rx="2"/>
-<rect x="314" y="1145" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1150.5">473/473</text>
-<rect x="314" y="1153" width="91.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1158.5">469/473</text>
-<rect x="314" y="1161" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1166.5">473/473</text>
-<rect class="bar-track" x="494" y="1145" width="92" height="22" rx="2"/>
-<rect x="494" y="1145" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1150.5">3624/3625</text>
-<rect x="494" y="1153" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1158.5">3624/3625</text>
-<rect x="494" y="1161" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="1166.5">3623/3624</text>
-<rect class="stripe" x="16" y="1172" width="636" height="32"/>
-<text class="lang-label" x="20" y="1191.5">ruby</text>
-<rect class="bar-track" x="134" y="1177" width="92" height="22" rx="2"/>
-<rect x="134" y="1177" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1182.5">124/124</text>
-<rect x="134" y="1185" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1190.5">124/124</text>
-<rect x="134" y="1193" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1198.5">124/124</text>
-<rect class="bar-track" x="314" y="1177" width="92" height="22" rx="2"/>
-<rect x="314" y="1177" width="83.2" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="1182.5">19/21</text>
-<rect x="314" y="1185" width="83.2" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1190.5">19/21</text>
-<rect x="314" y="1193" width="65.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1198.5">15/21</text>
-<rect class="bar-track" x="494" y="1177" width="92" height="22" rx="2"/>
-<rect x="494" y="1177" width="85.3" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="590" y="1182.5">115/124</text>
-<rect x="494" y="1185" width="85.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1190.5">115/124</text>
-<rect x="494" y="1193" width="85.3" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="1198.5">115/124</text>
-<text class="lang-label" x="20" y="1223.5">rust</text>
-<rect class="bar-track" x="134" y="1209" width="92" height="22" rx="2"/>
-<rect x="134" y="1209" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1214.5">1927/1927</text>
-<rect x="134" y="1217" width="84.7" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1222.5">1775/1927</text>
-<rect x="134" y="1225" width="84.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1230.5">1774/1927</text>
-<rect class="bar-track" x="314" y="1209" width="92" height="22" rx="2"/>
-<rect x="314" y="1209" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1214.5">312/312</text>
-<rect x="314" y="1217" width="84.6" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1222.5">287/312</text>
-<rect x="314" y="1225" width="83.7" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1230.5">284/312</text>
-<rect class="bar-track" x="494" y="1209" width="92" height="22" rx="2"/>
-<rect x="494" y="1209" width="89.8" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="590" y="1214.5">1732/1774</text>
-<rect x="494" y="1217" width="89.8" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1222.5">1732/1774</text>
-<rect x="494" y="1225" width="90.6" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="590" y="1230.5">1392/1413</text>
-<rect class="stripe" x="16" y="1236" width="636" height="32"/>
-<text class="lang-label" x="20" y="1255.5">scala</text>
-<rect class="bar-track" x="134" y="1241" width="92" height="22" rx="2"/>
-<rect x="134" y="1241" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1246.5">541/541</text>
-<rect x="134" y="1249" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1254.5">541/541</text>
-<rect class="bar-track" x="314" y="1241" width="92" height="22" rx="2"/>
-<rect x="314" y="1241" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1246.5">24/24</text>
-<rect x="314" y="1249" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1254.5">24/24</text>
-<rect class="bar-track" x="494" y="1241" width="92" height="22" rx="2"/>
-<rect x="494" y="1241" width="89.3" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1246.5">525/541</text>
-<rect x="494" y="1249" width="89.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1254.5">525/541</text>
-<text class="lang-label" x="20" y="1287.5">scheme</text>
-<rect class="bar-track" x="134" y="1273" width="92" height="22" rx="2"/>
-<rect x="134" y="1273" width="2.0" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1278.5">0/75</text>
-<rect x="134" y="1281" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1286.5">75/75</text>
-<rect class="bar-track" x="314" y="1273" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="1273" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="1300" width="636" height="32"/>
-<text class="lang-label" x="20" y="1319.5">shell</text>
-<rect class="bar-track" x="134" y="1305" width="92" height="22" rx="2"/>
-<rect x="134" y="1305" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1310.5">3/3</text>
-<rect x="134" y="1313" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1318.5">3/3</text>
-<rect x="134" y="1321" width="92.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1326.5">3/3</text>
-<rect class="bar-track" x="314" y="1305" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="1305" width="92" height="22" rx="2"/>
-<rect x="494" y="1305" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1310.5">3/3</text>
-<rect x="494" y="1313" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1318.5">3/3</text>
-<text class="lang-label" x="20" y="1351.5">solidity</text>
-<rect class="bar-track" x="134" y="1337" width="92" height="22" rx="2"/>
-<rect x="134" y="1337" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="230" y="1342.5">105/105</text>
-<rect x="134" y="1345" width="86.7" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1350.5">99/105</text>
-<rect class="bar-track" x="314" y="1337" width="92" height="22" rx="2"/>
-<rect x="314" y="1337" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1342.5">7/7</text>
-<rect x="314" y="1345" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1350.5">7/7</text>
-<rect class="bar-track" x="494" y="1337" width="92" height="22" rx="2"/>
-<rect x="494" y="1337" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1342.5">99/99</text>
-<rect x="494" y="1345" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1350.5">99/99</text>
-<rect class="stripe" x="16" y="1364" width="636" height="32"/>
-<text class="lang-label" x="20" y="1383.5">sqlite</text>
-<text class="awaiting" x="134" y="1383.5">awaiting language-crucible corpus</text>
-<text class="lang-label" x="20" y="1415.5">swift</text>
-<rect class="bar-track" x="134" y="1401" width="92" height="22" rx="2"/>
-<rect x="134" y="1401" width="91.3" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1406.5">132/133</text>
-<rect x="134" y="1409" width="91.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1414.5">132/133</text>
-<rect class="bar-track" x="314" y="1401" width="92" height="22" rx="2"/>
-<rect x="314" y="1401" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1406.5">60/60</text>
-<rect x="314" y="1409" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1414.5">60/60</text>
-<rect class="bar-track" x="494" y="1401" width="92" height="22" rx="2"/>
-<rect x="494" y="1401" width="91.3" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1406.5">130/131</text>
-<rect x="494" y="1409" width="91.3" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1414.5">130/131</text>
-<rect class="stripe" x="16" y="1428" width="636" height="32"/>
-<text class="lang-label" x="20" y="1447.5">tcl</text>
-<rect class="bar-track" x="134" y="1433" width="92" height="22" rx="2"/>
-<rect x="134" y="1433" width="90.7" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1438.5">144/146</text>
-<rect x="134" y="1441" width="90.7" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1446.5">144/146</text>
-<rect x="134" y="1449" width="88.8" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1454.5">141/146</text>
-<rect class="bar-track" x="314" y="1433" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="1433" width="92" height="22" rx="2"/>
-<rect x="494" y="1433" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1438.5">138/138</text>
-<rect x="494" y="1441" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1446.5">138/138</text>
-<text class="lang-label" x="20" y="1479.5">typescript</text>
-<rect class="bar-track" x="134" y="1465" width="92" height="22" rx="2"/>
-<rect x="134" y="1465" width="84.4" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1470.5">2733/2980</text>
-<rect x="134" y="1473" width="90.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1478.5">2914/2980</text>
-<rect x="134" y="1481" width="26.0" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="230" y="1486.5">842/2980</text>
-<rect class="bar-track" x="314" y="1465" width="92" height="22" rx="2"/>
-<rect x="314" y="1465" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="410" y="1470.5">842/842</text>
-<rect x="314" y="1473" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1478.5">842/842</text>
-<rect x="314" y="1481" width="35.2" height="6" rx="2" fill="#1baf7a"/>
-<text class="value-label" x="410" y="1486.5">322/842</text>
-<rect class="bar-track" x="494" y="1465" width="92" height="22" rx="2"/>
-<rect x="494" y="1465" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1470.5">770/770</text>
-<rect x="494" y="1473" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1478.5">770/770</text>
-<rect class="stripe" x="16" y="1492" width="636" height="32"/>
-<text class="lang-label" x="20" y="1511.5">yacc</text>
-<rect class="bar-track" x="134" y="1497" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="1497" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="1497" width="92" height="22" rx="2"/>
-<text class="lang-label" x="20" y="1543.5">yaml</text>
-<rect class="bar-track" x="134" y="1529" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="314" y="1529" width="92" height="22" rx="2"/>
-<rect class="bar-track" x="494" y="1529" width="92" height="22" rx="2"/>
-<rect class="stripe" x="16" y="1556" width="636" height="32"/>
-<text class="lang-label" x="20" y="1575.5">zig</text>
-<rect class="bar-track" x="134" y="1561" width="92" height="22" rx="2"/>
-<rect x="134" y="1561" width="92.0" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="230" y="1566.5">2750/2751</text>
-<rect x="134" y="1569" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="230" y="1574.5">2751/2751</text>
-<rect class="bar-track" x="314" y="1561" width="92" height="22" rx="2"/>
-<rect x="314" y="1561" width="90.8" height="6" rx="2" fill="#9a9a95"/>
-<text class="value-label" x="410" y="1566.5">729/739</text>
-<rect x="314" y="1569" width="91.9" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="410" y="1574.5">738/739</text>
-<rect class="bar-track" x="494" y="1561" width="92" height="22" rx="2"/>
-<rect x="494" y="1561" width="92.0" height="6" rx="2" fill="#2a78d6"/>
-<text class="value-label" x="590" y="1566.5">2750/2750</text>
-<rect x="494" y="1569" width="92.0" height="6" rx="2" fill="#eb6834"/>
-<text class="value-label" x="590" y="1574.5">2750/2750</text>
-<text class="scope-note" x="16" y="1604">Value labels are raw counts (matched/total). Regenerate: tri_comparison_chart.py --all --write</text>
+<text class="legend-label" x="355" y="108">* = GitGalaxy, unaudited loss</text>
+<text class="panel-title" x="211.0" y="144">Func Recall</text>
+<text class="panel-title" x="343.0" y="144">Func Precision</text>
+<text class="panel-title" x="475.0" y="144">Class Recall</text>
+<text class="panel-title" x="607.0" y="144">Class Precision</text>
+<text class="panel-title" x="739.0" y="144">Args Match</text>
+<rect class="stripe" x="16" y="148" width="780" height="44"/>
+<text class="lang-label" x="20" y="173.5">abap</text>
+<rect class="bar-track" x="154" y="153" width="88" height="34" rx="2"/>
+<rect x="154" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="161">16/16</text>
+<rect class="bar-track" x="286" y="153" width="88" height="34" rx="2"/>
+<rect x="286" y="153" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="161">0/16</text>
+<rect class="bar-track" x="418" y="153" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="153" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="153" width="88" height="34" rx="2"/>
+<text class="lang-label" x="20" y="217.5">ada</text>
+<text class="awaiting" x="154" y="217.5">awaiting language-crucible corpus</text>
+<rect class="stripe" x="16" y="236" width="780" height="44"/>
+<text class="lang-label" x="20" y="261.5">agc_assembly</text>
+<rect class="bar-track" x="154" y="241" width="88" height="34" rx="2"/>
+<rect x="154" y="241" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="249">760/760</text>
+<rect x="154" y="253" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="261">0/760</text>
+<circle cx="258.0" cy="258.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="261.0">G</text>
+<rect class="bar-track" x="286" y="241" width="88" height="34" rx="2"/>
+<rect x="286" y="241" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="249">0/760*</text>
+<rect class="bar-track" x="418" y="241" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="241" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="241" width="88" height="34" rx="2"/>
+<text class="lang-label" x="20" y="305.5">apex</text>
+<rect class="bar-track" x="154" y="285" width="88" height="34" rx="2"/>
+<rect x="154" y="285" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="293">40/40</text>
+<rect x="154" y="297" width="83.6" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="305">38/40</text>
+<circle cx="258.0" cy="302.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="305.0">G</text>
+<rect class="bar-track" x="286" y="285" width="88" height="34" rx="2"/>
+<rect x="286" y="285" width="83.6" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="293">38/40*</text>
+<rect x="286" y="297" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="305">38/38</text>
+<circle cx="390.0" cy="302.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="305.0">T</text>
+<rect class="bar-track" x="418" y="285" width="88" height="34" rx="2"/>
+<rect x="418" y="285" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="293">4/4</text>
+<rect x="418" y="297" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="305">4/4</text>
+<rect class="bar-track" x="550" y="285" width="88" height="34" rx="2"/>
+<rect x="550" y="285" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="293">4/4</text>
+<rect x="550" y="297" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="305">4/4</text>
+<rect class="bar-track" x="682" y="285" width="88" height="34" rx="2"/>
+<rect x="682" y="285" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="293">38/38</text>
+<rect x="682" y="297" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="305">38/38</text>
+<rect class="stripe" x="16" y="324" width="780" height="44"/>
+<text class="lang-label" x="20" y="349.5">assembly</text>
+<rect class="bar-track" x="154" y="329" width="88" height="34" rx="2"/>
+<rect x="154" y="329" width="83.6" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="337">132/139*</text>
+<rect x="154" y="341" width="55.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="349">87/139</text>
+<circle cx="258.0" cy="346.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="349.0">G</text>
+<rect class="bar-track" x="286" y="329" width="88" height="34" rx="2"/>
+<rect x="286" y="329" width="53.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="337">80/132*</text>
+<rect x="286" y="341" width="80.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="349">80/87</text>
+<circle cx="390.0" cy="346.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="390.0" y="349.0">C</text>
+<rect class="bar-track" x="418" y="329" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="329" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="329" width="88" height="34" rx="2"/>
+<text class="lang-label" x="20" y="393.5">c</text>
+<rect class="bar-track" x="154" y="373" width="88" height="34" rx="2"/>
+<rect x="154" y="373" width="83.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="381">1730/1814*</text>
+<rect x="154" y="385" width="86.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="393">1790/1814</text>
+<rect x="154" y="397" width="83.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="405">1728/1814</text>
+<circle cx="258.0" cy="390.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="393.0">T</text>
+<rect class="bar-track" x="286" y="373" width="88" height="34" rx="2"/>
+<rect x="286" y="373" width="87.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="381">1726/1730*</text>
+<rect x="286" y="385" width="84.4" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="393">1716/1790</text>
+<rect x="286" y="397" width="87.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="405">1721/1728</text>
+<circle cx="390.0" cy="390.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="393.0">G</text>
+<rect class="bar-track" x="418" y="373" width="88" height="34" rx="2"/>
+<rect x="418" y="373" width="8.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="381">61/609*</text>
+<rect x="418" y="385" width="84.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="393">586/609</text>
+<rect x="418" y="397" width="10.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="405">75/609</text>
+<circle cx="522.0" cy="390.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="522.0" y="393.0">T</text>
+<rect class="bar-track" x="550" y="373" width="88" height="34" rx="2"/>
+<rect x="550" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="381">61/61</text>
+<rect x="550" y="385" width="9.2" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="393">61/586</text>
+<rect x="550" y="397" width="61.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="405">52/75</text>
+<circle cx="654.0" cy="390.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="393.0">G</text>
+<rect class="bar-track" x="682" y="373" width="88" height="34" rx="2"/>
+<rect x="682" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="381">1705/1705</text>
+<rect x="682" y="385" width="87.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="393">1704/1705</text>
+<rect x="682" y="397" width="82.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="405">1601/1705</text>
+<circle cx="786.0" cy="390.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="786.0" y="393.0">G</text>
+<rect class="stripe" x="16" y="412" width="780" height="44"/>
+<text class="lang-label" x="20" y="437.5">cobol</text>
+<rect class="bar-track" x="154" y="417" width="88" height="34" rx="2"/>
+<rect x="154" y="417" width="42.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="425">126/259*</text>
+<rect x="154" y="429" width="81.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="437">241/259</text>
+<circle cx="258.0" cy="434.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="258.0" y="437.0">C</text>
+<rect class="bar-track" x="286" y="417" width="88" height="34" rx="2"/>
+<rect x="286" y="417" width="75.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="425">108/126*</text>
+<rect x="286" y="429" width="39.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="437">108/241</text>
+<circle cx="390.0" cy="434.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="437.0">G</text>
+<rect class="bar-track" x="418" y="417" width="88" height="34" rx="2"/>
+<rect x="418" y="417" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="425">0/19*</text>
+<rect x="418" y="429" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="437">19/19</text>
+<circle cx="522.0" cy="434.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="522.0" y="437.0">C</text>
+<rect class="bar-track" x="550" y="417" width="88" height="34" rx="2"/>
+<rect x="550" y="417" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="425">0/19</text>
+<rect class="bar-track" x="682" y="417" width="88" height="34" rx="2"/>
+<text class="lang-label" x="20" y="481.5">cpp</text>
+<rect class="bar-track" x="154" y="461" width="88" height="34" rx="2"/>
+<rect x="154" y="461" width="49.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="469">1462/2622*</text>
+<rect x="154" y="473" width="50.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="481">1491/2622</text>
+<rect x="154" y="485" width="39.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="493">1184/2622</text>
+<circle cx="258.0" cy="478.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="481.0">T</text>
+<rect class="bar-track" x="286" y="461" width="88" height="34" rx="2"/>
+<rect x="286" y="461" width="83.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="469">1392/1462*</text>
+<rect x="286" y="473" width="82.2" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="481">1393/1491</text>
+<rect x="286" y="485" width="9.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="493">123/1184</text>
+<circle cx="390.0" cy="478.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="481.0">G</text>
+<rect class="bar-track" x="418" y="461" width="88" height="34" rx="2"/>
+<rect x="418" y="461" width="75.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="469">149/173*</text>
+<rect x="418" y="473" width="87.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="481">171/173</text>
+<rect x="418" y="485" width="15.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="493">31/173</text>
+<circle cx="522.0" cy="478.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="522.0" y="481.0">T</text>
+<rect class="bar-track" x="550" y="461" width="88" height="34" rx="2"/>
+<rect x="550" y="461" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="469">149/149</text>
+<rect x="550" y="473" width="76.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="481">149/171</text>
+<rect x="550" y="485" width="82.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="493">29/31</text>
+<circle cx="654.0" cy="478.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="481.0">G</text>
+<rect class="bar-track" x="682" y="461" width="88" height="34" rx="2"/>
+<rect x="682" y="461" width="70.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="469">97/122*</text>
+<rect x="682" y="473" width="85.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="481">118/122</text>
+<rect x="682" y="485" width="86.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="493">120/122</text>
+<circle cx="786.0" cy="478.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="786.0" y="481.0">C</text>
+<rect class="stripe" x="16" y="500" width="780" height="44"/>
+<text class="lang-label" x="20" y="525.5">csharp</text>
+<rect class="bar-track" x="154" y="505" width="88" height="34" rx="2"/>
+<rect x="154" y="505" width="87.5" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="513">961/966*</text>
+<rect x="154" y="517" width="58.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="525">647/966</text>
+<rect x="154" y="529" width="73.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="537">809/966</text>
+<circle cx="258.0" cy="522.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="525.0">G</text>
+<rect class="bar-track" x="286" y="505" width="88" height="34" rx="2"/>
+<rect x="286" y="505" width="83.6" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="513">913/961*</text>
+<rect x="286" y="517" width="87.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="525">646/647</text>
+<rect x="286" y="529" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="537">809/809</text>
+<circle cx="390.0" cy="522.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="390.0" y="525.0">C</text>
+<rect class="bar-track" x="418" y="505" width="88" height="34" rx="2"/>
+<rect x="418" y="505" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="513">33/33</text>
+<rect x="418" y="517" width="64.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="525">24/33</text>
+<rect x="418" y="529" width="58.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="537">22/33</text>
+<circle cx="522.0" cy="522.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="522.0" y="525.0">G</text>
+<rect class="bar-track" x="550" y="505" width="88" height="34" rx="2"/>
+<rect x="550" y="505" width="72.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="513">27/33*</text>
+<rect x="550" y="517" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="525">24/24</text>
+<rect x="550" y="529" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="537">22/22</text>
+<rect class="bar-track" x="682" y="505" width="88" height="34" rx="2"/>
+<rect x="682" y="505" width="86.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="513">526/534*</text>
+<rect x="682" y="517" width="87.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="525">532/534</text>
+<rect x="682" y="529" width="87.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="537">529/534</text>
+<circle cx="786.0" cy="522.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="786.0" y="525.0">T</text>
+<text class="lang-label" x="20" y="569.5">css</text>
+<rect class="bar-track" x="154" y="549" width="88" height="34" rx="2"/>
+<rect x="154" y="549" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="557">3/3</text>
+<rect x="154" y="561" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="569">3/3</text>
+<rect x="154" y="573" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="581">0/3</text>
+<rect class="bar-track" x="286" y="549" width="88" height="34" rx="2"/>
+<rect x="286" y="549" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="557">3/3</text>
+<rect x="286" y="561" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="569">3/3</text>
+<rect class="bar-track" x="682" y="549" width="88" height="34" rx="2"/>
+<rect class="stripe" x="16" y="588" width="780" height="44"/>
+<text class="lang-label" x="20" y="613.5">dart</text>
+<rect class="bar-track" x="154" y="593" width="88" height="34" rx="2"/>
+<rect x="154" y="593" width="87.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="601">1767/1785*</text>
+<rect x="154" y="605" width="86.2" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="613">1748/1785</text>
+<circle cx="258.0" cy="610.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="613.0">G</text>
+<rect class="bar-track" x="286" y="593" width="88" height="34" rx="2"/>
+<rect x="286" y="593" width="86.2" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="601">1730/1767*</text>
+<rect x="286" y="605" width="87.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="613">1730/1748</text>
+<circle cx="390.0" cy="610.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="613.0">T</text>
+<rect class="bar-track" x="418" y="593" width="88" height="34" rx="2"/>
+<rect x="418" y="593" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="601">200/200</text>
+<rect x="418" y="605" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="613">200/200</text>
+<rect class="bar-track" x="550" y="593" width="88" height="34" rx="2"/>
+<rect x="550" y="593" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="601">200/200</text>
+<rect x="550" y="605" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="613">200/200</text>
+<rect class="bar-track" x="682" y="593" width="88" height="34" rx="2"/>
+<rect x="682" y="593" width="77.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="601">1514/1730*</text>
+<rect x="682" y="605" width="77.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="613">1514/1730</text>
+<text class="lang-label" x="20" y="657.5">dockerfile</text>
+<rect class="bar-track" x="154" y="637" width="88" height="34" rx="2"/>
+<rect x="154" y="637" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="645">17/17</text>
+<rect class="bar-track" x="286" y="637" width="88" height="34" rx="2"/>
+<rect x="286" y="637" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="645">0/17</text>
+<rect class="bar-track" x="418" y="637" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="637" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="637" width="88" height="34" rx="2"/>
+<rect class="stripe" x="16" y="676" width="780" height="44"/>
+<text class="lang-label" x="20" y="701.5">embedded_python</text>
+<text class="awaiting" x="154" y="701.5">awaiting language-crucible corpus</text>
+<text class="lang-label" x="20" y="745.5">fortran</text>
+<rect class="bar-track" x="154" y="725" width="88" height="34" rx="2"/>
+<rect x="154" y="725" width="86.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="733">137/139*</text>
+<rect x="154" y="737" width="77.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="745">123/139</text>
+<rect x="154" y="749" width="86.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="757">137/139</text>
+<rect class="bar-track" x="286" y="725" width="88" height="34" rx="2"/>
+<rect x="286" y="725" width="86.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="733">135/137*</text>
+<rect x="286" y="737" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="745">123/123</text>
+<rect x="286" y="749" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="757">137/137</text>
+<rect class="bar-track" x="418" y="725" width="88" height="34" rx="2"/>
+<rect x="418" y="725" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="733">11/11</text>
+<rect x="418" y="737" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="745">11/11</text>
+<rect x="418" y="749" width="24.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="757">3/11</text>
+<rect class="bar-track" x="550" y="725" width="88" height="34" rx="2"/>
+<rect x="550" y="725" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="733">11/11</text>
+<rect x="550" y="737" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="745">11/11</text>
+<rect x="550" y="749" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="757">3/3</text>
+<rect class="bar-track" x="682" y="725" width="88" height="34" rx="2"/>
+<rect x="682" y="725" width="87.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="733">120/121*</text>
+<rect x="682" y="737" width="87.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="745">120/121</text>
+<rect x="682" y="749" width="87.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="757">94/95</text>
+<rect class="stripe" x="16" y="764" width="780" height="44"/>
+<text class="lang-label" x="20" y="789.5">go</text>
+<rect class="bar-track" x="154" y="769" width="88" height="34" rx="2"/>
+<rect x="154" y="769" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="777">897/897</text>
+<rect x="154" y="781" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="789">897/897</text>
+<rect x="154" y="793" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="801">897/897</text>
+<rect class="bar-track" x="286" y="769" width="88" height="34" rx="2"/>
+<rect x="286" y="769" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="777">897/897</text>
+<rect x="286" y="781" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="789">897/897</text>
+<rect x="286" y="793" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="801">897/897</text>
+<rect class="bar-track" x="418" y="769" width="88" height="34" rx="2"/>
+<rect x="418" y="769" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="777">69/69</text>
+<rect x="418" y="781" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="789">69/69</text>
+<rect x="418" y="793" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="801">69/69</text>
+<rect class="bar-track" x="550" y="769" width="88" height="34" rx="2"/>
+<rect x="550" y="769" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="777">69/69</text>
+<rect x="550" y="781" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="789">69/69</text>
+<rect x="550" y="793" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="801">69/69</text>
+<rect class="bar-track" x="682" y="769" width="88" height="34" rx="2"/>
+<rect x="682" y="769" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="777">897/897</text>
+<rect x="682" y="781" width="80.6" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="789">822/897</text>
+<rect x="682" y="793" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="801">894/894</text>
+<text class="lang-label" x="20" y="833.5">groovy</text>
+<text class="awaiting" x="154" y="833.5">awaiting language-crucible corpus</text>
+<rect class="stripe" x="16" y="852" width="780" height="44"/>
+<text class="lang-label" x="20" y="877.5">haskell</text>
+<rect class="bar-track" x="154" y="857" width="88" height="34" rx="2"/>
+<rect x="154" y="857" width="38.2" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="865">148/341*</text>
+<rect x="154" y="869" width="71.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="877">275/341</text>
+<rect x="154" y="881" width="46.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="889">179/341</text>
+<circle cx="258.0" cy="874.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="877.0">T</text>
+<rect class="bar-track" x="286" y="857" width="88" height="34" rx="2"/>
+<rect x="286" y="857" width="86.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="865">146/148*</text>
+<rect x="286" y="869" width="58.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="877">184/275</text>
+<rect x="286" y="881" width="56.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="889">115/179</text>
+<circle cx="390.0" cy="874.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="877.0">G</text>
+<rect class="bar-track" x="418" y="857" width="88" height="34" rx="2"/>
+<rect x="418" y="857" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="865">16/16</text>
+<rect x="418" y="869" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="877">16/16</text>
+<rect x="418" y="881" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="889">0/16</text>
+<rect class="bar-track" x="550" y="857" width="88" height="34" rx="2"/>
+<rect x="550" y="857" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="865">16/16</text>
+<rect x="550" y="869" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="877">16/16</text>
+<rect class="bar-track" x="682" y="857" width="88" height="34" rx="2"/>
+<rect x="682" y="857" width="77.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="865">68/77*</text>
+<rect x="682" y="869" width="77.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="877">68/77</text>
+<text class="lang-label" x="20" y="921.5">html</text>
+<text class="awaiting" x="154" y="921.5">no functions/classes found in this corpus by any tool</text>
+<rect class="stripe" x="16" y="940" width="780" height="44"/>
+<text class="lang-label" x="20" y="965.5">java</text>
+<rect class="bar-track" x="154" y="945" width="88" height="34" rx="2"/>
+<rect x="154" y="945" width="87.2" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="953">315/318*</text>
+<rect x="154" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="965">318/318</text>
+<rect x="154" y="969" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="977">0/318</text>
+<circle cx="258.0" cy="962.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="965.0">T</text>
+<rect class="bar-track" x="286" y="945" width="88" height="34" rx="2"/>
+<rect x="286" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="953">315/315</text>
+<rect x="286" y="957" width="87.2" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="965">315/318</text>
+<circle cx="390.0" cy="962.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="965.0">G</text>
+<rect class="bar-track" x="418" y="945" width="88" height="34" rx="2"/>
+<rect x="418" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="953">35/35</text>
+<rect x="418" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="965">35/35</text>
+<rect x="418" y="969" width="17.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="977">7/35</text>
+<rect class="bar-track" x="550" y="945" width="88" height="34" rx="2"/>
+<rect x="550" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="953">35/35</text>
+<rect x="550" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="965">35/35</text>
+<rect x="550" y="969" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="977">7/7</text>
+<rect class="bar-track" x="682" y="945" width="88" height="34" rx="2"/>
+<text class="lang-label" x="20" y="1009.5">javascript</text>
+<rect class="bar-track" x="154" y="989" width="88" height="34" rx="2"/>
+<rect x="154" y="989" width="77.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="997">793/905*</text>
+<rect x="154" y="1001" width="68.5" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1009">704/905</text>
+<rect x="154" y="1013" width="8.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1021">90/905</text>
+<circle cx="258.0" cy="1006.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="1009.0">G</text>
+<rect class="bar-track" x="286" y="989" width="88" height="34" rx="2"/>
+<rect x="286" y="989" width="67.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="997">611/793*</text>
+<rect x="286" y="1001" width="75.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1009">600/704</text>
+<rect x="286" y="1013" width="80.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1021">82/90</text>
+<circle cx="390.0" cy="1006.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="390.0" y="1009.0">C</text>
+<rect class="bar-track" x="418" y="989" width="88" height="34" rx="2"/>
+<rect x="418" y="989" width="72.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="997">29/35*</text>
+<rect x="418" y="1001" width="72.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1009">29/35</text>
+<rect x="418" y="1013" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1021">35/35</text>
+<circle cx="522.0" cy="1006.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="522.0" y="1009.0">C</text>
+<rect class="bar-track" x="550" y="989" width="88" height="34" rx="2"/>
+<rect x="550" y="989" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="997">29/29</text>
+<rect x="550" y="1001" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1009">29/29</text>
+<rect x="550" y="1013" width="72.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1021">29/35</text>
+<rect class="bar-track" x="682" y="989" width="88" height="34" rx="2"/>
+<rect x="682" y="989" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="997">71/71</text>
+<rect x="682" y="1001" width="79.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1009">64/71</text>
+<rect x="682" y="1013" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1021">71/71</text>
+<rect class="stripe" x="16" y="1028" width="780" height="44"/>
+<text class="lang-label" x="20" y="1053.5">jcl</text>
+<text class="awaiting" x="154" y="1053.5">no functions/classes found in this corpus by any tool</text>
+<text class="lang-label" x="20" y="1097.5">kotlin</text>
+<rect class="bar-track" x="154" y="1077" width="88" height="34" rx="2"/>
+<rect x="154" y="1077" width="57.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1085">28/43*</text>
+<rect x="154" y="1089" width="55.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1097">27/43</text>
+<rect x="154" y="1101" width="86.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1109">42/43</text>
+<circle cx="258.0" cy="1094.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="258.0" y="1097.0">C</text>
+<rect class="bar-track" x="286" y="1077" width="88" height="34" rx="2"/>
+<rect x="286" y="1077" width="84.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1085">27/28*</text>
+<rect x="286" y="1089" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1097">27/27</text>
+<rect x="286" y="1101" width="56.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1109">27/42</text>
+<circle cx="390.0" cy="1094.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="1097.0">T</text>
+<rect class="bar-track" x="418" y="1077" width="88" height="34" rx="2"/>
+<rect x="418" y="1077" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1085">7/7</text>
+<rect x="418" y="1089" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1097">7/7</text>
+<rect x="418" y="1101" width="50.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1109">4/7</text>
+<rect class="bar-track" x="550" y="1077" width="88" height="34" rx="2"/>
+<rect x="550" y="1077" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1085">7/7</text>
+<rect x="550" y="1089" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1097">7/7</text>
+<rect x="550" y="1101" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1109">4/4</text>
+<rect class="bar-track" x="682" y="1077" width="88" height="34" rx="2"/>
+<rect x="682" y="1077" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1085">27/27</text>
+<rect x="682" y="1089" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1097">27/27</text>
+<rect class="stripe" x="16" y="1116" width="780" height="44"/>
+<text class="lang-label" x="20" y="1141.5">livecode</text>
+<text class="awaiting" x="154" y="1141.5">no functions/classes found in this corpus by any tool</text>
+<text class="lang-label" x="20" y="1185.5">lua</text>
+<text class="awaiting" x="154" y="1185.5">awaiting language-crucible corpus</text>
+<rect class="stripe" x="16" y="1204" width="780" height="44"/>
+<text class="lang-label" x="20" y="1229.5">m4</text>
+<rect class="bar-track" x="154" y="1209" width="88" height="34" rx="2"/>
+<rect x="154" y="1209" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1217">1/148*</text>
+<rect x="154" y="1221" width="87.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1229">147/148</text>
+<circle cx="258.0" cy="1226.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="258.0" y="1229.0">C</text>
+<rect class="bar-track" x="286" y="1209" width="88" height="34" rx="2"/>
+<rect x="286" y="1209" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1217">0/1*</text>
+<rect x="286" y="1221" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1229">0/147</text>
+<rect class="bar-track" x="418" y="1209" width="88" height="34" rx="2"/>
+<rect x="418" y="1209" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1217">4/4</text>
+<rect x="418" y="1221" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1229">0/4</text>
+<circle cx="522.0" cy="1226.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="522.0" y="1229.0">G</text>
+<rect class="bar-track" x="550" y="1209" width="88" height="34" rx="2"/>
+<rect x="550" y="1209" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1217">0/4*</text>
+<rect class="bar-track" x="682" y="1209" width="88" height="34" rx="2"/>
+<text class="lang-label" x="20" y="1273.5">makefile</text>
+<rect class="bar-track" x="154" y="1253" width="88" height="34" rx="2"/>
+<rect x="154" y="1253" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1261">1/1</text>
+<rect x="154" y="1265" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1273">1/1</text>
+<rect x="154" y="1277" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1285">0/1</text>
+<rect class="bar-track" x="286" y="1253" width="88" height="34" rx="2"/>
+<rect x="286" y="1253" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1261">1/1</text>
+<rect x="286" y="1265" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1273">1/1</text>
+<rect class="bar-track" x="418" y="1253" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="1253" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="1253" width="88" height="34" rx="2"/>
+<rect class="stripe" x="16" y="1292" width="780" height="44"/>
+<text class="lang-label" x="20" y="1317.5">matlab</text>
+<rect class="bar-track" x="154" y="1297" width="88" height="34" rx="2"/>
+<rect x="154" y="1297" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1305">23/23</text>
+<rect x="154" y="1309" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1317">23/23</text>
+<rect x="154" y="1321" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1329">23/23</text>
+<rect class="bar-track" x="286" y="1297" width="88" height="34" rx="2"/>
+<rect x="286" y="1297" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1305">23/23</text>
+<rect x="286" y="1309" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1317">23/23</text>
+<rect x="286" y="1321" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1329">23/23</text>
+<rect class="bar-track" x="418" y="1297" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="1297" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="1297" width="88" height="34" rx="2"/>
+<rect x="682" y="1297" width="84.2" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1305">22/23*</text>
+<rect x="682" y="1309" width="84.2" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1317">22/23</text>
+<text class="lang-label" x="20" y="1361.5">objective-c</text>
+<rect class="bar-track" x="154" y="1341" width="88" height="34" rx="2"/>
+<rect x="154" y="1341" width="59.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1349">152/224*</text>
+<rect x="154" y="1353" width="60.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1361">153/224</text>
+<rect x="154" y="1365" width="39.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1373">101/224</text>
+<circle cx="258.0" cy="1358.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="1361.0">T</text>
+<rect class="bar-track" x="286" y="1341" width="88" height="34" rx="2"/>
+<rect x="286" y="1341" width="87.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1349">151/152*</text>
+<rect x="286" y="1353" width="86.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1361">151/153</text>
+<rect x="286" y="1365" width="27.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1373">31/101</text>
+<circle cx="390.0" cy="1358.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1361.0">G</text>
+<rect class="bar-track" x="418" y="1341" width="88" height="34" rx="2"/>
+<rect x="418" y="1341" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1349">5/5</text>
+<rect x="418" y="1353" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1361">5/5</text>
+<rect x="418" y="1365" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1373">5/5</text>
+<rect class="bar-track" x="550" y="1341" width="88" height="34" rx="2"/>
+<rect x="550" y="1341" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1349">5/5</text>
+<rect x="550" y="1353" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1361">5/5</text>
+<rect x="550" y="1365" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1373">5/5</text>
+<rect class="bar-track" x="682" y="1341" width="88" height="34" rx="2"/>
+<rect x="682" y="1341" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1349">31/31</text>
+<rect x="682" y="1353" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1361">31/31</text>
+<rect x="682" y="1365" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1373">31/31</text>
+<rect class="stripe" x="16" y="1380" width="780" height="44"/>
+<text class="lang-label" x="20" y="1405.5">perl</text>
+<rect class="bar-track" x="154" y="1385" width="88" height="34" rx="2"/>
+<rect x="154" y="1385" width="77.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1393">942/1071*</text>
+<rect x="154" y="1397" width="87.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1405">1063/1071</text>
+<rect x="154" y="1409" width="77.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1417">941/1071</text>
+<circle cx="258.0" cy="1402.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="1405.0">T</text>
+<rect class="bar-track" x="286" y="1385" width="88" height="34" rx="2"/>
+<rect x="286" y="1385" width="87.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1393">941/942*</text>
+<rect x="286" y="1397" width="77.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1405">941/1063</text>
+<rect x="286" y="1409" width="87.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1417">934/941</text>
+<circle cx="390.0" cy="1402.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1405.0">G</text>
+<rect class="bar-track" x="418" y="1385" width="88" height="34" rx="2"/>
+<rect x="418" y="1385" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1393">21/21</text>
+<rect x="418" y="1397" width="83.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1405">20/21</text>
+<rect x="418" y="1409" width="83.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1417">20/21</text>
+<circle cx="522.0" cy="1402.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="522.0" y="1405.0">G</text>
+<rect class="bar-track" x="550" y="1385" width="88" height="34" rx="2"/>
+<rect x="550" y="1385" width="83.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1393">20/21*</text>
+<rect x="550" y="1397" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1405">20/20</text>
+<rect x="550" y="1409" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1417">20/20</text>
+<rect class="bar-track" x="682" y="1385" width="88" height="34" rx="2"/>
+<rect x="682" y="1385" width="82.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1393">870/934*</text>
+<rect x="682" y="1397" width="82.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1405">870/934</text>
+<text class="lang-label" x="20" y="1449.5">php</text>
+<rect class="bar-track" x="154" y="1429" width="88" height="34" rx="2"/>
+<rect x="154" y="1429" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1437">1703/1703</text>
+<rect x="154" y="1441" width="87.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1449">1702/1703</text>
+<rect x="154" y="1453" width="84.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1461">1635/1703</text>
+<circle cx="258.0" cy="1446.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="1449.0">G</text>
+<rect class="bar-track" x="286" y="1429" width="88" height="34" rx="2"/>
+<rect x="286" y="1429" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1437">1703/1703</text>
+<rect x="286" y="1441" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1449">1702/1702</text>
+<rect x="286" y="1453" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1461">1635/1635</text>
+<rect class="bar-track" x="418" y="1429" width="88" height="34" rx="2"/>
+<rect x="418" y="1429" width="85.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1437">29/30*</text>
+<rect x="418" y="1441" width="85.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1449">29/30</text>
+<rect x="418" y="1453" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1461">30/30</text>
+<circle cx="522.0" cy="1446.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="522.0" y="1449.0">C</text>
+<rect class="bar-track" x="550" y="1429" width="88" height="34" rx="2"/>
+<rect x="550" y="1429" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1437">29/29</text>
+<rect x="550" y="1441" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1449">29/29</text>
+<rect x="550" y="1453" width="85.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1461">29/30</text>
+<rect class="bar-track" x="682" y="1429" width="88" height="34" rx="2"/>
+<rect x="682" y="1429" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1437">1634/1634</text>
+<rect x="682" y="1441" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1449">1634/1634</text>
+<rect x="682" y="1453" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1461">1634/1634</text>
+<rect class="stripe" x="16" y="1468" width="780" height="44"/>
+<text class="lang-label" x="20" y="1493.5">powershell</text>
+<rect class="bar-track" x="154" y="1473" width="88" height="34" rx="2"/>
+<rect x="154" y="1473" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1481">111/111</text>
+<rect x="154" y="1485" width="87.2" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1493">110/111</text>
+<rect x="154" y="1497" width="84.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1505">107/111</text>
+<circle cx="258.0" cy="1490.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="1493.0">G</text>
+<rect class="bar-track" x="286" y="1473" width="88" height="34" rx="2"/>
+<rect x="286" y="1473" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1481">111/111</text>
+<rect x="286" y="1485" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1493">110/110</text>
+<rect x="286" y="1497" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1505">107/107</text>
+<rect class="bar-track" x="418" y="1473" width="88" height="34" rx="2"/>
+<rect x="418" y="1473" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1481">7/7</text>
+<rect x="418" y="1485" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1493">7/7</text>
+<rect x="418" y="1497" width="62.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1505">5/7</text>
+<rect class="bar-track" x="550" y="1473" width="88" height="34" rx="2"/>
+<rect x="550" y="1473" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1481">7/7</text>
+<rect x="550" y="1485" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1493">7/7</text>
+<rect x="550" y="1497" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1505">5/5</text>
+<rect class="bar-track" x="682" y="1473" width="88" height="34" rx="2"/>
+<rect x="682" y="1473" width="83.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1481">101/106*</text>
+<rect x="682" y="1485" width="83.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1493">101/106</text>
+<rect x="682" y="1497" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1505">2/2</text>
+<circle cx="786.0" cy="1490.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="786.0" y="1493.0">C</text>
+<text class="lang-label" x="20" y="1537.5">python</text>
+<rect class="bar-track" x="154" y="1517" width="88" height="34" rx="2"/>
+<rect x="154" y="1517" width="86.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1525">3657/3725*</text>
+<rect x="154" y="1529" width="85.6" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1537">3625/3725</text>
+<rect x="154" y="1541" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1549">3725/3725</text>
+<circle cx="258.0" cy="1534.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="258.0" y="1537.0">C</text>
+<rect class="bar-track" x="286" y="1517" width="88" height="34" rx="2"/>
+<rect x="286" y="1517" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1525">3657/3657</text>
+<rect x="286" y="1529" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1537">3625/3625</text>
+<rect x="286" y="1541" width="86.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1549">3657/3725</text>
+<rect class="bar-track" x="418" y="1517" width="88" height="34" rx="2"/>
+<rect x="418" y="1517" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1525">473/473</text>
+<rect x="418" y="1529" width="87.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1537">469/473</text>
+<rect x="418" y="1541" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1549">473/473</text>
+<rect class="bar-track" x="550" y="1517" width="88" height="34" rx="2"/>
+<rect x="550" y="1517" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1525">473/473</text>
+<rect x="550" y="1529" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1537">469/469</text>
+<rect x="550" y="1541" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1549">473/473</text>
+<rect class="bar-track" x="682" y="1517" width="88" height="34" rx="2"/>
+<rect x="682" y="1517" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1525">3625/3625</text>
+<rect x="682" y="1529" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1537">3625/3625</text>
+<rect x="682" y="1541" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1549">3623/3624</text>
+<rect class="stripe" x="16" y="1556" width="780" height="44"/>
+<text class="lang-label" x="20" y="1581.5">ruby</text>
+<rect class="bar-track" x="154" y="1561" width="88" height="34" rx="2"/>
+<rect x="154" y="1561" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1569">124/124</text>
+<rect x="154" y="1573" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1581">124/124</text>
+<rect x="154" y="1585" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1593">124/124</text>
+<rect class="bar-track" x="286" y="1561" width="88" height="34" rx="2"/>
+<rect x="286" y="1561" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1569">124/124</text>
+<rect x="286" y="1573" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1581">124/124</text>
+<rect x="286" y="1585" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1593">124/124</text>
+<rect class="bar-track" x="418" y="1561" width="88" height="34" rx="2"/>
+<rect x="418" y="1561" width="79.6" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1569">19/21*</text>
+<rect x="418" y="1573" width="79.6" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1581">19/21</text>
+<rect x="418" y="1585" width="62.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1593">15/21</text>
+<rect class="bar-track" x="550" y="1561" width="88" height="34" rx="2"/>
+<rect x="550" y="1561" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1569">19/19</text>
+<rect x="550" y="1573" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1581">19/19</text>
+<rect x="550" y="1585" width="76.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1593">13/15</text>
+<rect class="bar-track" x="682" y="1561" width="88" height="34" rx="2"/>
+<rect x="682" y="1561" width="83.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1569">118/124*</text>
+<rect x="682" y="1573" width="85.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1581">121/124</text>
+<rect x="682" y="1585" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1593">124/124</text>
+<circle cx="786.0" cy="1578.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="786.0" y="1581.0">C</text>
+<text class="lang-label" x="20" y="1625.5">rust</text>
+<rect class="bar-track" x="154" y="1605" width="88" height="34" rx="2"/>
+<rect x="154" y="1605" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1613">1927/1927</text>
+<rect x="154" y="1617" width="81.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1625">1775/1927</text>
+<rect x="154" y="1629" width="81.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1637">1774/1927</text>
+<circle cx="258.0" cy="1622.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="1625.0">G</text>
+<rect class="bar-track" x="286" y="1605" width="88" height="34" rx="2"/>
+<rect x="286" y="1605" width="81.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1613">1775/1927*</text>
+<rect x="286" y="1617" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1625">1775/1775</text>
+<rect x="286" y="1629" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1637">1774/1774</text>
+<rect class="bar-track" x="418" y="1605" width="88" height="34" rx="2"/>
+<rect x="418" y="1605" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1613">312/312</text>
+<rect x="418" y="1617" width="80.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1625">287/312</text>
+<rect x="418" y="1629" width="80.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1637">284/312</text>
+<circle cx="522.0" cy="1622.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="522.0" y="1625.0">G</text>
+<rect class="bar-track" x="550" y="1605" width="88" height="34" rx="2"/>
+<rect x="550" y="1605" width="80.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1613">287/312*</text>
+<rect x="550" y="1617" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1625">287/287</text>
+<rect x="550" y="1629" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1637">284/284</text>
+<rect class="bar-track" x="682" y="1605" width="88" height="34" rx="2"/>
+<rect x="682" y="1605" width="85.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1613">1732/1774*</text>
+<rect x="682" y="1617" width="87.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1625">1753/1774</text>
+<rect x="682" y="1629" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1637">1413/1413</text>
+<circle cx="786.0" cy="1622.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="786.0" y="1625.0">C</text>
+<rect class="stripe" x="16" y="1644" width="780" height="44"/>
+<text class="lang-label" x="20" y="1669.5">scala</text>
+<rect class="bar-track" x="154" y="1649" width="88" height="34" rx="2"/>
+<rect x="154" y="1649" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1657">541/541</text>
+<rect x="154" y="1661" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1669">541/541</text>
+<rect class="bar-track" x="286" y="1649" width="88" height="34" rx="2"/>
+<rect x="286" y="1649" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1657">541/541</text>
+<rect x="286" y="1661" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1669">541/541</text>
+<rect class="bar-track" x="418" y="1649" width="88" height="34" rx="2"/>
+<rect x="418" y="1649" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1657">24/24</text>
+<rect x="418" y="1661" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1669">24/24</text>
+<rect class="bar-track" x="550" y="1649" width="88" height="34" rx="2"/>
+<rect x="550" y="1649" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1657">24/24</text>
+<rect x="550" y="1661" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1669">24/24</text>
+<rect class="bar-track" x="682" y="1649" width="88" height="34" rx="2"/>
+<rect x="682" y="1649" width="85.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1657">525/541*</text>
+<rect x="682" y="1661" width="85.4" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1669">525/541</text>
+<text class="lang-label" x="20" y="1713.5">scheme</text>
+<rect class="bar-track" x="154" y="1693" width="88" height="34" rx="2"/>
+<rect x="154" y="1693" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1701">0/75*</text>
+<rect x="154" y="1705" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1713">75/75</text>
+<circle cx="258.0" cy="1710.0" r="8" fill="#1baf7a"/>
+<text class="badge-label" x="258.0" y="1713.0">C</text>
+<rect class="bar-track" x="286" y="1693" width="88" height="34" rx="2"/>
+<rect x="286" y="1693" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1701">0/75</text>
+<rect class="bar-track" x="418" y="1693" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="1693" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="1693" width="88" height="34" rx="2"/>
+<rect class="stripe" x="16" y="1732" width="780" height="44"/>
+<text class="lang-label" x="20" y="1757.5">shell</text>
+<rect class="bar-track" x="154" y="1737" width="88" height="34" rx="2"/>
+<rect x="154" y="1737" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1745">3/3</text>
+<rect x="154" y="1749" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1757">3/3</text>
+<rect x="154" y="1761" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1769">3/3</text>
+<rect class="bar-track" x="286" y="1737" width="88" height="34" rx="2"/>
+<rect x="286" y="1737" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1745">3/3</text>
+<rect x="286" y="1749" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1757">3/3</text>
+<rect x="286" y="1761" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1769">3/3</text>
+<rect class="bar-track" x="418" y="1737" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="1737" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="1737" width="88" height="34" rx="2"/>
+<rect x="682" y="1737" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1745">3/3</text>
+<rect x="682" y="1749" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1757">3/3</text>
+<text class="lang-label" x="20" y="1801.5">solidity</text>
+<rect class="bar-track" x="154" y="1781" width="88" height="34" rx="2"/>
+<rect x="154" y="1781" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1789">105/105</text>
+<rect x="154" y="1793" width="83.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1801">99/105</text>
+<circle cx="258.0" cy="1798.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="258.0" y="1801.0">G</text>
+<rect class="bar-track" x="286" y="1781" width="88" height="34" rx="2"/>
+<rect x="286" y="1781" width="83.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1789">99/105*</text>
+<rect x="286" y="1793" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1801">99/99</text>
+<circle cx="390.0" cy="1798.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="1801.0">T</text>
+<rect class="bar-track" x="418" y="1781" width="88" height="34" rx="2"/>
+<rect x="418" y="1781" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1789">7/7</text>
+<rect x="418" y="1793" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1801">7/7</text>
+<rect class="bar-track" x="550" y="1781" width="88" height="34" rx="2"/>
+<rect x="550" y="1781" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1789">7/7</text>
+<rect x="550" y="1793" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1801">7/7</text>
+<rect class="bar-track" x="682" y="1781" width="88" height="34" rx="2"/>
+<rect x="682" y="1781" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1789">99/99</text>
+<rect x="682" y="1793" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1801">99/99</text>
+<rect class="stripe" x="16" y="1820" width="780" height="44"/>
+<text class="lang-label" x="20" y="1845.5">sqlite</text>
+<text class="awaiting" x="154" y="1845.5">awaiting language-crucible corpus</text>
+<text class="lang-label" x="20" y="1889.5">swift</text>
+<rect class="bar-track" x="154" y="1869" width="88" height="34" rx="2"/>
+<rect x="154" y="1869" width="87.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1877">132/133*</text>
+<rect x="154" y="1881" width="87.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1889">132/133</text>
+<rect class="bar-track" x="286" y="1869" width="88" height="34" rx="2"/>
+<rect x="286" y="1869" width="87.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1877">131/132*</text>
+<rect x="286" y="1881" width="87.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1889">131/132</text>
+<rect class="bar-track" x="418" y="1869" width="88" height="34" rx="2"/>
+<rect x="418" y="1869" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1877">60/60</text>
+<rect x="418" y="1881" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1889">60/60</text>
+<rect class="bar-track" x="550" y="1869" width="88" height="34" rx="2"/>
+<rect x="550" y="1869" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1877">60/60</text>
+<rect x="550" y="1881" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1889">60/60</text>
+<rect class="bar-track" x="682" y="1869" width="88" height="34" rx="2"/>
+<rect x="682" y="1869" width="87.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1877">130/131*</text>
+<rect x="682" y="1881" width="87.3" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1889">130/131</text>
+<rect class="stripe" x="16" y="1908" width="780" height="44"/>
+<text class="lang-label" x="20" y="1933.5">tcl</text>
+<rect class="bar-track" x="154" y="1913" width="88" height="34" rx="2"/>
+<rect x="154" y="1913" width="86.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1921">144/146*</text>
+<rect x="154" y="1925" width="86.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1933">144/146</text>
+<rect x="154" y="1937" width="85.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1945">141/146</text>
+<rect class="bar-track" x="286" y="1913" width="88" height="34" rx="2"/>
+<rect x="286" y="1913" width="87.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1921">143/144*</text>
+<rect x="286" y="1925" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1933">144/144</text>
+<rect x="286" y="1937" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1945">141/141</text>
+<rect class="bar-track" x="418" y="1913" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="550" y="1913" width="88" height="34" rx="2"/>
+<rect class="bar-track" x="682" y="1913" width="88" height="34" rx="2"/>
+<rect x="682" y="1913" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1921">138/138</text>
+<rect x="682" y="1925" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1933">138/138</text>
+<text class="lang-label" x="20" y="1977.5">typescript</text>
+<rect class="bar-track" x="154" y="1957" width="88" height="34" rx="2"/>
+<rect x="154" y="1957" width="80.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1965">2733/2980*</text>
+<rect x="154" y="1969" width="86.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1977">2914/2980</text>
+<rect x="154" y="1981" width="24.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1989">842/2980</text>
+<circle cx="258.0" cy="1974.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="1977.0">T</text>
+<rect class="bar-track" x="286" y="1957" width="88" height="34" rx="2"/>
+<rect x="286" y="1957" width="87.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1965">2731/2733*</text>
+<rect x="286" y="1969" width="82.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1977">2739/2914</text>
+<rect x="286" y="1981" width="81.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1989">778/842</text>
+<circle cx="390.0" cy="1974.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1977.0">G</text>
+<rect class="bar-track" x="418" y="1957" width="88" height="34" rx="2"/>
+<rect x="418" y="1957" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1965">842/842</text>
+<rect x="418" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1977">842/842</text>
+<rect x="418" y="1981" width="33.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1989">322/842</text>
+<rect class="bar-track" x="550" y="1957" width="88" height="34" rx="2"/>
+<rect x="550" y="1957" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1965">842/842</text>
+<rect x="550" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="1977">842/842</text>
+<rect x="550" y="1981" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1989">322/322</text>
+<rect class="bar-track" x="682" y="1957" width="88" height="34" rx="2"/>
+<rect x="682" y="1957" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="1965">770/770</text>
+<rect x="682" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="1977">770/770</text>
+<rect class="stripe" x="16" y="1996" width="780" height="44"/>
+<text class="lang-label" x="20" y="2021.5">yacc</text>
+<text class="awaiting" x="154" y="2021.5">awaiting language-crucible corpus</text>
+<text class="lang-label" x="20" y="2065.5">yaml</text>
+<text class="awaiting" x="154" y="2065.5">no functions/classes found in this corpus by any tool</text>
+<rect class="stripe" x="16" y="2084" width="780" height="44"/>
+<text class="lang-label" x="20" y="2109.5">zig</text>
+<rect class="bar-track" x="154" y="2089" width="88" height="34" rx="2"/>
+<rect x="154" y="2089" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="2097">2750/2751*</text>
+<rect x="154" y="2101" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="2109">2751/2751</text>
+<circle cx="258.0" cy="2106.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="258.0" y="2109.0">T</text>
+<rect class="bar-track" x="286" y="2089" width="88" height="34" rx="2"/>
+<rect x="286" y="2089" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="2097">2750/2750</text>
+<rect x="286" y="2101" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="2109">2750/2751</text>
+<circle cx="390.0" cy="2106.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="2109.0">G</text>
+<rect class="bar-track" x="418" y="2089" width="88" height="34" rx="2"/>
+<rect x="418" y="2089" width="86.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="2097">729/739*</text>
+<rect x="418" y="2101" width="87.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="2109">738/739</text>
+<circle cx="522.0" cy="2106.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="522.0" y="2109.0">T</text>
+<rect class="bar-track" x="550" y="2089" width="88" height="34" rx="2"/>
+<rect x="550" y="2089" width="87.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="2097">728/729*</text>
+<rect x="550" y="2101" width="86.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="2109">728/738</text>
+<circle cx="654.0" cy="2106.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="2109.0">G</text>
+<rect class="bar-track" x="682" y="2089" width="88" height="34" rx="2"/>
+<rect x="682" y="2089" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="2097">2750/2750</text>
+<rect x="682" y="2101" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="2109">2750/2750</text>
+<line x1="16" y1="2138" x2="796" y2="2138" stroke="#dedcd6" stroke-width="1"/>
+<text class="summary-title" x="16" y="2152">Summary -- best tool per (language, metric), 137 real comparisons (1-bar groups and empty panels don't count)</text>
+<circle cx="23" cy="2170" r="7" fill="#2a78d6"/>
+<text class="badge-label" x="23" y="2173">G</text>
+<text class="legend-label" x="36" y="2174">GitGalaxy best: 27 (20%)</text>
+<circle cx="215.8" cy="2170" r="7" fill="#eb6834"/>
+<text class="badge-label" x="215.8" y="2173">T</text>
+<text class="legend-label" x="228.8" y="2174">tree-sitter best: 16 (12%)</text>
+<circle cx="421.0" cy="2170" r="7" fill="#1baf7a"/>
+<text class="badge-label" x="421.0" y="2173">C</text>
+<text class="legend-label" x="434.0" y="2174">ctags best: 15 (11%)</text>
+<circle cx="589.0" cy="2170" r="7" fill="#9a9a95"/>
+<text class="legend-label" x="602.0" y="2174">Ties: 79 (58%)</text>
+<text class="scope-note" x="16" y="2194">Value labels are raw counts (matched/total). Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -7,11 +7,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:21Z",
+      "first_seen_at": "2026-08-18T22:44:15Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-18T21:38:40Z",
+      "last_reconciled_at": "2026-08-18T22:44:15Z",
       "last_seen_count": 760,
       "last_seen_examples": [
         {
@@ -108,11 +108,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:21Z",
+      "first_seen_at": "2026-08-18T22:44:15Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-18T21:38:40Z",
+      "last_reconciled_at": "2026-08-18T22:44:15Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -145,11 +145,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:21Z",
+      "first_seen_at": "2026-08-18T22:44:15Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-18T21:38:40Z",
+      "last_reconciled_at": "2026-08-18T22:44:15Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -222,11 +222,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:21Z",
+      "first_seen_at": "2026-08-18T22:44:15Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-18T21:38:40Z",
+      "last_reconciled_at": "2026-08-18T22:44:15Z",
       "last_seen_count": 52,
       "last_seen_examples": [
         {
@@ -324,11 +324,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -436,11 +436,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -539,11 +539,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -651,11 +651,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -682,11 +682,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -794,11 +794,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -906,11 +906,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -955,11 +955,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1040,11 +1040,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -1134,11 +1134,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1192,11 +1192,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:24Z",
+      "first_seen_at": "2026-08-18T22:44:18Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-18T21:38:43Z",
+      "last_reconciled_at": "2026-08-18T22:44:18Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1303,11 +1303,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:26Z",
+      "first_seen_at": "2026-08-18T22:44:20Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-18T21:38:45Z",
+      "last_reconciled_at": "2026-08-18T22:44:20Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1404,11 +1404,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:26Z",
+      "first_seen_at": "2026-08-18T22:44:20Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-18T21:38:45Z",
+      "last_reconciled_at": "2026-08-18T22:44:20Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1505,11 +1505,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:26Z",
+      "first_seen_at": "2026-08-18T22:44:20Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-18T21:38:45Z",
+      "last_reconciled_at": "2026-08-18T22:44:20Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1607,11 +1607,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1647,11 +1647,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 120,
       "last_seen_examples": [
         {
@@ -1759,11 +1759,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1871,11 +1871,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1920,11 +1920,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 24,
       "last_seen_examples": [
         {
@@ -2024,37 +2024,6 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "cpp/function/args/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
-      "agreeing_tools": [
-        "ctags"
-      ],
-      "dissenting_tools": [
-        "gitgalaxy",
-        "tree_sitter"
-      ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
-      "investigated_at": null,
-      "investigated_by": null,
-      "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
-      "last_seen_count": 1,
-      "last_seen_examples": [
-        {
-          "file_path": "NVDA/storage.cpp",
-          "name": "outputEscapedAttribute",
-          "readings": {
-            "ctags": 3,
-            "gitgalaxy": 0,
-            "tree_sitter": 2
-          }
-        }
-      ],
-      "metric": "args",
-      "status": "unvalidated",
-      "still_reproduces": true,
-      "symbol_type": "function",
-      "verdict": null
-    },
     "cpp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy",
@@ -2063,11 +2032,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2086,6 +2055,36 @@
       "symbol_type": "function",
       "verdict": null
     },
+    "cpp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
+      "dissenting_tools": [
+        "ctags",
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-18T22:44:22Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "cpp",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
+      "last_seen_count": 1,
+      "last_seen_examples": [
+        {
+          "file_path": "NVDA/storage.cpp",
+          "name": "outputEscapedAttribute",
+          "readings": {
+            "ctags": 3,
+            "gitgalaxy": 0,
+            "tree_sitter": 2
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
     "cpp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
         "ctags",
@@ -2094,11 +2093,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2125,11 +2124,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 1061,
       "last_seen_examples": [
         {
@@ -2237,11 +2236,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 1270,
       "last_seen_examples": [
         {
@@ -2349,11 +2348,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 70,
       "last_seen_examples": [
         {
@@ -2461,11 +2460,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:28Z",
+      "first_seen_at": "2026-08-18T22:44:22Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-18T21:38:47Z",
+      "last_reconciled_at": "2026-08-18T22:44:22Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2573,11 +2572,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2622,11 +2621,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2689,11 +2688,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2765,11 +2764,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2796,11 +2795,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -2873,37 +2872,6 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "csharp/function/args/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
-      "agreeing_tools": [
-        "ctags"
-      ],
-      "dissenting_tools": [
-        "gitgalaxy",
-        "tree_sitter"
-      ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
-      "investigated_at": null,
-      "investigated_by": null,
-      "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
-      "last_seen_count": 1,
-      "last_seen_examples": [
-        {
-          "file_path": "roslyn/Workspace.cs",
-          "name": "SetCurrentSolution",
-          "readings": {
-            "ctags": 5,
-            "gitgalaxy": 0,
-            "tree_sitter": 4
-          }
-        }
-      ],
-      "metric": "args",
-      "status": "unvalidated",
-      "still_reproduces": true,
-      "symbol_type": "function",
-      "verdict": null
-    },
     "csharp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy",
@@ -2912,11 +2880,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2962,6 +2930,36 @@
       "symbol_type": "function",
       "verdict": null
     },
+    "csharp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
+      "dissenting_tools": [
+        "ctags",
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-18T22:44:25Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "csharp",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
+      "last_seen_count": 1,
+      "last_seen_examples": [
+        {
+          "file_path": "roslyn/Workspace.cs",
+          "name": "SetCurrentSolution",
+          "readings": {
+            "ctags": 5,
+            "gitgalaxy": 0,
+            "tree_sitter": 4
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
     "csharp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
       "agreeing_tools": [
         "ctags",
@@ -2970,11 +2968,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3082,11 +3080,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3140,11 +3138,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -3252,11 +3250,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3364,11 +3362,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3387,230 +3385,6 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "css/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
-      "agreeing_tools": [
-        "ctags"
-      ],
-      "dissenting_tools": [
-        "gitgalaxy",
-        "tree_sitter"
-      ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
-      "investigated_at": null,
-      "investigated_by": null,
-      "language": "css",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
-      "last_seen_count": 85,
-      "last_seen_examples": [
-        {
-          "file_path": "element/common.css",
-          "name": "#app.is-component .headerWrapper .container",
-          "readings": {
-            "ctags": 166,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "element/fonts-baseline.css",
-          "name": ".icon-rate-face-1:before",
-          "readings": {
-            "ctags": 30,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "element/fonts-baseline.css",
-          "name": ".icon-rate-face-2:before",
-          "readings": {
-            "ctags": 33,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "element/fonts-baseline.css",
-          "name": ".icon-rate-face-3:before",
-          "readings": {
-            "ctags": 36,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "element/fonts-baseline.css",
-          "name": ".icon-rate-face-off:before",
-          "readings": {
-            "ctags": 27,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "odoo/control_panel_mobile.css",
-          "name": ".o-control-panel-adaptive-dropdown.dropdown-menu > :nth-child(1 of :not(.d-none",
-          "readings": {
-            "ctags": 24,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "odoo/control_panel_mobile.css",
-          "name": ".o_control_panel_main_buttons:has(> .o-control-panel-adaptive-dropdown:only-child)",
-          "readings": {
-            "ctags": 19,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "odoo/control_panel_mobile.css",
-          "name": ".o_hidden))",
-          "readings": {
-            "ctags": 24,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "odoo/icons-baseline.css",
-          "name": ".o_rtl .oi-arrow-down-left",
-          "readings": {
-            "ctags": 99,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "odoo/icons-baseline.css",
-          "name": ".o_rtl .oi-arrow-down-right",
-          "readings": {
-            "ctags": 100,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        }
-      ],
-      "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
-      "symbol_type": "class",
-      "verdict": null
-    },
-    "css/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
-      "agreeing_tools": [
-        "gitgalaxy",
-        "tree_sitter"
-      ],
-      "dissenting_tools": [
-        "ctags"
-      ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
-      "investigated_at": null,
-      "investigated_by": null,
-      "language": "css",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
-      "last_seen_count": 112,
-      "last_seen_examples": [
-        {
-          "file_path": "element/common.css",
-          "name": ".is-component",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 10
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".is-component",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 18
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".is-component",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 166
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": "#app",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 15
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": "#app",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 166
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".main-cnt",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 73
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".headerWrapper",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 28
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".headerWrapper",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 166
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".container",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 161
-          }
-        },
-        {
-          "file_path": "element/common.css",
-          "name": ".container",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 166
-          }
-        }
-      ],
-      "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
-      "symbol_type": "class",
-      "verdict": null
-    },
     "css/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy",
@@ -3619,11 +3393,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:31Z",
+      "first_seen_at": "2026-08-18T22:44:25Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-18T21:38:50Z",
+      "last_reconciled_at": "2026-08-18T22:44:25Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3660,18 +3434,17 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "dart/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "dart/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:33Z",
+      "first_seen_at": "2026-08-18T22:44:26Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-18T21:38:51Z",
+      "last_reconciled_at": "2026-08-18T22:44:26Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3768,11 +3541,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:33Z",
+      "first_seen_at": "2026-08-18T22:44:26Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-18T21:38:51Z",
+      "last_reconciled_at": "2026-08-18T22:44:26Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3869,11 +3642,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:33Z",
+      "first_seen_at": "2026-08-18T22:44:26Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-18T21:38:51Z",
+      "last_reconciled_at": "2026-08-18T22:44:26Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -3971,11 +3744,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:35Z",
+      "first_seen_at": "2026-08-18T22:44:29Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-18T21:38:54Z",
+      "last_reconciled_at": "2026-08-18T22:44:29Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4057,19 +3830,18 @@
       "symbol_type": "class",
       "verdict": null
     },
-    "fortran/function/args/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
-      "agreeing_tools": [
-        "ctags"
-      ],
+    "fortran/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "ctags",
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:35Z",
+      "first_seen_at": "2026-08-18T22:44:29Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-18T21:38:54Z",
+      "last_reconciled_at": "2026-08-18T22:44:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4096,11 +3868,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:35Z",
+      "first_seen_at": "2026-08-18T22:44:29Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-18T21:38:54Z",
+      "last_reconciled_at": "2026-08-18T22:44:29Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4208,11 +3980,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:35Z",
+      "first_seen_at": "2026-08-18T22:44:29Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-18T21:38:54Z",
+      "last_reconciled_at": "2026-08-18T22:44:29Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4248,11 +4020,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:35Z",
+      "first_seen_at": "2026-08-18T22:44:29Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-18T21:38:54Z",
+      "last_reconciled_at": "2026-08-18T22:44:29Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4288,11 +4060,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:36Z",
+      "first_seen_at": "2026-08-18T22:44:29Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-18T21:38:54Z",
+      "last_reconciled_at": "2026-08-18T22:44:29Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4400,11 +4172,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4504,18 +4276,17 @@
       "symbol_type": "class",
       "verdict": null
     },
-    "haskell/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "haskell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4614,11 +4385,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4726,11 +4497,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -4838,11 +4609,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -4950,11 +4721,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4990,11 +4761,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:37Z",
+      "first_seen_at": "2026-08-18T22:44:30Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-18T21:38:55Z",
+      "last_reconciled_at": "2026-08-18T22:44:30Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5102,11 +4873,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:38Z",
+      "first_seen_at": "2026-08-18T22:44:31Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-18T21:38:56Z",
+      "last_reconciled_at": "2026-08-18T22:44:31Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5214,11 +4985,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:38Z",
+      "first_seen_at": "2026-08-18T22:44:31Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-18T21:38:56Z",
+      "last_reconciled_at": "2026-08-18T22:44:31Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5326,11 +5097,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:38Z",
+      "first_seen_at": "2026-08-18T22:44:31Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-18T21:38:56Z",
+      "last_reconciled_at": "2026-08-18T22:44:31Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5375,11 +5146,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -5451,11 +5222,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -5536,11 +5307,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -5648,11 +5419,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -5742,11 +5513,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 529,
       "last_seen_examples": [
         {
@@ -5854,11 +5625,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -5966,11 +5737,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:39Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6078,11 +5849,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:40Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6127,11 +5898,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:40Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6239,11 +6010,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:40Z",
+      "first_seen_at": "2026-08-18T22:44:32Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-18T21:38:57Z",
+      "last_reconciled_at": "2026-08-18T22:44:32Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6269,11 +6040,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:42Z",
+      "first_seen_at": "2026-08-18T22:44:34Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-18T21:38:59Z",
+      "last_reconciled_at": "2026-08-18T22:44:34Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6322,11 +6093,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:42Z",
+      "first_seen_at": "2026-08-18T22:44:34Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-18T21:38:59Z",
+      "last_reconciled_at": "2026-08-18T22:44:34Z",
       "last_seen_count": 147,
       "last_seen_examples": [
         {
@@ -6423,11 +6194,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:42Z",
+      "first_seen_at": "2026-08-18T22:44:34Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-18T21:38:59Z",
+      "last_reconciled_at": "2026-08-18T22:44:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6453,11 +6224,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:42Z",
+      "first_seen_at": "2026-08-18T22:44:35Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-18T21:39:00Z",
+      "last_reconciled_at": "2026-08-18T22:44:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6476,18 +6247,17 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "matlab/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "matlab/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:43Z",
+      "first_seen_at": "2026-08-18T22:44:35Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-18T21:39:00Z",
+      "last_reconciled_at": "2026-08-18T22:44:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6514,11 +6284,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:43Z",
+      "first_seen_at": "2026-08-18T22:44:35Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-18T21:39:01Z",
+      "last_reconciled_at": "2026-08-18T22:44:35Z",
       "last_seen_count": 70,
       "last_seen_examples": [
         {
@@ -6626,11 +6396,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:43Z",
+      "first_seen_at": "2026-08-18T22:44:35Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-18T21:39:01Z",
+      "last_reconciled_at": "2026-08-18T22:44:35Z",
       "last_seen_count": 120,
       "last_seen_examples": [
         {
@@ -6738,11 +6508,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:43Z",
+      "first_seen_at": "2026-08-18T22:44:35Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-18T21:39:01Z",
+      "last_reconciled_at": "2026-08-18T22:44:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6769,11 +6539,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:43Z",
+      "first_seen_at": "2026-08-18T22:44:35Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-18T21:39:01Z",
+      "last_reconciled_at": "2026-08-18T22:44:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6809,11 +6579,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:47Z",
+      "first_seen_at": "2026-08-18T22:44:39Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-18T21:39:04Z",
+      "last_reconciled_at": "2026-08-18T22:44:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6832,18 +6602,17 @@
       "symbol_type": "class",
       "verdict": null
     },
-    "perl/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "perl/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:47Z",
+      "first_seen_at": "2026-08-18T22:44:39Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-18T21:39:04Z",
+      "last_reconciled_at": "2026-08-18T22:44:39Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -6951,11 +6720,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:47Z",
+      "first_seen_at": "2026-08-18T22:44:39Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-18T21:39:04Z",
+      "last_reconciled_at": "2026-08-18T22:44:39Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7036,11 +6805,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:47Z",
+      "first_seen_at": "2026-08-18T22:44:39Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-18T21:39:04Z",
+      "last_reconciled_at": "2026-08-18T22:44:39Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7121,11 +6890,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:47Z",
+      "first_seen_at": "2026-08-18T22:44:39Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-18T21:39:04Z",
+      "last_reconciled_at": "2026-08-18T22:44:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7152,11 +6921,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:47Z",
+      "first_seen_at": "2026-08-18T22:44:39Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-18T21:39:04Z",
+      "last_reconciled_at": "2026-08-18T22:44:39Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7264,11 +7033,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:49Z",
+      "first_seen_at": "2026-08-18T22:44:40Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-18T21:39:05Z",
+      "last_reconciled_at": "2026-08-18T22:44:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7295,11 +7064,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:49Z",
+      "first_seen_at": "2026-08-18T22:44:40Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-18T21:39:05Z",
+      "last_reconciled_at": "2026-08-18T22:44:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7326,11 +7095,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:49Z",
+      "first_seen_at": "2026-08-18T22:44:40Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-18T21:39:05Z",
+      "last_reconciled_at": "2026-08-18T22:44:40Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -7438,11 +7207,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:50Z",
+      "first_seen_at": "2026-08-18T22:44:41Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-18T21:39:06Z",
+      "last_reconciled_at": "2026-08-18T22:44:41Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7470,18 +7239,17 @@
       "symbol_type": "class",
       "verdict": null
     },
-    "powershell/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "powershell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:50Z",
+      "first_seen_at": "2026-08-18T22:44:41Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-18T21:39:06Z",
+      "last_reconciled_at": "2026-08-18T22:44:41Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -7544,11 +7312,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:50Z",
+      "first_seen_at": "2026-08-18T22:44:41Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-18T21:39:06Z",
+      "last_reconciled_at": "2026-08-18T22:44:41Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7575,11 +7343,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:50Z",
+      "first_seen_at": "2026-08-18T22:44:41Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-18T21:39:06Z",
+      "last_reconciled_at": "2026-08-18T22:44:41Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7633,11 +7401,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:53Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-18T21:39:10Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7691,11 +7459,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:53Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-18T21:39:10Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7722,11 +7490,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:53Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-18T21:39:10Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -7834,11 +7602,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:53Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-18T21:39:10Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -7946,11 +7714,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:54Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-18T21:39:11Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7986,11 +7754,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:54Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-18T21:39:11Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8062,11 +7830,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:54Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-18T21:39:11Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8111,11 +7879,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:54Z",
+      "first_seen_at": "2026-08-18T22:44:45Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-18T21:39:11Z",
+      "last_reconciled_at": "2026-08-18T22:44:45Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8187,11 +7955,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:55Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-18T21:39:12Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8236,11 +8004,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:55Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-18T21:39:12Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -8348,11 +8116,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:55Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-18T21:39:12Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -8452,18 +8220,17 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "rust/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:55Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-18T21:39:12Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -8571,11 +8338,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:01:55Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-18T21:39:12Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8602,11 +8369,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:55Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-18T21:39:12Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -8706,18 +8473,17 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "scala/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "scala/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:56Z",
+      "first_seen_at": "2026-08-18T22:44:47Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-18T21:39:13Z",
+      "last_reconciled_at": "2026-08-18T22:44:47Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8814,11 +8580,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:58Z",
+      "first_seen_at": "2026-08-18T22:44:49Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-18T21:39:15Z",
+      "last_reconciled_at": "2026-08-18T22:44:49Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -8915,11 +8681,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:59Z",
+      "first_seen_at": "2026-08-18T22:44:50Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-18T21:39:15Z",
+      "last_reconciled_at": "2026-08-18T22:44:50Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8977,18 +8743,17 @@
       "symbol_type": "function",
       "verdict": null
     },
-    "swift/function/args/agree[gitgalaxy]_vs[tree_sitter]": {
-      "agreeing_tools": [
-        "gitgalaxy"
-      ],
+    "swift/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
       "dissenting_tools": [
+        "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:59Z",
+      "first_seen_at": "2026-08-18T22:44:50Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9013,11 +8778,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:01:59Z",
+      "first_seen_at": "2026-08-18T22:44:50Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9042,11 +8807,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:01:59Z",
+      "first_seen_at": "2026-08-18T22:44:50Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9072,11 +8837,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:02:00Z",
+      "first_seen_at": "2026-08-18T22:44:51Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9103,11 +8868,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:02:00Z",
+      "first_seen_at": "2026-08-18T22:44:51Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9143,11 +8908,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:02:00Z",
+      "first_seen_at": "2026-08-18T22:44:51Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:51Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -9201,11 +8966,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:02:00Z",
+      "first_seen_at": "2026-08-18T22:44:51Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-18T21:39:16Z",
+      "last_reconciled_at": "2026-08-18T22:44:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9232,11 +8997,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:02:16Z",
+      "first_seen_at": "2026-08-18T22:45:07Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-18T21:39:32Z",
+      "last_reconciled_at": "2026-08-18T22:45:07Z",
       "last_seen_count": 520,
       "last_seen_examples": [
         {
@@ -9344,11 +9109,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:02:16Z",
+      "first_seen_at": "2026-08-18T22:45:07Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-18T21:39:32Z",
+      "last_reconciled_at": "2026-08-18T22:45:07Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -9438,11 +9203,11 @@
         "gitgalaxy",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:02:16Z",
+      "first_seen_at": "2026-08-18T22:45:07Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-18T21:39:32Z",
+      "last_reconciled_at": "2026-08-18T22:45:07Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -9550,11 +9315,11 @@
       "dissenting_tools": [
         "ctags"
       ],
-      "first_seen_at": "2026-08-18T21:02:16Z",
+      "first_seen_at": "2026-08-18T22:45:07Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-18T21:39:32Z",
+      "last_reconciled_at": "2026-08-18T22:45:07Z",
       "last_seen_count": 1961,
       "last_seen_examples": [
         {
@@ -9662,11 +9427,11 @@
         "ctags",
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:02:16Z",
+      "first_seen_at": "2026-08-18T22:45:07Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-18T21:39:32Z",
+      "last_reconciled_at": "2026-08-18T22:45:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9702,11 +9467,11 @@
         "ctags",
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:02:16Z",
+      "first_seen_at": "2026-08-18T22:45:07Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-18T21:39:32Z",
+      "last_reconciled_at": "2026-08-18T22:45:07Z",
       "last_seen_count": 175,
       "last_seen_examples": [
         {
@@ -9813,11 +9578,11 @@
       "dissenting_tools": [
         "tree_sitter"
       ],
-      "first_seen_at": "2026-08-18T21:02:19Z",
+      "first_seen_at": "2026-08-18T22:45:10Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-18T21:39:35Z",
+      "last_reconciled_at": "2026-08-18T22:45:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9842,11 +9607,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:02:19Z",
+      "first_seen_at": "2026-08-18T22:45:10Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-18T21:39:35Z",
+      "last_reconciled_at": "2026-08-18T22:45:10Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -9943,11 +9708,11 @@
       "dissenting_tools": [
         "gitgalaxy"
       ],
-      "first_seen_at": "2026-08-18T21:02:19Z",
+      "first_seen_at": "2026-08-18T22:45:10Z",
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-18T21:39:35Z",
+      "last_reconciled_at": "2026-08-18T22:45:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/tests/tools/tri_comparison_chart.py
+++ b/tests/tools/tri_comparison_chart.py
@@ -11,54 +11,96 @@ USAGE
     python tests/tools/tri_comparison_chart.py --languages python,rust,csharp --write
     python tests/tools/tri_comparison_chart.py --all --write   # every language with a corpus
 
-PANELS
-    Three, not five: Function Existence, Class Existence, Args Exact-Match. Deliberately not the
-    old chart's five (func recall, func precision, class recall, class precision, args) --
-    tree_sitter_accuracy_audit.py could split recall from precision because it had a privileged
-    ground truth to measure false positives against (an "extra" -- something a tool reported that
-    ground truth says isn't real). This tool has no privileged ground truth (see
-    tri_comparison_reconcile.py's own module docstring for why), so "existence" here is a
-    single recall-shaped number: of everything ANY available tool reported, how much did this
-    ONE tool also report. A true precision-style "corroboration rate" metric (of what THIS tool
-    reported, how much did at least one other tool confirm) is a real, useful, and currently
-    MISSING second metric -- noted here rather than silently treated as equivalent to what this
-    chart actually shows, and left as a clearly-scoped follow-up rather than guessed at under
-    time pressure.
+PANELS: FIVE, MATCHING THE OLD CHART'S SHAPE
+    Function Recall, Function Precision, Class Recall, Class Precision, Args Exact-Match. An
+    earlier version of this chart collapsed recall and precision into one "existence" panel,
+    reasoning that there's no privileged ground truth here to measure false positives against
+    the way tree_sitter_accuracy_audit.py's bi-comparison could. That reasoning doesn't actually
+    require dropping precision, just redefining it without a privileged ground truth --
+    tri_comparison_reconcile.py now computes both from the exact same underlying per-slot
+    agreement data:
+      - recall_t = (slots tool t reported) / (every slot ANY available tool reported).
+      - precision_t = (slots tool t reported that at least one OTHER tool corroborated) /
+        (slots tool t reported, period).
+    This produces real, differentiated signal, not just more panels for their own sake --
+    confirmed on rust: GitGalaxy sits at 100% recall (it's the strict superset -- tree-sitter and
+    ctags both independently miss the same 152 real occurrences) but only ~92% precision (some of
+    what only GitGalaxy reports isn't corroborated), while tree-sitter/ctags sit at ~92% recall
+    but ~100% precision. That's a genuine recall/precision tradeoff, not an artifact of the
+    formula.
+
+CSS/HTML CLASS PANELS: OUT OF SCOPE, NOT JUST LOW-SCORING
+    GitGalaxy's own `class_start` for css/html targets selector/tag-shaped entities (`.foo {`),
+    not OOP-shaped classes -- the bi-comparison chart already treats this as permanently out of
+    scope by design (epic #1295), not an unmeasured gap. This chart matches that: css and html
+    are excluded from class_recall/class_precision reconciliation entirely (see
+    _CLASS_SCOPE_EXCLUDED_LANGS below), not scored and hidden, so a discrepancy ledger entry
+    never gets manufactured for a comparison that was never a fair one to begin with.
 
 BAR GROUPS: VARIABLE, NOT ALWAYS THREE
-    Every language gets a GitGalaxy bar. Only 24 of GitGalaxy's 45 languages get all three (both
-    tree-sitter and ctags available); 7 more get GitGalaxy+tree-sitter only (ctags has no parser
-    for them); 9 get GitGalaxy+ctags only (tree-sitter has no grammar for them -- ada,
-    agc_assembly, assembly, cobol, embedded_python, m4, scheme, sqlite, yacc); the rest render
-    GitGalaxy alone. Bars are drawn compactly -- a 2-bar group is never padded with an empty slot
-    for the missing tool -- but ALWAYS in the fixed order GitGalaxy, tree-sitter, ctags, so a
-    given vertical position in the stack means the same tool in every row that includes it.
+    Every language with real data gets a GitGalaxy bar. Only 24 of GitGalaxy's 45 languages get
+    all three (both tree-sitter and ctags available); 7 more get GitGalaxy+tree-sitter only
+    (ctags has no parser for them); 9 get GitGalaxy+ctags only (tree-sitter has no grammar for
+    them -- ada, agc_assembly, assembly, cobol, embedded_python, m4, scheme, sqlite, yacc); the
+    rest render GitGalaxy alone. Bars are drawn compactly -- a 2-bar group is never padded with
+    an empty slot for the missing tool -- but ALWAYS in the fixed order GitGalaxy, tree-sitter,
+    ctags, so a given vertical position in the stack means the same tool in every row.
 
-GITGALAXY'S BAR: GRAY VS. COLORED
-    The one piece of this chart that's a genuine design decision, not just a rendering choice:
-    GitGalaxy's bar renders its normal categorical color when it TIES the other available tool(s)
-    for a given (language, symbol_type, metric), or when tri_comparison_ledger.py's
-    is_language_metric_clean() says every discrepancy where GitGalaxy is on the losing
-    (dissenting) side has a validated verdict. It renders GRAY when GitGalaxy's score is lower
-    than at least one other available tool's AND at least one of the discrepancies behind that
-    gap hasn't been investigated yet (see docs/self_scan/how_to_investigate_a_discrepancy.md).
-    Gray means "unaudited," not "wrong" -- tree-sitter and ctags bars never render gray; only
-    GitGalaxy's does, because this whole tool exists to audit GitGalaxy specifically, not to
-    grade the other two.
+    "Real data" is stricter than "the corpus directory exists", in two distinct ways, each
+    confirmed by hand rather than assumed:
+      - lua and groovy have a language-crucible directory with files in it, but GitGalaxy's own
+        language routing finds ZERO files that are actually lua/groovy source (Redis's C
+        Lua-embedding code; Groovy tooling written in Java) -- gather_language() returns an empty
+        result list, treated identically to a missing corpus directory (embedded_python, sqlite,
+        ada): an "awaiting language-crucible corpus" row.
+      - jcl and livecode have real, CORRECTLY-routed files (3 real .jcl files; 2 real livecode
+        files) but every tool finds zero functions/classes in all of them -- every score is an
+        undefined 0/0, not a low one. Same visual "awaiting" treatment, honest wording
+        (`LanguageChartData.awaiting_note`) since the corpus genuinely isn't missing here, just
+        empty of anything comparable in this small a sample.
+
+GITGALAXY'S BAR: ALWAYS BLUE, ASTERISK FOR AN UNAUDITED LOSS
+    An earlier version of this chart turned GitGalaxy's bar gray when it lost to another
+    available tool and that gap hadn't been investigated. Recoloring an entire bar species read
+    as more alarming than intended and made the chart harder to scan at a glance for a value that
+    hasn't actually changed meaning -- GitGalaxy's bar is now ALWAYS its normal categorical blue.
+    The same "beaten and not yet investigated" signal instead appends `*` to GitGalaxy's OWN
+    value label for that cell (e.g. `126/259*`) -- still visible, far less visually loud. See
+    docs/self_scan/how_to_investigate_a_discrepancy.md for what an asterisk is asking for.
+
+    Recall and precision fail in OPPOSITE shapes, and the asterisk check has to know which one
+    it's looking at -- confirmed the hard way: GitGalaxy's rust func PRECISION (92.1%, genuinely
+    beaten by both tree-sitter and ctags at 100%) first shipped with no `*` at all, because the
+    check only looked for GitGalaxy on recall's failure side (`dissenting_tools`, "GitGalaxy
+    missed something real"), and precision's failure side is the opposite one (`agreeing_tools`
+    == just GitGalaxy alone, "GitGalaxy claims something nobody corroborates"). Each panel below
+    passes its own `aspect` ("recall" or "precision") to `is_language_metric_clean()` -- see that
+    function's own docstring in tri_comparison_ledger.py for the full reasoning.
+
+VALUE LABELS: CENTERED ON EACH BAR, NOT STACKED TO THE SIDE
+    Each bar carries its own `matched/total` label centered horizontally within the bar-track
+    (the fixed-width background, not the variable-length fill -- so a short bar's label doesn't
+    end up crammed against its own left edge), in white for contrast against the saturated fill.
+
+WINNER BADGE
+    The space a stacked column of raw numbers used to occupy (to the right of each panel) now
+    holds ONE badge per (language, panel): a colored letter -- G/T/C -- naming whichever
+    available tool scored strictly highest there, in that tool's own categorical color. No badge
+    at all when there's a tie for the top score (including a 1-bar group, which can't have a
+    "winner" over nothing) -- a badge only ever appears when there's an actual winner to name.
 
 COLOR SOURCE
     Categorical slots 1-3 of the validated reference palette (see the `dataviz` skill's
     references/palette.md) -- GitGalaxy=blue, tree-sitter=orange, ctags=aqua. Those three slots
     are the ones documented as clearing the ALL-PAIRS CVD/contrast gates in both light and dark
-    mode, the relevant gate for a small-multiples chart with this many rows. The gray override on
-    GitGalaxy is a status-like "unaudited" signal, not a fourth series -- reserved, not reused for
-    series identity, per the same skill's rule.
+    mode, the relevant gate for a small-multiples chart with this many rows.
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from collections import Counter
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -76,9 +118,13 @@ _GG_ONLY_LANGS = (
     "jcl", "livecode", "m4", "scheme", "sqlite", "yacc", "yaml",
 )
 
+# See module docstring's CSS/HTML CLASS PANELS section -- class_start there targets
+# selector/tag-shaped entities, not OOP classes; excluded from class reconciliation entirely
+# (epic #1295 precedent), not scored and hidden.
+_CLASS_SCOPE_EXCLUDED_LANGS = frozenset({"css", "html"})
+
 _TOOL_LABEL = {"gitgalaxy": "GitGalaxy", "tree_sitter": "tree-sitter", "ctags": "ctags"}
-# Fixed tool order everywhere in this chart -- reuses reconcile.py's ALL_TOOLS rather than a
-# second, easy-to-drift copy of the same three-tuple.
+_TOOL_BADGE_LETTER = {"gitgalaxy": "G", "tree_sitter": "T", "ctags": "C"}
 
 # Categorical palette slots 1-3 (validated all-pairs, both modes -- see dataviz skill's
 # references/palette.md). Light-mode values; this is a static, light-surface-only SVG, matching
@@ -86,7 +132,6 @@ _TOOL_LABEL = {"gitgalaxy": "GitGalaxy", "tree_sitter": "tree-sitter", "ctags": 
 _COLOR_GITGALAXY = "#2a78d6"
 _COLOR_TREE_SITTER = "#eb6834"
 _COLOR_CTAGS = "#1baf7a"
-_COLOR_GRAY = "#9a9a95"  # status-like "unaudited" override on GitGalaxy's bar only
 _COLOR_TOOL = {"gitgalaxy": _COLOR_GITGALAXY, "tree_sitter": _COLOR_TREE_SITTER, "ctags": _COLOR_CTAGS}
 
 
@@ -118,9 +163,12 @@ class LanguageChartData:
     def __init__(self, lang: str):
         self.lang = lang
         self.available_tools = _available_tools(lang)
-        self.corpus_available = _corpus_exists(lang)
-        self.func_existence: dict[str, MetricScore] = {}
-        self.class_existence: dict[str, MetricScore] = {}
+        self.has_data = _corpus_exists(lang)  # refined in run_pipeline once gather actually runs
+        self.awaiting_note = "awaiting language-crucible corpus"
+        self.func_recall: dict[str, MetricScore] = {}
+        self.func_precision: dict[str, MetricScore] = {}
+        self.class_recall: dict[str, MetricScore] = {}
+        self.class_precision: dict[str, MetricScore] = {}
         self.args: dict[str, MetricScore] = {}
 
 
@@ -131,7 +179,7 @@ def run_pipeline(languages: list[str], verbose: bool = True) -> dict[str, Langua
     for lang in languages:
         data = LanguageChartData(lang)
         out[lang] = data
-        if not data.corpus_available:
+        if not data.has_data:
             if verbose:
                 print(f"tri_comparison_chart: {lang} -- no language-crucible corpus, skipping (awaiting data)")
             continue
@@ -142,23 +190,83 @@ def run_pipeline(languages: list[str], verbose: bool = True) -> dict[str, Langua
         except SystemExit as e:
             if verbose:
                 print(f"tri_comparison_chart: {lang} -- gather failed ({e}), skipping")
-            data.corpus_available = False
+            data.has_data = False
             continue
 
-        func_existence, args_scores, func_groups = reconcile_symbols(results, "function", data.available_tools)
-        class_existence, _, class_groups = reconcile_symbols(results, "class", data.available_tools)
-        data.func_existence = func_existence
-        data.class_existence = class_existence
+        if not results:
+            # Corpus directory exists but GitGalaxy's own language routing found zero files
+            # actually written in this language (confirmed cases: lua, groovy -- see module
+            # docstring). Functionally identical to no corpus at all for chart purposes.
+            if verbose:
+                print(f"tri_comparison_chart: {lang} -- corpus has no real {lang} files, treating as awaiting data")
+            data.has_data = False
+            continue
+
+        func_recall, func_precision, args_scores, func_groups = reconcile_symbols(
+            results, "function", data.available_tools
+        )
+        data.func_recall = func_recall
+        data.func_precision = func_precision
         data.args = args_scores
+
+        class_groups: list = []
+        if lang not in _CLASS_SCOPE_EXCLUDED_LANGS:
+            class_recall, class_precision, _, class_groups = reconcile_symbols(
+                results, "class", data.available_tools
+            )
+            data.class_recall = class_recall
+            data.class_precision = class_precision
+
+        # Different case from the empty-results one above: real, correctly-routed files exist
+        # (confirmed cases: jcl -- 3 real .jcl files; livecode -- 2 real files) but EVERY tool
+        # found zero functions/classes in all of them, so every score is an undefined 0/0
+        # (MetricScore.rate_pct is None). Rendering three empty bar-tracks with no bars at all
+        # reads as a broken row, not a "nothing to compare" one -- same visual "awaiting" note,
+        # honest wording since the corpus genuinely isn't missing here.
+        any_real_score = any(
+            s.rate_pct is not None
+            for d in (data.func_recall, data.class_recall, data.args)
+            for s in d.values()
+        )
+        if not any_real_score:
+            if verbose:
+                print(f"tri_comparison_chart: {lang} -- {len(results)} real file(s) but 0 functions/classes found by any tool")
+            data.has_data = False
+            data.awaiting_note = "no functions/classes found in this corpus by any tool"
 
         ledger_mod.merge_and_save(lang, func_groups + class_groups, path=ledger_mod.LEDGER_PATH)
     return out
 
 
-def _gg_bar_color(lang: str, symbol_type: str, metric: str) -> str:
-    if ledger_mod.is_language_metric_clean(lang, symbol_type, metric, path=ledger_mod.LEDGER_PATH):
-        return _COLOR_GITGALAXY
-    return _COLOR_GRAY
+def _gg_needs_asterisk(lang: str, symbol_type: str, ledger_metric: str, aspect: str) -> bool:
+    return not ledger_mod.is_language_metric_clean(
+        lang, symbol_type, ledger_metric, path=ledger_mod.LEDGER_PATH, aspect=aspect
+    )
+
+
+def _winner_or_tie(scores: dict[str, MetricScore], available_tools: tuple[str, ...]) -> str | None:
+    """Tool name with the strictly-highest score among available tools with real data; the
+    literal string "tie" if 2+ tools share the top score; None if fewer than 2 tools have real
+    data at all (a 1-bar group, or an empty panel) -- that last case isn't a comparison, so it's
+    kept distinct from a real tie rather than folded into it. The badge renderer only cares about
+    the winner case (see _winner below); the bottom-of-chart tally (render_chart's summary
+    block) needs all three states to count "how many of the 5x45 possible comparisons actually
+    happened, and how did each one resolve" without silently inflating the tie count with cells
+    that were never a real comparison to begin with."""
+    vals = [(t, scores[t].rate_pct) for t in available_tools if t in scores and scores[t].rate_pct is not None]
+    if len(vals) < 2:
+        return None
+    vals.sort(key=lambda tv: -tv[1])
+    if vals[0][1] == vals[1][1]:
+        return "tie"
+    return vals[0][0]
+
+
+def _winner(scores: dict[str, MetricScore], available_tools: tuple[str, ...]) -> str | None:
+    """Tool name with the strictly-highest score, or None on a tie OR no real comparison --
+    the coarser two-way split the badge renderer actually needs (draw a badge, or don't)."""
+    result = _winner_or_tie(scores, available_tools)
+    return result if result != "tie" else None
 
 
 _CHART_STYLE = """<style>
@@ -166,13 +274,15 @@ _CHART_STYLE = """<style>
   .title { font-size: 15px; font-weight: 600; fill: #0b0b0b; }
   .subtitle { font-size: 11px; fill: #52514e; }
   .scope-note { font-size: 10px; fill: #706f6a; }
-  .panel-title { font-size: 11px; font-weight: 600; fill: #0b0b0b; text-anchor: middle; }
-  .lang-label { font-size: 10.5px; fill: #0b0b0b; }
-  .value-label { font-size: 8.5px; fill: #52514e; }
+  .panel-title { font-size: 10.5px; font-weight: 600; fill: #0b0b0b; text-anchor: middle; }
+  .summary-title { font-size: 10.5px; font-weight: 600; fill: #0b0b0b; text-anchor: start; }
+  .lang-label { font-size: 13px; font-weight: 700; fill: #0b0b0b; }
+  .bar-value-label { font-size: 8px; fill: #ffffff; text-anchor: middle; font-weight: 600; }
   .legend-label { font-size: 10px; fill: #0b0b0b; }
   .stripe { fill: #f0efec; }
   .awaiting { font-size: 9.5px; fill: #9a9a95; font-style: italic; }
   .bar-track { fill: #eeede9; }
+  .badge-label { font-size: 8.5px; font-weight: 700; fill: #ffffff; text-anchor: middle; }
 </style>"""
 
 
@@ -182,27 +292,54 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
     langs = sorted(data_by_lang.keys())
     n = len(langs)
 
-    label_col_w = 118
-    bar_max_w = 92
-    value_label_w = 56
-    panel_w = bar_max_w + value_label_w + 10
-    panel_gap = 22
+    label_col_w = 138  # room for "embedded_python" (longest name) bold at 13px
+    bar_max_w = 88
+    badge_col_w = 20
+    inner_gap = 6
+    panel_w = bar_max_w + inner_gap + badge_col_w
+    panel_gap = 18
     left_margin, right_margin = 16, 16
     top_margin = 128
     header_h = 20
     bottom_margin = 44
-    bar_h = 6
+    bar_h = 10
     sub_gap = 2
     row_pad = 5
     row_h = row_pad * 2 + 3 * bar_h + 2 * sub_gap  # room for up to 3 stacked bars, always
 
-    panels = [("func_existence", "function", "existence", "Function Existence"),
-              ("class_existence", "class", "existence", "Class Existence"),
-              ("args", "function", "args", "Args Exact-Match")]
+    # (data attr, symbol_type, ledger metric, panel title, asterisk aspect -- see
+    # ledger_mod.is_language_metric_clean's own docstring for why recall and precision need
+    # different aspects, not just different data)
+    panels = [
+        ("func_recall", "function", "existence", "Func Recall", "recall"),
+        ("func_precision", "function", "existence", "Func Precision", "precision"),
+        ("class_recall", "class", "existence", "Class Recall", "recall"),
+        ("class_precision", "class", "existence", "Class Precision", "precision"),
+        ("args", "function", "args", "Args Match", "recall"),
+    ]
 
     panels_x_start = left_margin + label_col_w
     width = panels_x_start + len(panels) * panel_w + (len(panels) - 1) * panel_gap + right_margin
-    height = top_margin + header_h + n * row_h + bottom_margin
+
+    # Tally: one vote per (language, panel) cell that's an actual comparison (2+ tools with real
+    # data) -- 5 panels x up to 45 languages, but a 1-bar group or an empty panel (css/html class,
+    # a blank args column) contributes no vote at all, per _winner_or_tie's own docstring on why
+    # "no comparison happened" has to stay distinct from "it was a tie".
+    tally: Counter[str] = Counter()
+    for data in data_by_lang.values():
+        if not data.has_data:
+            continue
+        for attr, _, _, _, _ in panels:
+            scores = getattr(data, attr)
+            if not scores:
+                continue
+            result = _winner_or_tie(scores, data.available_tools)
+            if result is not None:
+                tally[result] += 1
+    total_votes = sum(tally.values())
+
+    summary_h = 76
+    height = top_margin + header_h + n * row_h + bottom_margin + summary_h
     rows_top = top_margin + header_h
 
     parts: list[str] = [
@@ -215,14 +352,16 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
         f'<text class="subtitle" x="{left_margin}" y="36">{datetime.now(timezone.utc).strftime("%Y-%m-%d")} '
         + f"&#183; source: tests/tools/tri_comparison_chart.py &#183; "
         + f"ledger: docs/self_scan/tri_comparison_ledger.json</text>",
-        f'<text class="scope-note" x="{left_margin}" y="52">No tool is ground truth -- each bar is that '
-        + f"tool's own agreement rate vs. everything anyone found.</text>",
+        f'<text class="scope-note" x="{left_margin}" y="52">No tool is ground truth -- recall is vs. '
+        + f"everything anyone found, precision is vs. what each tool itself claimed.</text>",
         f'<text class="scope-note" x="{left_margin}" y="64">Bar groups vary 1-3 by language\'s tool coverage '
-        + f"-- order is always GitGalaxy, tree-sitter, ctags.</text>",
-        f'<text class="scope-note" x="{left_margin}" y="76">GitGalaxy\'s bar is GRAY when beaten and '
-        + f"unaudited, colored when tied or validated.</text>",
+        + f"-- order is always GitGalaxy, tree-sitter, ctags. css/html class panels are out of "
+        + f"scope by design (selectors, not OOP classes).</text>",
+        f'<text class="scope-note" x="{left_margin}" y="76">GitGalaxy\'s bar is always blue; `*` marks an '
+        + f"unaudited loss to another tool, not a verdict. Badge = the tool that scored strictly "
+        + f"highest (blank on a tie).</text>",
         f'<text class="scope-note" x="{left_margin}" y="88">See docs/self_scan/how_to_investigate_a_discrepancy.md '
-        + f"for what an unaudited gap means.</text>",
+        + f"for what `*` is asking for.</text>",
     ]
 
     legend_y = 108
@@ -231,12 +370,14 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
         parts.append(f'<rect x="{lx}" y="{legend_y - 8}" width="14" height="8" rx="2" fill="{_COLOR_TOOL[tool]}"/>')
         parts.append(f'<text class="legend-label" x="{lx + 18}" y="{legend_y}">{_TOOL_LABEL[tool]}</text>')
         lx += 18 + 9 * len(_TOOL_LABEL[tool]) + 20
-    parts.append(f'<rect x="{lx}" y="{legend_y - 8}" width="14" height="8" rx="2" fill="{_COLOR_GRAY}"/>')
-    parts.append(f'<text class="legend-label" x="{lx + 18}" y="{legend_y}">GitGalaxy, unaudited gap</text>')
+    parts.append(f'<text class="legend-label" x="{lx}" y="{legend_y}">* = GitGalaxy, unaudited loss</text>')
 
-    for i, (_, _, _, title) in enumerate(panels):
+    for i, (_, _, _, title, _) in enumerate(panels):
         px = panels_x_start + i * (panel_w + panel_gap)
-        parts.append(f'<text class="panel-title" x="{px + panel_w / 2}" y="{top_margin + header_h - 4}">{title}</text>')
+        parts.append(
+            f'<text class="panel-title" x="{px + (bar_max_w + inner_gap + badge_col_w) / 2}" '
+            f'y="{top_margin + header_h - 4}">{title}</text>'
+        )
 
     for row_i, lang in enumerate(langs):
         y = rows_top + row_i * row_h
@@ -245,31 +386,63 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
             parts.append(f'<rect class="stripe" x="{left_margin}" y="{y}" width="{width - left_margin - right_margin}" height="{row_h}"/>')
         parts.append(f'<text class="lang-label" x="{left_margin + 4}" y="{y + row_h / 2 + 3.5}">{lang}</text>')
 
-        if not data.corpus_available:
-            parts.append(f'<text class="awaiting" x="{panels_x_start}" y="{y + row_h / 2 + 3.5}">awaiting language-crucible corpus</text>')
+        if not data.has_data:
+            parts.append(f'<text class="awaiting" x="{panels_x_start}" y="{y + row_h / 2 + 3.5}">{data.awaiting_note}</text>')
             continue
 
-        for panel_i, (attr, symbol_type, metric, _) in enumerate(panels):
+        for panel_i, (attr, symbol_type, ledger_metric, _, aspect) in enumerate(panels):
             px = panels_x_start + panel_i * (panel_w + panel_gap)
             scores: dict[str, MetricScore] = getattr(data, attr)
+            if not scores:
+                continue  # class panel on a css/html row, or a metric with no comparable data
             bar_y = y + row_pad
-            parts.append(f'<rect class="bar-track" x="{px}" y="{bar_y}" width="{bar_max_w}" height="{3 * bar_h + 2 * sub_gap}" rx="2"/>')
+            track_h = 3 * bar_h + 2 * sub_gap
+            parts.append(f'<rect class="bar-track" x="{px}" y="{bar_y}" width="{bar_max_w}" height="{track_h}" rx="2"/>')
             for tool in data.available_tools:
-                if tool not in scores:
+                if tool not in scores or scores[tool].rate_pct is None:
                     continue
                 score = scores[tool]
-                if score.rate_pct is None:
-                    continue
                 w = max(2, bar_max_w * score.rate_pct / 100.0)
-                color = _gg_bar_color(lang, symbol_type, metric) if tool == "gitgalaxy" else _COLOR_TOOL[tool]
+                color = _COLOR_TOOL[tool]
                 parts.append(f'<rect x="{px}" y="{bar_y}" width="{w:.1f}" height="{bar_h}" rx="2" fill="{color}"/>')
+                label = f"{score.matched_consensus}/{score.total_slots}"
+                if tool == "gitgalaxy" and _gg_needs_asterisk(lang, symbol_type, ledger_metric, aspect):
+                    label += "*"
                 parts.append(
-                    f'<text class="value-label" x="{px + bar_max_w + 4}" y="{bar_y + bar_h - 0.5}">'
-                    f"{score.matched_consensus}/{score.total_slots}</text>"
+                    f'<text class="bar-value-label" x="{px + bar_max_w / 2}" y="{bar_y + bar_h - 2}">{label}</text>'
                 )
                 bar_y += bar_h + sub_gap
 
-    footer_y = height - bottom_margin + 16
+            winner = _winner(scores, data.available_tools)
+            if winner:
+                bx = px + bar_max_w + inner_gap + badge_col_w / 2
+                by = y + row_h / 2
+                parts.append(f'<circle cx="{bx}" cy="{by}" r="8" fill="{_COLOR_TOOL[winner]}"/>')
+                parts.append(f'<text class="badge-label" x="{bx}" y="{by + 3}">{_TOOL_BADGE_LETTER[winner]}</text>')
+
+    summary_top = rows_top + n * row_h + 20
+    parts.append(f'<line x1="{left_margin}" y1="{summary_top - 10}" x2="{width - right_margin}" y2="{summary_top - 10}" stroke="#dedcd6" stroke-width="1"/>')
+    parts.append(
+        f'<text class="summary-title" x="{left_margin}" y="{summary_top + 4}">'
+        f"Summary -- best tool per (language, metric), {total_votes} real comparisons "
+        f'(1-bar groups and empty panels don\'t count)</text>'
+    )
+    stat_y = summary_top + 26
+    sx = left_margin
+    for tool in ALL_TOOLS:
+        count = tally.get(tool, 0)
+        pct = 100.0 * count / total_votes if total_votes else 0.0
+        parts.append(f'<circle cx="{sx + 7}" cy="{stat_y - 4}" r="7" fill="{_COLOR_TOOL[tool]}"/>')
+        parts.append(f'<text class="badge-label" x="{sx + 7}" y="{stat_y - 1}">{_TOOL_BADGE_LETTER[tool]}</text>')
+        stat_text = f"{_TOOL_LABEL[tool]} best: {count} ({pct:.0f}%)"
+        parts.append(f'<text class="legend-label" x="{sx + 20}" y="{stat_y}">{stat_text}</text>')
+        sx += 20 + 6.2 * len(stat_text) + 24
+    tie_count = tally.get("tie", 0)
+    tie_pct = 100.0 * tie_count / total_votes if total_votes else 0.0
+    parts.append(f'<circle cx="{sx + 7}" cy="{stat_y - 4}" r="7" fill="#9a9a95"/>')
+    parts.append(f'<text class="legend-label" x="{sx + 20}" y="{stat_y}">Ties: {tie_count} ({tie_pct:.0f}%)</text>')
+
+    footer_y = summary_top + 46
     parts.append(
         f'<text class="scope-note" x="{left_margin}" y="{footer_y}">Value labels are raw counts '
         f"(matched/total). Regenerate: tri_comparison_chart.py --all --write</text>"

--- a/tests/tools/tri_comparison_ledger.py
+++ b/tests/tools/tri_comparison_ledger.py
@@ -132,26 +132,40 @@ def merge_and_save(
 
 
 def is_language_metric_clean(
-    language: str, symbol_type: str, metric: str, path: Path = LEDGER_PATH
+    language: str, symbol_type: str, metric: str, path: Path = LEDGER_PATH, aspect: str = "recall"
 ) -> bool:
-    """The one question the chart actually needs answered: does GitGalaxy's bar for this
-    (language, symbol_type, metric) render gray or colored? True (colored) means either no
+    """The one question the chart actually needs answered: does GitGalaxy's value label for this
+    (language, symbol_type, metric) get a `*` (an unaudited loss) or not? True means either no
     discrepancy currently reproduces here, or every one that does has a validated verdict.
-    False (gray) means at least one currently-reproducing, GitGalaxy-involving discrepancy for
-    this cell has never been investigated. A discrepancy where GitGalaxy is on the AGREEING side
-    (e.g. csharp's agree[ctags,gitgalaxy]_vs[tree_sitter]) doesn't gray the chart on its own --
-    "gray bars for any situation where gitgalaxy is beaten" per the design this implements: only
-    shapes where gitgalaxy is in `dissenting_tools` matter here.
+
+    `aspect` matters because recall and precision fail in OPPOSITE shapes, and checking the wrong
+    one silently misses real cases -- confirmed on rust: GitGalaxy's func precision (92.1%,
+    genuinely beaten by both tree-sitter and ctags at 100%) rendered with no `*` at all under the
+    recall-only check this function used to be, because GitGalaxy was never in `dissenting_tools`
+    for the shape actually causing that gap.
+      - "recall" (default; also correct for the "args" metric, whose discrepancy groups are
+        already majority/minority-shaped, not agree/disagree-shaped): GitGalaxy MISSED something
+        real -- flagged when GitGalaxy is in `dissenting_tools` (recall's actual failure mode).
+      - "precision": GitGalaxy is the LONE, uncorroborated claimant of something -- flagged only
+        when GitGalaxy is in `agreeing_tools` AND is the ONLY tool in that set (present but
+        nobody else backs it up). A shape like csharp's agree[ctags,gitgalaxy]_vs[tree_sitter]
+        does NOT flag precision -- ctags corroborates GitGalaxy there, precision is fine; only
+        agree[gitgalaxy]_vs[...] (GitGalaxy truly alone) does.
     """
     ledger = load_ledger(path)
     for entry in ledger.get("entries", {}).values():
-        if (
+        if not (
             entry["language"] == language
             and entry["symbol_type"] == symbol_type
             and entry["metric"] == metric
             and entry["still_reproduces"]
-            and "gitgalaxy" in entry["dissenting_tools"]
             and entry["status"] != "validated"
         ):
+            continue
+        if aspect == "precision":
+            flagged = entry["agreeing_tools"] == ["gitgalaxy"]
+        else:
+            flagged = "gitgalaxy" in entry["dissenting_tools"]
+        if flagged:
             return False
     return True

--- a/tests/tools/tri_comparison_reconcile.py
+++ b/tests/tools/tri_comparison_reconcile.py
@@ -142,14 +142,33 @@ def reconcile_symbols(
     results: list[FileReadings],
     symbol_type: str,
     available_tools: tuple[str, ...],
-) -> tuple[dict[str, MetricScore], dict[str, MetricScore], list[DiscrepancyGroup]]:
+) -> tuple[dict[str, MetricScore], dict[str, MetricScore], dict[str, MetricScore], list[DiscrepancyGroup]]:
     """symbol_type: "function" or "class". available_tools: whichever of ALL_TOOLS actually have
     a reading for this language -- both tree-sitter (absent for 9 of GitGalaxy's 45 languages,
     ctags-only there) and ctags (absent for 7 of the 31 tree-sitter-baselined languages) are
     independently optional per language; GitGalaxy is the only one always present.
-    Returns (existence_scores, args_scores, discrepancy_groups). args_scores is only ever
-    non-empty for symbol_type == "function" -- classes carry no args value in any reader."""
-    existence_scores = {t: MetricScore(t, 0, 0) for t in available_tools}
+
+    Returns (recall_scores, precision_scores, args_scores, discrepancy_groups). args_scores is
+    only ever non-empty for symbol_type == "function" -- classes carry no args value in any
+    reader. recall_scores and precision_scores are two different views of the exact same
+    underlying per-slot agreement data (there's no separate "precision ground truth" to measure
+    against -- see this module's own docstring for why no reader is privileged), which is also
+    why both draw on the SAME "existence" discrepancy groups below rather than needing a second,
+    separate discrepancy dimension:
+      - recall_t = (slots tool t reported) / (every slot ANY available tool reported -- the
+        union). Was this function's only "existence_scores" before recall/precision were split
+        apart; unchanged in meaning, just renamed.
+      - precision_t = (slots tool t reported that at least one OTHER available tool also
+        reported) / (slots tool t reported, period). A tool that reports something nobody else
+        agrees with pays for it here, not in recall -- confirmed meaningful on real data: rust's
+        152 GitGalaxy-only occurrences (tree-sitter and ctags both independently miss them) leave
+        GitGalaxy's recall at 100% (it's the superset) but its precision below 100% (some of what
+        it alone reports is uncorroborated), while tree-sitter/ctags sit at ~92% recall but
+        ~100% precision there -- a real, classic recall/precision tradeoff, not a coincidence of
+        this specific formula.
+    """
+    recall_scores = {t: MetricScore(t, 0, 0) for t in available_tools}
+    precision_scores = {t: MetricScore(t, 0, 0) for t in available_tools}
     args_scores = {t: MetricScore(t, 0, 0) for t in available_tools}
     existence_groups: dict[frozenset, DiscrepancyGroup] = {}
     args_groups: dict[frozenset, DiscrepancyGroup] = {}
@@ -174,19 +193,29 @@ def reconcile_symbols(
                 present = frozenset(t for t, o in slot.items() if o is not None)
                 absent = frozenset(available_tools) - present
 
-                # Score is each tool's own recall against the UNION of every occurrence-slot any
+                # Recall: each tool's own rate against the UNION of every occurrence-slot any
                 # available tool reported -- every slot counts once in every tool's denominator,
                 # and a tool's numerator moves only for slots IT reported, whether or not the
                 # other tools agreed. This is a real, honest number regardless of validation
                 # status: "no credit for anyone until a human signs off" would silently deflate
                 # every tool's rate on disputed slots and conflate two different questions (what
                 # did each tool find vs. do we trust the disputed cases yet). Validation status
-                # drives the ledger and the chart's gray/colored decision separately, below and
-                # in tri_comparison_ledger.py -- never the score itself.
+                # drives the ledger and the chart's asterisk decision separately, below and in
+                # tri_comparison_ledger.py -- never the score itself.
                 for t in available_tools:
-                    existence_scores[t].total_slots += 1
+                    recall_scores[t].total_slots += 1
                     if t in present:
-                        existence_scores[t].matched_consensus += 1
+                        recall_scores[t].matched_consensus += 1
+
+                # Precision: scoped to what EACH tool itself reported, not the shared union --
+                # a tool that's absent from this slot doesn't have its precision denominator
+                # touched by it at all (precision is "of what you claimed, how much held up",
+                # not "how much of everything did you claim"). len(present) >= 2 means at least
+                # one OTHER available tool corroborates this specific slot.
+                for t in present:
+                    precision_scores[t].total_slots += 1
+                    if len(present) >= 2:
+                        precision_scores[t].matched_consensus += 1
 
                 if present != frozenset(available_tools):
                     key = frozenset([("agree", present), ("dissent", absent)])
@@ -229,11 +258,32 @@ def reconcile_symbols(
                     for t in comparable:
                         args_scores[t].matched_consensus += 1
                 else:
+                    # BUG FIXED: this branch used to award matched_consensus to nobody at all --
+                    # the exact same "no credit until everyone agrees" mistake already caught and
+                    # fixed for recall/precision above, just never applied here too. A 2-vs-1
+                    # split has two tools that genuinely agree with EACH OTHER; denying them
+                    # credit because a third tool differs was silently deflating every language's
+                    # args score below what the data actually supports (confirmed: no language
+                    # could reach 100% even when only a small minority of occurrences had any
+                    # disagreement at all, since majority-agreeing tools were being penalized for
+                    # a minority outlier they had nothing to do with).
                     agree_val_counts = defaultdict(list)
                     for t, v in comparable.items():
                         agree_val_counts[v].append(t)
-                    majority_val, majority_tools = max(agree_val_counts.items(), key=lambda kv: len(kv[1]))
-                    majority_tools = frozenset(majority_tools)
+                    ranked = sorted(agree_val_counts.items(), key=lambda kv: -len(kv[1]))
+                    top_tools = ranked[0][1]
+                    second_size = len(ranked[1][1]) if len(ranked) > 1 else 0
+                    if len(top_tools) > second_size:
+                        # A REAL majority (strictly larger than the next-biggest group) -- e.g.
+                        # 2 tools agree, 1 differs. Only the tied case (2 comparable tools that
+                        # simply disagree, or a genuine 3-way split with no group larger than
+                        # any other) has no real majority; nobody gets credit there, correctly,
+                        # since there's no sense in which any side "won" a tie.
+                        majority_tools = frozenset(top_tools)
+                        for t in majority_tools:
+                            args_scores[t].matched_consensus += 1
+                    else:
+                        majority_tools = frozenset()
                     minority_tools = frozenset(comparable) - majority_tools
                     key = frozenset([("agree", majority_tools), ("dissent", minority_tools)])
                     grp = args_groups.setdefault(
@@ -254,4 +304,4 @@ def reconcile_symbols(
                         )
 
     all_groups = list(existence_groups.values()) + list(args_groups.values())
-    return existence_scores, args_scores, all_groups
+    return recall_scores, precision_scores, args_scores, all_groups


### PR DESCRIPTION
## Summary

Follow-up to #1859 (already merged, squash-commit `2f343080`) covering review feedback on the tri-comparison chart's first shipped version, plus two real bugs found along the way. Rebased onto current `main` since #1859 merged while this work was in progress -- this PR's diff is only the new work.

**Chart redesign:**
- **5 panels again** (Func/Class Recall + Precision, Args Match), not the 3 that shipped in #1859. `tri_comparison_reconcile.py` now computes precision alongside recall from the same per-slot agreement data -- no privileged ground truth needed: `recall_t = (slots t reported) / (union of everything anyone reported)`; `precision_t = (slots t reported that at least one OTHER tool corroborated) / (slots t reported, period)`. Confirmed this produces real, differentiated signal, not just more panels: on rust, GitGalaxy sits at 100% recall (it's the strict superset) but only ~92% precision (some of what only it reports goes uncorroborated), while tree-sitter/ctags sit at ~92% recall but ~100% precision -- a genuine tradeoff.
- **GitGalaxy's bar is now always blue.** The gray-on-loss treatment from #1859 read as more alarming than intended. The same "beaten and unaudited" signal now appends `*` to GitGalaxy's own value label instead (e.g. `126/259*`).
- **Value labels moved onto each bar**, centered, instead of stacked in a column to the side.
- That freed-up space now holds a **winner badge** (G/T/C, colored) naming whichever tool scored strictly highest for that cell -- blank on a tie.
- **Language names are bold and larger.**
- **New summary block** at the bottom tallies every (language, metric) comparison across the whole chart: GitGalaxy best 27/137 (20%), tree-sitter 16 (12%), ctags 15 (11%), ties 79 (58%). 1-bar groups and empty panels don't count -- there's no real comparison there.
- **css/html class panels excluded from reconciliation entirely**, matching an existing team precedent (epic #1295): their `class_start` targets CSS selectors, not OOP-shaped classes, so scoring them alongside real classes was misleading, not just low-scoring.
- **lua/livecode/jcl/yacc/yaml now correctly render "awaiting data"** instead of silently blank rows. Two distinct real causes, both reported honestly now: lua/groovy/yacc's corpus directories contain zero files GitGalaxy's own routing actually tags as that language (confirmed by hand -- Redis's C Lua-embedding code, Groovy tooling written in Java); jcl/livecode/yaml have real, correctly-routed files where every tool finds zero functions/classes in this small a sample.

**Two real bugs found and fixed:**
1. `tri_comparison_reconcile.py` -- the args-disagreement branch never gave majority-agreeing tools credit, even when 2 of 3 tools agreed with each other and only one differed. Same "no credit until everyone agrees" mistake already caught and fixed for recall in #1859, just never applied to args -- found because a user noticed args scores looked suspiciously capped below 100% everywhere. Confirmed the fix moved real numbers, not just formatting.
2. `tri_comparison_ledger.py`'s `is_language_metric_clean()` -- the asterisk check only looked for GitGalaxy on recall's failure side (`dissenting_tools`, "GitGalaxy missed something real"). Precision fails in the *opposite* shape (GitGalaxy alone claiming something nobody corroborates), so it needed its own `aspect` parameter. Confirmed by hand: rust's func precision (92.1%, genuinely beaten by both other tools at 100%) shipped with no asterisk under the old check; correctly gets one now.

## Test plan

- [x] All 3 modified Python files compile cleanly.
- [x] Regenerated `docs/self_scan/tri_comparison_chart.svg` and `tri_comparison_ledger.json` across all 45 languages.
- [x] Verified directly against the raw SVG source (not just a screenshot) that: ties correctly suppress badges (apex's Class Recall/Precision, both tools tied at 4/4, no badge either time); asterisks land on exactly the right panel (rust's Func Precision gets `*`, Func Recall -- where GitGalaxy is untied top scorer -- does not); the summary tally's arithmetic matches its own stated total (27+16+15+79=137).
- [x] Confirmed the patch this PR applies is exactly the diff between the two commits that were `#1859`'s HEAD and this branch's predecessor -- i.e. this PR contains only new work, nothing already merged.
- [ ] N/A: no changes to `gitgalaxy/core/` or `language_standards.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)