### PR TITLE
fix(abap): named class list and class-scope-end truncation (found regenerating the chart)

### DIFF
--- a/.claude/skills/tri-comparison-ledger-sweep/SKILL.md
+++ b/.claude/skills/tri-comparison-ledger-sweep/SKILL.md
@@ -447,3 +447,15 @@ Commit messages should name the shapes validated, not just say "update ledger" -
   -- two regex/grammar engines both fooled by the same macro-definition text is a shared mechanism,
   not a coincidence). Only split them if the verdict specifically distinguishes one as right and
   the other as coincidentally also wrong for an unrelated reason -- rare.
+- Fixing one confirmed engine bug is not proof the surrounding extraction path is now fully
+  correct -- re-verify the fix against the REAL pipeline/DB output (step 2b) before moving on,
+  every time, not just once per language. ABAP's manual-verification pass (2026-08-19/20) found 4
+  separate, independent bugs this way, not 1: fixing #1898 (a `prism.py` comment-stripping bug)
+  and re-checking its actual DB output surfaced #1899 (a completely different `detector.py`
+  slicing-mode bug) sitting right next to it; fixing #1899 and regenerating the tri-comparison
+  chart surfaced #1904 (a THIRD, independent bug -- a named-class-extraction allowlist gap); and
+  verifying #1904's own fix surfaced #1907 (a fourth -- a class-boundary detector confused by
+  ABAP's own string-template syntax). Each bug was invisible until the previous one was fixed and
+  re-checked against real output -- stopping at the first green result after fix #1 would have
+  left 3 more silently in place. See `docs/language_status/abap.md` §9 for the full evidence
+  trail.

--- a/docs/language_status/abap.md
+++ b/docs/language_status/abap.md
@@ -205,19 +205,25 @@ deeper inspection is needed.
 
 ## 9. Manual verification: GitGalaxy alone (no tree-sitter or ctags for ABAP)
 
