### PR TITLE
feat(tri-comparison): manual-verification precision marker for gg-only langs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,10 @@ museum_2/
 # tri_comparison_ledger.py's own docstring) -- committed and hand-edited like the baselines
 # above, not disposable scan output.
 !docs/self_scan/tri_comparison_ledger.json
+# ...and the manual-verification record for zero-comparison-tool languages (no tree-sitter,
+# no ctags -- e.g. abap): hand-reviewed and committed like the ledger above, read by
+# tests/tools/tri_comparison_chart.py but never written by it.
+!docs/self_scan/manual_verification.json
 *_llm.md
 venvs/
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,22 @@ languages have a full written audit one level deeper than this chart —
 [#1193](https://github.com/squid-protocol/gitgalaxy/issues/1193) (still open) got found in
 the first place; the rest of the 31 are baseline-only so far, not yet manually audited.
 
+5. **[Cross-checked against Tree-sitter AND ctags](tests/tools/tri_comparison_chart.py), not just one.** [`tests/tools/tri_comparison_chart.py`](tests/tools/tri_comparison_chart.py) runs all three independently against the same `language-crucible` corpus with no reader treated as privileged ground truth — every disagreement is logged to a reviewed ledger ([`docs/self_scan/tri_comparison_ledger.json`](docs/self_scan/tri_comparison_ledger.json)) and investigated by hand rather than assumed:
+
+<p align="center">
+  <img src="docs/self_scan/tri_comparison_chart.svg" alt="GitGalaxy structural extraction tri-comparison vs. Tree-sitter and ctags, function/class found-counts and precision by language" width="700">
+</p>
+
+24 of the 45 languages get all three tools compared; 16 more get two (Tree-sitter or ctags,
+whichever has coverage); the remaining 5 (`abap`, `dockerfile`, `jcl`, `livecode`, `yaml`) have
+no comparison tool at all, so their precision panel is marked `**` and backed by a committed,
+hand-reviewed record ([`docs/self_scan/manual_verification.json`](docs/self_scan/manual_verification.json))
+instead of cross-tool agreement — a real but different evidentiary category, never conflated
+with the `*` marker used elsewhere in the chart for genuine unresolved tool disagreements. See
+[`docs/self_scan/how_to_investigate_a_discrepancy.md`](docs/self_scan/how_to_investigate_a_discrepancy.md)
+for the investigation methodology, and [ABAP's own writeup](docs/language_status/abap.md) for a
+worked example of a zero-comparison-tool language, including five real engine bugs this process
+found and fixed.
 
 </div>
 

--- a/docs/self_scan/manual_verification.json
+++ b/docs/self_scan/manual_verification.json
@@ -1,0 +1,20 @@
+{
+  "languages": {
+    "abap": {
+      "class": {
+        "note": "class_start regex applied directly to source text, cross-checked against every real CLASS DEFINITION/IMPLEMENTATION pair in the corpus by direct reading -- see docs/language_status/abap.md §9.",
+        "total": 12,
+        "verified": 12,
+        "verified_at": "2026-08-19",
+        "verified_by": "Claude Sonnet 5"
+      },
+      "function": {
+        "note": "func_start regex applied directly to source text, cross-checked against an independent grep (grep -nE \"^\\s*METHOD\\s+[a-zA-Z]\") that shares no implementation with the primary regex -- see docs/language_status/abap.md §9.",
+        "total": 124,
+        "verified": 124,
+        "verified_at": "2026-08-19",
+        "verified_by": "Claude Sonnet 5"
+      }
+    }
+  }
+}

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -28,6 +28,7 @@
 <rect x="272" y="100" width="14" height="8" rx="2" fill="#1baf7a"/>
 <text class="legend-label" x="290" y="108">ctags</text>
 <text class="legend-label" x="355" y="108">* = unvalidated disagreement here</text>
+<text class="legend-label" x="16" y="122">** = validated by human/LLM inspection in lieu of another function-finding tool</text>
 <text class="panel-title" x="211.0" y="144">Functions Found</text>
 <text class="panel-title" x="343.0" y="144">Func Precision</text>
 <text class="panel-title" x="475.0" y="144">Classes Found</text>
@@ -39,14 +40,14 @@
 <rect x="154" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="161">124</text>
 <rect class="bar-track" x="286" y="153" width="88" height="34" rx="2"/>
-<rect x="286" y="153" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="161">0/124</text>
+<rect x="286" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="161">124/124**</text>
 <rect class="bar-track" x="418" y="153" width="88" height="34" rx="2"/>
 <rect x="418" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="161">12</text>
 <rect class="bar-track" x="550" y="153" width="88" height="34" rx="2"/>
-<rect x="550" y="153" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="161">0/12</text>
+<rect x="550" y="153" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="161">12/12**</text>
 <rect class="bar-track" x="682" y="153" width="88" height="34" rx="2"/>
 <text class="lang-label" x="20" y="217.5">ada</text>
 <text class="awaiting" x="154" y="217.5">awaiting language-crucible corpus</text>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T13:00:06Z",
+      "last_reconciled_at": "2026-08-20T13:12:49Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -116,7 +116,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T13:00:06Z",
+      "last_reconciled_at": "2026-08-20T13:12:49Z",
       "last_seen_count": 35,
       "last_seen_examples": [
         {
@@ -219,7 +219,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-20T13:00:08Z",
+      "last_reconciled_at": "2026-08-20T13:12:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -258,7 +258,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T13:00:10Z",
+      "last_reconciled_at": "2026-08-20T13:12:53Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -353,7 +353,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T13:00:10Z",
+      "last_reconciled_at": "2026-08-20T13:12:53Z",
       "last_seen_count": 20,
       "last_seen_examples": [
         {
@@ -457,7 +457,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -571,7 +571,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -676,7 +676,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -790,7 +790,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -823,7 +823,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -856,7 +856,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -973,7 +973,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1024,7 +1024,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1111,7 +1111,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1164,7 +1164,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1224,7 +1224,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T13:00:15Z",
+      "last_reconciled_at": "2026-08-20T13:12:59Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1339,7 +1339,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T13:00:20Z",
+      "last_reconciled_at": "2026-08-20T13:13:04Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1442,7 +1442,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T13:00:20Z",
+      "last_reconciled_at": "2026-08-20T13:13:04Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1545,7 +1545,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T13:00:20Z",
+      "last_reconciled_at": "2026-08-20T13:13:04Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1649,7 +1649,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1691,7 +1691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 95,
       "last_seen_examples": [
         {
@@ -1805,7 +1805,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1919,7 +1919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2033,7 +2033,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -2147,7 +2147,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2179,7 +2179,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2212,7 +2212,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -2308,7 +2308,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2341,7 +2341,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 1074,
       "last_seen_examples": [
         {
@@ -2455,7 +2455,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 1097,
       "last_seen_examples": [
         {
@@ -2569,7 +2569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 62,
       "last_seen_examples": [
         {
@@ -2683,7 +2683,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T13:00:25Z",
+      "last_reconciled_at": "2026-08-20T13:13:08Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2797,7 +2797,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2848,7 +2848,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2917,7 +2917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2995,7 +2995,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3028,7 +3028,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3115,7 +3115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3174,7 +3174,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3207,7 +3207,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3321,7 +3321,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3381,7 +3381,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3414,7 +3414,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3528,7 +3528,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3642,7 +3642,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T13:00:31Z",
+      "last_reconciled_at": "2026-08-20T13:13:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3675,7 +3675,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-20T13:00:32Z",
+      "last_reconciled_at": "2026-08-20T13:13:15Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3724,7 +3724,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T13:00:36Z",
+      "last_reconciled_at": "2026-08-20T13:13:19Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3827,7 +3827,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T13:00:36Z",
+      "last_reconciled_at": "2026-08-20T13:13:19Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3930,7 +3930,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T13:00:36Z",
+      "last_reconciled_at": "2026-08-20T13:13:19Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4034,7 +4034,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T13:00:42Z",
+      "last_reconciled_at": "2026-08-20T13:13:25Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4129,7 +4129,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T13:00:42Z",
+      "last_reconciled_at": "2026-08-20T13:13:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4162,7 +4162,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T13:00:42Z",
+      "last_reconciled_at": "2026-08-20T13:13:25Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4276,7 +4276,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T13:00:42Z",
+      "last_reconciled_at": "2026-08-20T13:13:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4318,7 +4318,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T13:00:42Z",
+      "last_reconciled_at": "2026-08-20T13:13:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4360,7 +4360,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-20T13:00:44Z",
+      "last_reconciled_at": "2026-08-20T13:13:28Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4474,7 +4474,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4586,7 +4586,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4691,7 +4691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4805,7 +4805,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4919,7 +4919,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5033,7 +5033,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5074,7 +5074,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5114,7 +5114,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T13:00:47Z",
+      "last_reconciled_at": "2026-08-20T13:13:31Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5228,7 +5228,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5342,7 +5342,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5456,7 +5456,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5569,7 +5569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5602,7 +5602,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5653,7 +5653,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5767,7 +5767,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T13:00:50Z",
+      "last_reconciled_at": "2026-08-20T13:13:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5818,7 +5818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -5932,7 +5932,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6019,7 +6019,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6061,7 +6061,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6175,7 +6175,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6289,7 +6289,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6403,7 +6403,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6517,7 +6517,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T13:00:53Z",
+      "last_reconciled_at": "2026-08-20T13:13:36Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6631,7 +6631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T13:00:55Z",
+      "last_reconciled_at": "2026-08-20T13:13:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6682,7 +6682,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T13:00:55Z",
+      "last_reconciled_at": "2026-08-20T13:13:39Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6796,7 +6796,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T13:00:55Z",
+      "last_reconciled_at": "2026-08-20T13:13:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6828,7 +6828,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T13:01:02Z",
+      "last_reconciled_at": "2026-08-20T13:13:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6883,7 +6883,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T13:01:02Z",
+      "last_reconciled_at": "2026-08-20T13:13:45Z",
       "last_seen_count": 79,
       "last_seen_examples": [
         {
@@ -6986,7 +6986,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T13:01:02Z",
+      "last_reconciled_at": "2026-08-20T13:13:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7018,7 +7018,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-20T13:01:03Z",
+      "last_reconciled_at": "2026-08-20T13:13:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7049,7 +7049,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-20T13:01:05Z",
+      "last_reconciled_at": "2026-08-20T13:13:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7082,7 +7082,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T13:01:06Z",
+      "last_reconciled_at": "2026-08-20T13:13:49Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7196,7 +7196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T13:01:06Z",
+      "last_reconciled_at": "2026-08-20T13:13:49Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7310,7 +7310,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T13:01:06Z",
+      "last_reconciled_at": "2026-08-20T13:13:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7343,7 +7343,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T13:01:06Z",
+      "last_reconciled_at": "2026-08-20T13:13:49Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7385,7 +7385,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7418,7 +7418,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7449,7 +7449,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7563,7 +7563,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7650,7 +7650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7737,7 +7737,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7770,7 +7770,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T13:01:12Z",
+      "last_reconciled_at": "2026-08-20T13:13:55Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7884,7 +7884,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T13:01:17Z",
+      "last_reconciled_at": "2026-08-20T13:14:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7917,7 +7917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T13:01:17Z",
+      "last_reconciled_at": "2026-08-20T13:14:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T13:01:17Z",
+      "last_reconciled_at": "2026-08-20T13:14:00Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8064,7 +8064,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T13:01:19Z",
+      "last_reconciled_at": "2026-08-20T13:14:02Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8149,7 +8149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T13:01:19Z",
+      "last_reconciled_at": "2026-08-20T13:14:02Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8218,7 +8218,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T13:01:19Z",
+      "last_reconciled_at": "2026-08-20T13:14:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8251,7 +8251,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T13:01:19Z",
+      "last_reconciled_at": "2026-08-20T13:14:02Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8365,7 +8365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T13:01:28Z",
+      "last_reconciled_at": "2026-08-20T13:14:12Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8425,7 +8425,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T13:01:28Z",
+      "last_reconciled_at": "2026-08-20T13:14:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8458,7 +8458,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T13:01:28Z",
+      "last_reconciled_at": "2026-08-20T13:14:12Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -8572,7 +8572,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T13:01:28Z",
+      "last_reconciled_at": "2026-08-20T13:14:12Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8686,7 +8686,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T13:01:29Z",
+      "last_reconciled_at": "2026-08-20T13:14:13Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8728,7 +8728,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T13:01:29Z",
+      "last_reconciled_at": "2026-08-20T13:14:13Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8806,7 +8806,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T13:01:29Z",
+      "last_reconciled_at": "2026-08-20T13:14:13Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8857,7 +8857,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T13:01:29Z",
+      "last_reconciled_at": "2026-08-20T13:14:13Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8935,7 +8935,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T13:01:33Z",
+      "last_reconciled_at": "2026-08-20T13:14:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8986,7 +8986,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T13:01:33Z",
+      "last_reconciled_at": "2026-08-20T13:14:17Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9100,7 +9100,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T13:01:33Z",
+      "last_reconciled_at": "2026-08-20T13:14:17Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9212,7 +9212,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T13:01:33Z",
+      "last_reconciled_at": "2026-08-20T13:14:17Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9326,7 +9326,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T13:01:33Z",
+      "last_reconciled_at": "2026-08-20T13:14:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9359,7 +9359,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T13:01:33Z",
+      "last_reconciled_at": "2026-08-20T13:14:17Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9471,7 +9471,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-20T13:01:36Z",
+      "last_reconciled_at": "2026-08-20T13:14:19Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9574,7 +9574,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T13:01:40Z",
+      "last_reconciled_at": "2026-08-20T13:14:23Z",
       "last_seen_count": 92,
       "last_seen_examples": [
         {
@@ -9678,7 +9678,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-20T13:01:41Z",
+      "last_reconciled_at": "2026-08-20T13:14:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9710,7 +9710,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-20T13:01:42Z",
+      "last_reconciled_at": "2026-08-20T13:14:26Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9780,7 +9780,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T13:01:44Z",
+      "last_reconciled_at": "2026-08-20T13:14:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9811,7 +9811,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T13:01:44Z",
+      "last_reconciled_at": "2026-08-20T13:14:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9842,7 +9842,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T13:01:44Z",
+      "last_reconciled_at": "2026-08-20T13:14:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9874,7 +9874,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T13:01:46Z",
+      "last_reconciled_at": "2026-08-20T13:14:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9907,7 +9907,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T13:01:46Z",
+      "last_reconciled_at": "2026-08-20T13:14:29Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9949,7 +9949,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T13:01:46Z",
+      "last_reconciled_at": "2026-08-20T13:14:29Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10009,7 +10009,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T13:01:46Z",
+      "last_reconciled_at": "2026-08-20T13:14:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10042,7 +10042,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10084,7 +10084,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10196,7 +10196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10256,7 +10256,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10361,7 +10361,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10475,7 +10475,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -10589,7 +10589,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10631,7 +10631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T13:02:06Z",
+      "last_reconciled_at": "2026-08-20T13:14:50Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -10744,7 +10744,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T13:02:15Z",
+      "last_reconciled_at": "2026-08-20T13:14:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10775,7 +10775,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T13:02:15Z",
+      "last_reconciled_at": "2026-08-20T13:14:59Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -10878,7 +10878,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T13:02:15Z",
+      "last_reconciled_at": "2026-08-20T13:14:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/tests/tools/tri_comparison_chart.py
+++ b/tests/tools/tri_comparison_chart.py
@@ -116,6 +116,7 @@ COLOR SOURCE
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections import Counter
 from pathlib import Path
@@ -126,6 +127,36 @@ import tri_comparison_ledger as ledger_mod  # noqa: E402
 from tri_comparison_reconcile import ALL_TOOLS, MetricScore, reconcile_symbols  # noqa: E402
 
 CHART_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "self_scan" / "tri_comparison_chart.svg"
+
+# For a language with only ONE available tool (no tree-sitter, no ctags -- e.g. abap), precision
+# is structurally always 0/N: reconcile_symbols' matched_consensus requires a SECOND tool to
+# corroborate a slot, and there isn't one to ask. That's an honest number, not a wrong one -- but
+# it silently discards real evidence when a slower, manual pass (direct source cross-check, an
+# independent grep, an LLM read of the actual corpus) has already confirmed some or all of a
+# tool's claims by a different method than tool-vs-tool agreement. This file is that record,
+# reviewed and committed by hand -- never machine-generated, never auto-updated by a gather run --
+# so precision can show `verified/total**` instead of a bare `0/N` where a human (or an LLM,
+# reviewed by a human) has actually done the checking. `**` is deliberately distinct from `*`
+# (ledger_mod's "unvalidated cross-tool disagreement") -- this is a different evidentiary category
+# (single-source manual review, not multi-tool corroboration), not a stronger or weaker version of
+# the same claim, and the chart must never blur the two together.
+MANUAL_VERIFICATION_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "self_scan" / "manual_verification.json"
+
+
+def _load_manual_verification() -> dict:
+    if not MANUAL_VERIFICATION_PATH.exists():
+        return {}
+    return json.loads(MANUAL_VERIFICATION_PATH.read_text()).get("languages", {})
+
+
+def _manual_verification_entry(manual_verification: dict, lang: str, symbol_type: str) -> dict | None:
+    """Returns the (verified, total) record for (lang, symbol_type) only if it's still current --
+    `total` must equal the tool's OWN present found-count, not just exist. A stale record (the
+    engine's count moved since the record was written, e.g. a later fix or regression) must fall
+    back to the plain, honest `0/N` rather than silently keep claiming a verification that no
+    longer matches what the tool actually reports today. Never inferred/auto-refreshed here --
+    staleness is a signal to go re-verify and update the file by hand, not to guess."""
+    return manual_verification.get(lang, {}).get(symbol_type)
 
 # The 45 languages with real structural signatures (see docs/language_status/README.md) --
 # NODE_MAPS's 31 tree-sitter-baselined languages plus the 14 GitGalaxy extracts from but
@@ -327,6 +358,8 @@ _CHART_STYLE = """<style>
 def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
     from datetime import datetime, timezone
 
+    manual_verification = _load_manual_verification()
+
     langs = sorted(data_by_lang.keys())
     n = len(langs)
 
@@ -426,6 +459,10 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
         parts.append(f'<text class="legend-label" x="{lx + 18}" y="{legend_y}">{_TOOL_LABEL[tool]}</text>')
         lx += 18 + 9 * len(_TOOL_LABEL[tool]) + 20
     parts.append(f'<text class="legend-label" x="{lx}" y="{legend_y}">* = unvalidated disagreement here</text>')
+    parts.append(
+        f'<text class="legend-label" x="{left_margin}" y="{legend_y + 14}">** = validated by human/LLM '
+        + "inspection in lieu of another function-finding tool</text>"
+    )
 
     for i, (_, _, _, title, _, _) in enumerate(panels):
         px = panels_x_start + i * (panel_w + panel_gap)
@@ -488,6 +525,16 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
                 if ranked:
                     w = max(2, bar_max_w * score.rate_pct / 100.0)
                     label = f"{score.matched_consensus}/{score.total_slots}"
+                    # A manual-verification override only makes sense for a genuine 1-tool
+                    # group -- GitGalaxy alone, nothing to corroborate against at all. A 2-3
+                    # tool language's 0/N is a REAL precision problem worth seeing plainly;
+                    # papering over that with a manual record would hide the exact signal this
+                    # chart exists to surface. See MANUAL_VERIFICATION_PATH's own comment.
+                    if len(data.available_tools) == 1:
+                        mv = _manual_verification_entry(manual_verification, lang, symbol_type)
+                        if mv is not None and mv["total"] == score.total_slots:
+                            w = bar_max_w
+                            label = f"{mv['verified']}/{mv['total']}**"
                 else:
                     found = getattr(score, found_field)
                     w = max(2, bar_max_w * found / row_max_found) if row_max_found else 2


### PR DESCRIPTION
## Summary

The tri-comparison chart's precision panel structurally shows `0/N` for any language with only one available tool (no tree-sitter, no ctags -- `abap`, `dockerfile`, `jcl`, `livecode`, `yaml`): `matched_consensus` requires a SECOND tool to corroborate a slot, and there isn't one to ask. That's honest, but it silently discards real evidence when a slower manual pass (direct source cross-check, an independent grep, an LLM read of the actual corpus) has already confirmed a tool's claims by a different method.

## Changes

- Adds `docs/self_scan/manual_verification.json` -- a hand-reviewed, committed record (never machine-generated, never auto-updated by a gather run) that `tri_comparison_chart.py` reads to override a 1-tool language's precision label from `0/N` to `verified/total**` when the record's `total` still matches the tool's own current found-count (a staleness guard -- if the count moves later, the override silently stops applying rather than showing a stale verification).
- `**` is deliberately distinct from the existing `*` (unvalidated cross-tool disagreement) -- a different evidentiary category, single-source manual review vs. multi-tool corroboration, never conflated in the chart or its legend. New legend line added.
- Seeded abap's function/class precision (124/124, 12/12) from the verification already done in `docs/language_status/abap.md`'s §9 -- the same evidence that found and fixed 5 real engine bugs (#1898, #1899, #1904, #1907, #1911) in prior PRs.
- Added a matching `docs/self_scan/manual_verification.json` `.gitignore` negation (the blanket `*.json` rule was silently swallowing it, same pattern as the existing `tri_comparison_ledger.json` exception).
- Adds the tri-comparison chart to the root README's "Proof, Not Just Claims" section (item 5) alongside the existing tree-sitter-only chart, following `readme-maintenance`'s five rules -- numbers and links for every claim, the 5 zero-tool languages' `**` marker explicitly disclosed as a different evidentiary category rather than glossed over.

No changes to `gitgalaxy/` or the reconciliation logic itself (`tri_comparison_reconcile.py`) -- this is a display-layer feature in the chart renderer only, backed by a hand-reviewed data file, never a change to how cross-tool agreement is computed.

## Test plan

- [x] Regenerated the chart end-to-end (`tri_comparison_chart.py --all --write`) -- abap's row now shows `Func Precision: 124/124**`, `Class Precision: 12/12**`, both bars full-width; every other language's row unchanged.
- [x] Confirmed only 3 `**` occurrences in the whole SVG (the legend line + abap's two precision cells) -- no other language accidentally picked one up.
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key/ast-accuracy all clear.
- [x] Verified every new README link resolves to a real file in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)