### PR TITLE
fix(cobol): add cobol to class_start named-extraction allowlist

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -383,6 +383,19 @@ _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset(
         "abap",
         "apex",
         "c",
+        # #1858: cobol's own class_start regex already matches PROGRAM-ID/CLASS-ID/
+        # INTERFACE-ID/FACTORY/OBJECT correctly and identically to universal-ctags'
+        # independent reading (verified directly, e.g. cics-banking-sample-application-
+        # cbsa/BANKDATA.cbl:35's `PROGRAM-ID. BANKDATA.` -> "BANKDATA", matching ctags'
+        # own tag) -- cobol was simply never added to this allowlist (not decided out
+        # like css/html, just never in scope for epic #1295 since that epic's own
+        # verification method requires a tree-sitter grammar cobol doesn't have; this
+        # one is verified via docs/self_scan/tri_comparison_ledger.json's
+        # cobol/class/existence/agree[ctags]_vs[gitgalaxy] entry against ctags instead).
+        # Without this entry the generic fallback regex (class|struct|interface|trait|
+        # enum) can never match COBOL's PROGRAM-ID syntax, so the named classes list
+        # stayed permanently empty (0/19 real classes) despite cobol's own regex working.
+        "cobol",
         "cpp",
         "csharp",
         "css",


### PR DESCRIPTION
## Summary
- Closes #1858. Adds `"cobol"` to `detector.py`'s `_CLASS_START_NAMED_EXTRACTION_LANGS` allowlist.
- cobol's own `class_start` regex already matches `PROGRAM-ID`/`CLASS-ID`/`INTERFACE-ID`/`FACTORY`/`OBJECT` correctly and identically to universal-ctags' independent reading -- the match just never reached named-entity output because cobol was never added to this allowlist (epic #1295). Not decided out like css/html, simply never in scope since that epic's own verification method requires a tree-sitter grammar cobol doesn't have; verified instead via the tri-comparison ledger's `cobol/class/existence/agree[ctags]_vs[gitgalaxy]` entry (already validated and credited to ctags in a prior sweep, pending this fix).

## Verification
- Directly against the tri-comparison gatherer: GitGalaxy now finds **19/19** real classes across the cobol corpus, matching ctags exactly (was 0/19 before this fix).
- `tests/extraction/languages/test_cobol.py` + `test_cobol_strict.py`: 144/144 pass.
- Full `tests/core_engine/` + `tests/extraction/`: 6747 passed, 2 skipped, 11 xfailed, 3 xpassed -- no regressions.
- `python tests/tools/crucible_check.py`: full_precision PASS, zero_dependency PASS.
- `ruff_audit.py --ci` / `mypy_audit.py --ci` / `ruff format --check`: clean, no new findings.

## Test plan
- [x] Verified fix against real corpus via the tri-comparison gatherer (19/19, not just a synthetic fixture)
- [x] Full extraction/core_engine suite green
- [x] `crucible_check.py` differential scan clean (both venvs)
- [x] Baseline-gated audits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)