### PR TITLE
chore(ci): bump Muninn scanner to v0.3.9

### DIFF
--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run Muninn
         # zizmor: ignore[github_action_from_unverified_creator_used]
-        uses: skaldlab/muninn@6426b13b68ed0331598886218414985fb28b8e2f # v0.3.8
+        uses: skaldlab/muninn@1dfc9bb2e5092f3b2fa111e3cbafe278a3cf502c # v0.3.9
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail-on: info


### PR DESCRIPTION
## Summary
- bump `skaldlab/muninn` from `v0.3.8` to `v0.3.9` in `.github/workflows/muninn.yml`
- pin to commit `1dfc9bb2e5092f3b2fa111e3cbafe278a3cf502c` for reproducible CI runs

## Why
- `v0.3.9` includes scanner dependency updates (`osv-scanner`, `trivy`, `semgrep`) and latest Muninn release fixes

## Test plan
- [x] Muninn workflow passes on this PR