### PR TITLE
Resolve 8 of 11 c tri-comparison ledger shapes, 2 more tooling fixes

### DIFF
--- a/docs/language_status/README.md
+++ b/docs/language_status/README.md
@@ -60,7 +60,7 @@ epic #813), not that no cases exist.
 | agc_assembly | production | line_exclusive | 39/48 | 155 | 76 | not written |
 | apex | production | standard_block | 43/48 | 4* | 93 | not written |
 | assembly | production | line_exclusive | 42/52 | 148 | 83 | not written |
-| c | production | standard_block | 50/52 | 37 | 86 | not written |
+| **[c](c.md)** | production | standard_block | 50/52 | 42 | 86 | **written** |
 | cobol | production | positional_anchored | 48/52 | 62 | 82 | not written |
 | cpp | production | standard_block | 52/52 | 42 | 76 | not written |
 | csharp | production | standard_block | 51/52 | 44 | 106 | not written |

--- a/docs/language_status/c.md
+++ b/docs/language_status/c.md
@@ -1,0 +1,363 @@
+# C — Structural Signature Coverage
+
+Snapshot generated 2026-08-19 against `main`. Source: `LANGUAGE_DEFINITIONS["c"]` in
+`gitgalaxy/standards/language_standards.py`, `tests/extraction/languages/test_c.py` /
+`test_c_strict.py`, closed GitHub issues, and
+[`gitgalaxy-raw-output`](https://github.com/squid-protocol/gitgalaxy-raw-output). Re-run the
+`language-status` skill's data-gathering commands before trusting these numbers if this doc looks
+old relative to `last_updated` below.
+
+## 1. At a glance
+
+| Field | Value |
+|---|---|
+| `_meta.status` | `production` |
+| `_meta.target_version` | C23 (ISO/IEC 9899:2024 — `constexpr`, `#embed`, `[[attributes]]`, `nullptr`, `typeof`) |
+| `_meta.blueprint_version` | v5.0 |
+| `_meta.last_updated` | 2026-02-18 |
+| `lexical_family` | `standard_block` (`//` line comments, `/* */` block comments — C has no raw-string syntax, unlike C++'s `R"()"`) |
+| Structural signature keys wired | 50 / 52 (2 explicit `None`, see §4) |
+| Extraction-gauntlet tests (`test_c.py`) | 42 |
+| Strict-signature tests (`test_c_strict.py`) | 86 |
+| Total dedicated C test cases | 128 |
+
+## 2. Identification surface
+
+- **Extensions:** `.c .h .cl .inc .y .idc .cats .dts .dtsi` — standard sources/headers, OpenCL
+  kernels, Yacc grammars, C-like ATS/scripting files, and Device Tree Source (`.dts`/`.dtsi`,
+  hardware maps).
+- **Exact filenames:** none — C has no extensionless canonical entry-point convention the way
+  Python (`setup.py`) or PHP (`artisan`) do.
+- **Discriminators:** `.c`, `Makefile`, `configure.ac`, `configure.in`, `configure`,
+  `CMakeLists.txt`, `Kconfig` — ecosystem anchors used to disambiguate `.h`/`.inc` from other
+  C-family or unrelated languages.
+- **Shebangs:** `tcc`, `picoc`, `cscript` — the three real C interpreters/scripters that appear on
+  a line-1 shebang.
+
+## 3. What GitGalaxy detects
+
+Grouped by the phase headers `language_standards.py` uses for C. Description is what C's *actual*
+regex matches, not the generic cross-language definition.
+
+**Topology & structure**
+| Key | What it captures for C |
+|---|---|
+| `branch` | `if else switch case default for while do break continue goto`, plus `&& \|\| ?` |
+| `args` | Parameter-list capture guarded by the "Nested Pointer Shield" (a 1-level nesting trick so function-pointer parameters like `void (*cb)(int)` don't need unbounded backtracking) and a typed-parameter-list requirement (C builtin primitives, `struct`/`enum`, PascalCase/typedef'd `_t`-suffixed names, or leading-underscore reserved identifiers like `_PyStackRef`) so it doesn't fire on bare control-flow keywords; #1209 wrapped the parenthesized span in its own capture group so the counter isolates just `(...)`; #1282/#1283 widened the whitelist after finding it only ever recognized builtin primitives, missing the overwhelming majority of real cpython signatures (`FILE *fp`, `PyThreadState *tstate`) |
+| `structural_boundaries` | `struct union enum typedef return void restrict auto bool true false _BitInt alignas alignof` |
+| `func_start` | Anchors function definitions: steps over up to 5 stacked `__attribute__((...))` lines (the "Compiler Attribute Shield"), up to 3 storage/linkage modifiers (`static inline extern _Noreturn __inline__ __forceinline constexpr`), an optional `struct/union/enum` prefix, a linear return type, and up to 5 macro-wrapper tokens between the return type and the name (`PyAPI_FUNC(int)`, `_Py_HOT_FUNCTION`); also supports legacy K&R-style parameter declarations between `)` and `{` (up to 15 semicolon-terminated lines) and the MS-DOS `BEGIN` macro as a brace substitute (DOOM/legacy-DOS-era code). Guarded by the "K&R Ambiguity Trap"/"Iron Wall" fix that instantly rejects control-flow keywords (`if for while switch return`, and `BEGIN` itself inside the K&R gap) rather than backtracking through whitespace permutations |
+| `class_start` | Anchors `struct`/`union`/`enum`, optionally preceded by `typedef`; the tag name is optional so anonymous `typedef struct { ... } MyStruct;` matches. Deliberately also fires on bare variable declarations of an existing struct type (`struct foo_ops ops;`) — documented as intentional in `test_c_intentional_double_classification_sweep` so it can pair with the `_ops`-vtable-style `dependency_injection` heuristic below |
+
+**Safety & risk**
+| Key | What it captures for C |
+|---|---|
+| `safety` | `assert static_assert _Static_assert size_t snprintf strncat strncpy calloc nullptr unreachable ckd_add ckd_sub ckd_mul` |
+| `safety_bypasses` | `strcpy strcat sprintf gets alloca`, plus raw C-style pointer casts (`(type *)ptr`) |
+| `high_risk_execution` | `system popen execl execv fork longjmp setjmp` |
+| `io` | `fopen fclose fread fwrite fscanf sscanf socket recv send open read write close stat fseek remove rename` |
+| `api` | `extern`, `__declspec(dllexport)`, `__attribute__((visibility("default")))`, and non-`static` top-level variable/function declarations (linker-visible-by-default heuristic — same "public unless marked otherwise" logic C's linkage rules actually use) |
+| `state_mutation` | Bare `=` (excludes `== != <= >=`), pointer-deref assignment (`*x = ...`, excludes `*const`), `++`/`--` |
+| `dead_code` | Commented-out (`//` or `/*`) `if for while struct union enum void int return` |
+| `doc` | `///`, `/**`, Doxygen `@param @return @brief @details` and `\param \return \brief \details` |
+| `test` | `TEST TEST_F TEST_CASE CU_ASSERT RUN_TEST EXPECT_* ASSERT_*`, plus `assert(` |
+
+**Architecture & domain sensors**
+| Key | What it captures for C |
+|---|---|
+| `concurrency` | `thrd_create thrd_join mtx_lock pthread_create pthread_mutex_lock atomic_int _Atomic memory_order_* thread_local` |
+| `ui_framework` | `GtkWidget CreateWindow MessageBox XOpenDisplay gtk_window_new Fl_Window initscr wprintw` |
+| `closures` | `None` — see §4 |
+| `globals` | Top-level (optionally `static`/`extern`) variable declaration with an initializer |
+| `decorators` | C23 `[[attribute]]` bracket syntax |
+| `generics` | `_Generic(...)` (C11 type-generic selection) |
+| `comprehensions` | `None` — see §4 |
+| `scientific` | `math.h tgmath.h complex.h dgemm sin cos tan exp log sqrt complex I _Float* __m*`, plus a `cblas_` prefix match (BLAS routines) |
+| `reflection_metaprogramming` | Function-like macro definitions (`#define NAME(...)`) and `goto` |
+| `import` | `#include`/`#embed` with `<>` or `""` delimiters |
+| `_dependency_capture` | Extracts the exact include target path from the above |
+| `ownership` | `@author \author Author: Created by: Copyright` |
+
+**Specialized subsystems**
+| Key | What it captures for C |
+|---|---|
+| `planned_debt` / `fragile_debt` | Shared `GLOBAL_` TODO/FIXME-family markers |
+| `spec_exposure` | `[SPEC-123]`, `[spec ...]`, `[audit ...]` traceability tags, bounded to 300 chars to avoid the adjacent-unbounded-quantifier ReDoS shape (recurring bug class, same family fixed elsewhere via #713) |
+| `ssr_boundaries` | `FCGI_Accept khttp_parse MHD_start_daemon facil.io` |
+| `events` | `epoll_wait epoll_ctl kqueue kevent select poll libev libuv` |
+| `dependency_injection` | `plugin_register vtable`, and `struct *_ops` (vtable-suffix convention) |
+| `macros` | `#define #undef #if #elif #else #endif #pragma #warning #error` |
+| `pointers` | `->`, `uintptr_t intptr_t ptrdiff_t size_t`, address-of `&x` and dereference `*x` in argument/assignment position |
+| `memory_alloc` | `malloc calloc realloc free aligned_alloc mmap alloca` |
+| `inline_asm` | `__asm__`/`asm`/`__asm` (with optional `volatile`/`__volatile__`), parenthesized or brace form |
+
+**Resource management & stability**
+| Key | What it captures for C |
+|---|---|
+| `telemetry` | `syslog openlog log_info log_error log_warn log_debug vsyslog` |
+| `debug_prints` | `printf fprintf vprintf puts putchar perror` |
+| `explicit_casts` | `(int\|float\|double\|char\|bool\|long\|short\|unsigned\|signed\|void [*]*) identifier` |
+| `panics_and_aborts` | `abort exit _Exit quick_exit`, and `return -1` |
+| `thread_sleeps` | `sleep usleep nanosleep thrd_sleep` |
+| `bitwise_ops` | `<< >> ^ ~ <<= >>= &= \|= ^=` |
+| `sync_locks` | `mtx_lock mtx_unlock pthread_mutex_lock atomic_flag_test_and_set atomic_store` |
+| `immutability_locks` | `const constexpr alignas restrict` |
+| `cleanup` | `free( fclose( close( munmap( destroy( shutdown(` |
+| `encapsulation` | Leading `static` at line start — translation-unit-private linkage, C's only real privacy signal |
+| `listeners` | `on_event handler callback signal( sigaction(` |
+| `test_skip` | `IGNORE_TEST test.skip`, `mock(`, `fake(` |
+
+**Hybrid domain sensors (C specifics)**
+| Key | What it captures for C |
+|---|---|
+| `serialization_parsing` | `cJSON_Parse json_loads xmlReadMemory xmlParseFile jansson` |
+| `regex_execution` | `regcomp regexec regfree` |
+| `time_date_logic` | `time_t clock_gettime gettimeofday localtime_r? strftime` |
+| `ipc_rpc_bridges` | `fork pipe shmget shmat mmap socket bind listen accept` |
+
+Several of the pairs above are **deliberate double-classifications**, not collisions — e.g.
+`free(p)` fires both `cleanup` and `memory_alloc`; `mmap(...)` fires both `memory_alloc` and
+`ipc_rpc_bridges`; `pthread_mutex_lock(&m)` fires both `concurrency` and `sync_locks`; `restrict`
+and `alignas(...)` fire both `structural_boundaries` and `immutability_locks`. All ten pairs are
+enumerated and asserted in `test_c_intentional_double_classification_sweep`
+(`tests/extraction/languages/test_c_strict.py`).
+
+## 4. What GitGalaxy explicitly does not track
+
+Two keys are hard-set to `None` in C's `rules` dict (Rule 4 of the engine's generation rules:
+explicitly `None`, never a forced-fit regex, when a dimension doesn't exist natively):
+
+- **`closures`** — strict C23 has no native closure construct (GCC/Clang "nested functions" and
+  Apple "blocks" are non-standard compiler extensions, not part of the target C23 standard).
+- **`comprehensions`** — C has no list/set/dict comprehension or generator-expression syntax at
+  all (no inline reason comment in source for this one; the omission is self-evident given the
+  language has never had this construct in any standard revision).
+
+## 5. Known limitations (accepted, not fixed)
+
+One gap is deliberately documented rather than fixed, via a `known_limitation`-named test in
+`test_c.py`:
+
+1. **`func_start` matches function-shaped text on undecorated block-comment continuation lines.**
+   The rule has no comment/string awareness at the point it anchors `^[ \t]*` — a block comment
+   like `/*\nint TargetFunc() {\n*/` with no leading `*` continuation marker (a common real style
+   for commenting out code) still matches at true line start. This is a variant of recurring bug
+   class 3 (`tests/extraction/how_to_harden_extraction.md`) manifesting via **comments** rather
+   than **string literals**. A companion test in the same file
+   (`test_c_func_start_string_literal_concatenation_does_not_false_positive`) confirms the
+   string-literal variant of this bug class does *not* reproduce for C: C has no raw-string syntax
+   (unlike C++'s `R"()"`), so every string-literal content line necessarily starts with a literal
+   `"` character, which blocks `^[ \t]*` from ever reaching function-shaped text before it. The
+   real fix (matching against shielded code) lives in `detector.py`'s `_slice_by_braces` and is
+   currently gated to javascript/typescript only — not fixed here, tracked as future follow-up
+   work in the epic.
+
+## 6. Test depth
+
+- **Extraction gauntlet** (`func_start`/`args`/`class_start`/`_dependency_capture`): 42 tests in
+  `tests/extraction/languages/test_c.py` — valid/invalid/pathological cases per rule, plus the
+  known-limitation test and its string-literal-concatenation companion above. Fully migrated to
+  the per-language file (epic #813, issue #822) — nothing left for `c` in the old monolithic
+  gauntlet files, and `class_start` had no prior test entry at all before this migration.
+- **Strict signature suite** (all other wired keys): 86 tests in
+  `tests/extraction/languages/test_c_strict.py` (epic #518, issue #773) — positive/negative match
+  coverage per signature, a ReDoS-immunity sweep, K&R-ambiguity and pointer-ambiguity regression
+  tests, `__declspec`/`__attribute__` visibility-boundary regression, `cblas_` prefix boundary
+  regression, `test_skip` empty-call boundary regression, `spec_exposure` ReDoS regression,
+  `explicit_casts`-vs-`pointers` and `func_start`-vs-macros no-false-collision tests, and the
+  10-pair intentional-double-classification sweep described in §3.
+
+## 7. Relevant closed work
+
+**Epic-level hardening passes:**
+- [#773](https://github.com/squid-protocol/gitgalaxy/issues/773) — Strict parsing tests for C
+  structural signatures (epic #518).
+- [#822](https://github.com/squid-protocol/gitgalaxy/issues/822) — Extraction hardening for C
+  (epic #813).
+
+**Real bugs found and fixed (C-specific):**
+- [#1754](https://github.com/squid-protocol/gitgalaxy/issues/1754) (CLOSED, merged
+  [#1794](https://github.com/squid-protocol/gitgalaxy/pull/1794)) — `func_start` missed
+  macro-wrapped parameter names (`Py_UNUSED(consts)`), function-pointer arguments, and
+  macro-decorated return types/annotations. Fixed via macro shielding and nested-parenthesis
+  tracking; also cleared tree-sitter "macro hallucination" false positives from the accuracy
+  baseline. Newly recovered real functions on cpython included `_PyEval_EvalFrameDefault` and
+  `PlinkPrint`.
+- [#1282](https://github.com/squid-protocol/gitgalaxy/issues/1282) (CLOSED, merged
+  [#1283](https://github.com/squid-protocol/gitgalaxy/pull/1283)) — the `args` regex's
+  typed-parameter-list whitelist only ever recognized C's built-in primitive keywords, so a
+  parameter typed with a real-world custom typedef/struct name (`FILE *fp`, `PyThreadState
+  *tstate`) never matched at all — `args_count` silently fell back to 0 for functions with real,
+  nonzero arity. Confirmed against cpython's `ceval.c` that this is the overwhelming majority
+  shape of real C signatures, not an edge case.
+- [#1646](https://github.com/squid-protocol/gitgalaxy/issues/1646) (CLOSED, merged
+  [#1672](https://github.com/squid-protocol/gitgalaxy/pull/1672), superseding an earlier attempt
+  [#1671](https://github.com/squid-protocol/gitgalaxy/pull/1671) that was closed unmerged) — the
+  `args` regex's unbounded `.search()` wasn't bounded to the signature span, so on at least one
+  real cpython function (`_PyCompile_MaybeAddStaticAttributeToClass`) it skipped the real
+  `(compiler *c, expr_ty e)` signature entirely and matched a `RETURN_IF_ERROR(...)` call several
+  lines into the function body instead — previously masked by an unrelated depth-counting
+  coincidence in the zig-specific fix #1645. Two-part fix: bounded the args search to the
+  signature span only (generalizing objc's `objc_args_sig_end` mechanism from #1335 into a
+  general `args_sig_end` for `c`), and widened the type-alternation to accept a lowercase
+  custom-typedef-plus-pointer/identifier shape as a parameter's first token.
+
+**Cross-language fixes that touched C along the way:**
+- [#1816](https://github.com/squid-protocol/gitgalaxy/pull/1816) (MERGED) — a same-day
+  multi-language parsing pass (TypeScript/JavaScript/Go/Rust/C); C's piece hardened the K&R
+  parameter gap with the "Iron Wall" fix, forcing instant regex failure on control-flow keywords
+  (`BEGIN if while`) inside the K&R gap instead of backtracking through whitespace permutations
+  (the original 34-second ReDoS hang documented in `func_start`'s own header comment).
+
+**Measurement-tool-only findings (not GitGalaxy engine defects):**
+- [#1265](https://github.com/squid-protocol/gitgalaxy/issues/1265) (CLOSED, diagnosis landed in
+  [#1280](https://github.com/squid-protocol/gitgalaxy/pull/1280)) — the tree-sitter accuracy
+  measurement tool reported `real_functions=0` across 31 real C corpus files, which looked
+  implausible. Root cause: `tree_sitter_accuracy_audit.py`'s `_get_node_name()` reads a node's
+  name via `child_by_field_name("name")`, but tree-sitter-c's `function_definition` node has no
+  `name` field at all — the identifier sits two levels deep behind a `function_declarator` (and an
+  extra `pointer_declarator` for pointer-returning functions). Confirmed as a measurement-tool
+  ground-truth gap, not a GitGalaxy regression; this is the same underlying tree-sitter-C-grammar
+  shape independently documented for `args`-counting in
+  [#1282](https://github.com/squid-protocol/gitgalaxy/issues/1282) above.
+- [#1641](https://github.com/squid-protocol/gitgalaxy/issues/1641) (CLOSED, merged
+  [#1643](https://github.com/squid-protocol/gitgalaxy/pull/1643)) — the same measurement tool's
+  `class_precision` for C looked artificially low (78.2%); all 17 "extra classes" it counted were
+  the exact same literal string `Anonymous_Class` — GitGalaxy's own synthetic placeholder name for
+  an anonymous `typedef struct {...}` — being compared against tree-sitter's real class names
+  instead of being excluded the same way the tool already excluded synthetic function names.
+
+Search performed via `gh issue list --search 'in:title "Extraction hardening: c"'` /
+`'in:title "Strict parsing tests: \`c\`"'` / `'in:title c'` (2026-08-19), plus direct checks of
+issues #1754/#1794/#1816/#1826/#1828 per the skill's own pointer list — #1826 was excluded (a
+routine auto-generated tree-sitter-accuracy-history CSV update, not a C-specific change) and #1828
+was excluded (its title mentions "C++, PHP, and Zig" — `cpp`, not `c`).
+
+## 8. Real-world evidence (`gitgalaxy-raw-output`)
+
+Four repos from the `v2.4.7` batch, chosen for a size/era spread — a large adversarial kernel, a
+small 1990s-era legacy codebase, a famous mid-size single-purpose library, and a well-known
+small-to-mid networking library:
+
+- **[`linux`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/linux/linux_galaxy_llm.md)**
+  — the Linux kernel (`torvalds/linux.git`), the largest and most adversarial C corpus available:
+  decades of eras, heavy macro/attribute stacking, every K&R-to-C23 idiom the engine's `func_start`
+  regex has hardening comments for. Scanned in 387.42s.
+- **[`original_doom`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/original_doom/original_doom_galaxy_llm.md)**
+  — id Software's original 1993 DOOM source (`id-Software/DOOM.git`). A small, genuinely
+  legacy-era C codebase, directly relevant to the MS-DOS `BEGIN`-macro and K&R parameter-gap
+  handling documented inline in `func_start`'s own regex comments. Scanned in 0.59s.
+- **[`sqlite`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/sqlite/sqlite_galaxy_llm.md)**
+  — SQLite's own reference implementation (`sqlite/sqlite.git`), a famous mid-size single-purpose
+  C library; its generated parser `lemon.c` is one of the corpus files behind the `class_start`
+  measurement-tool finding in #1641 above. Scanned in 5.62s.
+- **[`curl`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/curl/curl_galaxy_llm.md)**
+  — curl's own C implementation (`curl/curl`), a well-known small-to-mid networking library;
+  a useful lower-noise contrast point against the kernel and legacy-game extremes above. Scanned
+  in 3.33s.
+
+Each `_galaxy_llm.md` is the human-readable architectural brief; `_galaxy_audit.json.gz` and
+`_galaxy_sbom.json.gz` in the same directory carry the raw per-file signature counts and SBOM if
+deeper inspection is needed.
+
+Note: the `v2.4.7` batch also contains a repo named `redis`, but its scan target path
+(`pypi_top_200/redis`) and 0.32s scan duration confirm it's the Python `redis` client package, not
+the actual C `redis` server — excluded here as not a genuine C data point.
+
+## 9. Tri-comparison: GitGalaxy vs. tree-sitter vs. ctags
+
+This section is a different shape from python.md's/javascript.md's §9 on purpose: those diff
+GitGalaxy against one privileged ground-truth parser (`ast`, `tree-sitter-language-pack`). C has
+two independent, non-privileged comparison tools available (`tree-sitter-c` and `universal-ctags`)
+and neither is treated as ground truth — see
+`tests/tools/tri_comparison_reconcile.py`'s own module docstring for why (multiple confirmed cases
+below show GitGalaxy right when tree-sitter is wrong, and vice versa). Every discrepancy the three
+tools produced against each other was investigated by reading real source
+(`docs/self_scan/how_to_investigate_a_discrepancy.md`'s process), not assumed — the full record is
+`docs/self_scan/tri_comparison_ledger.json`, filterable to `"language": "c"`.
+
+**Result: 11 of 11 discrepancy shapes (766 individual occurrences) resolved, zero confirmed
+GitGalaxy engine defects.** Every disagreement either resolved in GitGalaxy's favor, or turned out
+to be a bug in this repo's own comparison tooling (found and fixed as part of the same pass) or a
+known tree-sitter-c/ctags limitation — never GitGalaxy's regex engine itself. Current measured
+numbers (`tests/tools/tri_comparison_chart.py --languages c`, `language-crucible/data/c/` —
+cpython, doom, sqlite, micropython, and more):
+
+| Signal | GitGalaxy | tree-sitter | ctags | Read as |
+|---|---|---|---|---|
+| Functions found (of 1,814 total claimed by any tool) | 1,730 | 1,790 | 1,733 | tree-sitter's higher count is mostly noise, not real recall — see precision row |
+| Function precision (of what each tool claimed, how much corroborates) | **99.8%** (1726/1730) | 95.9% (1716/1790) | 99.6% (1726/1733) | GitGalaxy has the highest precision of the three |
+| Class recall/precision | **100%** (61/61) | 100% (61/61) | 100% (61/61) | fully reconciled after this pass's fixes — see below |
+| Args exact-match | **100%** (1710/1710) | 99.9% (1709/1710) | 100% (1710/1710) | tied for best |
+
+### Where GitGalaxy wins outright
+
+- **Macro-body parsing.** GitGalaxy's regex has no concept of "inside a macro" and simply parses
+  whatever function-shaped text it finds — which turns out to be a real advantage. A bare
+  `SLOT0`/`SLOT1`/`RICHCMP_WRAPPER(...)`-style macro-invocation line (CPython's `typeobject.c`
+  boilerplate generators, no trailing semicolon, not valid freestanding C without macro expansion)
+  locally confuses both tree-sitter's and ctags' parse of the single real function immediately
+  following it — GitGalaxy has no such adjacency sensitivity and finds all of them (confirmed at 4
+  sites: `slot_mp_ass_subscript`, `slot_nb_inplace_power`, `slot_tp_repr`, `slot_tp_hash`). New
+  evidence for `docs/why_gitgalaxy_beats_ast_here.md`'s Claim 3 (parse-error cascade).
+- **CPP-directive immunity.** tree-sitter-c has no preprocessor model at all and loses real
+  functions at 3 distinct trigger shapes GitGalaxy is entirely unaffected by: an `#if`/`#else`
+  pair splitting a single `if` condition mid-body, an `#if`/`#endif` wrapping only the `static`
+  storage-class specifier (separating it from the rest of the signature), and bare
+  un-semicoloned diagnostic-pragma macros the grammar can't cleanly recover from (13 occurrences
+  total, `cpython/ceval.c`, `cpython/object.c`, `micropython/compile.c`). New evidence for Claim 7
+  (CPP-directive recall loss, previously only cited for Fortran) — C's version is local (one
+  function lost per trigger), not Fortran's cascading whole-section loss.
+- **Dead-code and macro-hallucination immunity (precision).** tree-sitter hallucinates functions
+  from text that merely *looks* structural: the bare keyword `if` (a preprocessor-guarded
+  `#if`/`else if` sequence desyncs the parse), `PyMethodDef` array-initializer macro names
+  (`DICT___REVERSED___METHODDEF`), and genuinely well-formed functions sitting entirely inside
+  `#if 0 ... #endif` dead-code blocks (`_PyObject_ManagedDictValidityCheck`,
+  `tos_char`/`print_stack`/`print_stacks`) — 71 of tree-sitter's raw `extra_functions` on this
+  corpus trace to exactly this (Claim 8). GitGalaxy's own `extra_functions` on the same corpus: 9,
+  all genuine regex false positives, none of this shape.
+
+### Where the *other* tools have real, documented gaps (not GitGalaxy's problem to fix)
+
+- ctags misreads the same macro-invocation lines as GitGalaxy correctly skips, tagging
+  `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL` themselves as function names (7 occurrences) —
+  and separately fails to tag the real function immediately following one (3 more, shared root
+  cause with the tree-sitter Claim 3 instance above). Documented in `tests/tools/ctags_reader.py`,
+  not fixed (would require a curated macro-name list, the same kind of ground-truth judgment call
+  this tooling deliberately keeps out of the raw readers).
+- ctags' C parser has no kind for `union` at all (confirmed via `ctags --list-kinds-full=C`) — a
+  real `union Foo { ... }` (Rust-adjacent, but real, common C, e.g. wasmtime's register-union
+  types) is structurally invisible to it.
+
+### Two real bugs found in this repo's own tooling, fixed the same session
+
+Not GitGalaxy, tree-sitter, or ctags defects — bugs in `tests/tools/ctags_reader.py`'s own parsing
+of ctags' output, found while investigating why ctags appeared to miss things it actually handles
+fine:
+
+1. **Tab-splitting bug.** Old-style C source using literal tab characters for column alignment
+   (`byte*⇥I_AllocLow(int length)`, confirmed in `doom/i_system.c`) gets that tab echoed verbatim
+   into ctags' own tag-file address field; `read_ctags_symbols`' blind `line.split("\t")` then
+   misreads a fragment of the *source line* as the kind field and silently drops the symbol.
+   Reproduced byte-for-byte by running ctags with the exact flags this code uses. Fixed: parse now
+   locates the tag-file format's guaranteed `;"` address-terminator instead of blind-splitting.
+2. **`CTAGS_CLASS_KINDS["c"]` was struct-only.** GitGalaxy's own C `class_start` regex matches
+   `struct|union|enum`, but the ctags kind map only ever included `struct` — silently dropping
+   every real enum/union from the comparison for no reason (ctags itself parses them fine). Fixed:
+   now `{"s", "g", "u"}`. The same gap was found unfixed in `cpp`'s equivalent map
+   ([#1877](https://github.com/squid-protocol/gitgalaxy/issues/1877), filed not fixed — C++'s
+   scoped-vs-unscoped `enum class` distinction needs its own verification before assuming the same
+   fix shape applies).
+
+### Confirmed GitGalaxy engine bugs found for C: zero
+
+Contrast with `rust`, where the same sweep methodology found and filed two real GitGalaxy
+`detector.py` bugs
+([#1872](https://github.com/squid-protocol/gitgalaxy/issues/1872) — a lifetime-tick handling
+defect in argument counting). For C, every one of the 766 investigated occurrences resolved
+without implicating GitGalaxy's own regex engine — the closest thing to a caveat is the tab-
+splitting and ctags-kind-mapping bugs above, both in this repo's *test tooling*, not the shipped
+`gitgalaxy` package.
+
+**Full investigation record:** `docs/self_scan/tri_comparison_ledger.json` (filter to
+`"language": "c"`), rendered human-readable at
+`docs/self_scan/tri_comparison_points_of_interest.md`.

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -49,13 +49,15 @@
 <rect class="stripe" x="16" y="236" width="780" height="44"/>
 <text class="lang-label" x="20" y="261.5">agc_assembly</text>
 <rect class="bar-track" x="154" y="241" width="88" height="34" rx="2"/>
-<rect x="154" y="241" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="241" width="67.6" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="249">760*</text>
-<rect x="154" y="253" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="261">0*</text>
+<rect x="154" y="253" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="261">990*</text>
 <rect class="bar-track" x="286" y="241" width="88" height="34" rx="2"/>
-<rect x="286" y="241" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="249">0/760*</text>
+<rect x="286" y="241" width="83.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="249">725/760*</text>
+<rect x="286" y="253" width="64.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="261">725/990*</text>
 <rect class="bar-track" x="418" y="241" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="241" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="241" width="88" height="34" rx="2"/>
@@ -90,52 +92,54 @@
 <rect class="bar-track" x="154" y="329" width="88" height="34" rx="2"/>
 <rect x="154" y="329" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="337">132*</text>
-<rect x="154" y="341" width="58.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="349">87*</text>
+<rect x="154" y="341" width="80.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="349">121*</text>
 <rect class="bar-track" x="286" y="329" width="88" height="34" rx="2"/>
-<rect x="286" y="329" width="53.3" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="337">80/132*</text>
-<rect x="286" y="341" width="80.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="349">80/87*</text>
+<rect x="286" y="329" width="74.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="337">112/132*</text>
+<rect x="286" y="341" width="81.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="349">112/121*</text>
 <rect class="bar-track" x="418" y="329" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="329" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="329" width="88" height="34" rx="2"/>
 <text class="lang-label" x="20" y="393.5">c</text>
 <rect class="bar-track" x="154" y="373" width="88" height="34" rx="2"/>
 <rect x="154" y="373" width="85.1" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="381">1730*</text>
+<text class="bar-value-label" x="198.0" y="381">1730</text>
 <rect x="154" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="393">1790*</text>
-<rect x="154" y="397" width="85.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="405">1728*</text>
+<text class="bar-value-label" x="198.0" y="393">1790</text>
+<rect x="154" y="397" width="85.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="405">1733</text>
 <rect class="bar-track" x="286" y="373" width="88" height="34" rx="2"/>
 <rect x="286" y="373" width="87.8" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="381">1726/1730*</text>
+<text class="bar-value-label" x="330.0" y="381">1726/1730</text>
 <rect x="286" y="385" width="84.4" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="393">1716/1790*</text>
+<text class="bar-value-label" x="330.0" y="393">1716/1790</text>
 <rect x="286" y="397" width="87.6" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="405">1721/1728*</text>
+<text class="bar-value-label" x="330.0" y="405">1726/1733</text>
+<circle cx="390.0" cy="390.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="393.0">G</text>
 <rect class="bar-track" x="418" y="373" width="88" height="34" rx="2"/>
 <rect x="418" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="381">61*</text>
+<text class="bar-value-label" x="462.0" y="381">61</text>
 <rect x="418" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="393">61*</text>
-<rect x="418" y="397" width="75.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="405">52*</text>
+<text class="bar-value-label" x="462.0" y="393">61</text>
+<rect x="418" y="397" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="405">61</text>
 <rect class="bar-track" x="550" y="373" width="88" height="34" rx="2"/>
 <rect x="550" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="381">61/61*</text>
+<text class="bar-value-label" x="594.0" y="381">61/61</text>
 <rect x="550" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="393">61/61*</text>
+<text class="bar-value-label" x="594.0" y="393">61/61</text>
 <rect x="550" y="397" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="405">52/52*</text>
+<text class="bar-value-label" x="594.0" y="405">61/61</text>
 <rect class="bar-track" x="682" y="373" width="88" height="34" rx="2"/>
 <rect x="682" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="381">1705</text>
+<text class="bar-value-label" x="726.0" y="381">1710</text>
 <rect x="682" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="393">1705</text>
+<text class="bar-value-label" x="726.0" y="393">1710</text>
 <rect x="682" y="397" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="405">1705</text>
+<text class="bar-value-label" x="726.0" y="405">1710</text>
 <rect class="stripe" x="16" y="412" width="780" height="44"/>
 <text class="lang-label" x="20" y="437.5">cobol</text>
 <rect class="bar-track" x="154" y="417" width="88" height="34" rx="2"/>
@@ -163,36 +167,36 @@
 <text class="bar-value-label" x="198.0" y="469">1462*</text>
 <rect x="154" y="473" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="481">1491*</text>
-<rect x="154" y="485" width="67.8" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="493">1148*</text>
+<rect x="154" y="485" width="81.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="493">1378*</text>
 <rect class="bar-track" x="286" y="461" width="88" height="34" rx="2"/>
-<rect x="286" y="461" width="83.8" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="469">1392/1462*</text>
+<rect x="286" y="461" width="84.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="469">1400/1462*</text>
 <rect x="286" y="473" width="82.2" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="481">1393/1491*</text>
-<rect x="286" y="485" width="9.4" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="493">123/1148*</text>
+<rect x="286" y="485" width="19.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="493">304/1378*</text>
 <rect class="bar-track" x="418" y="461" width="88" height="34" rx="2"/>
 <rect x="418" y="461" width="76.7" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="469">149*</text>
 <rect x="418" y="473" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="481">171*</text>
-<rect x="418" y="485" width="16.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="493">31*</text>
+<rect x="418" y="485" width="28.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="493">56*</text>
 <rect class="bar-track" x="550" y="461" width="88" height="34" rx="2"/>
 <rect x="550" y="461" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="469">149/149*</text>
 <rect x="550" y="473" width="76.7" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="481">149/171*</text>
-<rect x="550" y="485" width="82.3" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="493">29/31*</text>
+<rect x="550" y="485" width="84.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="493">54/56*</text>
 <rect class="bar-track" x="682" y="461" width="88" height="34" rx="2"/>
 <rect x="682" y="461" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="469">122*</text>
+<text class="bar-value-label" x="726.0" y="469">295*</text>
 <rect x="682" y="473" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="481">122*</text>
+<text class="bar-value-label" x="726.0" y="481">295*</text>
 <rect x="682" y="485" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="493">122*</text>
+<text class="bar-value-label" x="726.0" y="493">295*</text>
 <rect class="stripe" x="16" y="500" width="780" height="44"/>
 <text class="lang-label" x="20" y="525.5">csharp</text>
 <rect class="bar-track" x="154" y="505" width="88" height="34" rx="2"/>
@@ -403,64 +407,72 @@
 <text class="bar-value-label" x="198.0" y="953">315*</text>
 <rect x="154" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="965">318*</text>
-<rect x="154" y="969" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="977">0*</text>
+<rect x="154" y="969" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="977">318*</text>
 <rect class="bar-track" x="286" y="945" width="88" height="34" rx="2"/>
 <rect x="286" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="953">315/315*</text>
-<rect x="286" y="957" width="87.2" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="965">315/318*</text>
+<rect x="286" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="965">318/318*</text>
+<rect x="286" y="969" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="977">318/318*</text>
 <rect class="bar-track" x="418" y="945" width="88" height="34" rx="2"/>
 <rect x="418" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="953">35*</text>
+<text class="bar-value-label" x="462.0" y="953">35</text>
 <rect x="418" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="965">35*</text>
-<rect x="418" y="969" width="17.6" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="977">7*</text>
+<text class="bar-value-label" x="462.0" y="965">35</text>
+<rect x="418" y="969" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="977">35</text>
 <rect class="bar-track" x="550" y="945" width="88" height="34" rx="2"/>
 <rect x="550" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="953">35/35*</text>
+<text class="bar-value-label" x="594.0" y="953">35/35</text>
 <rect x="550" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="965">35/35*</text>
+<text class="bar-value-label" x="594.0" y="965">35/35</text>
 <rect x="550" y="969" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="977">7/7*</text>
+<text class="bar-value-label" x="594.0" y="977">35/35</text>
 <rect class="bar-track" x="682" y="945" width="88" height="34" rx="2"/>
+<rect x="682" y="945" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="726.0" y="953">315*</text>
+<rect x="682" y="957" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="726.0" y="965">315*</text>
+<rect x="682" y="969" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="977">315*</text>
 <text class="lang-label" x="20" y="1009.5">javascript</text>
 <rect class="bar-track" x="154" y="989" width="88" height="34" rx="2"/>
 <rect x="154" y="989" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="997">793*</text>
 <rect x="154" y="1001" width="78.1" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1009">704*</text>
-<rect x="154" y="1013" width="10.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1021">90*</text>
+<rect x="154" y="1013" width="54.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1021">495*</text>
 <rect class="bar-track" x="286" y="989" width="88" height="34" rx="2"/>
-<rect x="286" y="989" width="67.7" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="997">610/793*</text>
+<rect x="286" y="989" width="67.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="997">611/793*</text>
 <rect x="286" y="1001" width="75.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1009">600/704*</text>
-<rect x="286" y="1013" width="80.2" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1021">82/90*</text>
+<rect x="286" y="1013" width="61.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1021">345/495*</text>
 <rect class="bar-track" x="418" y="989" width="88" height="34" rx="2"/>
-<rect x="418" y="989" width="26.6" height="10" rx="2" fill="#2a78d6"/>
+<rect x="418" y="989" width="20.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="997">29*</text>
-<rect x="418" y="1001" width="26.6" height="10" rx="2" fill="#eb6834"/>
+<rect x="418" y="1001" width="20.4" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1009">29*</text>
 <rect x="418" y="1013" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1021">96*</text>
+<text class="bar-value-label" x="462.0" y="1021">125*</text>
 <rect class="bar-track" x="550" y="989" width="88" height="34" rx="2"/>
 <rect x="550" y="989" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="997">29/29*</text>
 <rect x="550" y="1001" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1009">29/29*</text>
-<rect x="550" y="1013" width="26.6" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1021">29/96*</text>
+<rect x="550" y="1013" width="20.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1021">29/125*</text>
 <rect class="bar-track" x="682" y="989" width="88" height="34" rx="2"/>
 <rect x="682" y="989" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="997">72*</text>
+<text class="bar-value-label" x="726.0" y="997">334*</text>
 <rect x="682" y="1001" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1009">72*</text>
+<text class="bar-value-label" x="726.0" y="1009">334*</text>
 <rect x="682" y="1013" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="1021">72*</text>
+<text class="bar-value-label" x="726.0" y="1021">334*</text>
 <rect class="stripe" x="16" y="1028" width="780" height="44"/>
 <text class="lang-label" x="20" y="1053.5">jcl</text>
 <text class="awaiting" x="154" y="1053.5">no functions/classes found in this corpus by any tool</text>
@@ -509,12 +521,12 @@
 <rect x="154" y="1209" width="2.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1217">1*</text>
 <rect x="154" y="1221" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1229">48*</text>
+<text class="bar-value-label" x="198.0" y="1229">79*</text>
 <rect class="bar-track" x="286" y="1209" width="88" height="34" rx="2"/>
 <rect x="286" y="1209" width="2.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1217">0/1*</text>
 <rect x="286" y="1221" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1229">0/48*</text>
+<text class="bar-value-label" x="330.0" y="1229">0/79*</text>
 <rect class="bar-track" x="418" y="1209" width="88" height="34" rx="2"/>
 <rect x="418" y="1209" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1217">4*</text>
@@ -569,15 +581,15 @@
 <text class="bar-value-label" x="198.0" y="1349">152*</text>
 <rect x="154" y="1353" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1361">153*</text>
-<rect x="154" y="1365" width="58.7" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1373">102*</text>
+<rect x="154" y="1365" width="79.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1373">138*</text>
 <rect class="bar-track" x="286" y="1341" width="88" height="34" rx="2"/>
 <rect x="286" y="1341" width="87.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1349">151/152*</text>
 <rect x="286" y="1353" width="86.8" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1361">151/153*</text>
-<rect x="286" y="1365" width="26.7" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1373">31/102*</text>
+<rect x="286" y="1365" width="30.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1373">47/138*</text>
 <rect class="bar-track" x="418" y="1341" width="88" height="34" rx="2"/>
 <rect x="418" y="1341" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1349">5</text>
@@ -594,11 +606,11 @@
 <text class="bar-value-label" x="594.0" y="1373">5/5</text>
 <rect class="bar-track" x="682" y="1341" width="88" height="34" rx="2"/>
 <rect x="682" y="1341" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1349">31</text>
+<text class="bar-value-label" x="726.0" y="1349">47</text>
 <rect x="682" y="1353" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1361">31</text>
+<text class="bar-value-label" x="726.0" y="1361">47</text>
 <rect x="682" y="1365" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="1373">31</text>
+<text class="bar-value-label" x="726.0" y="1373">47</text>
 <rect class="stripe" x="16" y="1380" width="780" height="44"/>
 <text class="lang-label" x="20" y="1405.5">perl</text>
 <rect class="bar-track" x="154" y="1385" width="88" height="34" rx="2"/>
@@ -640,15 +652,15 @@
 <text class="bar-value-label" x="198.0" y="1437">1703*</text>
 <rect x="154" y="1441" width="87.9" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1449">1702*</text>
-<rect x="154" y="1453" width="84.5" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1461">1635*</text>
+<rect x="154" y="1453" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1461">1703*</text>
 <rect class="bar-track" x="286" y="1429" width="88" height="34" rx="2"/>
 <rect x="286" y="1429" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1437">1703/1703*</text>
 <rect x="286" y="1441" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1449">1702/1702*</text>
 <rect x="286" y="1453" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1461">1635/1635*</text>
+<text class="bar-value-label" x="330.0" y="1461">1703/1703*</text>
 <rect class="bar-track" x="418" y="1429" width="88" height="34" rx="2"/>
 <rect x="418" y="1429" width="85.1" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1437">29*</text>
@@ -665,11 +677,11 @@
 <text class="bar-value-label" x="594.0" y="1461">29/30*</text>
 <rect class="bar-track" x="682" y="1429" width="88" height="34" rx="2"/>
 <rect x="682" y="1429" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1437">1634</text>
+<text class="bar-value-label" x="726.0" y="1437">1702</text>
 <rect x="682" y="1441" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1449">1634</text>
+<text class="bar-value-label" x="726.0" y="1449">1702</text>
 <rect x="682" y="1453" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="1461">1634</text>
+<text class="bar-value-label" x="726.0" y="1461">1702</text>
 <rect class="stripe" x="16" y="1468" width="780" height="44"/>
 <text class="lang-label" x="20" y="1493.5">powershell</text>
 <rect class="bar-track" x="154" y="1473" width="88" height="34" rx="2"/>
@@ -960,34 +972,34 @@
 <text class="bar-value-label" x="198.0" y="1965">2733*</text>
 <rect x="154" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1977">2914*</text>
-<rect x="154" y="1981" width="21.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1989">697*</text>
+<rect x="154" y="1981" width="27.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1989">894*</text>
 <rect class="bar-track" x="286" y="1957" width="88" height="34" rx="2"/>
 <rect x="286" y="1957" width="87.9" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1965">2731/2733*</text>
 <rect x="286" y="1969" width="82.7" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1977">2739/2914*</text>
-<rect x="286" y="1981" width="80.3" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1989">636/697*</text>
+<text class="bar-value-label" x="330.0" y="1977">2740/2914*</text>
+<rect x="286" y="1981" width="82.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1989">833/894*</text>
 <rect class="bar-track" x="418" y="1957" width="88" height="34" rx="2"/>
 <rect x="418" y="1957" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1965">842*</text>
 <rect x="418" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1977">842*</text>
-<rect x="418" y="1981" width="34.2" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1989">327*</text>
+<rect x="418" y="1981" width="35.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1989">343*</text>
 <rect class="bar-track" x="550" y="1957" width="88" height="34" rx="2"/>
 <rect x="550" y="1957" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1965">842/842*</text>
 <rect x="550" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1977">842/842*</text>
-<rect x="550" y="1981" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1989">327/327*</text>
+<rect x="550" y="1981" width="87.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1989">341/343*</text>
 <rect class="bar-track" x="682" y="1957" width="88" height="34" rx="2"/>
 <rect x="682" y="1957" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1965">628</text>
+<text class="bar-value-label" x="726.0" y="1965">824*</text>
 <rect x="682" y="1969" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1977">628</text>
+<text class="bar-value-label" x="726.0" y="1977">824*</text>
 <rect class="stripe" x="16" y="1996" width="780" height="44"/>
 <text class="lang-label" x="20" y="2021.5">yacc</text>
 <text class="awaiting" x="154" y="2021.5">awaiting language-crucible corpus</text>
@@ -1021,17 +1033,17 @@
 <rect x="682" y="2101" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2109">2750</text>
 <line x1="16" y1="2138" x2="796" y2="2138" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2152">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 15 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2152">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 18 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2170" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2173">G</text>
-<text class="legend-label" x="36" y="2174">GitGalaxy best: 0 (0%)</text>
+<text class="legend-label" x="36" y="2174">GitGalaxy best: 1 (6%)</text>
 <circle cx="203.4" cy="2170" r="7" fill="#eb6834"/>
 <text class="badge-label" x="203.4" y="2173">T</text>
-<text class="legend-label" x="216.4" y="2174">tree-sitter best: 1 (7%)</text>
+<text class="legend-label" x="216.4" y="2174">tree-sitter best: 1 (6%)</text>
 <circle cx="396.20000000000005" cy="2170" r="7" fill="#1baf7a"/>
 <text class="badge-label" x="396.20000000000005" y="2173">C</text>
 <text class="legend-label" x="409.20000000000005" y="2174">ctags best: 0 (0%)</text>
 <circle cx="551.8000000000001" cy="2170" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="564.8000000000001" y="2174">Ties: 14 (93%)</text>
+<text class="legend-label" x="564.8000000000001" y="2174">Ties: 16 (89%)</text>
 <text class="scope-note" x="16" y="2194">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -116,26 +116,26 @@
 <rect x="286" y="397" width="87.6" height="10" rx="2" fill="#1baf7a"/>
 <text class="bar-value-label" x="330.0" y="405">1721/1728*</text>
 <rect class="bar-track" x="418" y="373" width="88" height="34" rx="2"/>
-<rect x="418" y="373" width="71.6" height="10" rx="2" fill="#2a78d6"/>
+<rect x="418" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="381">61*</text>
-<rect x="418" y="385" width="71.6" height="10" rx="2" fill="#eb6834"/>
+<rect x="418" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="393">61*</text>
-<rect x="418" y="397" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="405">75*</text>
+<rect x="418" y="397" width="75.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="405">52*</text>
 <rect class="bar-track" x="550" y="373" width="88" height="34" rx="2"/>
 <rect x="550" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="381">61/61*</text>
 <rect x="550" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="393">61/61*</text>
-<rect x="550" y="397" width="61.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="405">52/75*</text>
+<rect x="550" y="397" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="405">52/52*</text>
 <rect class="bar-track" x="682" y="373" width="88" height="34" rx="2"/>
 <rect x="682" y="373" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="381">1705*</text>
+<text class="bar-value-label" x="726.0" y="381">1705</text>
 <rect x="682" y="385" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="393">1705*</text>
+<text class="bar-value-label" x="726.0" y="393">1705</text>
 <rect x="682" y="397" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="405">1705*</text>
+<text class="bar-value-label" x="726.0" y="405">1705</text>
 <rect class="stripe" x="16" y="412" width="780" height="44"/>
 <text class="lang-label" x="20" y="437.5">cobol</text>
 <rect class="bar-track" x="154" y="417" width="88" height="34" rx="2"/>
@@ -163,15 +163,15 @@
 <text class="bar-value-label" x="198.0" y="469">1462*</text>
 <rect x="154" y="473" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="481">1491*</text>
-<rect x="154" y="485" width="69.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="493">1184*</text>
+<rect x="154" y="485" width="67.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="493">1148*</text>
 <rect class="bar-track" x="286" y="461" width="88" height="34" rx="2"/>
 <rect x="286" y="461" width="83.8" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="469">1392/1462*</text>
 <rect x="286" y="473" width="82.2" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="481">1393/1491*</text>
-<rect x="286" y="485" width="9.1" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="493">123/1184*</text>
+<rect x="286" y="485" width="9.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="493">123/1148*</text>
 <rect class="bar-track" x="418" y="461" width="88" height="34" rx="2"/>
 <rect x="418" y="461" width="76.7" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="469">149*</text>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -11,7 +11,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-19T20:26:16Z",
+      "last_reconciled_at": "2026-08-19T23:12:49Z",
       "last_seen_count": 760,
       "last_seen_examples": [
         {
@@ -112,7 +112,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-19T20:26:18Z",
+      "last_reconciled_at": "2026-08-19T23:12:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -149,7 +149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-19T20:26:20Z",
+      "last_reconciled_at": "2026-08-19T23:12:53Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -226,7 +226,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-19T20:26:20Z",
+      "last_reconciled_at": "2026-08-19T23:12:53Z",
       "last_seen_count": 52,
       "last_seen_examples": [
         {
@@ -325,10 +325,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -423,10 +423,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
+      "status": "validated",
+      "still_reproduces": false,
       "symbol_type": "class",
-      "verdict": null
+      "verdict": "Confirmed tooling gap, now fixed -- not a GitGalaxy or tree-sitter defect. Every one of the 10 sampled names (__anon2570bd640108, __anonf1d666540108, etc.) is ctags' own synthesized placeholder name for an anonymous struct/union/enum, confirmed directly: cpython/ceval.c's __anon2570bd640108 backs a real `typedef struct { ... }` (the platform pthread-attr shim at line ~94) with no name in the source. GitGalaxy and tree-sitter both correctly report nothing (there is no real name to report); ctags synthesizes one for its own internal bookkeeping. Same category as GitGalaxy's own _SYNTHETIC_GG_CLASS_NAMES exclusion, just on ctags' side -- added _is_ctags_synthetic_anon_name() to tri_comparison_gatherer.py (matches ctags' documented __anon<hex> naming convention, applied to both func and class ctags readings) and documented in ctags_reader.py alongside its existing per-language notes. Generalizes to the full 23 by construction (a structural naming-pattern match, not a per-instance judgment)."
     },
     "c/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -440,7 +440,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -543,7 +543,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -652,10 +652,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -669,10 +669,10 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Not a tool defect on either side -- an inherent CPP-conditional-compilation ambiguity. gc_mark_subtree is declared AND defined twice in micropython/gc.c, once under `#if MICROPY_GC_SPLIT_HEAP` (2 args: area, block -- lines 137/501) and once under the matching `#else` (1 arg: block -- lines 139/503). Neither signature is more 'real' than the other -- which one actually compiles depends on a macro none of these three tools evaluates (no real preprocessor run in any of them). GG and ctags happened to align on the 2-arg branch, tree-sitter on the 1-arg branch; this is a coin-flip of which #if branch a tool's occurrence-matching happens to pick up, not a real disagreement about ground truth. N=1 in this corpus -- not chased further given the tiny sample and the ambiguity being structural rather than a bug."
     },
     "c/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -686,7 +686,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -798,7 +798,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -907,10 +907,10 @@
         "gitgalaxy"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -942,10 +942,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed."
     },
     "c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
       "agreeing_tools": [
@@ -956,10 +956,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1027,10 +1027,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes."
     },
     "c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -1044,7 +1044,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -1135,10 +1135,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1179,10 +1179,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up."
     },
     "c/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]": {
       "agreeing_tools": [
@@ -1196,7 +1196,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T20:26:25Z",
+      "last_reconciled_at": "2026-08-19T23:12:58Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1307,7 +1307,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-19T20:26:31Z",
+      "last_reconciled_at": "2026-08-19T23:13:03Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1408,7 +1408,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-19T20:26:31Z",
+      "last_reconciled_at": "2026-08-19T23:13:03Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1509,7 +1509,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-19T20:26:31Z",
+      "last_reconciled_at": "2026-08-19T23:13:03Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1611,7 +1611,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1651,7 +1651,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 120,
       "last_seen_examples": [
         {
@@ -1763,7 +1763,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1875,7 +1875,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1924,7 +1924,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 24,
       "last_seen_examples": [
         {
@@ -2036,7 +2036,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2066,7 +2066,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2097,7 +2097,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2128,8 +2128,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
-      "last_seen_count": 1061,
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_seen_count": 1025,
       "last_seen_examples": [
         {
           "file_path": "NVDA/storage.cpp",
@@ -2240,7 +2240,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 1270,
       "last_seen_examples": [
         {
@@ -2352,7 +2352,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 70,
       "last_seen_examples": [
         {
@@ -2464,7 +2464,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T20:26:35Z",
+      "last_reconciled_at": "2026-08-19T23:13:08Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2576,7 +2576,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2625,7 +2625,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2692,7 +2692,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2768,7 +2768,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2799,7 +2799,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -2884,7 +2884,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2941,7 +2941,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2972,7 +2972,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3084,7 +3084,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3142,7 +3142,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3173,7 +3173,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3285,7 +3285,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3397,7 +3397,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T20:26:41Z",
+      "last_reconciled_at": "2026-08-19T23:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3428,7 +3428,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-19T20:26:42Z",
+      "last_reconciled_at": "2026-08-19T23:13:15Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3475,7 +3475,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-19T20:26:46Z",
+      "last_reconciled_at": "2026-08-19T23:13:19Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3576,7 +3576,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-19T20:26:46Z",
+      "last_reconciled_at": "2026-08-19T23:13:19Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3677,7 +3677,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-19T20:26:46Z",
+      "last_reconciled_at": "2026-08-19T23:13:19Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -3779,7 +3779,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T20:26:52Z",
+      "last_reconciled_at": "2026-08-19T23:13:25Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -3872,7 +3872,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T20:26:52Z",
+      "last_reconciled_at": "2026-08-19T23:13:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3903,7 +3903,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T20:26:52Z",
+      "last_reconciled_at": "2026-08-19T23:13:25Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4015,7 +4015,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T20:26:52Z",
+      "last_reconciled_at": "2026-08-19T23:13:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4055,7 +4055,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T20:26:52Z",
+      "last_reconciled_at": "2026-08-19T23:13:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4095,7 +4095,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-19T20:26:55Z",
+      "last_reconciled_at": "2026-08-19T23:13:28Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4207,7 +4207,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4317,7 +4317,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4420,7 +4420,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4532,7 +4532,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4644,7 +4644,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -4756,7 +4756,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4795,7 +4795,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4833,7 +4833,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T20:26:57Z",
+      "last_reconciled_at": "2026-08-19T23:13:30Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -4945,7 +4945,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-19T20:27:00Z",
+      "last_reconciled_at": "2026-08-19T23:13:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5057,7 +5057,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-19T20:27:00Z",
+      "last_reconciled_at": "2026-08-19T23:13:33Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5169,7 +5169,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-19T20:27:00Z",
+      "last_reconciled_at": "2026-08-19T23:13:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5218,7 +5218,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 67,
       "last_seen_examples": [
         {
@@ -5330,7 +5330,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -5415,7 +5415,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -5527,7 +5527,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -5621,7 +5621,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 528,
       "last_seen_examples": [
         {
@@ -5733,7 +5733,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -5845,7 +5845,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T20:27:03Z",
+      "last_reconciled_at": "2026-08-19T23:13:36Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -5957,7 +5957,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-19T20:27:05Z",
+      "last_reconciled_at": "2026-08-19T23:13:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6006,7 +6006,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-19T20:27:05Z",
+      "last_reconciled_at": "2026-08-19T23:13:39Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6118,7 +6118,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-19T20:27:05Z",
+      "last_reconciled_at": "2026-08-19T23:13:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6148,7 +6148,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-19T20:27:12Z",
+      "last_reconciled_at": "2026-08-19T23:13:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6201,7 +6201,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-19T20:27:12Z",
+      "last_reconciled_at": "2026-08-19T23:13:45Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -6302,7 +6302,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-19T20:27:12Z",
+      "last_reconciled_at": "2026-08-19T23:13:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6332,7 +6332,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-19T20:27:13Z",
+      "last_reconciled_at": "2026-08-19T23:13:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6361,7 +6361,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-19T20:27:15Z",
+      "last_reconciled_at": "2026-08-19T23:13:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6392,7 +6392,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T20:27:16Z",
+      "last_reconciled_at": "2026-08-19T23:13:49Z",
       "last_seen_count": 71,
       "last_seen_examples": [
         {
@@ -6504,7 +6504,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T20:27:16Z",
+      "last_reconciled_at": "2026-08-19T23:13:49Z",
       "last_seen_count": 120,
       "last_seen_examples": [
         {
@@ -6616,7 +6616,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T20:27:16Z",
+      "last_reconciled_at": "2026-08-19T23:13:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6647,7 +6647,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T20:27:16Z",
+      "last_reconciled_at": "2026-08-19T23:13:49Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6687,7 +6687,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6718,7 +6718,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6747,7 +6747,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -6859,7 +6859,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6944,7 +6944,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7029,7 +7029,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7060,7 +7060,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T20:27:23Z",
+      "last_reconciled_at": "2026-08-19T23:13:56Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7172,7 +7172,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-19T20:27:27Z",
+      "last_reconciled_at": "2026-08-19T23:14:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7203,7 +7203,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-19T20:27:27Z",
+      "last_reconciled_at": "2026-08-19T23:14:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7234,7 +7234,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-19T20:27:27Z",
+      "last_reconciled_at": "2026-08-19T23:14:00Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -7346,7 +7346,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T20:27:30Z",
+      "last_reconciled_at": "2026-08-19T23:14:03Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7429,7 +7429,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T20:27:30Z",
+      "last_reconciled_at": "2026-08-19T23:14:03Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -7496,7 +7496,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T20:27:30Z",
+      "last_reconciled_at": "2026-08-19T23:14:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7527,7 +7527,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T20:27:30Z",
+      "last_reconciled_at": "2026-08-19T23:14:03Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -7639,7 +7639,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T20:27:39Z",
+      "last_reconciled_at": "2026-08-19T23:14:12Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7697,7 +7697,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T20:27:39Z",
+      "last_reconciled_at": "2026-08-19T23:14:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7728,7 +7728,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T20:27:39Z",
+      "last_reconciled_at": "2026-08-19T23:14:12Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -7840,7 +7840,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T20:27:39Z",
+      "last_reconciled_at": "2026-08-19T23:14:12Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -7952,7 +7952,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T20:27:41Z",
+      "last_reconciled_at": "2026-08-19T23:14:13Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7992,7 +7992,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T20:27:41Z",
+      "last_reconciled_at": "2026-08-19T23:14:13Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8068,7 +8068,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T20:27:41Z",
+      "last_reconciled_at": "2026-08-19T23:14:13Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8117,7 +8117,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T20:27:41Z",
+      "last_reconciled_at": "2026-08-19T23:14:13Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8193,7 +8193,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T20:27:45Z",
+      "last_reconciled_at": "2026-08-19T23:14:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8242,7 +8242,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T20:27:45Z",
+      "last_reconciled_at": "2026-08-19T23:14:17Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -8354,7 +8354,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T20:27:45Z",
+      "last_reconciled_at": "2026-08-19T23:14:17Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -8464,7 +8464,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T20:27:45Z",
+      "last_reconciled_at": "2026-08-19T23:14:17Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -8576,7 +8576,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T20:27:45Z",
+      "last_reconciled_at": "2026-08-19T23:14:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8607,7 +8607,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T20:27:45Z",
+      "last_reconciled_at": "2026-08-19T23:14:17Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -8717,7 +8717,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-19T20:27:47Z",
+      "last_reconciled_at": "2026-08-19T23:14:20Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8818,7 +8818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-19T20:27:51Z",
+      "last_reconciled_at": "2026-08-19T23:14:24Z",
       "last_seen_count": 92,
       "last_seen_examples": [
         {
@@ -8920,7 +8920,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-19T20:27:53Z",
+      "last_reconciled_at": "2026-08-19T23:14:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8950,7 +8950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-19T20:27:54Z",
+      "last_reconciled_at": "2026-08-19T23:14:27Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9018,7 +9018,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-19T20:27:56Z",
+      "last_reconciled_at": "2026-08-19T23:14:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9047,7 +9047,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-19T20:27:56Z",
+      "last_reconciled_at": "2026-08-19T23:14:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9076,7 +9076,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-19T20:27:56Z",
+      "last_reconciled_at": "2026-08-19T23:14:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9106,7 +9106,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T20:27:57Z",
+      "last_reconciled_at": "2026-08-19T23:14:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9137,7 +9137,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T20:27:57Z",
+      "last_reconciled_at": "2026-08-19T23:14:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9177,7 +9177,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T20:27:57Z",
+      "last_reconciled_at": "2026-08-19T23:14:30Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -9235,7 +9235,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T20:27:57Z",
+      "last_reconciled_at": "2026-08-19T23:14:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9266,7 +9266,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T20:28:18Z",
+      "last_reconciled_at": "2026-08-19T23:14:51Z",
       "last_seen_count": 515,
       "last_seen_examples": [
         {
@@ -9378,7 +9378,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T20:28:18Z",
+      "last_reconciled_at": "2026-08-19T23:14:51Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -9472,7 +9472,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T20:28:18Z",
+      "last_reconciled_at": "2026-08-19T23:14:51Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -9584,7 +9584,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T20:28:18Z",
+      "last_reconciled_at": "2026-08-19T23:14:51Z",
       "last_seen_count": 2103,
       "last_seen_examples": [
         {
@@ -9696,7 +9696,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T20:28:18Z",
+      "last_reconciled_at": "2026-08-19T23:14:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9736,7 +9736,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T20:28:18Z",
+      "last_reconciled_at": "2026-08-19T23:14:51Z",
       "last_seen_count": 175,
       "last_seen_examples": [
         {
@@ -9847,7 +9847,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-19T20:28:26Z",
+      "last_reconciled_at": "2026-08-19T23:14:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9876,7 +9876,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-19T20:28:26Z",
+      "last_reconciled_at": "2026-08-19T23:14:59Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -9977,7 +9977,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-19T20:28:26Z",
+      "last_reconciled_at": "2026-08-19T23:14:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -1,5 +1,106 @@
 {
   "entries": {
+    "agc_assembly/function/existence/agree[ctags]_vs[gitgalaxy]": {
+      "agreeing_tools": [
+        "ctags"
+      ],
+      "dissenting_tools": [
+        "gitgalaxy"
+      ],
+      "first_seen_at": "2026-08-19T23:28:20Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "agc_assembly",
+      "last_reconciled_at": "2026-08-19T23:28:20Z",
+      "last_seen_count": 265,
+      "last_seen_examples": [
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ADRS1",
+          "readings": {
+            "ctags": 155,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "CNTRCHK",
+          "readings": {
+            "ctags": 328,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ELOOPFIN",
+          "readings": {
+            "ctags": 303,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ERASCON1",
+          "readings": {
+            "ctags": 133,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ERASCON2",
+          "readings": {
+            "ctags": 134,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ERASCON3",
+          "readings": {
+            "ctags": 136,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ERASCON4",
+          "readings": {
+            "ctags": 137,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "ERASCON5",
+          "readings": {
+            "ctags": 146,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "LSTBNKCH",
+          "readings": {
+            "ctags": 512,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
+          "name": "S10BITS",
+          "readings": {
+            "ctags": 138,
+            "gitgalaxy": null
+          }
+        }
+      ],
+      "metric": "existence",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
     "agc_assembly/function/existence/agree[gitgalaxy]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy"
@@ -11,17 +112,9 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-19T23:12:49Z",
-      "last_seen_count": 760,
+      "last_reconciled_at": "2026-08-19T23:28:20Z",
+      "last_seen_count": 35,
       "last_seen_examples": [
-        {
-          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "ADRSCHK",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 418
-          }
-        },
         {
           "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
           "name": "1CHK",
@@ -32,66 +125,74 @@
         },
         {
           "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "CONTINU",
+          "name": "27TO30",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 437
+            "gitgalaxy": 466
           }
         },
         {
           "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "ERASLOOP",
+          "name": "0EBANK",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 262
+            "gitgalaxy": 236
           }
         },
         {
           "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "SMODECHK",
+          "name": "2EBANK",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 191
+            "gitgalaxy": 250
           }
         },
         {
           "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "COMADRS",
+          "name": "17TO20",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 381
+            "gitgalaxy": 460
           }
         },
         {
-          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "SOPT",
+          "file_path": "apollo-11/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc",
+          "name": "TIG-35",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 496
+            "gitgalaxy": 250
           }
         },
         {
-          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "SOPTION",
+          "file_path": "apollo-11/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc",
+          "name": "TIG-30",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 482
+            "gitgalaxy": 292
           }
         },
         {
-          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "FXFX",
+          "file_path": "apollo-11/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc",
+          "name": "CALLT-35",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 391
+            "gitgalaxy": 222
           }
         },
         {
-          "file_path": "apollo-11/AGC_BLOCK_TWO_SELF-CHECK.agc",
-          "name": "BNKCHK",
+          "file_path": "apollo-11/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc",
+          "name": "TIG-0",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 505
+            "gitgalaxy": 390
+          }
+        },
+        {
+          "file_path": "apollo-11/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc",
+          "name": "TIG-5",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 354
           }
         }
       ],
@@ -112,7 +213,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-19T23:12:50Z",
+      "last_reconciled_at": "2026-08-19T23:28:22Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -149,8 +250,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-19T23:12:53Z",
-      "last_seen_count": 7,
+      "last_reconciled_at": "2026-08-19T23:28:24Z",
+      "last_seen_count": 9,
       "last_seen_examples": [
         {
           "file_path": "bootos/os.asm",
@@ -201,6 +302,22 @@
           }
         },
         {
+          "file_path": "cosmopolitan/ape.S",
+          "name": "Lenv0",
+          "readings": {
+            "ctags": 1784,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "hellosilicon/matrixmultneon.s",
+          "name": "C",
+          "readings": {
+            "ctags": 90,
+            "gitgalaxy": null
+          }
+        },
+        {
           "file_path": "hellosilicon/matrixmultneon.s",
           "name": "prtstr",
           "readings": {
@@ -226,8 +343,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-19T23:12:53Z",
-      "last_seen_count": 52,
+      "last_reconciled_at": "2026-08-19T23:28:24Z",
+      "last_seen_count": 20,
       "last_seen_examples": [
         {
           "file_path": "bootos/counter.asm",
@@ -287,26 +404,26 @@
         },
         {
           "file_path": "cosmopolitan/ape.S",
-          "name": "a20",
+          "name": "netbsd.ident",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1466
+            "gitgalaxy": 840
           }
         },
         {
           "file_path": "cosmopolitan/ape.S",
-          "name": "e820",
+          "name": "ape.ident",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1421
+            "gitgalaxy": 784
           }
         },
         {
           "file_path": "cosmopolitan/ape.S",
-          "name": "dsknfo",
+          "name": "freebsd.ident",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 348
+            "gitgalaxy": 810
           }
         }
       ],
@@ -328,7 +445,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -437,10 +554,10 @@
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -526,10 +643,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
+      "status": "validated",
+      "still_reproduces": false,
       "symbol_type": "class",
-      "verdict": null
+      "verdict": "Single cause, confirmed independently twice (dispatched agent + a second independent spot-check, no disagreement) -- a bug in THIS tool's ctags_reader.py, not ctags itself. CTAGS_CLASS_KINDS['c'] was {'s'} (struct only), but GitGalaxy's own C class_start regex (gitgalaxy/standards/language_standards.py) is `struct|union|enum` -- all 3. ctags' C parser handles enum ('g' kind) and union ('u' kind) fine (confirmed via direct ctags runs against sqlite/lemon.c and others, finding all 9 sampled declarations correctly); this map was silently dropping them before reconciliation ever saw them. Fixed: CTAGS_CLASS_KINDS['c'] now {'s', 'g', 'u'}, verified all 9 sampled names (6 enum in sqlite/lemon.c, 1 enum each in cpython/frameobject.c and cpython/gc.c, 1 union in micropython/objtype.c) now correctly found. No GitHub issue -- fixed directly."
     },
     "c/class/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]": {
       "agreeing_tools": [
@@ -543,7 +660,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -655,7 +772,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -686,7 +803,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -795,10 +912,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -893,10 +1010,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "3 distinct causes, all genuine tree-sitter-c grammar limitations (GitGalaxy and ctags both correct in all 10 sampled cases) -- confirmed via dispatched investigation (which ran tree-sitter's C grammar directly and found ERROR nodes in every case) plus independent source-level spot-checks of all 3 trigger shapes. This is a C-scale instance of Claim 7 (CPP-directive-driven recall loss) -- added to that claim's evidence section. (1) 4 samples: an #if/#else pair splitting a single `if` condition inside a function body (ceval.c:33, _Py_ReachedRecursionLimitWithMargin). (2) 5 samples: bare, un-semicoloned macro invocations the grammar can't cleanly recover from, losing the next real function (object.c:1269-1271's _Py_COMP_DIAG_PUSH/IGNORE_DEPR_DECLS/POP before _PyObject_SetAttributeErrorContext; similar shape for the typeobject.c slot-getattr cluster). (3) 1 sample: #if/#endif wrapping only the `static` storage-class specifier, separated from the rest of the signature (micropython/compile.c:3473-3476, mp_compile_to_raw_code). Unlike Fortran's existing Claim 7 evidence (entire trailing sections lost), C's version is local -- one function lost per trigger, not a cascading region. No GitHub issue -- documented as new Claim 7 evidence, not a fixable tooling bug (this repo doesn't control tree-sitter-c's grammar)."
     },
     "c/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
@@ -910,7 +1027,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -959,7 +1076,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1041,11 +1158,11 @@
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:18Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-19T00:00:00Z",
+      "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
-      "last_seen_count": 8,
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
+      "last_seen_count": 3,
       "last_seen_examples": [
         {
           "file_path": "cpython/typeobject.c",
@@ -1073,58 +1190,13 @@
             "gitgalaxy": 10106,
             "tree_sitter": 10106
           }
-        },
-        {
-          "file_path": "doom/i_system.c",
-          "name": "I_AllocLow",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 147,
-            "tree_sitter": 147
-          }
-        },
-        {
-          "file_path": "doom/i_system.c",
-          "name": "I_ZoneBase",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 76,
-            "tree_sitter": 76
-          }
-        },
-        {
-          "file_path": "doom/i_system.c",
-          "name": "I_BaseTiccmd",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 65,
-            "tree_sitter": 65
-          }
-        },
-        {
-          "file_path": "doom/r_bsp.c",
-          "name": "R_CheckBBox",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 381,
-            "tree_sitter": 381
-          }
-        },
-        {
-          "file_path": "doom/r_bsp.c",
-          "name": "R_AddLine",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 259,
-            "tree_sitter": 259
-          }
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Two distinct causes, both confirmed by independent verification, not one -- resolved via dispatched investigation plus direct fixes. (1) 5 of 8 (I_AllocLow, I_ZoneBase, I_BaseTiccmd, R_CheckBBox, R_AddLine, all doom): a real bug in THIS tool's OWN ctags_reader.py, not a ctags limitation. Old Doom source uses literal TAB characters for column alignment (e.g. `byte*\\tI_AllocLow(int length)`); ctags faithfully echoes that tab into its tag-file's address/pattern field, and read_ctags_symbols' naive line.split('\\t') then misreads a fragment of the SOURCE LINE as the kind field, fails the kind-membership check, and silently drops the symbol. Confirmed by running ctags with the exact flags this code uses and inspecting the raw tab-delimited output directly -- reproduced the exact column-shift byte for byte. Fixed: parse now finds the tag-file format's guaranteed `;\"` address-terminator marker instead of blind-splitting the whole line, only tab-splitting the safe trailer after it. Verified: all 5 names now correctly found. (2) 3 of 8 (slot_nb_power, slot_nb_bool, wrap_next, all cpython typeobject.c): extension of the already-documented SLOT-macro ctags limitation -- each follows a SLOT1BINFULL/SLOT0/RICHCMP_WRAPPER macro invocation ctags misreads as a function (confirmed at typeobject.c:10574/10577/10630), which also swallows the real function immediately after it. Not code-fixed (same ground-truth-judgment reasoning as the sibling 7-occurrence shape) -- already covered by ctags_reader.py's existing note on this mechanism."
     },
     "c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]": {
       "agreeing_tools": [
@@ -1138,7 +1210,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1196,7 +1268,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-19T23:12:58Z",
+      "last_reconciled_at": "2026-08-19T23:28:29Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1307,7 +1379,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-19T23:13:03Z",
+      "last_reconciled_at": "2026-08-19T23:28:34Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1408,7 +1480,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-19T23:13:03Z",
+      "last_reconciled_at": "2026-08-19T23:28:34Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1509,7 +1581,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cobol",
-      "last_reconciled_at": "2026-08-19T23:13:03Z",
+      "last_reconciled_at": "2026-08-19T23:28:34Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1611,7 +1683,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1651,8 +1723,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
-      "last_seen_count": 120,
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 95,
       "last_seen_examples": [
         {
           "file_path": "godot/editor_node.h",
@@ -1763,7 +1835,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1875,12 +1947,12 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
-      "last_seen_count": 3,
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 13,
       "last_seen_examples": [
         {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "GetTFLiteType",
+          "file_path": "godot/editor_node.h",
+          "name": "save_scene_to_path",
           "readings": {
             "ctags": 2,
             "gitgalaxy": 2,
@@ -1888,21 +1960,84 @@
           }
         },
         {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "Insert",
+          "file_path": "godot/editor_node.h",
+          "name": "step",
           "readings": {
-            "ctags": 5,
-            "gitgalaxy": 5,
-            "tree_sitter": 4
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
           }
         },
         {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "ExportBuffer",
+          "file_path": "godot/node.h",
+          "name": "get_index",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "godot/node.h",
+          "name": "atr_n",
           "readings": {
             "ctags": 4,
             "gitgalaxy": 4,
             "tree_sitter": 3
+          }
+        },
+        {
+          "file_path": "godot/node.h",
+          "name": "atr",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "godot/object.cpp",
+          "name": "ObjectSignalLock",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "notification",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "RequiredResult",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "RequiredParam",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "godot/rendering_server_default.h",
+          "name": "shader_create_from_code",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
           }
         }
       ],
@@ -1924,8 +2059,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
-      "last_seen_count": 24,
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 30,
       "last_seen_examples": [
         {
           "file_path": "NVDA/inProcess.cpp",
@@ -1942,6 +2077,24 @@
           "readings": {
             "ctags": 0,
             "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "godot/editor_node.h",
+          "name": "new_inherited_scene",
+          "readings": {
+            "ctags": 0,
+            "gitgalaxy": 2,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "godot/editor_node.h",
+          "name": "show_about",
+          "readings": {
+            "ctags": 0,
+            "gitgalaxy": 2,
             "tree_sitter": 0
           }
         },
@@ -1973,48 +2126,30 @@
           }
         },
         {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "CreateLocation",
+          "file_path": "godot/object.h",
+          "name": "get_gdtype_static_mutable",
           "readings": {
-            "ctags": 5,
+            "ctags": 0,
             "gitgalaxy": 1,
-            "tree_sitter": 5
+            "tree_sitter": 0
           }
         },
         {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "GetStringsFromDictionaryAttr",
+          "file_path": "godot/object.h",
+          "name": "_internal_ptr_dont_use",
           "readings": {
-            "ctags": 2,
-            "gitgalaxy": 0,
-            "tree_sitter": 2
+            "ctags": 0,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
           }
         },
         {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "CreateOpLocation",
+          "file_path": "godot/object.h",
+          "name": "is_ref_counted",
           "readings": {
-            "ctags": 5,
-            "gitgalaxy": 0,
-            "tree_sitter": 5
-          }
-        },
-        {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "GetTensorFlowNodeDef",
-          "readings": {
-            "ctags": 1,
-            "gitgalaxy": 11,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "mlir/flatbuffer_export.cc",
-          "name": "MlirToFlatBufferTranslateFunction",
-          "readings": {
-            "ctags": 3,
-            "gitgalaxy": 0,
-            "tree_sitter": 3
+            "ctags": 0,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
           }
         }
       ],
@@ -2036,7 +2171,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2051,7 +2186,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -2066,7 +2201,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2085,6 +2220,100 @@
       "symbol_type": "function",
       "verdict": null
     },
+    "cpp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
+      "agreeing_tools": [
+        "ctags",
+        "gitgalaxy"
+      ],
+      "dissenting_tools": [
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-19T23:28:39Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "cpp",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 8,
+      "last_seen_examples": [
+        {
+          "file_path": "godot/object.h",
+          "name": "RequiredResult",
+          "readings": {
+            "ctags": 995,
+            "gitgalaxy": 994,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "RequiredResult",
+          "readings": {
+            "ctags": 1004,
+            "gitgalaxy": 1003,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "RequiredResult",
+          "readings": {
+            "ctags": 1013,
+            "gitgalaxy": 1012,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "RequiredParam",
+          "readings": {
+            "ctags": 1131,
+            "gitgalaxy": 1130,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/object.h",
+          "name": "operator ptr_type",
+          "readings": {
+            "ctags": 1031,
+            "gitgalaxy": 1031,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/variant.h",
+          "name": "~Variant",
+          "readings": {
+            "ctags": 873,
+            "gitgalaxy": 873,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/variant.h",
+          "name": "~PackedArrayRefBase",
+          "readings": {
+            "ctags": 217,
+            "gitgalaxy": 217,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "godot/variant.h",
+          "name": "operator T",
+          "readings": {
+            "ctags": 477,
+            "gitgalaxy": 476,
+            "tree_sitter": null
+          }
+        }
+      ],
+      "metric": "existence",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
     "cpp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
         "ctags",
@@ -2097,7 +2326,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2128,8 +2357,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
-      "last_seen_count": 1025,
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 1074,
       "last_seen_examples": [
         {
           "file_path": "NVDA/storage.cpp",
@@ -2240,8 +2469,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
-      "last_seen_count": 1270,
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 1097,
       "last_seen_examples": [
         {
           "file_path": "NVDA/storage.cpp",
@@ -2352,8 +2581,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
-      "last_seen_count": 70,
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
+      "last_seen_count": 62,
       "last_seen_examples": [
         {
           "file_path": "godot/gdscript_vm.cpp",
@@ -2437,11 +2666,11 @@
           }
         },
         {
-          "file_path": "godot/object.h",
-          "name": "RequiredResult",
+          "file_path": "godot/variant.cpp",
+          "name": "Variant::operator Transform3D",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 994,
+            "gitgalaxy": 1914,
             "tree_sitter": null
           }
         }
@@ -2464,7 +2693,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-19T23:13:08Z",
+      "last_reconciled_at": "2026-08-19T23:28:39Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2576,7 +2805,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2625,7 +2854,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2692,7 +2921,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2768,7 +2997,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2799,7 +3028,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -2884,7 +3113,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2941,7 +3170,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2972,7 +3201,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3084,7 +3313,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3142,7 +3371,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3173,7 +3402,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3285,7 +3514,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3397,7 +3626,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-19T23:13:14Z",
+      "last_reconciled_at": "2026-08-19T23:28:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3428,7 +3657,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-19T23:13:15Z",
+      "last_reconciled_at": "2026-08-19T23:28:46Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3475,7 +3704,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-19T23:13:19Z",
+      "last_reconciled_at": "2026-08-19T23:28:50Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3576,7 +3805,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-19T23:13:19Z",
+      "last_reconciled_at": "2026-08-19T23:28:50Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3677,7 +3906,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-19T23:13:19Z",
+      "last_reconciled_at": "2026-08-19T23:28:50Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -3779,7 +4008,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T23:13:25Z",
+      "last_reconciled_at": "2026-08-19T23:28:56Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -3872,7 +4101,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T23:13:25Z",
+      "last_reconciled_at": "2026-08-19T23:28:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3903,7 +4132,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T23:13:25Z",
+      "last_reconciled_at": "2026-08-19T23:28:56Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4015,7 +4244,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T23:13:25Z",
+      "last_reconciled_at": "2026-08-19T23:28:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4055,7 +4284,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-19T23:13:25Z",
+      "last_reconciled_at": "2026-08-19T23:28:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4095,7 +4324,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-19T23:13:28Z",
+      "last_reconciled_at": "2026-08-19T23:28:58Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4207,7 +4436,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4317,7 +4546,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4420,7 +4649,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4532,7 +4761,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4644,7 +4873,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -4756,7 +4985,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4795,7 +5024,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4833,7 +5062,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-19T23:13:30Z",
+      "last_reconciled_at": "2026-08-19T23:29:01Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -4945,7 +5174,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-19T23:13:33Z",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5041,8 +5270,311 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
+      "verdict": null
+    },
+    "java/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
+      "agreeing_tools": [
+        "ctags",
+        "gitgalaxy"
+      ],
+      "dissenting_tools": [
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-19T23:29:04Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "java",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
+      "last_seen_count": 12,
+      "last_seen_examples": [
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "Binder",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "exit",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "run",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "run",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "run",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "with",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "SpringApplication",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "addInitializers",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "addListeners",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "withAdditionalProfiles",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 1,
+            "tree_sitter": 0
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
+    "java/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
+      "agreeing_tools": [
+        "ctags",
+        "tree_sitter"
+      ],
+      "dissenting_tools": [
+        "gitgalaxy"
+      ],
+      "first_seen_at": "2026-08-19T23:29:04Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "java",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
+      "last_seen_count": 28,
+      "last_seen_examples": [
+        {
+          "file_path": "springboot/AutoConfigurationImportSelector.java",
+          "name": "getAttributes",
+          "readings": {
+            "ctags": 1,
+            "gitgalaxy": 2,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "bindDataObject",
+          "readings": {
+            "ctags": 6,
+            "gitgalaxy": 2,
+            "tree_sitter": 6
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "bindObject",
+          "readings": {
+            "ctags": 5,
+            "gitgalaxy": 0,
+            "tree_sitter": 5
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "handleBindResult",
+          "readings": {
+            "ctags": 6,
+            "gitgalaxy": 1,
+            "tree_sitter": 6
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "bind",
+          "readings": {
+            "ctags": 4,
+            "gitgalaxy": 1,
+            "tree_sitter": 4
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "bind",
+          "readings": {
+            "ctags": 6,
+            "gitgalaxy": 1,
+            "tree_sitter": 6
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "getAggregateBinder",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 0,
+            "tree_sitter": 2
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "bindAggregate",
+          "readings": {
+            "ctags": 5,
+            "gitgalaxy": 3,
+            "tree_sitter": 5
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "findProperty",
+          "readings": {
+            "ctags": 3,
+            "gitgalaxy": 0,
+            "tree_sitter": 3
+          }
+        },
+        {
+          "file_path": "springboot/Binder.java",
+          "name": "handleBindError",
+          "readings": {
+            "ctags": 5,
+            "gitgalaxy": 0,
+            "tree_sitter": 5
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
+    "java/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
+      "dissenting_tools": [
+        "ctags",
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-19T23:29:04Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "java",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
+      "last_seen_count": 1,
+      "last_seen_examples": [
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "SpringApplication",
+          "readings": {
+            "ctags": 2,
+            "gitgalaxy": 0,
+            "tree_sitter": 1
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
+    "java/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
+      "agreeing_tools": [
+        "ctags",
+        "tree_sitter"
+      ],
+      "dissenting_tools": [
+        "gitgalaxy"
+      ],
+      "first_seen_at": "2026-08-19T23:29:04Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "java",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
+      "last_seen_count": 3,
+      "last_seen_examples": [
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "processUptime",
+          "readings": {
+            "ctags": 1817,
+            "gitgalaxy": null,
+            "tree_sitter": 1816
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "action",
+          "readings": {
+            "ctags": 1823,
+            "gitgalaxy": null,
+            "tree_sitter": 1822
+          }
+        },
+        {
+          "file_path": "springboot/SpringApplication.java",
+          "name": "startTime",
+          "readings": {
+            "ctags": 1832,
+            "gitgalaxy": null,
+            "tree_sitter": 1831
+          }
+        }
+      ],
+      "metric": "existence",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
       "verdict": null
     },
     "java/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
@@ -5057,7 +5589,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-19T23:13:33Z",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5153,7 +5685,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -5169,7 +5701,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-19T23:13:33Z",
+      "last_reconciled_at": "2026-08-19T23:29:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5202,7 +5734,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -5218,14 +5750,50 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
-      "last_seen_count": 67,
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
+      "last_seen_count": 96,
       "last_seen_examples": [
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "jqXHR",
+          "readings": {
+            "ctags": 448,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/css.js",
+          "name": "cssHooks",
+          "readings": {
+            "ctags": 357,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/css.js",
+          "name": "cssNormalTransform",
+          "readings": {
+            "ctags": 22,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
         {
           "file_path": "jquery/css.js",
           "name": "cssShow",
           "readings": {
             "ctags": 21,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/deferred.js",
+          "name": "promise",
+          "readings": {
+            "ctags": 58,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -5249,64 +5817,28 @@
           }
         },
         {
+          "file_path": "jquery/event.js",
+          "name": "special",
+          "readings": {
+            "ctags": 756,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/event.js",
+          "name": "special",
+          "readings": {
+            "ctags": 812,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
           "file_path": "react/ReactFiberBeginWork.js",
           "name": "cachePool",
           "readings": {
             "ctags": 2281,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "derivedState",
-          "readings": {
-            "ctags": 1245,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "initialState",
-          "readings": {
-            "ctags": 1224,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "instance",
-          "readings": {
-            "ctags": 3577,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "markerInstance",
-          "readings": {
-            "ctags": 1297,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "memoizedState",
-          "readings": {
-            "ctags": 3347,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "newOffscreenQueue",
-          "readings": {
-            "ctags": 2452,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -5330,7 +5862,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -5403,6 +5935,46 @@
       "symbol_type": "function",
       "verdict": null
     },
+    "javascript/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
+      "agreeing_tools": [
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "dissenting_tools": [
+        "ctags"
+      ],
+      "first_seen_at": "2026-08-19T23:29:07Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "javascript",
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
+      "last_seen_count": 2,
+      "last_seen_examples": [
+        {
+          "file_path": "jquery/event.js",
+          "name": "setup",
+          "readings": {
+            "ctags": 0,
+            "gitgalaxy": 1,
+            "tree_sitter": 1
+          }
+        },
+        {
+          "file_path": "jquery/event.js",
+          "name": "trigger",
+          "readings": {
+            "ctags": 0,
+            "gitgalaxy": 1,
+            "tree_sitter": 1
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
     "javascript/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
       "agreeing_tools": [
         "ctags",
@@ -5415,8 +5987,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
-      "last_seen_count": 10,
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
+      "last_seen_count": 11,
       "last_seen_examples": [
         {
           "file_path": "react/ReactFiberBeginWork.js",
@@ -5527,9 +6099,72 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
-      "last_seen_count": 8,
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
+      "last_seen_count": 150,
       "last_seen_examples": [
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860100",
+          "readings": {
+            "ctags": 55,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860200",
+          "readings": {
+            "ctags": 94,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860300",
+          "readings": {
+            "ctags": 369,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860400",
+          "readings": {
+            "ctags": 383,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860500",
+          "readings": {
+            "ctags": 694,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860600",
+          "readings": {
+            "ctags": 848,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860700",
+          "readings": {
+            "ctags": 852,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
         {
           "file_path": "jquery/ajax.js",
           "name": "AnonymousFunctionc3e813860800",
@@ -5549,55 +6184,10 @@
           }
         },
         {
-          "file_path": "jquery/css.js",
-          "name": "AnonymousFunctionae2e564b0300",
+          "file_path": "jquery/ajax.js",
+          "name": "converters",
           "readings": {
-            "ctags": 306,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/css.js",
-          "name": "AnonymousFunctionae2e564b0500",
-          "readings": {
-            "ctags": 356,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/event.js",
-          "name": "AnonymousFunction9671c0e40a00",
-          "readings": {
-            "ctags": 732,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/event.js",
-          "name": "AnonymousFunction9671c0e40b00",
-          "readings": {
-            "ctags": 811,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFlightServer.js",
-          "name": "[ASYNC_ITERATOR]",
-          "readings": {
-            "ctags": 1616,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFlightServer.js",
-          "name": "[Symbol.iterator]",
-          "readings": {
-            "ctags": 1576,
+            "ctags": 764,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -5621,8 +6211,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
-      "last_seen_count": 528,
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
+      "last_seen_count": 266,
       "last_seen_examples": [
         {
           "file_path": "jquery/ajax.js",
@@ -5631,60 +6221,6 @@
             "ctags": null,
             "gitgalaxy": 383,
             "tree_sitter": 383
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "done",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 715,
-            "tree_sitter": 715
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "inspect",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 91,
-            "tree_sitter": 91
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "getResponseHeader",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 452,
-            "tree_sitter": 452
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "statusCode",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 498,
-            "tree_sitter": 498
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "setRequestHeader",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 480,
-            "tree_sitter": 480
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "abort",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 517,
-            "tree_sitter": 517
           }
         },
         {
@@ -5698,20 +6234,74 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "overrideMimeType",
+          "name": "getJSON",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 490,
-            "tree_sitter": 490
+            "gitgalaxy": 848,
+            "tree_sitter": 848
           }
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "getAllResponseHeaders",
+          "name": "getScript",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 475,
-            "tree_sitter": 475
+            "gitgalaxy": 852,
+            "tree_sitter": 852
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "extend",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 115,
+            "tree_sitter": 115
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "each",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 70,
+            "tree_sitter": 70
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "each",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 237,
+            "tree_sitter": 237
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "map",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 74,
+            "tree_sitter": 74
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "map",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 370,
+            "tree_sitter": 370
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "text",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 260,
+            "tree_sitter": 260
           }
         }
       ],
@@ -5733,8 +6323,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
-      "last_seen_count": 183,
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
+      "last_seen_count": 182,
       "last_seen_examples": [
         {
           "file_path": "react/ReactFiberBeginWork.js",
@@ -5845,7 +6435,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-19T23:13:36Z",
+      "last_reconciled_at": "2026-08-19T23:29:07Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -5957,7 +6547,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-19T23:13:39Z",
+      "last_reconciled_at": "2026-08-19T23:29:10Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6006,7 +6596,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-19T23:13:39Z",
+      "last_reconciled_at": "2026-08-19T23:29:10Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6118,7 +6708,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-19T23:13:39Z",
+      "last_reconciled_at": "2026-08-19T23:29:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6148,7 +6738,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-19T23:13:45Z",
+      "last_reconciled_at": "2026-08-19T23:29:16Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6201,8 +6791,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-19T23:13:45Z",
-      "last_seen_count": 48,
+      "last_reconciled_at": "2026-08-19T23:29:16Z",
+      "last_seen_count": 79,
       "last_seen_examples": [
         {
           "file_path": "curl/configure.ac",
@@ -6302,7 +6892,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-19T23:13:45Z",
+      "last_reconciled_at": "2026-08-19T23:29:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6332,7 +6922,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-19T23:13:46Z",
+      "last_reconciled_at": "2026-08-19T23:29:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6361,7 +6951,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-19T23:13:48Z",
+      "last_reconciled_at": "2026-08-19T23:29:19Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6392,8 +6982,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T23:13:49Z",
-      "last_seen_count": 71,
+      "last_reconciled_at": "2026-08-19T23:29:20Z",
+      "last_seen_count": 91,
       "last_seen_examples": [
         {
           "file_path": "worldwideweb/Anchor.m",
@@ -6478,9 +7068,9 @@
         },
         {
           "file_path": "worldwideweb/HyperManager.m",
-          "name": "closeOthers:",
+          "name": "back:",
           "readings": {
-            "ctags": 357,
+            "ctags": 198,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -6504,8 +7094,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T23:13:49Z",
-      "last_seen_count": 120,
+      "last_reconciled_at": "2026-08-19T23:29:20Z",
+      "last_seen_count": 104,
       "last_seen_examples": [
         {
           "file_path": "worldwideweb/Anchor.m",
@@ -6616,7 +7206,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T23:13:49Z",
+      "last_reconciled_at": "2026-08-19T23:29:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6647,7 +7237,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-19T23:13:49Z",
+      "last_reconciled_at": "2026-08-19T23:29:20Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6687,7 +7277,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6718,7 +7308,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6747,7 +7337,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -6859,7 +7449,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6944,7 +7534,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7029,7 +7619,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7060,7 +7650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-19T23:13:56Z",
+      "last_reconciled_at": "2026-08-19T23:29:26Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7172,7 +7762,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-19T23:14:00Z",
+      "last_reconciled_at": "2026-08-19T23:29:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7203,7 +7793,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-19T23:14:00Z",
+      "last_reconciled_at": "2026-08-19T23:29:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7234,7 +7824,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-19T23:14:00Z",
+      "last_reconciled_at": "2026-08-19T23:29:31Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -7330,7 +7920,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -7346,7 +7936,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T23:14:03Z",
+      "last_reconciled_at": "2026-08-19T23:29:33Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7429,7 +8019,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T23:14:03Z",
+      "last_reconciled_at": "2026-08-19T23:29:33Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -7496,7 +8086,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T23:14:03Z",
+      "last_reconciled_at": "2026-08-19T23:29:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7527,7 +8117,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-19T23:14:03Z",
+      "last_reconciled_at": "2026-08-19T23:29:33Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -7639,7 +8229,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T23:14:12Z",
+      "last_reconciled_at": "2026-08-19T23:29:42Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7697,7 +8287,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T23:14:12Z",
+      "last_reconciled_at": "2026-08-19T23:29:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7728,7 +8318,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T23:14:12Z",
+      "last_reconciled_at": "2026-08-19T23:29:42Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -7840,7 +8430,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-19T23:14:12Z",
+      "last_reconciled_at": "2026-08-19T23:29:42Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -7952,7 +8542,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T23:14:13Z",
+      "last_reconciled_at": "2026-08-19T23:29:44Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7992,7 +8582,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T23:14:13Z",
+      "last_reconciled_at": "2026-08-19T23:29:44Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8068,7 +8658,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T23:14:13Z",
+      "last_reconciled_at": "2026-08-19T23:29:44Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8117,7 +8707,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-19T23:14:13Z",
+      "last_reconciled_at": "2026-08-19T23:29:44Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8193,7 +8783,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T23:14:17Z",
+      "last_reconciled_at": "2026-08-19T23:29:48Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8242,7 +8832,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T23:14:17Z",
+      "last_reconciled_at": "2026-08-19T23:29:48Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -8354,7 +8944,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T23:14:17Z",
+      "last_reconciled_at": "2026-08-19T23:29:48Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -8464,7 +9054,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T23:14:17Z",
+      "last_reconciled_at": "2026-08-19T23:29:48Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -8576,7 +9166,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T23:14:17Z",
+      "last_reconciled_at": "2026-08-19T23:29:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8607,7 +9197,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-19T23:14:17Z",
+      "last_reconciled_at": "2026-08-19T23:29:48Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -8717,7 +9307,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-19T23:14:20Z",
+      "last_reconciled_at": "2026-08-19T23:29:50Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8818,7 +9408,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-19T23:14:24Z",
+      "last_reconciled_at": "2026-08-19T23:29:54Z",
       "last_seen_count": 92,
       "last_seen_examples": [
         {
@@ -8920,7 +9510,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-19T23:14:25Z",
+      "last_reconciled_at": "2026-08-19T23:29:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8950,7 +9540,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-19T23:14:27Z",
+      "last_reconciled_at": "2026-08-19T23:29:57Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9018,7 +9608,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-19T23:14:28Z",
+      "last_reconciled_at": "2026-08-19T23:29:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9047,7 +9637,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-19T23:14:28Z",
+      "last_reconciled_at": "2026-08-19T23:29:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9076,7 +9666,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-19T23:14:28Z",
+      "last_reconciled_at": "2026-08-19T23:29:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9106,7 +9696,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T23:14:30Z",
+      "last_reconciled_at": "2026-08-19T23:30:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9137,7 +9727,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T23:14:30Z",
+      "last_reconciled_at": "2026-08-19T23:30:00Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9177,7 +9767,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T23:14:30Z",
+      "last_reconciled_at": "2026-08-19T23:30:00Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -9235,7 +9825,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-19T23:14:30Z",
+      "last_reconciled_at": "2026-08-19T23:30:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9254,6 +9844,46 @@
       "symbol_type": "function",
       "verdict": null
     },
+    "typescript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [
+        "ctags"
+      ],
+      "dissenting_tools": [
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-19T23:30:21Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "typescript",
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
+      "last_seen_count": 2,
+      "last_seen_examples": [
+        {
+          "file_path": "vscode/instantiationService.ts",
+          "name": "extends",
+          "readings": {
+            "ctags": 410,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "vscode/lifecycle.ts",
+          "name": "implements",
+          "readings": {
+            "ctags": 235,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        }
+      ],
+      "metric": "existence",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "class",
+      "verdict": null
+    },
     "typescript/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy",
@@ -9266,8 +9896,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T23:14:51Z",
-      "last_seen_count": 515,
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
+      "last_seen_count": 501,
       "last_seen_examples": [
         {
           "file_path": "assemblyscript/ast.ts",
@@ -9366,6 +9996,62 @@
       "symbol_type": "class",
       "verdict": null
     },
+    "typescript/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
+      "agreeing_tools": [],
+      "dissenting_tools": [
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "first_seen_at": "2026-08-19T23:30:21Z",
+      "investigated_at": null,
+      "investigated_by": null,
+      "language": "typescript",
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
+      "last_seen_count": 4,
+      "last_seen_examples": [
+        {
+          "file_path": "vscode/async.ts",
+          "name": "constructor",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 0
+          }
+        },
+        {
+          "file_path": "vscode/vscode.d.ts",
+          "name": "constructor",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 5,
+            "tree_sitter": 2
+          }
+        },
+        {
+          "file_path": "vscode/vscode.d.ts",
+          "name": "constructor",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 1,
+            "tree_sitter": 2
+          }
+        },
+        {
+          "file_path": "vscode/vscode.d.ts",
+          "name": "constructor",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 1,
+            "tree_sitter": 4
+          }
+        }
+      ],
+      "metric": "args",
+      "status": "unvalidated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": null
+    },
     "typescript/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
         "ctags",
@@ -9378,8 +10064,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T23:14:51Z",
-      "last_seen_count": 8,
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
+      "last_seen_count": 9,
       "last_seen_examples": [
         {
           "file_path": "fp-ts/pipeable.ts",
@@ -9452,6 +10138,15 @@
             "gitgalaxy": null,
             "tree_sitter": 509
           }
+        },
+        {
+          "file_path": "vscode/ipc.ts",
+          "name": "drain",
+          "readings": {
+            "ctags": 105,
+            "gitgalaxy": null,
+            "tree_sitter": 105
+          }
         }
       ],
       "metric": "existence",
@@ -9472,7 +10167,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T23:14:51Z",
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -9584,8 +10279,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T23:14:51Z",
-      "last_seen_count": 2103,
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
+      "last_seen_count": 1907,
       "last_seen_examples": [
         {
           "file_path": "assemblyscript/ast.ts",
@@ -9696,7 +10391,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T23:14:51Z",
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9736,8 +10431,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-19T23:14:51Z",
-      "last_seen_count": 175,
+      "last_reconciled_at": "2026-08-19T23:30:21Z",
+      "last_seen_count": 174,
       "last_seen_examples": [
         {
           "file_path": "fp-ts/Either.ts",
@@ -9847,7 +10542,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-19T23:14:59Z",
+      "last_reconciled_at": "2026-08-19T23:30:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9876,7 +10571,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-19T23:14:59Z",
+      "last_reconciled_at": "2026-08-19T23:30:30Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -9977,7 +10672,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-19T23:14:59Z",
+      "last_reconciled_at": "2026-08-19T23:30:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_points_of_interest.md
+++ b/docs/self_scan/tri_comparison_points_of_interest.md
@@ -8,7 +8,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `agc_assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 760 occurrences as of 2026-08-19T20:26:16Z*
+*2-vs-1 -- 760 occurrences as of 2026-08-19T23:12:49Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`agc_assembly/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -29,7 +29,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `apex` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:18Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:12:50Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`apex/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -42,7 +42,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 52 occurrences as of 2026-08-19T20:26:20Z*
+*2-vs-1 -- 52 occurrences as of 2026-08-19T23:12:53Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`assembly/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -61,7 +61,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:26:20Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:12:53Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`assembly/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -77,63 +77,9 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ## c
 
-### ❓ `c` function existence: GitGalaxy, ctags agree, tree-sitter differ
-
-*2-vs-1 -- 13 occurrences as of 2026-08-19T20:26:25Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/ceval.c | `_Py_CheckRecursiveCall` | 282 | *(n/a)* | 283 |
-| cpython/ceval.c | `_Py_ReachedRecursionLimitWithMargin` | 28 | *(n/a)* | 29 |
-| cpython/ceval.c | `_Py_EnterRecursiveCallUnchecked` | 52 | *(n/a)* | 53 |
-| cpython/dictobject.c | `dictiter_iternextitem` | 5994 | *(n/a)* | 5995 |
-| cpython/object.c | `_PyObject_SetAttributeErrorContext` | 1279 | *(n/a)* | 1280 |
-| cpython/typeobject.c | `_Py_slot_tp_getattr_hook` | 10817 | *(n/a)* | 10818 |
-| cpython/typeobject.c | `call_attribute` | 10792 | *(n/a)* | 10793 |
-| cpython/typeobject.c | `slot_tp_call` | 10768 | *(n/a)* | 10769 |
-| cpython/typeobject.c | `_Py_slot_tp_getattro` | 10785 | *(n/a)* | 10786 |
-| micropython/compile.c | `mp_compile_to_raw_code` | 3474 | *(n/a)* | 3476 |
-
-### ❓ `c` class existence: GitGalaxy, tree-sitter agree, ctags differ
-
-*2-vs-1 -- 9 occurrences as of 2026-08-19T20:26:25Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/frameobject.c | `kind` | *(n/a)* | 1175 | *(n/a)* |
-| cpython/gc.c | `flagstates` | *(n/a)* | 377 | *(n/a)* |
-| micropython/objtype.c | `_setname_list_t` | *(n/a)* | 981 | *(n/a)* |
-| sqlite/lemon.c | `option_type` | *(n/a)* | 271 | *(n/a)* |
-| sqlite/lemon.c | `symbol_type` | *(n/a)* | 319 | *(n/a)* |
-| sqlite/lemon.c | `e_assoc` | *(n/a)* | 324 | *(n/a)* |
-| sqlite/lemon.c | `cfgstatus` | *(n/a)* | 389 | *(n/a)* |
-| sqlite/lemon.c | `e_action` | *(n/a)* | 405 | *(n/a)* |
-| sqlite/lemon.c | `e_state` | *(n/a)* | 2323 | *(n/a)* |
-
-### ❓ `c` function existence: GitGalaxy, tree-sitter agree, ctags differ
-
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:26:25Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/typeobject.c | `slot_nb_power` | 10577 | 10577 | *(n/a)* |
-| cpython/typeobject.c | `slot_nb_bool` | 10630 | 10630 | *(n/a)* |
-| cpython/typeobject.c | `wrap_next` | 10106 | 10106 | *(n/a)* |
-| doom/i_system.c | `I_AllocLow` | 147 | 147 | *(n/a)* |
-| doom/i_system.c | `I_ZoneBase` | 76 | 76 | *(n/a)* |
-| doom/i_system.c | `I_BaseTiccmd` | 65 | 65 | *(n/a)* |
-| doom/r_bsp.c | `R_CheckBBox` | 381 | 381 | *(n/a)* |
-| doom/r_bsp.c | `R_AddLine` | 259 | 259 | *(n/a)* |
-
 ### ✅ `c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 74 occurrences as of 2026-08-19T20:26:25Z*
+*2-vs-1 -- 74 occurrences as of 2026-08-19T23:12:58Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed, independently verified all 6 sampled names against real source -- GitGalaxy and ctags both correct, tree-sitter over-recalling from two related but distinct preprocessor-driven mechanisms, both already covered by existing infrastructure: (1) keyword/macro misparse -- 'if' (dictobject.c:522-527, an `#if SIZEOF_VOID_P > 4` / `else if` sequence desyncs the parse) and 'DICT___REVERSED___METHODDEF' (dictobject.c:5102, a PyMethodDef array-initializer macro, not a definition) are both ALREADY in tree_sitter_accuracy_audit.py's `_C_KNOWN_MACRO_HALLUCINATIONS` exclusion set (confirmed by reading it directly) -- this tri-comparison tool's raw walk deliberately doesn't apply that list (it's a curated, ground-truth-shaped judgment call, appropriately left to reconciliation per this module's own stated design, not baked into the walk). (2) dead #if 0 code -- '_PyObject_ManagedDictValidityCheck' (dictobject.c:7396) and 'tos_char'/'print_stack'/'print_stacks' (frameobject.c:1264-1313) are genuinely well-formed function definitions sitting entirely inside `#if 0 ... #endif` guards; tree-sitter has no preprocessor model and parses the dead branch as live code. Both mechanisms are already the exact shape docs/why_gitgalaxy_beats_ast_here.md's Claim 8 names generically ('a dead #if 0 block... macro definitions... that merely look structural') -- added these 4 new concrete citations to Claim 8's evidence section rather than treating this as a new finding. No GitHub issue -- both tools already behave as intended; this is expected, already-documented tree-sitter preprocessor-blindness surfacing under the new tri-comparison reconciliation, not a fresh defect.
@@ -151,29 +97,66 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | cpython/object.c | `if` | *(n/a)* | 1272 | *(n/a)* |
 | micropython/gc.c | `if` | *(n/a)* | 1353 | *(n/a)* |
 
-### ✅ `c` class existence: ctags agree, GitGalaxy, tree-sitter differ
+### ✅ `c` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 23 occurrences as of 2026-08-19T20:26:25Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-19T23:12:58Z*
 
-**Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
-> Confirmed tooling gap, now fixed -- not a GitGalaxy or tree-sitter defect. Every one of the 10 sampled names (__anon2570bd640108, __anonf1d666540108, etc.) is ctags' own synthesized placeholder name for an anonymous struct/union/enum, confirmed directly: cpython/ceval.c's __anon2570bd640108 backs a real `typedef struct { ... }` (the platform pthread-attr shim at line ~94) with no name in the source. GitGalaxy and tree-sitter both correctly report nothing (there is no real name to report); ctags synthesizes one for its own internal bookkeeping. Same category as GitGalaxy's own _SYNTHETIC_GG_CLASS_NAMES exclusion, just on ctags' side -- added _is_ctags_synthetic_anon_name() to tri_comparison_gatherer.py (matches ctags' documented __anon<hex> naming convention, applied to both func and class ctags readings) and documented in ctags_reader.py alongside its existing per-language notes. Generalizes to the full 23 by construction (a structural naming-pattern match, not a per-instance judgment).
+**Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
+> 3 distinct causes, all genuine tree-sitter-c grammar limitations (GitGalaxy and ctags both correct in all 10 sampled cases) -- confirmed via dispatched investigation (which ran tree-sitter's C grammar directly and found ERROR nodes in every case) plus independent source-level spot-checks of all 3 trigger shapes. This is a C-scale instance of Claim 7 (CPP-directive-driven recall loss) -- added to that claim's evidence section. (1) 4 samples: an #if/#else pair splitting a single `if` condition inside a function body (ceval.c:33, _Py_ReachedRecursionLimitWithMargin). (2) 5 samples: bare, un-semicoloned macro invocations the grammar can't cleanly recover from, losing the next real function (object.c:1269-1271's _Py_COMP_DIAG_PUSH/IGNORE_DEPR_DECLS/POP before _PyObject_SetAttributeErrorContext; similar shape for the typeobject.c slot-getattr cluster). (3) 1 sample: #if/#endif wrapping only the `static` storage-class specifier, separated from the rest of the signature (micropython/compile.c:3473-3476, mp_compile_to_raw_code). Unlike Fortran's existing Claim 7 evidence (entire trailing sections lost), C's version is local -- one function lost per trigger, not a cascading region. No GitHub issue -- documented as new Claim 7 evidence, not a fixable tooling bug (this repo doesn't control tree-sitter-c's grammar).
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| cpython/ceval.c | `__anon2570bd640108` | *(n/a)* | *(n/a)* | 94 |
-| cpython/dictobject.c | `__anonf1d666540108` | *(n/a)* | *(n/a)* | 5420 |
-| cpython/object.c | `__anone3f65c900108` | *(n/a)* | *(n/a)* | 2973 |
-| cpython/typeobject.c | `__anonb81650120108` | *(n/a)* | *(n/a)* | 3808 |
-| cpython/typeobject.c | `__anonb81650120208` | *(n/a)* | *(n/a)* | 3830 |
-| cpython/typeobject.c | `__anonb81650120308` | *(n/a)* | *(n/a)* | 3936 |
-| cpython/typeobject.c | `__anonb81650120408` | *(n/a)* | *(n/a)* | 4191 |
-| cpython/typeobject.c | `__anonb81650120508` | *(n/a)* | *(n/a)* | 12342 |
-| doom/r_bsp.c | `__anoneeedd6d90108` | *(n/a)* | *(n/a)* | 81 |
-| doom/r_defs.h | `__anond0514f7b0108` | *(n/a)* | *(n/a)* | 72 |
+| cpython/ceval.c | `_Py_CheckRecursiveCall` | 282 | *(n/a)* | 283 |
+| cpython/ceval.c | `_Py_ReachedRecursionLimitWithMargin` | 28 | *(n/a)* | 29 |
+| cpython/ceval.c | `_Py_EnterRecursiveCallUnchecked` | 52 | *(n/a)* | 53 |
+| cpython/dictobject.c | `dictiter_iternextitem` | 5994 | *(n/a)* | 5995 |
+| cpython/object.c | `_PyObject_SetAttributeErrorContext` | 1279 | *(n/a)* | 1280 |
+| cpython/typeobject.c | `_Py_slot_tp_getattr_hook` | 10817 | *(n/a)* | 10818 |
+| cpython/typeobject.c | `call_attribute` | 10792 | *(n/a)* | 10793 |
+| cpython/typeobject.c | `slot_tp_call` | 10768 | *(n/a)* | 10769 |
+| cpython/typeobject.c | `_Py_slot_tp_getattro` | 10785 | *(n/a)* | 10786 |
+| micropython/compile.c | `mp_compile_to_raw_code` | 3474 | *(n/a)* | 3476 |
+
+### ✅ `c` class existence: GitGalaxy, tree-sitter agree, ctags differ
+
+*2-vs-1 -- 9 occurrences as of 2026-08-19T23:12:58Z*
+
+**Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
+> Single cause, confirmed independently twice (dispatched agent + a second independent spot-check, no disagreement) -- a bug in THIS tool's ctags_reader.py, not ctags itself. CTAGS_CLASS_KINDS['c'] was {'s'} (struct only), but GitGalaxy's own C class_start regex (gitgalaxy/standards/language_standards.py) is `struct|union|enum` -- all 3. ctags' C parser handles enum ('g' kind) and union ('u' kind) fine (confirmed via direct ctags runs against sqlite/lemon.c and others, finding all 9 sampled declarations correctly); this map was silently dropping them before reconciliation ever saw them. Fixed: CTAGS_CLASS_KINDS['c'] now {'s', 'g', 'u'}, verified all 9 sampled names (6 enum in sqlite/lemon.c, 1 enum each in cpython/frameobject.c and cpython/gc.c, 1 union in micropython/objtype.c) now correctly found. No GitHub issue -- fixed directly.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| cpython/frameobject.c | `kind` | *(n/a)* | 1175 | *(n/a)* |
+| cpython/gc.c | `flagstates` | *(n/a)* | 377 | *(n/a)* |
+| micropython/objtype.c | `_setname_list_t` | *(n/a)* | 981 | *(n/a)* |
+| sqlite/lemon.c | `option_type` | *(n/a)* | 271 | *(n/a)* |
+| sqlite/lemon.c | `symbol_type` | *(n/a)* | 319 | *(n/a)* |
+| sqlite/lemon.c | `e_assoc` | *(n/a)* | 324 | *(n/a)* |
+| sqlite/lemon.c | `cfgstatus` | *(n/a)* | 389 | *(n/a)* |
+| sqlite/lemon.c | `e_action` | *(n/a)* | 405 | *(n/a)* |
+| sqlite/lemon.c | `e_state` | *(n/a)* | 2323 | *(n/a)* |
+
+### ✅ `c` function existence: GitGalaxy, tree-sitter agree, ctags differ
+
+*2-vs-1 -- 8 occurrences as of 2026-08-19T23:12:58Z*
+
+**Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
+> Two distinct causes, both confirmed by independent verification, not one -- resolved via dispatched investigation plus direct fixes. (1) 5 of 8 (I_AllocLow, I_ZoneBase, I_BaseTiccmd, R_CheckBBox, R_AddLine, all doom): a real bug in THIS tool's OWN ctags_reader.py, not a ctags limitation. Old Doom source uses literal TAB characters for column alignment (e.g. `byte*\tI_AllocLow(int length)`); ctags faithfully echoes that tab into its tag-file's address/pattern field, and read_ctags_symbols' naive line.split('\t') then misreads a fragment of the SOURCE LINE as the kind field, fails the kind-membership check, and silently drops the symbol. Confirmed by running ctags with the exact flags this code uses and inspecting the raw tab-delimited output directly -- reproduced the exact column-shift byte for byte. Fixed: parse now finds the tag-file format's guaranteed `;"` address-terminator marker instead of blind-splitting the whole line, only tab-splitting the safe trailer after it. Verified: all 5 names now correctly found. (2) 3 of 8 (slot_nb_power, slot_nb_bool, wrap_next, all cpython typeobject.c): extension of the already-documented SLOT-macro ctags limitation -- each follows a SLOT1BINFULL/SLOT0/RICHCMP_WRAPPER macro invocation ctags misreads as a function (confirmed at typeobject.c:10574/10577/10630), which also swallows the real function immediately after it. Not code-fixed (same ground-truth-judgment reasoning as the sibling 7-occurrence shape) -- already covered by ctags_reader.py's existing note on this mechanism.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| cpython/typeobject.c | `slot_nb_power` | 10577 | 10577 | *(n/a)* |
+| cpython/typeobject.c | `slot_nb_bool` | 10630 | 10630 | *(n/a)* |
+| cpython/typeobject.c | `wrap_next` | 10106 | 10106 | *(n/a)* |
+| doom/i_system.c | `I_AllocLow` | 147 | 147 | *(n/a)* |
+| doom/i_system.c | `I_ZoneBase` | 76 | 76 | *(n/a)* |
+| doom/i_system.c | `I_BaseTiccmd` | 65 | 65 | *(n/a)* |
+| doom/r_bsp.c | `R_CheckBBox` | 381 | 381 | *(n/a)* |
+| doom/r_bsp.c | `R_AddLine` | 259 | 259 | *(n/a)* |
 
 ### ✅ `c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:26:25Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:12:58Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes.
@@ -190,7 +173,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:26:25Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T23:12:58Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up.
@@ -204,7 +187,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:25Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:12:58Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed.
@@ -217,7 +200,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:25Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:12:58Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a tool defect on either side -- an inherent CPP-conditional-compilation ambiguity. gc_mark_subtree is declared AND defined twice in micropython/gc.c, once under `#if MICROPY_GC_SPLIT_HEAP` (2 args: area, block -- lines 137/501) and once under the matching `#else` (1 arg: block -- lines 139/503). Neither signature is more 'real' than the other -- which one actually compiles depends on a macro none of these three tools evaluates (no real preprocessor run in any of them). GG and ctags happened to align on the 2-arg branch, tree-sitter on the 1-arg branch; this is a coin-flip of which #if branch a tool's occurrence-matching happens to pick up, not a real disagreement about ground truth. N=1 in this corpus -- not chased further given the tiny sample and the ambiguity being structural rather than a bug.
@@ -230,7 +213,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cobol` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 133 occurrences as of 2026-08-19T20:26:31Z*
+*2-vs-1 -- 133 occurrences as of 2026-08-19T23:13:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cobol/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -249,7 +232,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cobol` class existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 19 occurrences as of 2026-08-19T20:26:31Z*
+*2-vs-1 -- 19 occurrences as of 2026-08-19T23:13:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cobol/class/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -268,7 +251,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cobol` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 18 occurrences as of 2026-08-19T20:26:31Z*
+*2-vs-1 -- 18 occurrences as of 2026-08-19T23:13:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cobol/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -289,7 +272,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1270 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 1270 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -308,7 +291,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1061 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 1025 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -327,7 +310,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 120 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 120 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -346,7 +329,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 98 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 98 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -365,7 +348,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 70 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 70 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -384,7 +367,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 24 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 24 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -403,7 +386,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 22 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 22 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -422,7 +405,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -434,7 +417,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -445,7 +428,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -455,7 +438,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:35Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -465,7 +448,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:26:35Z*
+*3-way split -- 1 occurrence as of 2026-08-19T23:13:08Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -477,7 +460,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 271 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 271 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -496,7 +479,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 107 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 107 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -515,7 +498,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 48 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 48 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -534,7 +517,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -550,7 +533,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -565,7 +548,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 5 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 5 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -579,7 +562,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -592,7 +575,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -605,7 +588,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -617,7 +600,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -627,7 +610,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -637,7 +620,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:41Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -647,7 +630,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:26:41Z*
+*3-way split -- 1 occurrence as of 2026-08-19T23:13:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -659,7 +642,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `css` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:42Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:13:15Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`css/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -673,7 +656,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 37 occurrences as of 2026-08-19T20:26:46Z*
+*2-vs-1 -- 37 occurrences as of 2026-08-19T23:13:19Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -692,7 +675,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 18 occurrences as of 2026-08-19T20:26:46Z*
+*2-vs-1 -- 18 occurrences as of 2026-08-19T23:13:19Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -711,7 +694,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 216 occurrences as of 2026-08-19T20:26:46Z*
+*3-way split -- 216 occurrences as of 2026-08-19T23:13:19Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -732,7 +715,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 14 occurrences as of 2026-08-19T20:26:52Z*
+*2-vs-1 -- 14 occurrences as of 2026-08-19T23:13:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -751,7 +734,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:26:52Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T23:13:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -768,7 +751,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:52Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:13:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -779,7 +762,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:52Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:13:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -790,7 +773,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:26:52Z*
+*3-way split -- 1 occurrence as of 2026-08-19T23:13:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -802,7 +785,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `go` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 75 occurrences as of 2026-08-19T20:26:55Z*
+*2-vs-1 -- 75 occurrences as of 2026-08-19T23:13:28Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`go/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -823,7 +806,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 103 occurrences as of 2026-08-19T20:26:57Z*
+*2-vs-1 -- 103 occurrences as of 2026-08-19T23:13:30Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > All 10 sampled cases are ctags-side artifacts, not real GitGalaxy/tree-sitter misses -- confirmed via direct `ctags -x` output against the corpus. Three distinct ctags Haskell-parser weaknesses cover the sample: (1) multi-clause double/triple-tagging -- ctags tags every pattern-matched equation line as its own occurrence of the name (writerFn/writeFnBinary/expandFilterPath: confirmed 2-3 raw ctags tags per function, one per clause; a file-wide count found 45 such extra same-name tags across the 7-file corpus, e.g. blockToInlines alone has 14). GitGalaxy/tree-sitter both correctly anchor to the FIRST clause only, leaving ctags' later-clause tags as the ones unpaired. (2) keyword-as-identifier misparsing -- `class`/`where`/`pattern` (from PatternSynonyms) get tagged as function names when ctags fails to parse past the keyword; confirmed at Options.hs:62 (`class HasSyntaxExtensions`), Parsing.hs:184 (module-header `where`), and 3 PatternSynonyms declarations in Options.hs. (3) CAF/value-vs-function kind collapse -- defaultAbbrevs/defaultKaTeXURL/defaultMathJaxURL/defaultWebTeXURL are zero-arg top-level VALUES (non-arrow type signatures), not functions; ctags has no value/variable kind at all (`ctags --list-kinds-full=Haskell` shows only constructor/function/module/type) so it lumps every `name = expr` binding into "function". GitGalaxy (language_standards.py haskell rules, #1312) and tree-sitter's own audit tooling (_find_haskell_signature_for_bind, #1566) both independently make the same value-vs-function distinction correctly -- real cross-tool corroboration, not coincidence. (4) TH-splice call sites misread as definitions -- deriveJSON at Options.hs:454/458 is a Template Haskell splice INVOKING an imported function, not defining one; ctags misparses the call as a definition. No GitGalaxy/tree-sitter defect anywhere in this shape; purely a ctags parser limitation, same category as the already-documented empty CTAGS_CLASS_KINDS['haskell'].
@@ -843,7 +826,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 69 occurrences as of 2026-08-19T20:26:57Z*
+*2-vs-1 -- 69 occurrences as of 2026-08-19T23:13:30Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > Confirmed: all 10 sampled misses (and, by cross-check against additional non-sampled instances in Options.hs/Shared.hs, plausibly all 69) are locally-scoped function definitions -- `instance ... where` methods, `where`-clause helpers, or `let`-bound names inside `do` blocks -- never top-level module definitions. ctags' Haskell parser has no layout-rule/scope awareness and only tags equations anchored at column 1; it correctly handles multi-clause TOP-LEVEL definitions (verified via expandFilterPath, writeFnBinary, writerFn -- all tag fine, clauses and all), so this is a pure scope blind spot, not a clause-counting bug (distinct from the tree-sitter clause-splitting bug fixed earlier in this same effort, which shares 2 of the 10 sample names by coincidence of subject matter, not root cause). GitGalaxy and tree-sitter are both correct; ctags is not wrong so much as structurally incapable of seeing these. Known, expected limitation of ctags' Haskell parser, now documented alongside its existing Haskell notes in tests/tools/ctags_reader.py -- not a GitHub issue, nothing in this repo to fix.
@@ -863,7 +846,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-19T20:26:57Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-19T23:13:30Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Not a real discrepancy -- structural tooling gap, already documented in the codebase. tests/tools/ctags_reader.py:39-40,228 sets CTAGS_CLASS_KINDS['haskell'] = set() on purpose: "ctags' Haskell parser has no class-shaped kind at all (constructor/function/module/type only)". Every example in this shape (data/newtype/class declarations -- ReaderOptions, CiteMethod, HasSyntaxExtensions, etc.) is real; ctags structurally cannot report any of them for this language, not a sample-specific miss. No action needed beyond this note.
@@ -883,7 +866,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:57Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:13:30Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Mixed shape, resolved by reading both of the 2 occurrences directly (no larger sample needed). (1) Options.hs:438 getExtensions -- real function, `instance HasSyntaxExtensions WriterOptions where getExtensions opts = writerExtensions opts`. A sibling instance for ReaderOptions at Options.hs:80 has the identical shape. Tree-sitter's Haskell grammar doesn't expose typeclass-instance-method clause bodies the way it does top-level bindings, and ctags' Haskell parser has no instance-method kind either -- GitGalaxy is correct, both other tools have a real recall gap on typeclass instance methods. (2) Shared.hs:475 extensionEnabled -- NOT a real function. Imported from Text.Pandoc.Extensions (Shared.hs:114), only ever appears as a guard-clause call (`| extensionEnabled Ext_gfm_auto_identifiers exts = ...`). GitGalaxy's regex misreads a guard-clause invocation as a definition -- genuine GitGalaxy false positive, worth its own engine bug against language_standards.py's haskell func_start rule.
@@ -895,7 +878,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 9 occurrences as of 2026-08-19T20:26:57Z*
+*3-way split -- 9 occurrences as of 2026-08-19T23:13:30Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > One systematic cause, confirmed by reading source for 3 of the 9 (getMetadataFromFiles App.hs:395-397, splitTextByIndices Shared.hs:142-143, tabFilter Shared.hs:256-259) and consistent with the shape of the remaining 6. Every case is a point-free/eta-reduced Haskell equation: the type signature declares N params, but the specific clause GitGalaxy and tree-sitter both align to only explicitly binds N-1 of them, handling the trailing argument via composition (`.`) or `\case`. GitGalaxy counts arity from the full type signature (the true logical arity); tree-sitter's declaration-only reading counts only the clause's explicitly-bound patterns (correct for that one equation, but undercounts true arity). Neither reader is wrong about what it's measuring -- same shape as Claim 1 in docs/why_gitgalaxy_beats_ast_here.md. GitGalaxy's answer is arguably the more useful coupling signal; recommend documenting as a candidate Claim rather than treating as an engine defect to fix toward matching tree-sitter.
@@ -916,7 +899,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 315 occurrences as of 2026-08-19T20:27:00Z*
+*2-vs-1 -- 315 occurrences as of 2026-08-19T23:13:33Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -935,7 +918,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 28 occurrences as of 2026-08-19T20:27:00Z*
+*2-vs-1 -- 28 occurrences as of 2026-08-19T23:13:33Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -954,7 +937,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:00Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:13:33Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -968,7 +951,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 528 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 528 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -987,7 +970,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 183 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 183 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1006,7 +989,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 104 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 104 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1025,7 +1008,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 67 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 67 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1044,7 +1027,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1063,7 +1046,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1080,7 +1063,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:03Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:13:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1098,7 +1081,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-19T20:27:05Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-19T23:13:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1117,7 +1100,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:05Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:13:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1129,7 +1112,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:05Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1141,7 +1124,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `m4` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 48 occurrences as of 2026-08-19T20:27:12Z*
+*2-vs-1 -- 48 occurrences as of 2026-08-19T23:13:45Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`m4/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1160,7 +1143,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `m4` class existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:27:12Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T23:13:45Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`m4/class/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1173,7 +1156,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `m4` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:12Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:45Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`m4/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1185,7 +1168,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `makefile` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:13Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`makefile/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1197,7 +1180,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `matlab` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:27:15Z*
+*3-way split -- 1 occurrence as of 2026-08-19T23:13:48Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`matlab/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1209,7 +1192,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 120 occurrences as of 2026-08-19T20:27:16Z*
+*2-vs-1 -- 120 occurrences as of 2026-08-19T23:13:49Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1228,7 +1211,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 71 occurrences as of 2026-08-19T20:27:16Z*
+*2-vs-1 -- 71 occurrences as of 2026-08-19T23:13:49Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1247,7 +1230,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:27:16Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:13:49Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1258,7 +1241,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:16Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:49Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1270,7 +1253,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 122 occurrences as of 2026-08-19T20:27:23Z*
+*2-vs-1 -- 122 occurrences as of 2026-08-19T23:13:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1289,7 +1272,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:23Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:13:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1305,7 +1288,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:23Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:13:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1321,7 +1304,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:23Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1331,7 +1314,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:23Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:13:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1341,7 +1324,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 64 occurrences as of 2026-08-19T20:27:23Z*
+*3-way split -- 64 occurrences as of 2026-08-19T23:13:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1362,7 +1345,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 68 occurrences as of 2026-08-19T20:27:27Z*
+*2-vs-1 -- 68 occurrences as of 2026-08-19T23:14:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1381,7 +1364,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:27Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1391,7 +1374,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:27Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1403,7 +1386,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-19T20:27:30Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-19T23:14:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1422,7 +1405,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:30Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T23:14:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1438,7 +1421,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:30Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1448,7 +1431,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 5 occurrences as of 2026-08-19T20:27:30Z*
+*3-way split -- 5 occurrences as of 2026-08-19T23:14:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1464,7 +1447,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 68 occurrences as of 2026-08-19T20:27:39Z*
+*2-vs-1 -- 68 occurrences as of 2026-08-19T23:14:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1483,7 +1466,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 32 occurrences as of 2026-08-19T20:27:39Z*
+*2-vs-1 -- 32 occurrences as of 2026-08-19T23:14:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1502,7 +1485,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:27:39Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T23:14:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1515,7 +1498,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:39Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1527,7 +1510,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:27:41Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T23:14:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1542,7 +1525,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:27:41Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T23:14:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1557,7 +1540,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:41Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:14:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1569,7 +1552,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:27:41Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:14:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1582,7 +1565,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 152 occurrences as of 2026-08-19T20:27:45Z*
+*2-vs-1 -- 152 occurrences as of 2026-08-19T23:14:17Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch), 2026-08-19T00:00:00Z):
 > Not a new question -- already-documented, evidence-backed rust behavior (Claim 6, docs/why_gitgalaxy_beats_ast_here.md: 'structure recall inside opaque macro bodies'). Confirmed directly: all 5 sampled names (get_param, init_access, get_components, from_components, apply) are in bevy/bevy_ecs_macros.rs, inside a `quote! { ... }` proc-macro body (confirmed at source lines 444-460 -- `#path`/`#fields_alias` interpolation syntax is the classic quote! token-generation pattern). These are real Rust function definitions being code-generated by a proc macro; GitGalaxy's regex correctly parses real function syntax wherever it textually appears, including inside macro bodies. tree-sitter-rust and ctags' Rust parser both treat macro_rules!/macro-invocation bodies as opaque token trees and structurally cannot emit function nodes for anything inside one -- not a bug in either, a real grammar limitation. This is exactly why rust is one of the 3 languages (with csharp/fortran) already promoted into ground truth via blind-spot-region detection in the OLD bi-comparison tool (tree_sitter_accuracy_audit.py's _find_blind_spot_ranges) -- this tri-comparison ledger entry is that same, already-understood gap surfacing again under the new 3-tool reconciliation. GitGalaxy is correct; no engine defect, no issue needed. Resolved directly from existing documentation, no fresh dispatch required (tri-comparison-ledger-sweep skill step 1.3).
@@ -1602,7 +1585,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 25 occurrences as of 2026-08-19T20:27:45Z*
+*2-vs-1 -- 25 occurrences as of 2026-08-19T23:14:17Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Same mechanism as the already-resolved rust/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter] shape (Claim 6, docs/why_gitgalaxy_beats_ast_here.md) -- extended from `fn` definitions inside `quote!{}` invocation bodies to `struct` definitions inside `macro_rules!` DEFINITION bodies. All 6 sampled names confirmed, independently re-verified against source (not just the dispatched agent's own read): NonZeroVisitor (line 90), SaturatingVisitor (112), PrimitiveVisitor (136) inside serde/serde_core_de_impls.rs's `impl_deserialize_num!` macro (def starts line 81); SeqVisitor (998), SeqInPlaceVisitor (1036) inside `seq_impl!` (def starts 978); TupleVisitor (1403) inside `tuple_impl_body!` (nested in `tuple_impls!`, def starts 1396). All 6 are real, complete `struct` declarations, each immediately followed by a genuine `impl<'de,...> Visitor<'de> for <Name>` block -- generated once per macro invocation, not fragments or hallucinated matches. tree-sitter and ctags both treat a macro_rules! arm's body as an opaque, unexpanded token tree and structurally cannot emit struct nodes from inside one, for the identical reason they can't see function definitions inside quote!{} bodies. GitGalaxy is correct in all 6 sampled cases; judged (not independently re-confirmed beyond the sample) to generalize to the full 25, all same-shaped serde-crate occurrences. No new tool defect -- Claim 6's doc text already covered this generically (`struct_item` was already named) but had no concrete cited example for this specific shape; added one (docs/why_gitgalaxy_beats_ast_here.md) rather than filing an issue.
@@ -1622,7 +1605,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 21 occurrences as of 2026-08-19T20:27:45Z*
+*2-vs-1 -- 21 occurrences as of 2026-08-19T23:14:17Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together.
@@ -1642,7 +1625,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:45Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T23:14:17Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed structural ctags limitation, not a bug -- resolved directly (no dispatch needed). All 3 sampled names (XRegUnion, FRegUnion, VRegUnion) are real Rust `union { }` declarations (confirmed at wasmtime/wasmtime_pulley_interp.rs:404,529,604), distinct from `struct` -- Rust's less-common C-style unsafe union construct. Ran `ctags --list-kinds-full=Rust` directly: its Rust parser's kind list is macro/method/implementation/enumerator/function/enum/interface/field/module/struct/typedef/variable -- there is NO union kind at all. Confirmed via direct ctags run against this exact file: it correctly finds the wrapping `struct FRegVal(FRegUnion)`-shaped types right next to each missed union, so this isn't a general miss, specifically a missing Rust-union kind. Same category as the already-documented ctags Haskell class-kind gap (tests/tools/ctags_reader.py) -- worth a similar doc note there, not a GitHub issue (nothing to fix, ctags upstream has no union support for this language).
@@ -1655,7 +1638,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:45Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:17Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed via direct ctags run and sibling comparison, resolved directly (no dispatch needed). `done_decode` (wasmtime/wasmtime_pulley_interp.rs:964) has a destructuring-pattern parameter -- `Done { _priv }: Done`, not a simple `name: Type` binding. Ran ctags directly against the file: its IMMEDIATE SIBLING in the same impl block, `debug_assert_done_reason_none` (line 960, same visibility/receiver shape, ordinary `&mut self`-only signature), IS correctly found as a ctags 'method'. done_decode alone is missing from ctags' output. Isolates the cause precisely to the destructuring-pattern parameter -- ctags' regex-based Rust parser appears to fail/skip the whole function when a parameter is a struct pattern rather than a plain identifier binding. GitGalaxy and tree-sitter both handle this fine (both agree on line 964). N=1 in this corpus, plausibly a real, narrow ctags parser gap (not GitGalaxy's) -- not chasing further given the tiny sample, noting rather than filing an issue since there's nothing in this repo to fix.
@@ -1666,7 +1649,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 21 occurrences as of 2026-08-19T20:27:45Z*
+*3-way split -- 21 occurrences as of 2026-08-19T23:14:17Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, not a modeling disagreement -- tree-sitter is correct in all 8 sampled cases (and this generalizes to the full 21: every sampled name is a deserialize_*/spawn_*_caller-shaped signature carrying a rust lifetime annotation, the exact trigger). Root cause, independently confirmed via two methods (dispatched agent read the code path; a second grep pass confirmed the attribute is dead): `gitgalaxy/core/detector.py::StructuralExtractor._count_top_level_args` has a guard meant to exempt rust/scala lifetime marks (`'_`, `'static`) from its string-literal scanner -- `getattr(self, 'language', '') in ('rust', 'scala')` around line 3766 -- but the class stores the language as `self.primary_lang_id` (set at line 497), never `self.language`. `self.language` is referenced NOWHERE ELSE in the file, confirmed by grep. The getattr always silently falls back to `''`, so the exemption guard never fires for any language, ever -- every lifetime `'` gets treated as an unterminated string-literal opener, swallowing all subsequent top-level commas until a real closing quote or end-of-string, fusing 2+ parameters into 1. A signature with 3 lifetime marks (odd count) never exits string mode at all and undercounts every remaining parameter. Real signatures confirmed at source: bevy/bevy_ecs_world.rs:1106,1121,1270 (`MovingPtr<'_, B>` swallows the next comma, 3 vs real 4, or 2 vs real 3); serde/serde_core_de_mod.rs:1105,1115 (`&'static str` swallows the next comma, 2 vs real 3); serde_core_de_mod.rs:1136 (two lifetimes, both trailing commas swallowed, 2 vs real 4); serde_core_de_mod.rs:1152,1163 (three lifetime marks, odd count means string mode never exits, 2 vs real 4). ctags has null coverage for these specific occurrences because they're bodyless trait-method declarations (ending in `;` inside a `trait` block) -- unrelated to the args bug, ctags appears to skip signature-only declarations generally. Filed as its own GitHub issue (attribute-name mismatch, one-line fix: `self.language` -> `self.primary_lang_id`, or equivalent), separate from this ledger record.
@@ -1688,7 +1671,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scala` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 16 occurrences as of 2026-08-19T20:27:47Z*
+*3-way split -- 16 occurrences as of 2026-08-19T23:14:20Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scala/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1709,7 +1692,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scheme` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 92 occurrences as of 2026-08-19T20:27:51Z*
+*2-vs-1 -- 92 occurrences as of 2026-08-19T23:14:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scheme/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1730,7 +1713,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `shell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:53Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`shell/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1742,7 +1725,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `solidity` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:27:54Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T23:14:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`solidity/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1759,7 +1742,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:56Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:28Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1769,7 +1752,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:56Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:28Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1779,7 +1762,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:27:56Z*
+*3-way split -- 1 occurrence as of 2026-08-19T23:14:28Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1791,7 +1774,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:27:57Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T23:14:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1804,7 +1787,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:27:57Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:14:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1815,7 +1798,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:57Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1825,7 +1808,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:57Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1837,7 +1820,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2103 occurrences as of 2026-08-19T20:28:18Z*
+*2-vs-1 -- 2103 occurrences as of 2026-08-19T23:14:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1856,7 +1839,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 515 occurrences as of 2026-08-19T20:28:18Z*
+*2-vs-1 -- 515 occurrences as of 2026-08-19T23:14:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1875,7 +1858,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 175 occurrences as of 2026-08-19T20:28:18Z*
+*2-vs-1 -- 175 occurrences as of 2026-08-19T23:14:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1894,7 +1877,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 61 occurrences as of 2026-08-19T20:28:18Z*
+*2-vs-1 -- 61 occurrences as of 2026-08-19T23:14:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1913,7 +1896,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:28:18Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T23:14:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1930,7 +1913,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:28:18Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T23:14:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1943,7 +1926,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-19T20:28:26Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-19T23:14:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1962,7 +1945,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:28:26Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1972,7 +1955,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:28:26Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T23:14:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 

--- a/docs/self_scan/tri_comparison_points_of_interest.md
+++ b/docs/self_scan/tri_comparison_points_of_interest.md
@@ -8,7 +8,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `agc_assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 760 occurrences as of 2026-08-19T20:11:37Z*
+*2-vs-1 -- 760 occurrences as of 2026-08-19T20:26:16Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`agc_assembly/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -29,7 +29,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `apex` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:11:39Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`apex/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -42,7 +42,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 52 occurrences as of 2026-08-19T20:11:41Z*
+*2-vs-1 -- 52 occurrences as of 2026-08-19T20:26:20Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`assembly/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -61,7 +61,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:11:41Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:26:20Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`assembly/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -77,28 +77,9 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ## c
 
-### ❓ `c` class existence: ctags agree, GitGalaxy, tree-sitter differ
-
-*2-vs-1 -- 23 occurrences as of 2026-08-19T20:11:46Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/ceval.c | `__anon2570bd640108` | *(n/a)* | *(n/a)* | 94 |
-| cpython/dictobject.c | `__anonf1d666540108` | *(n/a)* | *(n/a)* | 5420 |
-| cpython/object.c | `__anone3f65c900108` | *(n/a)* | *(n/a)* | 2973 |
-| cpython/typeobject.c | `__anonb81650120108` | *(n/a)* | *(n/a)* | 3808 |
-| cpython/typeobject.c | `__anonb81650120208` | *(n/a)* | *(n/a)* | 3830 |
-| cpython/typeobject.c | `__anonb81650120308` | *(n/a)* | *(n/a)* | 3936 |
-| cpython/typeobject.c | `__anonb81650120408` | *(n/a)* | *(n/a)* | 4191 |
-| cpython/typeobject.c | `__anonb81650120508` | *(n/a)* | *(n/a)* | 12342 |
-| doom/r_bsp.c | `__anoneeedd6d90108` | *(n/a)* | *(n/a)* | 81 |
-| doom/r_defs.h | `__anond0514f7b0108` | *(n/a)* | *(n/a)* | 72 |
-
 ### ❓ `c` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-19T20:11:46Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-19T20:26:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -117,7 +98,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `c` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-19T20:11:46Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-19T20:26:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -125,7 +106,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 |---|---|---|---|---|
 | cpython/frameobject.c | `kind` | *(n/a)* | 1175 | *(n/a)* |
 | cpython/gc.c | `flagstates` | *(n/a)* | 377 | *(n/a)* |
-| micropython/objtype.c | `_setname_list_t` | *(n/a)* | 980 | *(n/a)* |
+| micropython/objtype.c | `_setname_list_t` | *(n/a)* | 981 | *(n/a)* |
 | sqlite/lemon.c | `option_type` | *(n/a)* | 271 | *(n/a)* |
 | sqlite/lemon.c | `symbol_type` | *(n/a)* | 319 | *(n/a)* |
 | sqlite/lemon.c | `e_assoc` | *(n/a)* | 324 | *(n/a)* |
@@ -135,7 +116,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:11:46Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T20:26:25Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -150,100 +131,9 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | doom/r_bsp.c | `R_CheckBBox` | 381 | 381 | *(n/a)* |
 | doom/r_bsp.c | `R_AddLine` | 259 | 259 | *(n/a)* |
 
-### ❓ `c` function existence: ctags agree, GitGalaxy, tree-sitter differ
-
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:11:46Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/typeobject.c | `RICHCMP_WRAPPER` | *(n/a)* | *(n/a)* | 10099 |
-| cpython/typeobject.c | `SLOT0` | *(n/a)* | *(n/a)* | 10626 |
-| cpython/typeobject.c | `SLOT0` | *(n/a)* | *(n/a)* | 10682 |
-| cpython/typeobject.c | `SLOT0` | *(n/a)* | *(n/a)* | 10728 |
-| cpython/typeobject.c | `SLOT1` | *(n/a)* | *(n/a)* | 10542 |
-| cpython/typeobject.c | `SLOT1` | *(n/a)* | *(n/a)* | 10703 |
-| cpython/typeobject.c | `SLOT1BINFULL` | *(n/a)* | *(n/a)* | 10575 |
-
-### ❓ `c` function existence: GitGalaxy agree, tree-sitter, ctags differ
-
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:11:46Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/typeobject.c | `slot_tp_hash` | 10730 | *(n/a)* | *(n/a)* |
-| cpython/typeobject.c | `slot_mp_ass_subscript` | 10544 | *(n/a)* | *(n/a)* |
-| cpython/typeobject.c | `slot_tp_repr` | 10714 | *(n/a)* | *(n/a)* |
-| cpython/typeobject.c | `slot_nb_inplace_power` | 10697 | *(n/a)* | *(n/a)* |
-
-### ❓ `c` function existence: tree-sitter, ctags agree, GitGalaxy differ
-
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:11:46Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 300 | 300 |
-| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 320 | 320 |
-| micropython/vm.c | `MICROPY_WRAP_MP_EXECUTE_BYTECODE` | *(n/a)* | 220 | 220 |
-
-### ❓ `c` function args: GitGalaxy, ctags agree, tree-sitter differ
-
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:11:46Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`c/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| micropython/gc.c | `gc_mark_subtree` | 2 | 1 | 2 |
-
-### ✅ `c` class existence: tree-sitter agree, GitGalaxy, ctags differ
-
-*2-vs-1 -- 525 occurrences as of 2026-08-19T20:11:46Z*
-
-**Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
-> Confirmed tooling defect in tri_comparison_gatherer.py's own raw tree-sitter walk, now fixed -- not a GitGalaxy defect (GitGalaxy and ctags are both correct in every sampled case). Independently verified all 8 sampled cases (7 distinct source lines, one -- compile.c:223 -- has both a declaration and a cast on the same line, explaining the duplicate sample) against real source: every single one is a pointer declaration, function parameter, or cast referencing an ALREADY-DEFINED struct type (`struct compiler_unit *u`, `(struct compiler_unit *)ptr`, etc.), never a `struct X { ... } ` definition. tree-sitter-c's `struct_specifier`/`union_specifier`/`enum_specifier` node type covers both a real definition and a bare type reference, distinguished only by whether the node has a `body` field -- `_walk_tree_sitter` counted every matching node type without checking for a body, so it counted every REFERENCE as a new class. `tests/tools/tree_sitter_accuracy_audit.py`'s own walk() already has this exact fix for C (`lang == 'c' and node.child_by_field_name('body') is None: pass`) -- ported the identical check into `_walk_tree_sitter`, same shape as the earlier haskell clause-splitting fix in this same file (a case where the newer, simpler walk didn't reuse a drop-rule the older tool already had, because it structurally can't apply the SAME reasoning that excludes ground-truth judgment calls -- a node's own `body` field is a neutral structural fact, not a cross-tool ground-truth call). Fix verified: this is the single largest shape in the entire ledger (525 occurrences, all from the same mechanism given how common struct-pointer usage is in idiomatic C), so this one fix plausibly clears most of it. No GitHub issue needed -- fixed directly in this same commit.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/ceval.c | `_py_code_state` | *(n/a)* | 3577 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 101 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 187 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 223 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 223 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 239 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 247 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 251 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 263 | *(n/a)* |
-| cpython/compile.c | `compiler_unit` | *(n/a)* | 586 | *(n/a)* |
-
-### ✅ `c` function args: GitGalaxy, tree-sitter agree, ctags differ
-
-*2-vs-1 -- 104 occurrences as of 2026-08-19T20:11:46Z*
-
-**Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
-> Not a GitGalaxy or ctags defect -- a bug in this tool's OWN _count_ctags_signature_params (tri_comparison_gatherer.py), now fixed. Confirmed directly: ran ctags against cpython/ceval.c, PyEval_GetLocals(void)'s raw signature field is literally the text '(void)'. GitGalaxy and tree-sitter both already special-case C's explicit empty-parameter-list idiom (0 real args, matching detector.py's own _count_top_level_args docstring) -- _count_ctags_signature_params did not, splitting '(void)' into one non-empty segment and counting it as 1 real parameter (the same class of bug its own docstring already describes fixing twice for Python's trailing-comma and bare * / marker cases). Added 'void' to the segment-exclusion set alongside the existing '*'/'/'/'**' -- verified fix: _count_ctags_signature_params('(void)') now returns 0. This corpus (cpython) uses the (void) idiom extremely heavily, plausibly explaining most/all of the 104 occurrences; not independently re-verified beyond the sample, but the mechanism is unconditional (any '(void)' signature was miscounted the same way, corpus-wide) so high confidence it generalizes. No GitHub issue needed -- fixed directly in this same commit, not a repo-code defect.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| cpython/ceval.c | `PyEval_GetLocals` | 0 | 0 | 1 |
-| cpython/ceval.c | `_PyEval_GetFrameLocals` | 0 | 0 | 1 |
-| cpython/ceval.c | `PyEval_GetFrame` | 0 | 0 | 1 |
-| cpython/ceval.c | `PyEval_GetFrameGlobals` | 0 | 0 | 1 |
-| cpython/ceval.c | `Py_GetRecursionLimit` | 0 | 0 | 1 |
-| cpython/ceval.c | `_PyEval_GetCoroutineOriginTrackingDepth` | 0 | 0 | 1 |
-| cpython/ceval.c | `_PyEval_GetAsyncGenFirstiter` | 0 | 0 | 1 |
-| cpython/ceval.c | `_PyEval_GetAsyncGenFinalizer` | 0 | 0 | 1 |
-| cpython/ceval.c | `_PyEval_GetFrame` | 0 | 0 | 1 |
-| cpython/ceval.c | `PyEval_GetBuiltins` | 0 | 0 | 1 |
-
 ### ✅ `c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 74 occurrences as of 2026-08-19T20:11:46Z*
+*2-vs-1 -- 74 occurrences as of 2026-08-19T20:26:25Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed, independently verified all 6 sampled names against real source -- GitGalaxy and ctags both correct, tree-sitter over-recalling from two related but distinct preprocessor-driven mechanisms, both already covered by existing infrastructure: (1) keyword/macro misparse -- 'if' (dictobject.c:522-527, an `#if SIZEOF_VOID_P > 4` / `else if` sequence desyncs the parse) and 'DICT___REVERSED___METHODDEF' (dictobject.c:5102, a PyMethodDef array-initializer macro, not a definition) are both ALREADY in tree_sitter_accuracy_audit.py's `_C_KNOWN_MACRO_HALLUCINATIONS` exclusion set (confirmed by reading it directly) -- this tri-comparison tool's raw walk deliberately doesn't apply that list (it's a curated, ground-truth-shaped judgment call, appropriately left to reconciliation per this module's own stated design, not baked into the walk). (2) dead #if 0 code -- '_PyObject_ManagedDictValidityCheck' (dictobject.c:7396) and 'tos_char'/'print_stack'/'print_stacks' (frameobject.c:1264-1313) are genuinely well-formed function definitions sitting entirely inside `#if 0 ... #endif` guards; tree-sitter has no preprocessor model and parses the dead branch as live code. Both mechanisms are already the exact shape docs/why_gitgalaxy_beats_ast_here.md's Claim 8 names generically ('a dead #if 0 block... macro definitions... that merely look structural') -- added these 4 new concrete citations to Claim 8's evidence section rather than treating this as a new finding. No GitHub issue -- both tools already behave as intended; this is expected, already-documented tree-sitter preprocessor-blindness surfacing under the new tri-comparison reconciliation, not a fresh defect.
@@ -261,11 +151,86 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | cpython/object.c | `if` | *(n/a)* | 1272 | *(n/a)* |
 | micropython/gc.c | `if` | *(n/a)* | 1353 | *(n/a)* |
 
+### ✅ `c` class existence: ctags agree, GitGalaxy, tree-sitter differ
+
+*2-vs-1 -- 23 occurrences as of 2026-08-19T20:26:25Z*
+
+**Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
+> Confirmed tooling gap, now fixed -- not a GitGalaxy or tree-sitter defect. Every one of the 10 sampled names (__anon2570bd640108, __anonf1d666540108, etc.) is ctags' own synthesized placeholder name for an anonymous struct/union/enum, confirmed directly: cpython/ceval.c's __anon2570bd640108 backs a real `typedef struct { ... }` (the platform pthread-attr shim at line ~94) with no name in the source. GitGalaxy and tree-sitter both correctly report nothing (there is no real name to report); ctags synthesizes one for its own internal bookkeeping. Same category as GitGalaxy's own _SYNTHETIC_GG_CLASS_NAMES exclusion, just on ctags' side -- added _is_ctags_synthetic_anon_name() to tri_comparison_gatherer.py (matches ctags' documented __anon<hex> naming convention, applied to both func and class ctags readings) and documented in ctags_reader.py alongside its existing per-language notes. Generalizes to the full 23 by construction (a structural naming-pattern match, not a per-instance judgment).
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| cpython/ceval.c | `__anon2570bd640108` | *(n/a)* | *(n/a)* | 94 |
+| cpython/dictobject.c | `__anonf1d666540108` | *(n/a)* | *(n/a)* | 5420 |
+| cpython/object.c | `__anone3f65c900108` | *(n/a)* | *(n/a)* | 2973 |
+| cpython/typeobject.c | `__anonb81650120108` | *(n/a)* | *(n/a)* | 3808 |
+| cpython/typeobject.c | `__anonb81650120208` | *(n/a)* | *(n/a)* | 3830 |
+| cpython/typeobject.c | `__anonb81650120308` | *(n/a)* | *(n/a)* | 3936 |
+| cpython/typeobject.c | `__anonb81650120408` | *(n/a)* | *(n/a)* | 4191 |
+| cpython/typeobject.c | `__anonb81650120508` | *(n/a)* | *(n/a)* | 12342 |
+| doom/r_bsp.c | `__anoneeedd6d90108` | *(n/a)* | *(n/a)* | 81 |
+| doom/r_defs.h | `__anond0514f7b0108` | *(n/a)* | *(n/a)* | 72 |
+
+### ✅ `c` function existence: ctags agree, GitGalaxy, tree-sitter differ
+
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:26:25Z*
+
+**Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
+> Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| cpython/typeobject.c | `RICHCMP_WRAPPER` | *(n/a)* | *(n/a)* | 10099 |
+| cpython/typeobject.c | `SLOT0` | *(n/a)* | *(n/a)* | 10626 |
+| cpython/typeobject.c | `SLOT0` | *(n/a)* | *(n/a)* | 10682 |
+| cpython/typeobject.c | `SLOT0` | *(n/a)* | *(n/a)* | 10728 |
+| cpython/typeobject.c | `SLOT1` | *(n/a)* | *(n/a)* | 10542 |
+| cpython/typeobject.c | `SLOT1` | *(n/a)* | *(n/a)* | 10703 |
+| cpython/typeobject.c | `SLOT1BINFULL` | *(n/a)* | *(n/a)* | 10575 |
+
+### ✅ `c` function existence: GitGalaxy agree, tree-sitter, ctags differ
+
+*2-vs-1 -- 4 occurrences as of 2026-08-19T20:26:25Z*
+
+**Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
+> Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| cpython/typeobject.c | `slot_tp_hash` | 10730 | *(n/a)* | *(n/a)* |
+| cpython/typeobject.c | `slot_mp_ass_subscript` | 10544 | *(n/a)* | *(n/a)* |
+| cpython/typeobject.c | `slot_tp_repr` | 10714 | *(n/a)* | *(n/a)* |
+| cpython/typeobject.c | `slot_nb_inplace_power` | 10697 | *(n/a)* | *(n/a)* |
+
+### ✅ `c` function existence: tree-sitter, ctags agree, GitGalaxy differ
+
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:25Z*
+
+**Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
+> Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 300 | 300 |
+| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 320 | 320 |
+| micropython/vm.c | `MICROPY_WRAP_MP_EXECUTE_BYTECODE` | *(n/a)* | 220 | 220 |
+
+### ✅ `c` function args: GitGalaxy, ctags agree, tree-sitter differ
+
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:25Z*
+
+**Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
+> Not a tool defect on either side -- an inherent CPP-conditional-compilation ambiguity. gc_mark_subtree is declared AND defined twice in micropython/gc.c, once under `#if MICROPY_GC_SPLIT_HEAP` (2 args: area, block -- lines 137/501) and once under the matching `#else` (1 arg: block -- lines 139/503). Neither signature is more 'real' than the other -- which one actually compiles depends on a macro none of these three tools evaluates (no real preprocessor run in any of them). GG and ctags happened to align on the 2-arg branch, tree-sitter on the 1-arg branch; this is a coin-flip of which #if branch a tool's occurrence-matching happens to pick up, not a real disagreement about ground truth. N=1 in this corpus -- not chased further given the tiny sample and the ambiguity being structural rather than a bug.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| micropython/gc.c | `gc_mark_subtree` | 2 | 1 | 2 |
+
 ## cobol
 
 ### ❓ `cobol` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 133 occurrences as of 2026-08-19T20:11:51Z*
+*2-vs-1 -- 133 occurrences as of 2026-08-19T20:26:31Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cobol/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -284,7 +249,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cobol` class existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 19 occurrences as of 2026-08-19T20:11:51Z*
+*2-vs-1 -- 19 occurrences as of 2026-08-19T20:26:31Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cobol/class/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -303,7 +268,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cobol` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 18 occurrences as of 2026-08-19T20:11:51Z*
+*2-vs-1 -- 18 occurrences as of 2026-08-19T20:26:31Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cobol/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -324,7 +289,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1270 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 1270 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -343,7 +308,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1061 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 1061 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -362,7 +327,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 120 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 120 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -381,7 +346,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 98 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 98 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -400,7 +365,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 70 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 70 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -419,7 +384,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 24 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 24 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -438,7 +403,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 22 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 22 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -457,7 +422,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -469,7 +434,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -480,7 +445,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -490,7 +455,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:11:56Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -500,7 +465,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:11:56Z*
+*3-way split -- 1 occurrence as of 2026-08-19T20:26:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -512,7 +477,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 271 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 271 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -531,7 +496,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 107 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 107 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -550,7 +515,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 48 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 48 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -569,7 +534,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -585,7 +550,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -600,7 +565,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 5 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 5 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -614,7 +579,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -627,7 +592,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -640,7 +605,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -652,7 +617,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -662,7 +627,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -672,7 +637,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:02Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -682,7 +647,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:12:02Z*
+*3-way split -- 1 occurrence as of 2026-08-19T20:26:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -694,7 +659,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `css` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:12:03Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:26:42Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`css/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -708,7 +673,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 37 occurrences as of 2026-08-19T20:12:07Z*
+*2-vs-1 -- 37 occurrences as of 2026-08-19T20:26:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -727,7 +692,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 18 occurrences as of 2026-08-19T20:12:07Z*
+*2-vs-1 -- 18 occurrences as of 2026-08-19T20:26:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -746,7 +711,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 216 occurrences as of 2026-08-19T20:12:07Z*
+*3-way split -- 216 occurrences as of 2026-08-19T20:26:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -767,7 +732,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 14 occurrences as of 2026-08-19T20:12:13Z*
+*2-vs-1 -- 14 occurrences as of 2026-08-19T20:26:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -786,7 +751,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:12:13Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T20:26:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -803,7 +768,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:12:13Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -814,7 +779,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:12:13Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -825,7 +790,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:12:13Z*
+*3-way split -- 1 occurrence as of 2026-08-19T20:26:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -837,7 +802,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `go` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 75 occurrences as of 2026-08-19T20:12:15Z*
+*2-vs-1 -- 75 occurrences as of 2026-08-19T20:26:55Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`go/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -858,7 +823,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 103 occurrences as of 2026-08-19T20:12:18Z*
+*2-vs-1 -- 103 occurrences as of 2026-08-19T20:26:57Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > All 10 sampled cases are ctags-side artifacts, not real GitGalaxy/tree-sitter misses -- confirmed via direct `ctags -x` output against the corpus. Three distinct ctags Haskell-parser weaknesses cover the sample: (1) multi-clause double/triple-tagging -- ctags tags every pattern-matched equation line as its own occurrence of the name (writerFn/writeFnBinary/expandFilterPath: confirmed 2-3 raw ctags tags per function, one per clause; a file-wide count found 45 such extra same-name tags across the 7-file corpus, e.g. blockToInlines alone has 14). GitGalaxy/tree-sitter both correctly anchor to the FIRST clause only, leaving ctags' later-clause tags as the ones unpaired. (2) keyword-as-identifier misparsing -- `class`/`where`/`pattern` (from PatternSynonyms) get tagged as function names when ctags fails to parse past the keyword; confirmed at Options.hs:62 (`class HasSyntaxExtensions`), Parsing.hs:184 (module-header `where`), and 3 PatternSynonyms declarations in Options.hs. (3) CAF/value-vs-function kind collapse -- defaultAbbrevs/defaultKaTeXURL/defaultMathJaxURL/defaultWebTeXURL are zero-arg top-level VALUES (non-arrow type signatures), not functions; ctags has no value/variable kind at all (`ctags --list-kinds-full=Haskell` shows only constructor/function/module/type) so it lumps every `name = expr` binding into "function". GitGalaxy (language_standards.py haskell rules, #1312) and tree-sitter's own audit tooling (_find_haskell_signature_for_bind, #1566) both independently make the same value-vs-function distinction correctly -- real cross-tool corroboration, not coincidence. (4) TH-splice call sites misread as definitions -- deriveJSON at Options.hs:454/458 is a Template Haskell splice INVOKING an imported function, not defining one; ctags misparses the call as a definition. No GitGalaxy/tree-sitter defect anywhere in this shape; purely a ctags parser limitation, same category as the already-documented empty CTAGS_CLASS_KINDS['haskell'].
@@ -878,7 +843,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 69 occurrences as of 2026-08-19T20:12:18Z*
+*2-vs-1 -- 69 occurrences as of 2026-08-19T20:26:57Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > Confirmed: all 10 sampled misses (and, by cross-check against additional non-sampled instances in Options.hs/Shared.hs, plausibly all 69) are locally-scoped function definitions -- `instance ... where` methods, `where`-clause helpers, or `let`-bound names inside `do` blocks -- never top-level module definitions. ctags' Haskell parser has no layout-rule/scope awareness and only tags equations anchored at column 1; it correctly handles multi-clause TOP-LEVEL definitions (verified via expandFilterPath, writeFnBinary, writerFn -- all tag fine, clauses and all), so this is a pure scope blind spot, not a clause-counting bug (distinct from the tree-sitter clause-splitting bug fixed earlier in this same effort, which shares 2 of the 10 sample names by coincidence of subject matter, not root cause). GitGalaxy and tree-sitter are both correct; ctags is not wrong so much as structurally incapable of seeing these. Known, expected limitation of ctags' Haskell parser, now documented alongside its existing Haskell notes in tests/tools/ctags_reader.py -- not a GitHub issue, nothing in this repo to fix.
@@ -898,7 +863,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-19T20:12:18Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-19T20:26:57Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Not a real discrepancy -- structural tooling gap, already documented in the codebase. tests/tools/ctags_reader.py:39-40,228 sets CTAGS_CLASS_KINDS['haskell'] = set() on purpose: "ctags' Haskell parser has no class-shaped kind at all (constructor/function/module/type only)". Every example in this shape (data/newtype/class declarations -- ReaderOptions, CiteMethod, HasSyntaxExtensions, etc.) is real; ctags structurally cannot report any of them for this language, not a sample-specific miss. No action needed beyond this note.
@@ -918,7 +883,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:12:18Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:26:57Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Mixed shape, resolved by reading both of the 2 occurrences directly (no larger sample needed). (1) Options.hs:438 getExtensions -- real function, `instance HasSyntaxExtensions WriterOptions where getExtensions opts = writerExtensions opts`. A sibling instance for ReaderOptions at Options.hs:80 has the identical shape. Tree-sitter's Haskell grammar doesn't expose typeclass-instance-method clause bodies the way it does top-level bindings, and ctags' Haskell parser has no instance-method kind either -- GitGalaxy is correct, both other tools have a real recall gap on typeclass instance methods. (2) Shared.hs:475 extensionEnabled -- NOT a real function. Imported from Text.Pandoc.Extensions (Shared.hs:114), only ever appears as a guard-clause call (`| extensionEnabled Ext_gfm_auto_identifiers exts = ...`). GitGalaxy's regex misreads a guard-clause invocation as a definition -- genuine GitGalaxy false positive, worth its own engine bug against language_standards.py's haskell func_start rule.
@@ -930,7 +895,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 9 occurrences as of 2026-08-19T20:12:18Z*
+*3-way split -- 9 occurrences as of 2026-08-19T20:26:57Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > One systematic cause, confirmed by reading source for 3 of the 9 (getMetadataFromFiles App.hs:395-397, splitTextByIndices Shared.hs:142-143, tabFilter Shared.hs:256-259) and consistent with the shape of the remaining 6. Every case is a point-free/eta-reduced Haskell equation: the type signature declares N params, but the specific clause GitGalaxy and tree-sitter both align to only explicitly binds N-1 of them, handling the trailing argument via composition (`.`) or `\case`. GitGalaxy counts arity from the full type signature (the true logical arity); tree-sitter's declaration-only reading counts only the clause's explicitly-bound patterns (correct for that one equation, but undercounts true arity). Neither reader is wrong about what it's measuring -- same shape as Claim 1 in docs/why_gitgalaxy_beats_ast_here.md. GitGalaxy's answer is arguably the more useful coupling signal; recommend documenting as a candidate Claim rather than treating as an engine defect to fix toward matching tree-sitter.
@@ -951,7 +916,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 315 occurrences as of 2026-08-19T20:12:21Z*
+*2-vs-1 -- 315 occurrences as of 2026-08-19T20:27:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -970,7 +935,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 28 occurrences as of 2026-08-19T20:12:21Z*
+*2-vs-1 -- 28 occurrences as of 2026-08-19T20:27:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -989,7 +954,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:12:21Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1003,7 +968,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 528 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 528 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1022,7 +987,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 183 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 183 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1041,7 +1006,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 104 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 104 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1060,7 +1025,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 67 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 67 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1079,7 +1044,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1098,7 +1063,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1115,7 +1080,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:12:24Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1133,7 +1098,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-19T20:12:27Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-19T20:27:05Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1152,7 +1117,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:12:27Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:05Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1164,7 +1129,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:27Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:05Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1176,7 +1141,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `m4` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 48 occurrences as of 2026-08-19T20:12:33Z*
+*2-vs-1 -- 48 occurrences as of 2026-08-19T20:27:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`m4/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1195,7 +1160,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `m4` class existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:12:33Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T20:27:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`m4/class/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1208,7 +1173,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `m4` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:33Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`m4/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1220,7 +1185,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `makefile` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:34Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`makefile/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1232,7 +1197,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `matlab` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:12:36Z*
+*3-way split -- 1 occurrence as of 2026-08-19T20:27:15Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`matlab/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1244,7 +1209,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 120 occurrences as of 2026-08-19T20:12:37Z*
+*2-vs-1 -- 120 occurrences as of 2026-08-19T20:27:16Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1263,7 +1228,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 71 occurrences as of 2026-08-19T20:12:37Z*
+*2-vs-1 -- 71 occurrences as of 2026-08-19T20:27:16Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1282,7 +1247,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:12:37Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:27:16Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1293,7 +1258,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:37Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:16Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1305,7 +1270,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 122 occurrences as of 2026-08-19T20:12:43Z*
+*2-vs-1 -- 122 occurrences as of 2026-08-19T20:27:23Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1324,7 +1289,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:12:43Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:23Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1340,7 +1305,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:12:43Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:23Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1356,7 +1321,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:43Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:23Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1366,7 +1331,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:43Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:23Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1376,7 +1341,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 64 occurrences as of 2026-08-19T20:12:43Z*
+*3-way split -- 64 occurrences as of 2026-08-19T20:27:23Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1397,7 +1362,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 68 occurrences as of 2026-08-19T20:12:48Z*
+*2-vs-1 -- 68 occurrences as of 2026-08-19T20:27:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1416,7 +1381,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:48Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1426,7 +1391,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:48Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1438,7 +1403,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-19T20:12:50Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-19T20:27:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1457,7 +1422,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-19T20:12:50Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-19T20:27:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1473,7 +1438,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:50Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1483,7 +1448,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 5 occurrences as of 2026-08-19T20:12:50Z*
+*3-way split -- 5 occurrences as of 2026-08-19T20:27:30Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1499,7 +1464,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 68 occurrences as of 2026-08-19T20:12:59Z*
+*2-vs-1 -- 68 occurrences as of 2026-08-19T20:27:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1518,7 +1483,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 32 occurrences as of 2026-08-19T20:12:59Z*
+*2-vs-1 -- 32 occurrences as of 2026-08-19T20:27:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1537,7 +1502,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:12:59Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T20:27:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1550,7 +1515,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:12:59Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1562,7 +1527,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:13:01Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T20:27:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1577,7 +1542,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:13:01Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T20:27:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1592,7 +1557,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:13:01Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1604,7 +1569,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:13:01Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:27:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1617,7 +1582,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 152 occurrences as of 2026-08-19T20:13:05Z*
+*2-vs-1 -- 152 occurrences as of 2026-08-19T20:27:45Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch), 2026-08-19T00:00:00Z):
 > Not a new question -- already-documented, evidence-backed rust behavior (Claim 6, docs/why_gitgalaxy_beats_ast_here.md: 'structure recall inside opaque macro bodies'). Confirmed directly: all 5 sampled names (get_param, init_access, get_components, from_components, apply) are in bevy/bevy_ecs_macros.rs, inside a `quote! { ... }` proc-macro body (confirmed at source lines 444-460 -- `#path`/`#fields_alias` interpolation syntax is the classic quote! token-generation pattern). These are real Rust function definitions being code-generated by a proc macro; GitGalaxy's regex correctly parses real function syntax wherever it textually appears, including inside macro bodies. tree-sitter-rust and ctags' Rust parser both treat macro_rules!/macro-invocation bodies as opaque token trees and structurally cannot emit function nodes for anything inside one -- not a bug in either, a real grammar limitation. This is exactly why rust is one of the 3 languages (with csharp/fortran) already promoted into ground truth via blind-spot-region detection in the OLD bi-comparison tool (tree_sitter_accuracy_audit.py's _find_blind_spot_ranges) -- this tri-comparison ledger entry is that same, already-understood gap surfacing again under the new 3-tool reconciliation. GitGalaxy is correct; no engine defect, no issue needed. Resolved directly from existing documentation, no fresh dispatch required (tri-comparison-ledger-sweep skill step 1.3).
@@ -1637,7 +1602,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 25 occurrences as of 2026-08-19T20:13:05Z*
+*2-vs-1 -- 25 occurrences as of 2026-08-19T20:27:45Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Same mechanism as the already-resolved rust/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter] shape (Claim 6, docs/why_gitgalaxy_beats_ast_here.md) -- extended from `fn` definitions inside `quote!{}` invocation bodies to `struct` definitions inside `macro_rules!` DEFINITION bodies. All 6 sampled names confirmed, independently re-verified against source (not just the dispatched agent's own read): NonZeroVisitor (line 90), SaturatingVisitor (112), PrimitiveVisitor (136) inside serde/serde_core_de_impls.rs's `impl_deserialize_num!` macro (def starts line 81); SeqVisitor (998), SeqInPlaceVisitor (1036) inside `seq_impl!` (def starts 978); TupleVisitor (1403) inside `tuple_impl_body!` (nested in `tuple_impls!`, def starts 1396). All 6 are real, complete `struct` declarations, each immediately followed by a genuine `impl<'de,...> Visitor<'de> for <Name>` block -- generated once per macro invocation, not fragments or hallucinated matches. tree-sitter and ctags both treat a macro_rules! arm's body as an opaque, unexpanded token tree and structurally cannot emit struct nodes from inside one, for the identical reason they can't see function definitions inside quote!{} bodies. GitGalaxy is correct in all 6 sampled cases; judged (not independently re-confirmed beyond the sample) to generalize to the full 25, all same-shaped serde-crate occurrences. No new tool defect -- Claim 6's doc text already covered this generically (`struct_item` was already named) but had no concrete cited example for this specific shape; added one (docs/why_gitgalaxy_beats_ast_here.md) rather than filing an issue.
@@ -1657,7 +1622,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 21 occurrences as of 2026-08-19T20:13:05Z*
+*2-vs-1 -- 21 occurrences as of 2026-08-19T20:27:45Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together.
@@ -1677,7 +1642,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-19T20:13:05Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-19T20:27:45Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed structural ctags limitation, not a bug -- resolved directly (no dispatch needed). All 3 sampled names (XRegUnion, FRegUnion, VRegUnion) are real Rust `union { }` declarations (confirmed at wasmtime/wasmtime_pulley_interp.rs:404,529,604), distinct from `struct` -- Rust's less-common C-style unsafe union construct. Ran `ctags --list-kinds-full=Rust` directly: its Rust parser's kind list is macro/method/implementation/enumerator/function/enum/interface/field/module/struct/typedef/variable -- there is NO union kind at all. Confirmed via direct ctags run against this exact file: it correctly finds the wrapping `struct FRegVal(FRegUnion)`-shaped types right next to each missed union, so this isn't a general miss, specifically a missing Rust-union kind. Same category as the already-documented ctags Haskell class-kind gap (tests/tools/ctags_reader.py) -- worth a similar doc note there, not a GitHub issue (nothing to fix, ctags upstream has no union support for this language).
@@ -1690,7 +1655,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:05Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:45Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed via direct ctags run and sibling comparison, resolved directly (no dispatch needed). `done_decode` (wasmtime/wasmtime_pulley_interp.rs:964) has a destructuring-pattern parameter -- `Done { _priv }: Done`, not a simple `name: Type` binding. Ran ctags directly against the file: its IMMEDIATE SIBLING in the same impl block, `debug_assert_done_reason_none` (line 960, same visibility/receiver shape, ordinary `&mut self`-only signature), IS correctly found as a ctags 'method'. done_decode alone is missing from ctags' output. Isolates the cause precisely to the destructuring-pattern parameter -- ctags' regex-based Rust parser appears to fail/skip the whole function when a parameter is a struct pattern rather than a plain identifier binding. GitGalaxy and tree-sitter both handle this fine (both agree on line 964). N=1 in this corpus, plausibly a real, narrow ctags parser gap (not GitGalaxy's) -- not chasing further given the tiny sample, noting rather than filing an issue since there's nothing in this repo to fix.
@@ -1701,7 +1666,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 21 occurrences as of 2026-08-19T20:13:05Z*
+*3-way split -- 21 occurrences as of 2026-08-19T20:27:45Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, not a modeling disagreement -- tree-sitter is correct in all 8 sampled cases (and this generalizes to the full 21: every sampled name is a deserialize_*/spawn_*_caller-shaped signature carrying a rust lifetime annotation, the exact trigger). Root cause, independently confirmed via two methods (dispatched agent read the code path; a second grep pass confirmed the attribute is dead): `gitgalaxy/core/detector.py::StructuralExtractor._count_top_level_args` has a guard meant to exempt rust/scala lifetime marks (`'_`, `'static`) from its string-literal scanner -- `getattr(self, 'language', '') in ('rust', 'scala')` around line 3766 -- but the class stores the language as `self.primary_lang_id` (set at line 497), never `self.language`. `self.language` is referenced NOWHERE ELSE in the file, confirmed by grep. The getattr always silently falls back to `''`, so the exemption guard never fires for any language, ever -- every lifetime `'` gets treated as an unterminated string-literal opener, swallowing all subsequent top-level commas until a real closing quote or end-of-string, fusing 2+ parameters into 1. A signature with 3 lifetime marks (odd count) never exits string mode at all and undercounts every remaining parameter. Real signatures confirmed at source: bevy/bevy_ecs_world.rs:1106,1121,1270 (`MovingPtr<'_, B>` swallows the next comma, 3 vs real 4, or 2 vs real 3); serde/serde_core_de_mod.rs:1105,1115 (`&'static str` swallows the next comma, 2 vs real 3); serde_core_de_mod.rs:1136 (two lifetimes, both trailing commas swallowed, 2 vs real 4); serde_core_de_mod.rs:1152,1163 (three lifetime marks, odd count means string mode never exits, 2 vs real 4). ctags has null coverage for these specific occurrences because they're bodyless trait-method declarations (ending in `;` inside a `trait` block) -- unrelated to the args bug, ctags appears to skip signature-only declarations generally. Filed as its own GitHub issue (attribute-name mismatch, one-line fix: `self.language` -> `self.primary_lang_id`, or equivalent), separate from this ledger record.
@@ -1723,7 +1688,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scala` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 16 occurrences as of 2026-08-19T20:13:07Z*
+*3-way split -- 16 occurrences as of 2026-08-19T20:27:47Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scala/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1744,7 +1709,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scheme` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 92 occurrences as of 2026-08-19T20:13:11Z*
+*2-vs-1 -- 92 occurrences as of 2026-08-19T20:27:51Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scheme/function/existence/agree[ctags]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1765,7 +1730,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `shell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:13Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:53Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`shell/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1777,7 +1742,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `solidity` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-19T20:13:14Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-19T20:27:54Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`solidity/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1794,7 +1759,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:15Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1804,7 +1769,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:15Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1814,7 +1779,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-19T20:13:15Z*
+*3-way split -- 1 occurrence as of 2026-08-19T20:27:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1826,7 +1791,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-19T20:13:17Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-19T20:27:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1839,7 +1804,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:13:17Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:27:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1850,7 +1815,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:17Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1860,7 +1825,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:17Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:27:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1872,7 +1837,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2103 occurrences as of 2026-08-19T20:13:38Z*
+*2-vs-1 -- 2103 occurrences as of 2026-08-19T20:28:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1891,7 +1856,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 515 occurrences as of 2026-08-19T20:13:38Z*
+*2-vs-1 -- 515 occurrences as of 2026-08-19T20:28:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1910,7 +1875,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 175 occurrences as of 2026-08-19T20:13:38Z*
+*2-vs-1 -- 175 occurrences as of 2026-08-19T20:28:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1929,7 +1894,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 61 occurrences as of 2026-08-19T20:13:38Z*
+*2-vs-1 -- 61 occurrences as of 2026-08-19T20:28:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1948,7 +1913,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-19T20:13:38Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-19T20:28:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1965,7 +1930,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-19T20:13:38Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-19T20:28:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1978,7 +1943,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-19T20:13:46Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-19T20:28:26Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1997,7 +1962,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:46Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:28:26Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -2007,7 +1972,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-19T20:13:46Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-19T20:28:26Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 

--- a/docs/why_gitgalaxy_beats_ast_here.md
+++ b/docs/why_gitgalaxy_beats_ast_here.md
@@ -280,6 +280,23 @@ Fixed in `tests/tools/tree_sitter_accuracy_audit.py`'s `measure()` (`walk()` clo
 GitGalaxy's engine — this is purely a measurement-tool correction; GitGalaxy's own detected
 function set for this corpus is byte-for-byte identical before and after.
 
+## A third confirmed instance: C, local single-function recovery (2026-08-19)
+
+A narrower version of this same mechanism, found via the tri-comparison ledger
+(`c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`, 4 occurrences,
+`cpython/typeobject.c`): a bare macro-invocation LINE at file scope with no expansion available to
+a raw grammar walk (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str,
+__str__)` — real CPython macros that generate a wrapper function, but aren't themselves valid
+freestanding C without expansion) locally confuses both tree-sitter's and ctags' parse of the
+SINGLE function immediately following it. Confirmed directly at 4 sites, same shape every time —
+`slot_mp_ass_subscript` (line 10544), `slot_nb_inplace_power` (10697), `slot_tp_repr` (10714),
+`slot_tp_hash` (10730) are all ordinary, unremarkable `static ... name(...) { ... }` definitions
+with nothing unusual about them individually; each sits directly after one of these bare macro
+lines. GitGalaxy's regex has no such adjacency sensitivity and finds all 4 correctly; ctags and
+tree-sitter both miss all 4. Unlike the csharp/javascript cascades above, this recovers
+immediately (only the one adjacent function is lost, not everything downstream) — a third,
+narrower recovery shape worth naming alongside the other two rather than assuming either.
+
 ## Where Claim 3 does NOT apply
 
 - This is a grammar-*implementation* limitation (a specific parser version's bug/gap on one

--- a/docs/why_gitgalaxy_beats_ast_here.md
+++ b/docs/why_gitgalaxy_beats_ast_here.md
@@ -493,6 +493,20 @@ For codebases that rely heavily on C Preprocessor (CPP) directives, grammar-base
 
 **The evidence:** The `tree-sitter-fortran` ground truth parser completely fails on files that rely heavily on C Preprocessor directives (like `#if ( EM_CORE == 1 )` in the WRF corpus), throwing errors and missing entire sections of code that contain valid functions. GitGalaxy is completely unaffected by the CPP noise and extracts these subroutines perfectly, resulting in false positive 'extra functions' reported by the audit.
 
+**C instance, narrower in scale (2026-08-19, tri-comparison ledger
+`c/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`, 13 occurrences):** where Fortran's
+gap swallows entire trailing sections of a file, tree-sitter-c's version is local -- one function
+lost per trigger, not a cascading region -- but the same "CPP directive breaks the grammar's parse"
+root cause, confirmed at 3 distinct trigger shapes (all cpython/micropython, all GitGalaxy+ctags
+correct, tree-sitter alone missing the function): (1) an `#if`/`#else` pair splitting a single `if`
+condition inside a function body (`cpython/ceval.c:33`, `_Py_ReachedRecursionLimitWithMargin`'s
+`#if _Py_STACK_GROWS_DOWN` / `#else` around its recursion-limit check); (2) an `#if`/`#endif`
+wrapping only the `static` storage-class specifier, separated from the rest of the signature
+(`micropython/compile.c:3473-3476`, `mp_compile_to_raw_code`); (3) bare, un-semicoloned macro
+invocations (`_Py_COMP_DIAG_PUSH`/`_Py_COMP_DIAG_IGNORE_DEPR_DECLS`/`_Py_COMP_DIAG_POP`,
+`cpython/object.c:1269-1271`) whose lack of a trailing `;` the grammar can't cleanly recover from,
+losing the next real function (`_PyObject_SetAttributeErrorContext`).
+
 ## Claim 8: precision under C preprocessor noise — dead-code shielding and macro hallucinations
 
 For C, the preprocessor adds a meta-layer of syntax (conditional compilation, macro definitions)

--- a/tests/tools/ctags_reader.py
+++ b/tests/tools/ctags_reader.py
@@ -62,6 +62,30 @@ KIND MAPS
         structural ctags limitation, not a GitGalaxy or tree-sitter defect.
       - shell: no class-shaped kind either (alias/function/heredoc/script) -- matches GitGalaxy's
         and tree-sitter's own class_recall/precision being N/A for shell already.
+      - c: ctags' C parser misreads a MACRO INVOCATION (not a definition) as a real function
+        when the macro name is used to generate boilerplate, e.g. cpython/typeobject.c's
+        `RICHCMP_WRAPPER(lt, Py_LT)` and `SLOT1(slot_mp_subscript, __getitem__, PyObject *)` --
+        both real calls to a previously-`#define`d macro, confirmed by reading the source; ctags
+        tags `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL` themselves as function names,
+        GitGalaxy and tree-sitter both correctly don't. Deliberately NOT added as a curated
+        name-exclusion list here (unlike the anonymous-struct fix below, this would be a
+        ground-truth judgment call -- "these specific macro names are known bad" -- the same
+        category of decision `tri_comparison_gatherer.py`'s own docstring explains keeping out of
+        the raw readers and in reconciliation instead). Investigated via
+        `c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]` (7 occurrences) -- a real
+        ctags limitation, not a GitGalaxy or tree-sitter defect.
+        Separately (also c, but function-agnostic -- affects both CTAGS_FUNC_KINDS and
+        CTAGS_CLASS_KINDS the same way, so noted once here): ctags synthesizes a placeholder name
+        (`__anon<hex>`) for an anonymous struct/union/enum
+        (`typedef struct { ... } Foo;`, e.g. cpython/ceval.c's platform pthread-attr shim).
+        Neither GitGalaxy nor tree-sitter report a name for an anonymous type at all -- there
+        genuinely isn't one -- so ctags' own bookkeeping name always surfaced as a false
+        discrepancy. FIXED in `tri_comparison_gatherer.py` (`_is_ctags_synthetic_anon_name`,
+        applied to both func and class ctags readings) rather than just documented, since
+        matching a structural naming pattern (not a curated list of specific names) is the same
+        kind of neutral fact the C struct-body-check fix already established is fair game for the
+        walk itself. Investigated via `c/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`
+        (23 occurrences, cpython + doom).
     Cross-reference gitgalaxy/standards/language_standards.py's own class_start/func_start
     definitions before ever widening one of these maps -- do not add a kind because its letter
     looks right.

--- a/tests/tools/ctags_reader.py
+++ b/tests/tools/ctags_reader.py
@@ -264,7 +264,13 @@ CTAGS_FUNC_KINDS: dict[str, set[str]] = {
 }
 
 CTAGS_CLASS_KINDS: dict[str, set[str]] = {
-    "c": {"s"},  # struct -- matches GitGalaxy's own C class_start convention
+    "c": {"s", "g", "u"},  # struct, enum, union -- matches GitGalaxy's own C class_start regex
+    # (struct|union|enum, gitgalaxy/standards/language_standards.py). Was struct-only until
+    # c/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags] (9 occurrences, 2026-08-19)
+    # surfaced it: ctags itself parses enum/union declarations fine (confirmed via a direct
+    # `ctags -x` run against sqlite/lemon.c and others), this map was just dropping them before
+    # reconciliation ever saw them -- a bug in this test harness, not in ctags, GitGalaxy, or
+    # tree-sitter.
     "cpp": {"c", "s"},  # class, struct
     "csharp": {"c", "s", "i"},  # class, struct, interface
     "css": {"c"},  # CSS "class" kind is a literal .class selector -- matches GitGalaxy's own
@@ -387,16 +393,32 @@ def read_ctags_symbols(filepath: Path, lang: str) -> list[CtagsSymbol]:
     for line in result.stdout.splitlines():
         if line.startswith("!"):
             continue
-        cols = line.split("\t")
-        if len(cols) < 4:
+        # NOT a blind line.split("\t") -- the address/pattern field (cols[2] in the naive
+        # reading) is `/^<verbatim matched source line>$/;"`, and that source text can itself
+        # contain a literal TAB character when the real code uses tabs for column alignment
+        # (confirmed real, not theoretical: language-crucible/data/c/doom/i_system.c's
+        # `byte*\tI_AllocLow(int length)` -- old-school Doom-era C formatting). A tab-splitting
+        # parser then reads a fragment of the SOURCE LINE as if it were the kind field, fails
+        # the `kind not in wanted_kinds` check below, and silently drops the whole symbol --
+        # confirmed via c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags] (I_AllocLow,
+        # I_ZoneBase, I_BaseTiccmd, R_CheckBBox, R_AddLine all missing from ctags' reading purely
+        # because of this parsing bug, not because ctags itself failed to tag them -- a raw
+        # ctags run against these files finds every one of them correctly). The tag-file format
+        # guarantees the address field always ends with the literal `;"` marker before the
+        # kind/extension-field trailer begins (ctags' own TAG_FILE_FORMAT spec) -- split on
+        # THAT instead, and only tab-split the trailer (extension fields are simple `key:value`
+        # pairs with no embedded source text, so tab-splitting is safe there).
+        marker_idx = line.find(';"\t')
+        if marker_idx == -1:
             continue
-        name = cols[0]
-        # cols[2] is the /pattern/;" search pattern, cols[3] is the kind, cols[4:] are
-        # extension fields (line:N, signature:(...), class:Foo, etc.)
-        kind = cols[3]
+        name = line.split("\t", 1)[0]
+        if not name:
+            continue
+        trailer_cols = line[marker_idx + len(';"\t') :].split("\t")
+        kind = trailer_cols[0]
         if kind not in wanted_kinds:
             continue
-        fields = _parse_extension_fields("\t".join(cols[4:]))
+        fields = _parse_extension_fields("\t".join(trailer_cols[1:]))
         line_no = int(fields["line"]) if "line" in fields else -1
         signature = fields.get("signature")
         symbols.append(CtagsSymbol(name=name, line=line_no, kind=kind, signature=signature))

--- a/tests/tools/tri_comparison_gatherer.py
+++ b/tests/tools/tri_comparison_gatherer.py
@@ -60,6 +60,7 @@ CTAGS' OWN READING
 
 from __future__ import annotations
 
+import re
 import sqlite3
 import sys
 import tempfile
@@ -184,6 +185,23 @@ def _walk_tree_sitter(root, func_node_types: set[str], class_node_types: set[str
     return funcs, classes
 
 
+_CTAGS_ANON_NAME_RE = re.compile(r"^__anon[0-9a-f]+$")
+
+
+def _is_ctags_synthetic_anon_name(name: str) -> bool:
+    """universal-ctags synthesizes a placeholder name (`__anon<hex hash>`, e.g.
+    `__anon2570bd640108`) for an anonymous struct/union/enum (`typedef struct { ... } Foo;` --
+    real, common C, e.g. cpython/ceval.c's platform-specific pthread attr shim) so it has
+    something to key the tag on internally. Neither GitGalaxy nor tree-sitter report a name for
+    an anonymous type at all (there genuinely isn't one), so ctags' internal bookkeeping name
+    always shows up as a lone `agree[ctags]_vs[gitgalaxy,tree_sitter]` false discrepancy --
+    confirmed via c/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter] (23 occurrences,
+    every single sample this exact shape, spanning cpython/doom). The same exclusion GitGalaxy's
+    own synthetic placeholder names already get (_SYNTHETIC_GG_FUNC_NAMES/
+    _SYNTHETIC_GG_CLASS_NAMES) applied to ctags' equivalent."""
+    return bool(_CTAGS_ANON_NAME_RE.match(name))
+
+
 def gather_language(lang: str, corpus_dir: Optional[Path] = None) -> list[FileReadings]:
     """Runs GitGalaxy always, tree-sitter if this language has a NODE_MAPS entry, and ctags if
     ctags_reader.ctags_available(lang) -- over every corpus file for `lang`, returns one
@@ -257,12 +275,12 @@ def gather_language(lang: str, corpus_dir: Optional[Path] = None) -> list[FileRe
                             args=_count_ctags_signature_params(s.signature),
                         )
                         for s in ct_syms
-                        if s.kind in ctags_func_kinds
+                        if s.kind in ctags_func_kinds and not _is_ctags_synthetic_anon_name(s.name)
                     ]
                     ctags_classes = [
                         Occurrence(name=s.name, line=s.line if s.line >= 0 else None, args=None)
                         for s in ct_syms
-                        if s.kind in ctags_class_kinds
+                        if s.kind in ctags_class_kinds and not _is_ctags_synthetic_anon_name(s.name)
                     ]
                 else:
                     ctags_funcs, ctags_classes = [], []


### PR DESCRIPTION
## Summary
Continuing the tri-comparison-ledger-sweep on `c` (following #1873). 8 of 11 shapes resolved this round, all directly (no dispatch needed) -- clear patterns confirmed via direct source/ctags reads.

**Fixed in `tri_comparison_gatherer.py`:**
- `c/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]` (23): ctags synthesizes `__anon<hex>` placeholder names for anonymous struct/union/enum. Added `_is_ctags_synthetic_anon_name()`, same category as GitGalaxy's own `_SYNTHETIC_GG_CLASS_NAMES` exclusion.

**Documented in `ctags_reader.py`** (not code-fixed -- would require a curated name list, the same ground-truth-judgment category this module's docstring keeps out of the raw readers):
- `c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]` (7): ctags misreads bare macro-invocation lines (`RICHCMP_WRAPPER(lt, Py_LT)`, `SLOT1(slot_mp_subscript, __getitem__, PyObject *)`) as function definitions.

**New evidence added to `docs/why_gitgalaxy_beats_ast_here.md`:**
- `c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]` (4): a third, narrower instance of Claim 3 (parse-error cascade) -- a bare macro-invocation line locally confuses both other tools' parse of the single real function immediately following it, recovering after just one function rather than cascading.

**Not new findings, already covered:**
- `c/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]` (3): both names already in `_C_KNOWN_MACRO_HALLUCINATIONS`.

**Structural ambiguity, not a defect:**
- `c/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]` (1): two genuinely valid signatures under `#if MICROPY_GC_SPLIT_HEAP`/`#else` -- no tool runs a real preprocessor.

3 shapes remain (13/9/8 occurrences, multi-file, no obvious single cause from the sample) -- dispatched to Gemini, in progress separately.

## Verification
- `ruff_audit.py --ci` / `mypy_audit.py --ci`: no new findings beyond baseline.
- Every applied verdict's citations independently confirmed via direct source or live `ctags` reads before being trusted.

## Test plan
- [x] `ruff_audit.py --ci` / `mypy_audit.py --ci` clean.
- [x] `_is_ctags_synthetic_anon_name` verified: matches real `__anon<hex>` names, doesn't match ordinary identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)