### PR TITLE
feat(tri-comparison): badge for verified Args Found, document gg-only workflow

### DIFF
--- a/.claude/skills/tri-comparison-ledger-sweep/SKILL.md
+++ b/.claude/skills/tri-comparison-ledger-sweep/SKILL.md
@@ -105,21 +105,84 @@ has anything to act on) and do a **manual verification** instead:
    `credit_tools`/`debit_tools` mechanism applies -- the papertrail is just the language_status doc
    (below) plus any GitHub issues / `why_gitgalaxy_beats_ast_here.md` entries from step 4, same
    three buckets as step 4.3 above, decided by hand instead of via a reviewed dispatch.
+7. **Once a signature is genuinely verified (not just checked once -- re-checked per step 2b/5's
+   discipline, ideally after any bugs found along the way are actually fixed), feed the real numbers
+   into `docs/self_scan/manual_verification.json` and regenerate the chart** so the work shows up
+   where a reader actually looks, not just in a doc nobody opens. This is a SEPARATE artifact from
+   the ledger (`docs/self_scan/tri_comparison_ledger.json`) -- gg-only languages never get ledger
+   entries at all (no second tool means no discrepancy shape to log), so this file is their entire
+   parallel papertrail, keyed `{"languages": {"<lang>": {"function": {...}, "class": {...},
+   "args": {...}}}}`. Each entry needs `total`, `verified`, `verified_at`, `verified_by`, and a
+   `note` describing HOW it was checked (the actual method -- direct source read, an independent
+   grep, hand-checking N functions across M files -- not just "verified", which isn't evidence).
+   Never machine-generated or auto-updated by a gather run -- hand-write and hand-review it exactly
+   like the ledger.
+     - **The chart shows `verified/total**`** instead of the honest-but-uninformative `0/N` a
+       1-tool language's precision panel would otherwise show. `**` is deliberately distinct from
+       `*` (ledger_mod's "unvalidated cross-tool disagreement") -- a different evidentiary category
+       (single-source manual/LLM review, not multi-tool corroboration), never blurred together in
+       the chart or its legend.
+     - **Staleness guard is mandatory, and its anchor is DIFFERENT per panel** -- a manual record
+       must stop applying the instant the engine's live count no longer matches what was verified,
+       rather than silently keep claiming a verification that's gone stale. Func/Class Found use
+       `matched_consensus` (a real per-tool raw count even for 1 tool); Func/Class Precision use
+       `total_slots` (ditto); but **Args Found's own `total_slots` is structurally always 0 for a
+       1-tool language** (`reconcile_symbols` only increments it when 2+ tools are comparable at a
+       slot -- there's no per-tool raw args count anywhere in `MetricScore` at all), so it needed
+       its OWN live anchor (`LanguageChartData.gg_args_found`, populated straight from
+       `Occurrence.args` in `run_pipeline`, independent of any cross-tool comparison machinery) --
+       don't assume every panel's staleness check can reuse the same field just because two of them
+       happen to.
+     - **A fully-verified 1-tool language can now earn a real badge**, not just the `**` label --
+       `_manual_verification_winner()` (a fallback used only when `_winner`/`_winner_or_tie` found
+       no real 2+-tool comparison at all) awards GitGalaxy's own badge when `verified == total`
+       EXACTLY, never for a partial verification (some slots checked, some not) -- partial credit
+       earns the `**` label's honesty but not a badge's full confidence claim. This exists on
+       purpose so GitGalaxy going after more tree-sitter/ctags-blind "frontier" languages doesn't
+       mean permanent badge-lessness for them -- a real, rigorous manual verification earns the
+       same "we know who's actually right" claim a cross-tool win earns, just via a different,
+       equally rigorous method, not a lesser one.
+     - Regenerate with the normal `--all --write` (step 6 below, same "never a partial
+       `--languages` list" rule) and confirm the diff is scoped to the language you just verified
+       plus expected ripple, same rigor as any other chart regeneration.
 
 Write the result up the same way step 8 does for a cleared ledger backlog -- a manual-verification
 section in `docs/language_status/<lang>.md` (not the tri-comparison template that assumes a second
 tool exists to compare against), following the same split: sections 1-8 via the `language-status`
 skill (dispatched separately, stopped before its own final section), this section written by hand
-in parallel. **Real result of the abap pass, after step 2b caught what step 2 alone missed
-(2026-08-19):** two confirmed engine defects, not zero -- `prism.py`'s positional-comment stripper
-reuses Fortran/COBOL's column-1 anchor set for ABAP, erasing every flush-left `CLASS ...
-DEFINITION`/`IMPLEMENTATION` line as a bogus comment before the (otherwise-correct) `class_start`
-regex ever runs ([#1898](https://github.com/squid-protocol/gitgalaxy/issues/1898)); and ABAP has no
-`ScopeParsingRegistry` entry in `detector.py`, so it silently falls through to brace-based function
-slicing despite having no braces, dropping ~87% of real named functions from `function_data`
-([#1899](https://github.com/squid-protocol/gitgalaxy/issues/1899)). The raw `func_start` regex
-itself really was 100% correct in isolation (124/124) -- that part of the first draft wasn't wrong,
-it was just an incomplete claim mistaken for a complete one.
+in parallel. **Real result of the full abap pass (2026-08-19/20), after step 2b/5's discipline
+caught what a single pass would have missed:** SEVEN confirmed engine defects, not zero -- found in
+three waves, each surfaced by re-verifying the previous fix rather than trusting it:
+- Wave 1 (raw pipeline vs. regex-in-isolation): `prism.py`'s positional-comment stripper reused
+  Fortran/COBOL's column-1 anchor set for ABAP, erasing every flush-left `CLASS ...
+  DEFINITION`/`IMPLEMENTATION` line as a bogus comment before `class_start` ever ran
+  ([#1898](https://github.com/squid-protocol/gitgalaxy/issues/1898)); ABAP had no
+  `ScopeParsingRegistry` entry in `detector.py`, silently falling through to brace-based function
+  slicing despite having no braces, dropping ~87% of real named functions
+  ([#1899](https://github.com/squid-protocol/gitgalaxy/issues/1899)).
+- Wave 2 (regenerating the chart after wave 1 merged, then verifying THAT fix): ABAP was missing
+  from `_CLASS_START_NAMED_EXTRACTION_LANGS`, so the named class list stayed empty even after
+  #1898's fix restored the raw signal
+  ([#1904](https://github.com/squid-protocol/gitgalaxy/issues/1904)); the class-boundary resolver's
+  brace search mistook ABAP's own string-template syntax (`|text { expr }|`) for a real body
+  opener, truncating class scope and breaking method-to-class linkage
+  ([#1907](https://github.com/squid-protocol/gitgalaxy/issues/1907)).
+- Wave 3 (going back to close out an "open question, not yet root-caused" note instead of leaving
+  it): the SAME `prism.py` stripper as #1898, a different unqualified character (`!`, ABAP's
+  parameter-name escape prefix, mistaken for Fortran's inline-comment marker)
+  ([#1911](https://github.com/squid-protocol/gitgalaxy/issues/1911)); the `args` regex itself had
+  two independent correctness bugs (the `!` prefix broke matching entirely; `VALUE(...)` mis-
+  captured the literal word `TYPE` as a second parameter)
+  ([#1917](https://github.com/squid-protocol/gitgalaxy/issues/1917)); and even with the regex
+  fixed, the per-function args COUNT searched the wrong section of the file (the sliced
+  IMPLEMENTATION body instead of the DEFINITION section's real declaration) with a derivation
+  mechanism that structurally couldn't produce a count from this regex's per-clause-existence
+  shape at all ([#1918](https://github.com/squid-protocol/gitgalaxy/issues/1918)).
+
+The raw `func_start` regex itself really was 100% correct in isolation from the very first pass
+(124/124) -- that part was never wrong, it was just an incomplete claim mistaken for a complete
+one. Every other signature needed at least one more layer of "fix it, then re-verify the fix
+itself" before the chart could honestly show `**`/a badge.
 
 ## 0. Housekeeping before starting a new sweep
 
@@ -396,7 +459,7 @@ that language, same PR is fine.
 
 ## The papertrail, end to end
 
-Six layers, each serving a different reader -- step 4.3's three buckets map directly onto layers
+Seven layers, each serving a different reader -- step 4.3's three buckets map directly onto layers
 2-4 below, so "which bucket" and "which papertrail layer" are the same decision, not two separate
 ones:
 1. **The ledger entry itself** (`status`, `verdict`, `investigated_by`, `investigated_at`,
@@ -418,6 +481,11 @@ ones:
 6. **`docs/language_status/<lang>.md`**'s tri-comparison section (step 8, once a language's
    backlog fully clears) -- the synthesized, human-readable "what did we learn about this
    language" capstone, distinct from the per-shape ledger entries it's built from.
+7. **`docs/self_scan/manual_verification.json`** (step 7 of the gg-only fallback procedure above)
+   -- the layer-1 equivalent for a language that can never get a ledger entry at all (no second
+   tool means no discrepancy shape to log). Same discipline as the ledger: hand-written, hand-
+   reviewed, never machine-generated, and read directly by `tri_comparison_chart.py` to render the
+   `**` label / earn a badge for a genuinely verified 1-tool language.
 
 Commit messages should name the shapes validated, not just say "update ledger" -- a future reader
 `git log`-ing this file should be able to tell what changed and why without opening the diff.
@@ -449,19 +517,29 @@ Commit messages should name the shapes validated, not just say "update ledger" -
   the other as coincidentally also wrong for an unrelated reason -- rare.
 - Fixing one confirmed engine bug is not proof the surrounding extraction path is now fully
   correct -- re-verify the fix against the REAL pipeline/DB output (step 2b) before moving on,
-  every time, not just once per language. ABAP's manual-verification pass (2026-08-19/20) found 5
-  separate, independent bugs this way, not 1: fixing #1898 (a `prism.py` comment-stripping bug)
-  and re-checking its actual DB output surfaced #1899 (a completely different `detector.py`
-  slicing-mode bug) sitting right next to it; fixing #1899 and regenerating the tri-comparison
-  chart surfaced #1904 (a THIRD, independent bug -- a named-class-extraction allowlist gap);
-  verifying #1904's own fix surfaced #1907 (a fourth -- a class-boundary detector confused by
-  ABAP's own string-template syntax); and going back to close out step 4's "noted as a known open
-  question, not evidence-backed enough to file" item on `args` (rather than leaving it open
-  indefinitely) found a FIFTH, #1911 -- the exact same `prism.py` comment-stripper as #1898, but a
-  different unqualified character (`!`, not `C`/`c`/`/`). An "open question, not yet root-caused"
-  note in step 4 is a lead to come back to, not a permanent resting state -- don't let a sweep
-  close out with unresolved "probably related" questions still sitting in the doc if there's more
-  budget to chase them down. Each bug was invisible until the previous one was fixed and
-  re-checked against real output -- stopping at the first green result after fix #1 would have
-  left 4 more silently in place. See `docs/language_status/abap.md` §9 for the full evidence
-  trail.
+  every time, not just once per language. ABAP's manual-verification pass (2026-08-19/20) found 7
+  separate, independent bugs this way, not 1, across three waves: fixing #1898 (a `prism.py`
+  comment-stripping bug) and re-checking its actual DB output surfaced #1899 (a completely
+  different `detector.py` slicing-mode bug) sitting right next to it; fixing #1899 and regenerating
+  the tri-comparison chart surfaced #1904 (a THIRD, independent bug -- a named-class-extraction
+  allowlist gap); verifying #1904's own fix surfaced #1907 (a fourth -- a class-boundary detector
+  confused by ABAP's own string-template syntax); going back to close out step 4's "noted as a
+  known open question, not evidence-backed enough to file" item on `args` (rather than leaving it
+  open indefinitely) found a fifth, #1911 (the exact same `prism.py` comment-stripper as #1898, a
+  different unqualified character -- `!`, not `C`/`c`/`/`); and building the args `**` chart display
+  on top of THAT fix (rather than assuming a green regex meant a green per-function count) found
+  two more, #1917 (two more regex-correctness bugs in the same `args` pattern) and #1918 (the
+  per-function count searched the wrong section of the file entirely, with a derivation mechanism
+  that couldn't have produced a real count even in the right span). An "open question, not yet
+  root-caused" note in step 4 is a lead to come back to, not a permanent resting state -- don't let
+  a sweep close out with unresolved "probably related" questions still sitting in the doc if
+  there's more budget to chase them down. Each bug was invisible until the previous one was fixed
+  and re-checked against real output -- stopping at the first green result after fix #1 would have
+  left 6 more silently in place. See `docs/language_status/abap.md` §9 for the full evidence trail.
+- A manual-verification badge (step 7's `_manual_verification_winner()`) requires
+  `verified == total` EXACTLY -- resist the temptation to award one for "verified most of it" or
+  "spot-checked a representative sample and it all matched." A partial verification is real,
+  useful evidence and belongs in the `**` label same as always, but a badge is a stronger claim
+  ("we know who's actually right," matching what a real cross-tool win asserts) than "probably
+  fine based on a sample" earns -- don't blur the two the way this skill's own `*`/`**` distinction
+  already refuses to blur unvalidated-disagreement from manual-review.

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -55,6 +55,8 @@
 <rect class="bar-track" x="682" y="153" width="88" height="34" rx="2"/>
 <rect x="682" y="153" width="88" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="161">265/265**</text>
+<circle cx="786.0" cy="170.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="786.0" y="173.0">G</text>
 <text class="lang-label" x="20" y="217.5">ada</text>
 <text class="awaiting" x="154" y="217.5">awaiting language-crucible corpus</text>
 <rect class="stripe" x="16" y="236" width="780" height="44"/>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T14:30:34Z",
+      "last_reconciled_at": "2026-08-20T15:02:38Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -116,7 +116,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T14:30:34Z",
+      "last_reconciled_at": "2026-08-20T15:02:38Z",
       "last_seen_count": 35,
       "last_seen_examples": [
         {
@@ -219,7 +219,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-20T14:30:36Z",
+      "last_reconciled_at": "2026-08-20T15:02:39Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -258,7 +258,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T14:30:38Z",
+      "last_reconciled_at": "2026-08-20T15:02:41Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -353,7 +353,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T14:30:38Z",
+      "last_reconciled_at": "2026-08-20T15:02:41Z",
       "last_seen_count": 20,
       "last_seen_examples": [
         {
@@ -457,7 +457,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -571,7 +571,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -676,7 +676,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -790,7 +790,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -823,7 +823,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -856,7 +856,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -973,7 +973,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1024,7 +1024,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1111,7 +1111,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1164,7 +1164,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1224,7 +1224,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T14:30:43Z",
+      "last_reconciled_at": "2026-08-20T15:02:46Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1339,7 +1339,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T14:30:48Z",
+      "last_reconciled_at": "2026-08-20T15:02:51Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1442,7 +1442,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T14:30:48Z",
+      "last_reconciled_at": "2026-08-20T15:02:51Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1545,7 +1545,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T14:30:48Z",
+      "last_reconciled_at": "2026-08-20T15:02:51Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1649,7 +1649,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1691,7 +1691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 95,
       "last_seen_examples": [
         {
@@ -1805,7 +1805,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1919,7 +1919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2033,7 +2033,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -2147,7 +2147,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2179,7 +2179,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2212,7 +2212,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -2308,7 +2308,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2341,7 +2341,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 1074,
       "last_seen_examples": [
         {
@@ -2455,7 +2455,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 1097,
       "last_seen_examples": [
         {
@@ -2569,7 +2569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 62,
       "last_seen_examples": [
         {
@@ -2683,7 +2683,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T14:30:53Z",
+      "last_reconciled_at": "2026-08-20T15:02:56Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2797,7 +2797,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2848,7 +2848,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2917,7 +2917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2995,7 +2995,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3028,7 +3028,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3115,7 +3115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3174,7 +3174,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3207,7 +3207,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3321,7 +3321,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3381,7 +3381,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3414,7 +3414,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3528,7 +3528,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3642,7 +3642,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T14:30:59Z",
+      "last_reconciled_at": "2026-08-20T15:03:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3675,7 +3675,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-20T14:31:00Z",
+      "last_reconciled_at": "2026-08-20T15:03:03Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3724,7 +3724,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T14:31:04Z",
+      "last_reconciled_at": "2026-08-20T15:03:07Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3827,7 +3827,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T14:31:04Z",
+      "last_reconciled_at": "2026-08-20T15:03:07Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3930,7 +3930,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T14:31:04Z",
+      "last_reconciled_at": "2026-08-20T15:03:07Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4034,7 +4034,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T14:31:10Z",
+      "last_reconciled_at": "2026-08-20T15:03:14Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4129,7 +4129,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T14:31:10Z",
+      "last_reconciled_at": "2026-08-20T15:03:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4162,7 +4162,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T14:31:10Z",
+      "last_reconciled_at": "2026-08-20T15:03:14Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4276,7 +4276,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T14:31:10Z",
+      "last_reconciled_at": "2026-08-20T15:03:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4318,7 +4318,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T14:31:10Z",
+      "last_reconciled_at": "2026-08-20T15:03:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4360,7 +4360,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-20T14:31:12Z",
+      "last_reconciled_at": "2026-08-20T15:03:16Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4474,7 +4474,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4586,7 +4586,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4691,7 +4691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4805,7 +4805,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4919,7 +4919,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5033,7 +5033,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5074,7 +5074,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5114,7 +5114,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T14:31:15Z",
+      "last_reconciled_at": "2026-08-20T15:03:19Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5228,7 +5228,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5342,7 +5342,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5456,7 +5456,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5569,7 +5569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5602,7 +5602,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5653,7 +5653,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5767,7 +5767,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T14:31:18Z",
+      "last_reconciled_at": "2026-08-20T15:03:22Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5818,7 +5818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -5932,7 +5932,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6019,7 +6019,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6061,7 +6061,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6175,7 +6175,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6289,7 +6289,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6403,7 +6403,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6517,7 +6517,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T14:31:21Z",
+      "last_reconciled_at": "2026-08-20T15:03:25Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6631,7 +6631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T14:31:23Z",
+      "last_reconciled_at": "2026-08-20T15:03:28Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6682,7 +6682,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T14:31:23Z",
+      "last_reconciled_at": "2026-08-20T15:03:28Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6796,7 +6796,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T14:31:23Z",
+      "last_reconciled_at": "2026-08-20T15:03:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6828,7 +6828,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T14:31:29Z",
+      "last_reconciled_at": "2026-08-20T15:03:34Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6883,7 +6883,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T14:31:29Z",
+      "last_reconciled_at": "2026-08-20T15:03:34Z",
       "last_seen_count": 79,
       "last_seen_examples": [
         {
@@ -6986,7 +6986,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T14:31:29Z",
+      "last_reconciled_at": "2026-08-20T15:03:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7018,7 +7018,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-20T14:31:30Z",
+      "last_reconciled_at": "2026-08-20T15:03:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7049,7 +7049,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-20T14:31:32Z",
+      "last_reconciled_at": "2026-08-20T15:03:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7082,7 +7082,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T14:31:34Z",
+      "last_reconciled_at": "2026-08-20T15:03:38Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7196,7 +7196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T14:31:34Z",
+      "last_reconciled_at": "2026-08-20T15:03:38Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7310,7 +7310,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T14:31:34Z",
+      "last_reconciled_at": "2026-08-20T15:03:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7343,7 +7343,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T14:31:34Z",
+      "last_reconciled_at": "2026-08-20T15:03:38Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7385,7 +7385,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7418,7 +7418,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7449,7 +7449,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7563,7 +7563,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7650,7 +7650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7737,7 +7737,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7770,7 +7770,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T14:31:40Z",
+      "last_reconciled_at": "2026-08-20T15:03:44Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7884,7 +7884,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T14:31:44Z",
+      "last_reconciled_at": "2026-08-20T15:03:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7917,7 +7917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T14:31:44Z",
+      "last_reconciled_at": "2026-08-20T15:03:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T14:31:44Z",
+      "last_reconciled_at": "2026-08-20T15:03:49Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8064,7 +8064,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T14:31:47Z",
+      "last_reconciled_at": "2026-08-20T15:03:51Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8149,7 +8149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T14:31:47Z",
+      "last_reconciled_at": "2026-08-20T15:03:51Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8218,7 +8218,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T14:31:47Z",
+      "last_reconciled_at": "2026-08-20T15:03:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8251,7 +8251,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T14:31:47Z",
+      "last_reconciled_at": "2026-08-20T15:03:51Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8365,7 +8365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T14:31:56Z",
+      "last_reconciled_at": "2026-08-20T15:04:00Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8425,7 +8425,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T14:31:56Z",
+      "last_reconciled_at": "2026-08-20T15:04:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8458,7 +8458,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T14:31:56Z",
+      "last_reconciled_at": "2026-08-20T15:04:00Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -8572,7 +8572,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T14:31:56Z",
+      "last_reconciled_at": "2026-08-20T15:04:00Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8686,7 +8686,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T14:31:57Z",
+      "last_reconciled_at": "2026-08-20T15:04:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8728,7 +8728,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T14:31:57Z",
+      "last_reconciled_at": "2026-08-20T15:04:02Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8806,7 +8806,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T14:31:57Z",
+      "last_reconciled_at": "2026-08-20T15:04:02Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8857,7 +8857,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T14:31:57Z",
+      "last_reconciled_at": "2026-08-20T15:04:02Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8935,7 +8935,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T14:32:01Z",
+      "last_reconciled_at": "2026-08-20T15:04:06Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8986,7 +8986,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T14:32:01Z",
+      "last_reconciled_at": "2026-08-20T15:04:06Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9100,7 +9100,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T14:32:01Z",
+      "last_reconciled_at": "2026-08-20T15:04:06Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9212,7 +9212,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T14:32:01Z",
+      "last_reconciled_at": "2026-08-20T15:04:06Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9326,7 +9326,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T14:32:01Z",
+      "last_reconciled_at": "2026-08-20T15:04:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9359,7 +9359,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T14:32:01Z",
+      "last_reconciled_at": "2026-08-20T15:04:06Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9471,7 +9471,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-20T14:32:03Z",
+      "last_reconciled_at": "2026-08-20T15:04:08Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9574,7 +9574,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T14:32:07Z",
+      "last_reconciled_at": "2026-08-20T15:04:12Z",
       "last_seen_count": 92,
       "last_seen_examples": [
         {
@@ -9678,7 +9678,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-20T14:32:09Z",
+      "last_reconciled_at": "2026-08-20T15:04:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9710,7 +9710,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-20T14:32:10Z",
+      "last_reconciled_at": "2026-08-20T15:04:15Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9780,7 +9780,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T14:32:12Z",
+      "last_reconciled_at": "2026-08-20T15:04:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9811,7 +9811,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T14:32:12Z",
+      "last_reconciled_at": "2026-08-20T15:04:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9842,7 +9842,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T14:32:12Z",
+      "last_reconciled_at": "2026-08-20T15:04:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9874,7 +9874,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T14:32:13Z",
+      "last_reconciled_at": "2026-08-20T15:04:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9907,7 +9907,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T14:32:13Z",
+      "last_reconciled_at": "2026-08-20T15:04:18Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9949,7 +9949,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T14:32:13Z",
+      "last_reconciled_at": "2026-08-20T15:04:18Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10009,7 +10009,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T14:32:13Z",
+      "last_reconciled_at": "2026-08-20T15:04:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10042,7 +10042,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10084,7 +10084,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10196,7 +10196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10256,7 +10256,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10361,7 +10361,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10475,7 +10475,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -10589,7 +10589,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10631,7 +10631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T14:32:34Z",
+      "last_reconciled_at": "2026-08-20T15:04:38Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -10744,7 +10744,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T14:32:42Z",
+      "last_reconciled_at": "2026-08-20T15:04:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10775,7 +10775,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T14:32:42Z",
+      "last_reconciled_at": "2026-08-20T15:04:47Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -10878,7 +10878,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T14:32:42Z",
+      "last_reconciled_at": "2026-08-20T15:04:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/tests/tools/tri_comparison_chart.py
+++ b/tests/tools/tri_comparison_chart.py
@@ -364,8 +364,8 @@ def _winner(scores: dict[str, MetricScore], available_tools: tuple[str, ...]) ->
 def _manual_verification_winner(
     manual_verification: dict,
     lang: str,
-    symbol_type: str,
-    scores: dict[str, MetricScore],
+    mv_key: str,
+    live_total: int | None,
     available_tools: tuple[str, ...],
 ) -> str | None:
     """A badge for a genuine cross-tool win means "we know who's actually right" -- but for a
@@ -378,19 +378,24 @@ def _manual_verification_winner(
     method (see MANUAL_VERIFICATION_PATH's own comment) -- it shouldn't be structurally locked
     out of the badge just because it's on the frontier. Returns "gitgalaxy" (the only tool that
     can ever hold this position) only when: exactly one tool is available, a manual-verification
-    record exists for (lang, symbol_type), that record's `total` still matches the tool's own
-    current found-count (the same staleness guard the `**` label uses), AND the record is a FULL
-    verification (`verified == total`) -- a partial one (some slots checked, some not) earns the
-    `**` label's honest partial credit but not the full confidence claim a badge makes. Never
-    called when _winner already found a real 2+-tool winner -- this is a fallback for the
-    "structurally couldn't have one" case only, not a replacement for real corroboration."""
+    record exists at manual_verification[lang][mv_key] (`mv_key` is "function"/"class" for the
+    precision panels, "args" for Args Found -- args uses a DIFFERENT key than symbol_type would
+    give, since symbol_type is "function" for both func precision AND args and the two must not
+    collide), that record's `total` still matches `live_total` -- the same staleness guard the
+    `**` label uses, and deliberately a CALLER-SUPPLIED value rather than always reading
+    score.total_slots here, since args_scores' own total_slots is structurally always 0 for a
+    1-tool language (see gg_args_found's own comment) and needs a different live anchor than the
+    precision panels do -- AND the record is a FULL verification (`verified == total`) -- a
+    partial one (some slots checked, some not) earns the `**` label's honest partial credit but
+    not the full confidence claim a badge makes. Never called when _winner already found a real
+    2+-tool winner -- this is a fallback for the "structurally couldn't have one" case only, not
+    a replacement for real corroboration."""
     if len(available_tools) != 1 or available_tools[0] != "gitgalaxy":
         return None
-    score = scores.get("gitgalaxy")
-    if score is None:
+    if live_total is None:
         return None
-    mv = _manual_verification_entry(manual_verification, lang, symbol_type)
-    if mv is None or mv["total"] != score.total_slots:
+    mv = _manual_verification_entry(manual_verification, lang, mv_key)
+    if mv is None or mv["total"] != live_total:
         return None
     if mv["verified"] != mv["total"]:
         return None
@@ -479,7 +484,14 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
                 continue
             result = _winner_or_tie(scores, data.available_tools)
             if result is None:
-                result = _manual_verification_winner(manual_verification, lang, symbol_type, scores, data.available_tools)
+                gg_score = scores.get("gitgalaxy")
+                result = _manual_verification_winner(
+                    manual_verification,
+                    lang,
+                    symbol_type,
+                    gg_score.total_slots if gg_score is not None else None,
+                    data.available_tools,
+                )
             if result is not None:
                 tally[result] += 1
     total_votes = sum(tally.values())
@@ -631,12 +643,19 @@ def render_chart(data_by_lang: dict[str, LanguageChartData]) -> str:
                 )
                 bar_y += bar_h + sub_gap
 
-            if ranked and not disputed:
-                winner = _winner(scores, data.available_tools)
+            # Args Found is unranked (see module docstring's PANELS section -- found-count
+            # panels have no cross-tool "winner" concept, more-found isn't more-correct), so
+            # it's included here ONLY for the manual-verification fallback path, never for a
+            # real _winner() cross-tool comparison -- there's no such thing to compute for it.
+            if (ranked or attr == "args") and not disputed:
+                winner = _winner(scores, data.available_tools) if ranked else None
                 if winner is None:
-                    winner = _manual_verification_winner(
-                        manual_verification, lang, symbol_type, scores, data.available_tools
+                    gg_score = scores.get("gitgalaxy")
+                    mv_key = symbol_type if ranked else "args"
+                    live_total = (
+                        (gg_score.total_slots if gg_score is not None else None) if ranked else data.gg_args_found
                     )
+                    winner = _manual_verification_winner(manual_verification, lang, mv_key, live_total, data.available_tools)
                 if winner:
                     bx = px + bar_max_w + inner_gap + badge_col_w / 2
                     by = y + row_h / 2


### PR DESCRIPTION
## Summary

### Args Found badge

Extended the badge mechanism from #1919 (func/class precision only) to also cover Args Found. Generalized `_manual_verification_winner()` to take an explicit `mv_key` + `live_total` pair instead of deriving them from `symbol_type`, since args needs a **different** `manual_verification.json` key (`"args"`, not `"function"` -- `symbol_type` is `"function"` for both func precision and args, which would otherwise collide) and a **different** live staleness anchor (`LanguageChartData.gg_args_found`, since `args_scores`' own `total_slots` is structurally always 0 for a 1-tool language). Extended the post-loop badge block to also fire for the (unranked) args panel via the manual-verification fallback only -- Args Found still has no real cross-tool "winner" concept, per the module docstring's own PANELS section.

abap's Args Found now shows a third "G" badge next to its existing two (func/class precision). Confirmed scoped to abap's own row -- no other language's row changed.

### SKILL.md: document the full gg-only workflow

Now that this has been through three full waves (7 confirmed bugs total across #1898/#1899/#1904/#1907/#1911/#1917/#1918):

- New step 7 on the manual-verification fallback procedure: once a signature is genuinely re-verified, feed it into `docs/self_scan/manual_verification.json` and regenerate the chart. Covers the `**`-vs-`*` distinction, the per-panel staleness-anchor gotcha (precision panels vs. Args Found need different live-count fields), and the badge mechanism's `verified == total` exactly gate.
- Added `manual_verification.json` as papertrail layer 7 -- the gg-only equivalent of the ledger (layer 1), since these languages never get a real ledger entry.
- Updated the "re-verify after every fix" gotcha bullet from 5 to all 7 confirmed bugs, reframed as three waves each triggered by refusing to stop at the previous fix's green result.
- New gotcha: a manual-verification badge requires `verified == total` exactly, never partial-credit -- a badge is a stronger claim than the `**` label makes.

## Test plan

- [x] Regenerated `tri_comparison_chart.svg` -- abap now shows 3 badges (func precision, class precision, args), all correctly scoped; confirmed via a script cross-referencing every badge in the file back to its row's language label.
- [x] `python tests/tools/audit_check.py` -- ruff/mypy/dead-key/ast-accuracy all clear.
- [x] No `gitgalaxy/` code touched -- this PR is scoped to the chart tool, docs, and skill only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)