-**Revised again 2026-08-20 — both engine bugs found in the previous revision are now FIXED,
-merged, and re-verified.** Recapping the timeline for anyone reading this cold: the first pass
-(2026-08-19) ran ABAP's `func_start`/`class_start` regexes directly against raw file text and
-concluded "100% precision, zero engine defects" — true of the regexes *in isolation*, but not the
-same claim as "GitGalaxy correctly extracts ABAP," since the real pipeline also runs `prism.py`'s
-comment/code splitter and `detector.py`'s segment-routing logic first. A same-day revision caught
-this and filed two real, confirmed engine defects
-([#1898](https://github.com/squid-protocol/gitgalaxy/issues/1898),
-[#1899](https://github.com/squid-protocol/gitgalaxy/issues/1899)). Both are now fixed (see each
-subsection below for the specific commit/mechanism) and verified against the real `galaxyscope`
-pipeline output, not just the regex. The lesson still generalizes: for a zero-comparison-tool
-language, "run the regex against text" is necessary but not sufficient — always also run the real
-scan and inspect its actual DB output before concluding a signature is correct.
+**Revised a third time, 2026-08-20 — four engine bugs found across this investigation are now
+FIXED, and each fix was re-verified rather than assumed complete.** Recapping the timeline for
+anyone reading this cold: the first pass (2026-08-19) ran ABAP's `func_start`/`class_start`
+regexes directly against raw file text and concluded "100% precision, zero engine defects" — true
+of the regexes *in isolation*, but not the same claim as "GitGalaxy correctly extracts ABAP,"
+since the real pipeline also runs `prism.py`'s comment/code splitter and `detector.py`'s
+segment-routing logic first. A same-day revision caught this and filed two real, confirmed engine
+defects ([#1898](https://github.com/squid-protocol/gitgalaxy/issues/1898),
+[#1899](https://github.com/squid-protocol/gitgalaxy/issues/1899)). Fixing and re-verifying those
+two (rather than trusting the fix and moving on) surfaced two MORE, independent bugs one layer
+deeper — [#1904](https://github.com/squid-protocol/gitgalaxy/issues/1904) (a separate named-
+class-extraction allowlist gap) and [#1907](https://github.com/squid-protocol/gitgalaxy/issues/1907)
+(a class-boundary detector confused by ABAP's own string-template syntax). All four are now fixed
+(see each subsection below for the specific mechanism) and verified against the real `galaxyscope`
+pipeline output, not just the regex. The lesson still generalizes, and generalizes further than
+the first revision realized: for a zero-comparison-tool language, "run the regex against text" is
+necessary but not sufficient, AND fixing one confirmed bug is not proof the surrounding extraction
+path is now fully correct — re-verify after every fix instead of stopping at the first green
+result.
 
 ABAP is one of only 5 languages in the whole registry with **neither** a tree-sitter grammar nor a
 ctags parser (the others: `dockerfile`, `jcl`, `livecode`, `yaml` — confirmed against
@@ -345,6 +351,63 @@ already established for objective-c) and 0 for the one file with no class — ex
 12 real matches found by applying the regex directly to unprocessed text. **Fixed via
 [#1898](https://github.com/squid-protocol/gitgalaxy/issues/1898).**
 
+### Named class list still empty after #1898 — a third, separate bug — FIXED (#1904)
+
+Fixing #1898 correctly restored `struct_class_start`/`class_count` to 2 per real class file, but
+regenerating `docs/self_scan/tri_comparison_chart.svg` afterward showed abap's "Classes Found"/
+"Class Precision" panels still completely blank, and `tri_comparison_gatherer.gather_language
+("abap")` still returned `gg_classes: []` for every file. `struct_class_start` (the raw regex
+signal) and the actual *named* `classes` list (what feeds `class_data`/the chart) turned out to be
+two independent code paths, and only the first one was fixed by #1898.
+
+Root cause: `detector.py`'s named-class extraction in `splice()` only reuses a language's own
+`class_start` rule when that language is listed in `_CLASS_START_NAMED_EXTRACTION_LANGS` (epic
+#1295) — every other language falls through to a generic legacy regex, `(?:class|struct|interface
+|trait|enum)`, compiled **without** `re.I`. ABAP was never added to that set — likely because the
+epic's own documented verification method (`tree_sitter_accuracy_audit.py --lang <x>` against
+tree-sitter ground truth) structurally cannot run for a language with no tree-sitter grammar at
+all. Real ABAP classes are always uppercase (`CLASS <name> DEFINITION`), so the case-sensitive
+fallback regex could never match ABAP source regardless of #1898's fix — the named list was
+guaranteed empty by construction.
+
+**Fix (2026-08-20):** added `"abap"` to `_CLASS_START_NAMED_EXTRACTION_LANGS`, using the
+verification already done in this doc (100% precision on all 12 real matches, direct source
+cross-check) in place of the epic's tree-sitter-based method, which doesn't apply here. Re-verified
+via `tri_comparison_gatherer.gather_language("abap")`: every real class file now returns 2 named
+class entries with correct names (e.g. `['zcl_abapgit_ajson', 'zcl_abapgit_ajson']` for the
+`DEFINITION`+`IMPLEMENTATION` pair — one file's two entries even preserve genuinely different
+source casing, `zcl_abapgit_xml_output` vs. `ZCL_ABAPGIT_XML_OUTPUT`, extracted faithfully rather
+than normalized away). **Fixed via
+[#1904](https://github.com/squid-protocol/gitgalaxy/issues/1904).**
+
+### Class→method linkage truncated by ABAP's own string-template syntax — a fourth bug — FIXED (#1907)
+
+Found while verifying #1904's fix: `zcl_abapgit_objects.clas.abap` has 30 real methods
+(`struct_func_start`/`function_count` both correctly show 30), but its class entry's
+`method_count` came back as **2**. `splice()`'s class-boundary resolver tries a brace-delimited
+body search first and only falls back to a flat "next class match" boundary if no `{` is found
+within 2000 chars. ABAP has no brace-delimited bodies at all, but it DOES have string-template
+interpolation syntax that legitimately contains braces:
+
+```abap
+ii_log->add_success( iv_msg = |Object { is_item-obj_name } ...| ).
+```
+
+`_build_brace_safe_stream()` shields `"`/`'`/backtick-style string literals before the brace
+search runs, but has no knowledge of ABAP's `|...|` pipe-delimited templates, so this `{` reached
+the search unshielded, got mistaken for the class's real body opener, and truncated the scope
+right after the first couple of methods — every subsequent method in the file never got linked to
+its class.
+
+**Fix (2026-08-20):** since ABAP classes are never nested, the flat "next class match, or EOF"
+fallback (already computed unconditionally at the call site) is always correct for ABAP — the
+brace-search path is now skipped entirely for `abap` rather than teaching the shared brace-safe
+stream builder about pipe-delimited string templates (a bigger, riskier change touching other
+regex signals too). Re-verified: `zcl_abapgit_objects`' class entry now shows `method_count: 30`,
+matching its real function count exactly, and every other file's linkage still matches its real
+method count too. **Fixed via
+[#1907](https://github.com/squid-protocol/gitgalaxy/issues/1907).**
+
 ### `args`: smaller, inconsistent discrepancies — not yet root-caused, still open
 
 `file_data.struct_args` vs. a raw-regex count on unprocessed text still disagree in both
@@ -358,13 +421,19 @@ line/mechanism the way #1898/#1899 were — noted here as a known open question 
 filed issue, since "probably related, not fully explained" isn't evidence-backed enough to file on
 its own yet.
 
-**Summary:** two confirmed engine defects found, fixed, and re-verified against the real pipeline
-(#1898, #1899 — both closed), plus one open args-counting discrepancy not yet root-caused. No
-`credit_tools`/`debit_tools` adjustment applies (there's no second tool to credit or debit
-against, and these were GitGalaxy-side bugs, not a cross-tool disagreement). Corpus is small (7
-files) — a wider manual pass (or, if ABAP ever gets ctags/tree-sitter support upstream, the normal
-ledger pipeline) would surface more; the finding here is real for the *sampled* corpus, not a
-guarantee no other issue exists. Both fixes went through the full Differential Scan protocol
-(`crucible_check.py` against the ~80-repo language-crucible corpus, both full-precision and
-zero-dependency modes) before merging — see the golden master fixtures' commit history for the
-complete before/after diff.
+**Summary:** four confirmed engine defects found, fixed, and re-verified against the real pipeline
+(#1898, #1899, #1904, #1907 — all closed), plus one open args-counting discrepancy not yet
+root-caused. Each fix was found by re-verifying the PREVIOUS fix against the real pipeline rather
+than assuming one fix meant the whole extraction path was now correct — #1899 surfaced while
+checking #1898's numbers against actual DB output, #1904 surfaced while regenerating the
+tri-comparison chart after #1898/#1899 merged, and #1907 surfaced while verifying #1904's fix
+itself. No `credit_tools`/`debit_tools` adjustment applies to any of the four (there's no second
+tool to credit or debit against, and these were GitGalaxy-side bugs, not a cross-tool
+disagreement). Corpus is small (7 files) — a wider manual pass (or, if ABAP ever gets ctags/
+tree-sitter support upstream, the normal ledger pipeline) would surface more; the finding here is
+real for the *sampled* corpus, not a guarantee no other issue exists. #1898/#1899 went through the
+full Differential Scan protocol (`crucible_check.py` against the ~80-repo language-crucible
+corpus, both full-precision and zero-dependency modes) and required regenerating both golden
+master fixtures; #1904/#1907 live entirely in the SQLite recorder's named-class-list path, which
+those fixtures don't exercise at all — `crucible_check.py` passed with zero drift both before and
+after, confirmed via the tri-comparison gatherer and a direct `--db-only` scan instead.

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -37,12 +37,16 @@
 <text class="lang-label" x="20" y="173.5">abap</text>
 <rect class="bar-track" x="154" y="153" width="88" height="34" rx="2"/>
 <rect x="154" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="161">16</text>
+<text class="bar-value-label" x="198.0" y="161">124</text>
 <rect class="bar-track" x="286" y="153" width="88" height="34" rx="2"/>
 <rect x="286" y="153" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="161">0/16</text>
+<text class="bar-value-label" x="330.0" y="161">0/124</text>
 <rect class="bar-track" x="418" y="153" width="88" height="34" rx="2"/>
+<rect x="418" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="161">12</text>
 <rect class="bar-track" x="550" y="153" width="88" height="34" rx="2"/>
+<rect x="550" y="153" width="2.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="161">0/12</text>
 <rect class="bar-track" x="682" y="153" width="88" height="34" rx="2"/>
 <text class="lang-label" x="20" y="217.5">ada</text>
 <text class="awaiting" x="154" y="217.5">awaiting language-crucible corpus</text>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T03:09:54Z",
+      "last_reconciled_at": "2026-08-20T12:20:14Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -116,7 +116,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T03:09:54Z",
+      "last_reconciled_at": "2026-08-20T12:20:14Z",
       "last_seen_count": 35,
       "last_seen_examples": [
         {
@@ -219,7 +219,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-20T03:09:56Z",
+      "last_reconciled_at": "2026-08-20T12:20:16Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -258,7 +258,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T03:09:58Z",
+      "last_reconciled_at": "2026-08-20T12:20:18Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -353,7 +353,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T03:09:58Z",
+      "last_reconciled_at": "2026-08-20T12:20:18Z",
       "last_seen_count": 20,
       "last_seen_examples": [
         {
@@ -457,7 +457,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -571,7 +571,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -676,7 +676,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -790,7 +790,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -823,7 +823,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -856,7 +856,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -973,7 +973,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1024,7 +1024,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1111,7 +1111,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1164,7 +1164,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1224,7 +1224,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T03:10:03Z",
+      "last_reconciled_at": "2026-08-20T12:20:24Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1339,7 +1339,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T03:10:08Z",
+      "last_reconciled_at": "2026-08-20T12:20:29Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1442,7 +1442,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T03:10:08Z",
+      "last_reconciled_at": "2026-08-20T12:20:29Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1545,7 +1545,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T03:10:08Z",
+      "last_reconciled_at": "2026-08-20T12:20:29Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1649,7 +1649,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1691,7 +1691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 95,
       "last_seen_examples": [
         {
@@ -1805,7 +1805,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1919,7 +1919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2033,7 +2033,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -2147,7 +2147,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2179,7 +2179,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2212,7 +2212,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -2308,7 +2308,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2341,7 +2341,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 1074,
       "last_seen_examples": [
         {
@@ -2455,7 +2455,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 1097,
       "last_seen_examples": [
         {
@@ -2569,7 +2569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 62,
       "last_seen_examples": [
         {
@@ -2683,7 +2683,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T03:10:13Z",
+      "last_reconciled_at": "2026-08-20T12:20:33Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2797,7 +2797,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2848,7 +2848,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2917,7 +2917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2995,7 +2995,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3028,7 +3028,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3115,7 +3115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3174,7 +3174,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3207,7 +3207,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3321,7 +3321,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3381,7 +3381,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3414,7 +3414,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3528,7 +3528,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3642,7 +3642,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T03:10:19Z",
+      "last_reconciled_at": "2026-08-20T12:20:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3675,7 +3675,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-20T03:10:20Z",
+      "last_reconciled_at": "2026-08-20T12:20:41Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3724,7 +3724,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T03:10:24Z",
+      "last_reconciled_at": "2026-08-20T12:20:45Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3827,7 +3827,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T03:10:24Z",
+      "last_reconciled_at": "2026-08-20T12:20:45Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3930,7 +3930,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T03:10:24Z",
+      "last_reconciled_at": "2026-08-20T12:20:45Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4034,7 +4034,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T03:10:30Z",
+      "last_reconciled_at": "2026-08-20T12:20:50Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4129,7 +4129,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T03:10:30Z",
+      "last_reconciled_at": "2026-08-20T12:20:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4162,7 +4162,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T03:10:30Z",
+      "last_reconciled_at": "2026-08-20T12:20:50Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4276,7 +4276,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T03:10:30Z",
+      "last_reconciled_at": "2026-08-20T12:20:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4318,7 +4318,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T03:10:30Z",
+      "last_reconciled_at": "2026-08-20T12:20:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4360,7 +4360,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-20T03:10:32Z",
+      "last_reconciled_at": "2026-08-20T12:20:53Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4474,7 +4474,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4586,7 +4586,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4691,7 +4691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4805,7 +4805,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4919,7 +4919,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5033,7 +5033,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5074,7 +5074,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5114,7 +5114,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T03:10:35Z",
+      "last_reconciled_at": "2026-08-20T12:20:56Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5228,7 +5228,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5342,7 +5342,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5456,7 +5456,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5569,7 +5569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5602,7 +5602,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5653,7 +5653,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5767,7 +5767,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T03:10:38Z",
+      "last_reconciled_at": "2026-08-20T12:20:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5818,7 +5818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -5932,7 +5932,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6019,7 +6019,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6061,7 +6061,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6175,12 +6175,12 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860100",
+          "name": "AnonymousFunction91b1053f0100",
           "readings": {
             "ctags": 55,
             "gitgalaxy": null,
@@ -6189,7 +6189,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860200",
+          "name": "AnonymousFunction91b1053f0200",
           "readings": {
             "ctags": 94,
             "gitgalaxy": null,
@@ -6198,7 +6198,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860300",
+          "name": "AnonymousFunction91b1053f0300",
           "readings": {
             "ctags": 369,
             "gitgalaxy": null,
@@ -6207,7 +6207,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860400",
+          "name": "AnonymousFunction91b1053f0400",
           "readings": {
             "ctags": 383,
             "gitgalaxy": null,
@@ -6216,7 +6216,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860500",
+          "name": "AnonymousFunction91b1053f0500",
           "readings": {
             "ctags": 694,
             "gitgalaxy": null,
@@ -6225,7 +6225,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860600",
+          "name": "AnonymousFunction91b1053f0600",
           "readings": {
             "ctags": 848,
             "gitgalaxy": null,
@@ -6234,7 +6234,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860700",
+          "name": "AnonymousFunction91b1053f0700",
           "readings": {
             "ctags": 852,
             "gitgalaxy": null,
@@ -6243,7 +6243,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860800",
+          "name": "AnonymousFunction91b1053f0800",
           "readings": {
             "ctags": 857,
             "gitgalaxy": null,
@@ -6252,7 +6252,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860900",
+          "name": "AnonymousFunction91b1053f0900",
           "readings": {
             "ctags": 879,
             "gitgalaxy": null,
@@ -6289,7 +6289,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6403,7 +6403,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6517,7 +6517,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T03:10:41Z",
+      "last_reconciled_at": "2026-08-20T12:21:01Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6631,7 +6631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T03:10:43Z",
+      "last_reconciled_at": "2026-08-20T12:21:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6682,7 +6682,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T03:10:43Z",
+      "last_reconciled_at": "2026-08-20T12:21:04Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6796,7 +6796,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T03:10:43Z",
+      "last_reconciled_at": "2026-08-20T12:21:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6828,7 +6828,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T03:10:49Z",
+      "last_reconciled_at": "2026-08-20T12:21:10Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6883,7 +6883,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T03:10:49Z",
+      "last_reconciled_at": "2026-08-20T12:21:10Z",
       "last_seen_count": 79,
       "last_seen_examples": [
         {
@@ -6986,7 +6986,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T03:10:49Z",
+      "last_reconciled_at": "2026-08-20T12:21:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7018,7 +7018,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-20T03:10:51Z",
+      "last_reconciled_at": "2026-08-20T12:21:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7049,7 +7049,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-20T03:10:52Z",
+      "last_reconciled_at": "2026-08-20T12:21:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7082,7 +7082,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T03:10:54Z",
+      "last_reconciled_at": "2026-08-20T12:21:15Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7196,7 +7196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T03:10:54Z",
+      "last_reconciled_at": "2026-08-20T12:21:15Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7310,7 +7310,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T03:10:54Z",
+      "last_reconciled_at": "2026-08-20T12:21:15Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7343,7 +7343,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T03:10:54Z",
+      "last_reconciled_at": "2026-08-20T12:21:15Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7385,7 +7385,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7418,7 +7418,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7449,7 +7449,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7563,7 +7563,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7650,7 +7650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7737,7 +7737,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7770,7 +7770,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T03:11:00Z",
+      "last_reconciled_at": "2026-08-20T12:21:21Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7884,12 +7884,12 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T03:11:05Z",
+      "last_reconciled_at": "2026-08-20T12:21:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
           "file_path": "laravel_core/BladeCompiler.php",
-          "name": "AnonymousClassea70ff800100",
+          "name": "AnonymousClass977bf1590100",
           "readings": {
             "ctags": 342,
             "gitgalaxy": null,
@@ -7917,7 +7917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T03:11:05Z",
+      "last_reconciled_at": "2026-08-20T12:21:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T03:11:05Z",
+      "last_reconciled_at": "2026-08-20T12:21:26Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8064,7 +8064,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T03:11:07Z",
+      "last_reconciled_at": "2026-08-20T12:21:28Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8149,7 +8149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T03:11:07Z",
+      "last_reconciled_at": "2026-08-20T12:21:28Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8218,7 +8218,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T03:11:07Z",
+      "last_reconciled_at": "2026-08-20T12:21:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8251,7 +8251,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T03:11:07Z",
+      "last_reconciled_at": "2026-08-20T12:21:28Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8365,7 +8365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T03:11:16Z",
+      "last_reconciled_at": "2026-08-20T12:21:37Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8425,7 +8425,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T03:11:16Z",
+      "last_reconciled_at": "2026-08-20T12:21:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8458,7 +8458,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T03:11:16Z",
+      "last_reconciled_at": "2026-08-20T12:21:37Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -8572,7 +8572,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T03:11:16Z",
+      "last_reconciled_at": "2026-08-20T12:21:37Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8686,7 +8686,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T03:11:18Z",
+      "last_reconciled_at": "2026-08-20T12:21:38Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8728,7 +8728,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T03:11:18Z",
+      "last_reconciled_at": "2026-08-20T12:21:38Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8806,7 +8806,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T03:11:18Z",
+      "last_reconciled_at": "2026-08-20T12:21:38Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8857,7 +8857,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T03:11:18Z",
+      "last_reconciled_at": "2026-08-20T12:21:38Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8935,7 +8935,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T03:11:22Z",
+      "last_reconciled_at": "2026-08-20T12:21:43Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8986,7 +8986,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T03:11:22Z",
+      "last_reconciled_at": "2026-08-20T12:21:43Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9100,7 +9100,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T03:11:22Z",
+      "last_reconciled_at": "2026-08-20T12:21:43Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9212,7 +9212,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T03:11:22Z",
+      "last_reconciled_at": "2026-08-20T12:21:43Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9326,7 +9326,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T03:11:22Z",
+      "last_reconciled_at": "2026-08-20T12:21:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9359,7 +9359,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T03:11:22Z",
+      "last_reconciled_at": "2026-08-20T12:21:43Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9471,7 +9471,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-20T03:11:24Z",
+      "last_reconciled_at": "2026-08-20T12:21:45Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9574,7 +9574,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T03:11:28Z",
+      "last_reconciled_at": "2026-08-20T12:21:49Z",
       "last_seen_count": 92,
       "last_seen_examples": [
         {
@@ -9678,7 +9678,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-20T03:11:29Z",
+      "last_reconciled_at": "2026-08-20T12:21:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9710,7 +9710,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-20T03:11:31Z",
+      "last_reconciled_at": "2026-08-20T12:21:52Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9780,7 +9780,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T03:11:32Z",
+      "last_reconciled_at": "2026-08-20T12:21:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9811,7 +9811,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T03:11:32Z",
+      "last_reconciled_at": "2026-08-20T12:21:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9842,7 +9842,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T03:11:32Z",
+      "last_reconciled_at": "2026-08-20T12:21:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9874,7 +9874,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T03:11:34Z",
+      "last_reconciled_at": "2026-08-20T12:21:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9907,7 +9907,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T03:11:34Z",
+      "last_reconciled_at": "2026-08-20T12:21:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9949,7 +9949,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T03:11:34Z",
+      "last_reconciled_at": "2026-08-20T12:21:55Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10009,7 +10009,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T03:11:34Z",
+      "last_reconciled_at": "2026-08-20T12:21:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10042,7 +10042,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10084,7 +10084,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10196,7 +10196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10256,7 +10256,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10361,7 +10361,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10475,7 +10475,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -10589,7 +10589,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10631,7 +10631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T03:11:54Z",
+      "last_reconciled_at": "2026-08-20T12:22:16Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -10744,7 +10744,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T03:12:03Z",
+      "last_reconciled_at": "2026-08-20T12:22:24Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10775,7 +10775,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T03:12:03Z",
+      "last_reconciled_at": "2026-08-20T12:22:24Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -10878,7 +10878,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T03:12:03Z",
+      "last_reconciled_at": "2026-08-20T12:22:24Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -368,6 +368,19 @@ class ScopeParsingRegistry:
 # gauntlets -- tracked as a follow-up (#1295), not attempted wholesale here.
 _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset(
     {
+        # #1904: ABAP can't go through this epic's own documented
+        # verification method (tree_sitter_accuracy_audit.py against
+        # tree-sitter ground truth) -- it has no tree-sitter grammar at
+        # all, one of only 5 gg_only languages with neither tree-sitter
+        # nor ctags. Verified instead via direct source cross-check
+        # (docs/language_status/abap.md §9): 100% precision on all 12 real
+        # DEFINITION/IMPLEMENTATION matches across abapGit's 6 real
+        # classes, zero false positives. Without this entry the generic
+        # fallback regex (lowercase-only `class|struct|interface|trait|
+        # enum`, no re.I) can never match ABAP's always-uppercase `CLASS
+        # <name> DEFINITION` syntax, so the named classes list stays
+        # permanently empty regardless of #1898's prism.py fix.
+        "abap",
         "apex",
         "c",
         "cpp",
@@ -783,9 +796,23 @@ class StructuralExtractor:
                 # Old flat boundary, now used only as a fallback for brace-less
                 # forward declarations where no real body can be located.
                 fallback_end_idx = class_matches[i + 1].start() if i + 1 < len(class_matches) else len(code_stream)
-                end_idx = self._resolve_class_scope_end(
-                    class_safe_stream, start_idx, fallback_end_idx, use_indentation_scoping
-                )
+                if self.primary_lang_id == "abap":
+                    # #1907: ABAP has no brace-delimited class bodies at all
+                    # (IMPLEMENTATION. ... ENDCLASS.), but DOES have string-
+                    # template interpolation syntax (`|Object { name }|`)
+                    # containing real `{`/`}` that _build_brace_safe_stream
+                    # doesn't know to shield (it only understands `"`/`'`/
+                    # backtick-style quoting). The brace search below would
+                    # mistake that interpolation brace for the class's real
+                    # body opener and truncate the scope after the first
+                    # couple of methods. ABAP classes are never nested, so
+                    # the flat "next class match, or EOF" fallback is always
+                    # correct here -- skip the brace search entirely.
+                    end_idx = fallback_end_idx
+                else:
+                    end_idx = self._resolve_class_scope_end(
+                        class_safe_stream, start_idx, fallback_end_idx, use_indentation_scoping
+                    )
 
                 # Convert raw string indices to line numbers for spatial bounding
                 start_line = code_stream.count("\n", 0, start_idx) + 1


### PR DESCRIPTION
## Summary

Found while regenerating `docs/self_scan/tri_comparison_chart.svg` after #1898/#1899 merged: "Functions Found" correctly jumped to 124, but "Classes Found" stayed blank despite `struct_class_start` already showing 2 per file. Root-caused two more real, independent bugs.

- **Fixes #1904** -- `detector.py`'s named-class extraction only reuses a language's own `class_start` rule when it's listed in `_CLASS_START_NAMED_EXTRACTION_LANGS` (epic #1295); every other language falls through to a generic legacy regex (`class|struct|interface|trait|enum`, no `re.I`). ABAP was never added -- likely because the epic's own verification method (`tree_sitter_accuracy_audit.py` against tree-sitter ground truth) structurally can't run for a language with no tree-sitter grammar. Real ABAP classes are always uppercase (`CLASS <name> DEFINITION`), so the case-sensitive fallback could never match regardless of #1898's fix -- `class_data` stayed permanently empty. Added `abap` to the allowlist, using the verification already done in `docs/language_status/abap.md` (100% precision, direct source cross-check) in place of the epic's tree-sitter method.
- **Fixes #1907** -- found while verifying #1904's fix: `zcl_abapgit_objects` has 30 real methods but its class entry showed `method_count=2`. `splice()`'s class-boundary resolver tries a brace-delimited body search first and only falls back to the flat "next class match" boundary if no brace is found. ABAP has no brace-delimited bodies, but DOES have string-template interpolation syntax (`|Object { name }|`) containing real braces that `_build_brace_safe_stream` doesn't know to shield -- the search mistook the interpolation brace for the class's real body opener and truncated the scope after the first couple of methods. Since ABAP classes are never nested, the existing flat fallback is always correct -- skip the brace search entirely for `abap`.

## Verification

Both bugs live in the SQLite recorder's named-class-list path (`class_data`), which `golden_master_audit.json` doesn't exercise at all -- `crucible_check.py` passes with zero drift both before and after this change, verified instead via `tri_comparison_gatherer.gather_language()` and a direct `--db-only` scan. Regenerated `tri_comparison_chart.svg`/`tri_comparison_ledger.json` -- abap now shows `Functions Found: 124`, `Classes Found: 12` (`DEFINITION`+`IMPLEMENTATION` pairs, matching the engine-wide convention already established for objective-c). Diff confirmed scoped to abap's own row only; no other language changed (ledger diff is timestamp/anonymous-placeholder-hash noise from the full re-gather, not content changes).

## Test plan

- [x] `tests/extraction/languages/` (6128 tests) pass.
- [x] Full suite: `python -m pytest tests/` -- 7004 passed, 2 skipped, 11 xfailed, 3 xpassed.
- [x] `python tests/tools/crucible_check.py` -- both modes pass, zero drift (expected -- these bugs aren't in the fixtures' coverage).
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key/ast-accuracy all clear.
- [x] `docs/language_status/abap.md` §9 updated with both fixes' evidence.
- [x] `tri-comparison-ledger-sweep`'s `SKILL.md` updated with a "re-verify after every fix" gotcha -- this investigation found 4 independent bugs total by re-checking each fix against real output instead of stopping at the first green result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)