### PR TITLE
Break tri-comparison precision ties by validated count; codify as a system-wide rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,39 @@ before/after, not "heuristics are sometimes better") — this doc's whole value 
 overstate the exception into "GitGalaxy is more accurate than tree-sitter" in general, which isn't
 true.
 
+## Comparative-correctness claims require verification, not just the higher number
+
+This generalizes a rule first proven necessary on the tri-comparison chart (`tests/tools/
+tri_comparison_chart.py`, `tri_comparison_ledger.py`) but applicable anywhere in this repo a claim
+gets made that one measurement is "more correct" than another — a badge, a README claim, a PR
+description, a chart, a doc. **Never treat a raw number comparison alone as settling who's right.**
+A strictly-highest-percentage rule doesn't know or care about sample size or whether anyone has
+actually checked the disagreement against real source: a 2-sample cell at 100% (2/2) can outrank an
+80-sample cell at 98.75% (79/80) with equal visual confidence, which is an artifact of an unverified
+comparison, not evidence either side is more correct. The fix isn't "always trust the bigger sample"
+either — it's requiring that a claim of correctness be backed by someone (human or a dispatched
+agent standing in for one) actually reading the real disputed source and recording *why*, before it
+drives a badge, a chart, or a claim in prose.
+
+**The concrete mechanism this models on:** `tri_comparison_ledger.py`'s `has_open_question()` — a
+cell only earns a badge/claim once every ledger entry touching it is `status == "validated"` (a
+human or agent read real source and recorded a verdict), regardless of how lopsided the raw numbers
+look before that. See the tri-comparison-ledger-sweep skill for the full investigate-and-verify
+workflow this drives.
+
+**Once verified, a rate-only TIE needs its own tie-break — don't leave it badge-less by default
+either.** Found via a real case: GitGalaxy, tree-sitter, and ctags can each land on 100% precision
+for the same language/metric (each is simply never wrong about what it itself claims, at very
+different claim counts) once GitGalaxy's extra claims are ledger-validated — a rate-only comparison
+ties 3 ways and awards nobody, even though GitGalaxy demonstrably found more of the validated-real
+total (`_winner_or_tie()` in `tri_comparison_chart.py`: a rate tie is broken by each tied party's
+*absolute count of validated-correct occurrences*, not the raw claim count). This is the same
+"more evidence should count for something" principle as the sample-size fix above, pointing the
+opposite direction — a smaller sample's identical rate shouldn't get an unearned edge, but neither
+should a much larger *validated* sample lose one just for tying instead of leading outright. Only
+apply a count-based tie-break to values that already cleared the verification bar above; breaking
+a tie with unverified counts is exactly the anti-pattern this rule exists to prevent.
+
 ## Issue generation and pipeline/CI triage
 
 Two subagents with pinned models are set up for this so routine triage doesn't burn main-context

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -831,6 +831,8 @@
 <text class="bar-value-label" x="330.0" y="1639">1775/1775</text>
 <rect x="286" y="1643" width="88.0" height="10" rx="2" fill="#1baf7a"/>
 <text class="bar-value-label" x="330.0" y="1651">1774/1774</text>
+<circle cx="390.0" cy="1636.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1639.0">G</text>
 <rect class="bar-track" x="418" y="1619" width="88" height="34" rx="2"/>
 <rect x="418" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1627">312</text>
@@ -845,6 +847,8 @@
 <text class="bar-value-label" x="594.0" y="1639">287/287</text>
 <rect x="550" y="1643" width="88.0" height="10" rx="2" fill="#1baf7a"/>
 <text class="bar-value-label" x="594.0" y="1651">284/284</text>
+<circle cx="654.0" cy="1636.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="1639.0">G</text>
 <rect class="bar-track" x="682" y="1619" width="88" height="34" rx="2"/>
 <rect x="682" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1627">1774</text>
@@ -1064,7 +1068,7 @@
 <text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 23 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 4 (17%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 6 (26%)</text>
 <circle cx="209.6" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="209.6" y="2187">T</text>
 <text class="legend-label" x="222.6" y="2188">tree-sitter best: 1 (4%)</text>
@@ -1072,6 +1076,6 @@
 <text class="badge-label" x="402.4" y="2187">C</text>
 <text class="legend-label" x="415.4" y="2188">ctags best: 0 (0%)</text>
 <circle cx="558.0" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="571.0" y="2188">Ties: 18 (78%)</text>
+<text class="legend-label" x="571.0" y="2188">Ties: 16 (70%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T17:47:41Z",
+      "last_reconciled_at": "2026-08-20T18:18:38Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -116,7 +116,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T17:47:41Z",
+      "last_reconciled_at": "2026-08-20T18:18:38Z",
       "last_seen_count": 35,
       "last_seen_examples": [
         {
@@ -219,7 +219,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-20T17:47:42Z",
+      "last_reconciled_at": "2026-08-20T18:18:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -258,7 +258,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T17:47:44Z",
+      "last_reconciled_at": "2026-08-20T18:18:42Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -353,7 +353,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T17:47:44Z",
+      "last_reconciled_at": "2026-08-20T18:18:42Z",
       "last_seen_count": 20,
       "last_seen_examples": [
         {
@@ -457,7 +457,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -571,7 +571,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -676,7 +676,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -790,7 +790,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -823,7 +823,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -856,7 +856,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -973,7 +973,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1024,7 +1024,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1111,7 +1111,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1164,7 +1164,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1224,7 +1224,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T17:47:49Z",
+      "last_reconciled_at": "2026-08-20T18:18:47Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1339,7 +1339,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T17:47:54Z",
+      "last_reconciled_at": "2026-08-20T18:18:53Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1442,7 +1442,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T17:47:54Z",
+      "last_reconciled_at": "2026-08-20T18:18:53Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1545,7 +1545,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T17:47:54Z",
+      "last_reconciled_at": "2026-08-20T18:18:53Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1649,7 +1649,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1691,7 +1691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 95,
       "last_seen_examples": [
         {
@@ -1805,7 +1805,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1919,7 +1919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2033,7 +2033,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -2147,7 +2147,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2179,7 +2179,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2212,7 +2212,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -2308,7 +2308,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2341,7 +2341,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 1074,
       "last_seen_examples": [
         {
@@ -2455,7 +2455,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 1097,
       "last_seen_examples": [
         {
@@ -2569,7 +2569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 62,
       "last_seen_examples": [
         {
@@ -2683,7 +2683,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T17:47:59Z",
+      "last_reconciled_at": "2026-08-20T18:18:57Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2797,7 +2797,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2848,7 +2848,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2917,7 +2917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2995,7 +2995,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3028,7 +3028,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3115,7 +3115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3174,7 +3174,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3207,7 +3207,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3321,7 +3321,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3381,7 +3381,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3414,7 +3414,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3528,7 +3528,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3642,7 +3642,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T17:48:05Z",
+      "last_reconciled_at": "2026-08-20T18:19:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3675,7 +3675,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-20T17:48:06Z",
+      "last_reconciled_at": "2026-08-20T18:19:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3724,7 +3724,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T17:48:10Z",
+      "last_reconciled_at": "2026-08-20T18:19:08Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3827,7 +3827,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T17:48:10Z",
+      "last_reconciled_at": "2026-08-20T18:19:08Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3930,7 +3930,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T17:48:10Z",
+      "last_reconciled_at": "2026-08-20T18:19:08Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4034,7 +4034,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T17:48:16Z",
+      "last_reconciled_at": "2026-08-20T18:19:14Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4129,7 +4129,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T17:48:16Z",
+      "last_reconciled_at": "2026-08-20T18:19:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4162,7 +4162,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T17:48:16Z",
+      "last_reconciled_at": "2026-08-20T18:19:14Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4276,7 +4276,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T17:48:16Z",
+      "last_reconciled_at": "2026-08-20T18:19:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4318,7 +4318,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T17:48:16Z",
+      "last_reconciled_at": "2026-08-20T18:19:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4360,7 +4360,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-20T17:48:19Z",
+      "last_reconciled_at": "2026-08-20T18:19:17Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4474,7 +4474,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4586,7 +4586,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4691,7 +4691,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4805,7 +4805,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4919,7 +4919,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5033,7 +5033,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5074,7 +5074,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5114,7 +5114,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T17:48:21Z",
+      "last_reconciled_at": "2026-08-20T18:19:19Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5228,7 +5228,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5342,7 +5342,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5456,7 +5456,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5569,7 +5569,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5602,7 +5602,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5653,7 +5653,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5767,7 +5767,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T17:48:24Z",
+      "last_reconciled_at": "2026-08-20T18:19:22Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5818,7 +5818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -5932,7 +5932,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6019,7 +6019,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6061,7 +6061,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6175,7 +6175,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6289,7 +6289,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6403,7 +6403,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6517,7 +6517,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T17:48:28Z",
+      "last_reconciled_at": "2026-08-20T18:19:25Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6631,7 +6631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T17:48:30Z",
+      "last_reconciled_at": "2026-08-20T18:19:28Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6682,7 +6682,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T17:48:30Z",
+      "last_reconciled_at": "2026-08-20T18:19:28Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6796,7 +6796,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T17:48:30Z",
+      "last_reconciled_at": "2026-08-20T18:19:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6828,7 +6828,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T17:48:36Z",
+      "last_reconciled_at": "2026-08-20T18:19:34Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6883,7 +6883,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T17:48:36Z",
+      "last_reconciled_at": "2026-08-20T18:19:34Z",
       "last_seen_count": 79,
       "last_seen_examples": [
         {
@@ -6986,7 +6986,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T17:48:36Z",
+      "last_reconciled_at": "2026-08-20T18:19:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7018,7 +7018,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-20T17:48:38Z",
+      "last_reconciled_at": "2026-08-20T18:19:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7049,7 +7049,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-20T17:48:39Z",
+      "last_reconciled_at": "2026-08-20T18:19:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7082,7 +7082,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T17:48:41Z",
+      "last_reconciled_at": "2026-08-20T18:19:38Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7196,7 +7196,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T17:48:41Z",
+      "last_reconciled_at": "2026-08-20T18:19:38Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7310,7 +7310,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T17:48:41Z",
+      "last_reconciled_at": "2026-08-20T18:19:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7343,7 +7343,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T17:48:41Z",
+      "last_reconciled_at": "2026-08-20T18:19:38Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7385,7 +7385,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7418,7 +7418,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7449,7 +7449,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7563,7 +7563,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7650,7 +7650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7737,7 +7737,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7770,7 +7770,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T17:48:47Z",
+      "last_reconciled_at": "2026-08-20T18:19:44Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7884,7 +7884,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T17:48:52Z",
+      "last_reconciled_at": "2026-08-20T18:19:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7917,7 +7917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T17:48:52Z",
+      "last_reconciled_at": "2026-08-20T18:19:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T17:48:52Z",
+      "last_reconciled_at": "2026-08-20T18:19:49Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8064,7 +8064,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T17:48:54Z",
+      "last_reconciled_at": "2026-08-20T18:19:51Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8149,7 +8149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T17:48:54Z",
+      "last_reconciled_at": "2026-08-20T18:19:51Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8218,7 +8218,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T17:48:54Z",
+      "last_reconciled_at": "2026-08-20T18:19:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8251,7 +8251,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T17:48:54Z",
+      "last_reconciled_at": "2026-08-20T18:19:51Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8365,7 +8365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T17:49:03Z",
+      "last_reconciled_at": "2026-08-20T18:20:01Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8425,7 +8425,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T17:49:03Z",
+      "last_reconciled_at": "2026-08-20T18:20:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8458,7 +8458,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T17:49:03Z",
+      "last_reconciled_at": "2026-08-20T18:20:01Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -8572,7 +8572,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T17:49:03Z",
+      "last_reconciled_at": "2026-08-20T18:20:01Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8686,7 +8686,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T17:49:05Z",
+      "last_reconciled_at": "2026-08-20T18:20:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8728,7 +8728,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T17:49:05Z",
+      "last_reconciled_at": "2026-08-20T18:20:02Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8806,7 +8806,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T17:49:05Z",
+      "last_reconciled_at": "2026-08-20T18:20:02Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8857,7 +8857,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T17:49:05Z",
+      "last_reconciled_at": "2026-08-20T18:20:02Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8935,7 +8935,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T17:49:08Z",
+      "last_reconciled_at": "2026-08-20T18:20:07Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8988,7 +8988,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T17:49:08Z",
+      "last_reconciled_at": "2026-08-20T18:20:07Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9102,7 +9102,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T17:49:08Z",
+      "last_reconciled_at": "2026-08-20T18:20:07Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9214,7 +9214,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T17:49:08Z",
+      "last_reconciled_at": "2026-08-20T18:20:07Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9328,7 +9328,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T17:49:08Z",
+      "last_reconciled_at": "2026-08-20T18:20:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9363,7 +9363,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T17:49:08Z",
+      "last_reconciled_at": "2026-08-20T18:20:07Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9475,7 +9475,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-20T17:49:11Z",
+      "last_reconciled_at": "2026-08-20T18:20:09Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9578,7 +9578,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T17:49:15Z",
+      "last_reconciled_at": "2026-08-20T18:20:13Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -9680,7 +9680,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T17:49:15Z",
+      "last_reconciled_at": "2026-08-20T18:20:13Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -9784,7 +9784,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-20T17:49:17Z",
+      "last_reconciled_at": "2026-08-20T18:20:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9816,7 +9816,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-20T17:49:18Z",
+      "last_reconciled_at": "2026-08-20T18:20:16Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9886,7 +9886,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T17:49:20Z",
+      "last_reconciled_at": "2026-08-20T18:20:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9917,7 +9917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T17:49:20Z",
+      "last_reconciled_at": "2026-08-20T18:20:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9948,7 +9948,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T17:49:20Z",
+      "last_reconciled_at": "2026-08-20T18:20:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9980,7 +9980,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T17:49:21Z",
+      "last_reconciled_at": "2026-08-20T18:20:19Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10013,7 +10013,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T17:49:21Z",
+      "last_reconciled_at": "2026-08-20T18:20:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10055,7 +10055,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T17:49:21Z",
+      "last_reconciled_at": "2026-08-20T18:20:19Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10115,7 +10115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T17:49:21Z",
+      "last_reconciled_at": "2026-08-20T18:20:19Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10148,7 +10148,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10190,7 +10190,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10302,7 +10302,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10362,7 +10362,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10467,7 +10467,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10581,7 +10581,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -10695,7 +10695,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10737,7 +10737,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T17:49:42Z",
+      "last_reconciled_at": "2026-08-20T18:20:40Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -10850,7 +10850,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T17:49:50Z",
+      "last_reconciled_at": "2026-08-20T18:20:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10881,7 +10881,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T17:49:50Z",
+      "last_reconciled_at": "2026-08-20T18:20:48Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -10984,7 +10984,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T17:49:50Z",
+      "last_reconciled_at": "2026-08-20T18:20:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/tests/tools/tri_comparison_chart.py
+++ b/tests/tools/tri_comparison_chart.py
@@ -101,10 +101,14 @@ WINNER BADGE: REQUIRES VERIFICATION, NOT JUST THE HIGHER NUMBER
     98.75% (79/80) with a badge exactly as confident-looking as any other, an artifact of sample
     size nobody had verified, not evidence that tool was more correct there. A cell only gets a
     badge now if `has_open_question()` is False for it (no ledger entry currently reproduces
-    unvalidated) AND one available tool scored strictly highest -- a colored letter (G/T/C) in
-    that tool's own categorical color, in the space a stacked column of raw numbers used to
-    occupy. No badge on a disputed cell (regardless of how lopsided the raw numbers look) or a
-    tie.
+    unvalidated) AND one available tool scored strictly highest, OR won a tie-break among tools
+    sharing the top rate (see `_winner_or_tie`'s own docstring -- a rate-only tie is broken by
+    each tied tool's absolute count of validated-correct occurrences, so a tool that's simply
+    never wrong but narrower in scope doesn't erase the badge a tool with a larger validated
+    claim count has earned) -- a colored letter (G/T/C) in that tool's own categorical color, in
+    the space a stacked column of raw numbers used to occupy. No badge on a disputed cell
+    (regardless of how lopsided the raw numbers look), or a tie the count tie-break also can't
+    resolve.
 
     A 1-bar group (GitGalaxy alone -- no tree-sitter, no ctags) CAN earn a badge, via a
     different path than a cross-tool win: `_manual_verification_winner()` awards GitGalaxy's own
@@ -388,20 +392,41 @@ def _disputed(lang: str, symbol_type: str, ledger_metric: str) -> bool:
 
 def _winner_or_tie(scores: dict[str, MetricScore], available_tools: tuple[str, ...]) -> str | None:
     """Tool name with the strictly-highest score among available tools with real data; the
-    literal string "tie" if 2+ tools share the top score; None if fewer than 2 tools have real
-    data at all (a 1-bar group, or an empty panel) -- that last case isn't a comparison, so it's
-    kept distinct from a real tie rather than folded into it. The badge renderer only cares about
-    the winner case (see _winner below); the bottom-of-chart tally (render_chart's summary
-    block) needs all three states to count "how many of the 5x45 possible comparisons actually
-    happened, and how did each one resolve" without silently inflating the tie count with cells
-    that were never a real comparison to begin with."""
+    literal string "tie" if 2+ tools share the top score AND the tie can't be broken (see below);
+    None if fewer than 2 tools have real data at all (a 1-bar group, or an empty panel) -- that
+    last case isn't a comparison, so it's kept distinct from a real tie rather than folded into
+    it. The badge renderer only cares about the winner case (see _winner below); the
+    bottom-of-chart tally (render_chart's summary block) needs all three states to count "how
+    many of the 5x45 possible comparisons actually happened, and how did each one resolve"
+    without silently inflating the tie count with cells that were never a real comparison to
+    begin with.
+
+    A tie at the top rate_pct is broken by each tied tool's own matched_consensus (its absolute
+    count of validated-correct occurrences) -- confirmed necessary by rust's func/class existence
+    panels: GitGalaxy, tree-sitter, and ctags all land on 100% precision once GitGalaxy's
+    macro-body-only claims are ledger-validated (each tool is simply never WRONG about what it
+    claims, at very different claim counts -- 1927 vs. 1775 vs. 1774), so a rate-only comparison
+    ties 3 ways and nobody gets a badge despite GitGalaxy having demonstrably found MORE of the
+    validated-real total. This is the inverse of the sample-size bug the rate-only rule was
+    already fixed for (see this module's WINNER BADGE docstring): there, a smaller sample's
+    identical rate got an unearned edge; here, a larger validated sample at an identical rate was
+    getting NO edge at all. Both are the same principle -- more evidence should count for
+    something -- pointing opposite directions. Only ever reached once the caller has already
+    confirmed the cell isn't disputed (`_disputed`/`has_open_question` is checked before this is
+    called), so every matched_consensus value used here is already either unquestioned or
+    ledger-validated -- this breaks ties with verified evidence, not a bare unverified count."""
     vals = [(t, scores[t].rate_pct) for t in available_tools if t in scores and scores[t].rate_pct is not None]
     if len(vals) < 2:
         return None
     vals.sort(key=lambda tv: -tv[1])
-    if vals[0][1] == vals[1][1]:
+    top_rate = vals[0][1]
+    tied = [t for t, rate in vals if rate == top_rate]
+    if len(tied) < 2:
+        return tied[0]
+    counts = sorted(((t, scores[t].matched_consensus) for t in tied), key=lambda tc: -tc[1])
+    if counts[0][1] == counts[1][1]:
         return "tie"
-    return vals[0][0]
+    return counts[0][0]
 
 
 def _winner(scores: dict[str, MetricScore], available_tools: tuple[str, ...]) -> str | None:


### PR DESCRIPTION
## Summary

Found while investigating why rust's tri-comparison chart shows zero badges despite having the highest, ledger-validated accuracy: `_winner_or_tie()` in `tests/tools/tri_comparison_chart.py` had no tie-break at all -- any 2+-way tie on `rate_pct` returned `"tie"`, blank badge, full stop.

Rust's real case: Func/Class Precision now ties 3-way at 100% (GitGalaxy 1927/1927, tree-sitter 1775/1775, ctags 1774/1774) once GitGalaxy's macro-body-only claims were ledger-validated (#1941). Each tool is simply never *wrong* about what it itself claims, at very different claim counts -- so a rate-only comparison awards nobody, despite GitGalaxy having demonstrably found more of the validated-real total.

## Fix

Break a rate tie using each tied tool's absolute `matched_consensus` (its count of validated-correct occurrences), not the raw rate alone. This is the same "more evidence should count for something" principle as the existing sample-size fix (a 2-sample 100% cell no longer silently outranks an 80-sample 98.75% cell) -- just pointed the other direction: a 1927-sample validated 100% shouldn't lose to a 1774-sample validated 100% just because both cleared the same bar.

Only ever reached after the caller's `has_open_question()` check (already gated before `_winner_or_tie` is called), so every count used in the tie-break is already either unquestioned or ledger-validated -- this is **not** a reversion to the "just trust the bigger number" anti-pattern the verification system exists to prevent.

## Verified

- Direct unit check against rust's real numbers: `gitgalaxy` now wins the tie.
- Guard case 1: a genuine unbreakable tie (equal rate AND equal count) still returns `"tie"`.
- Guard case 2: the original sample-size-bug scenario (2/2 @ 100% vs. 79/80 @ 98.75%) is unaffected -- it was never a tie to begin with, so this path isn't touched.
- Full 45-language chart regenerated (`tri_comparison_chart.py --all --write`, using tree-sitter-language-pack + a locally-built universal-ctags): diff is exactly rust's two new badges (Func Precision, Class Precision) plus the summary tally moving 4→6 GitGalaxy wins / 18→16 ties. **No other language's badges changed.** `tri_comparison_ledger.json`'s diff is routine `last_reconciled_at` timestamp churn from the same regen run, no verdict/status content changed.

## Also: codifies this as a system-wide CLAUDE.md rule

The "badges require verification, not just the higher number" principle (originally proven necessary on 2026-08-19, landed via PR #1868) was only ever documented inside `tri_comparison_chart.py`'s own docstring and the `tri-comparison-ledger-sweep` skill -- never promoted to a repo-wide instruction. Added a new CLAUDE.md section generalizing it to any comparative-correctness claim in this repo (a badge, a README claim, a PR description), plus this PR's new tie-break rule, so future sessions apply the same standard without re-deriving it from a specific tool's source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)