### PR TITLE
docs(self-scan): validate agc_assembly tri-comparison ledger

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -64,14 +64,16 @@
 <text class="lang-label" x="20" y="275.5">agc_assembly</text>
 <rect class="bar-track" x="154" y="255" width="88" height="34" rx="2"/>
 <rect x="154" y="255" width="67.6" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="263">760*</text>
+<text class="bar-value-label" x="198.0" y="263">760</text>
 <rect x="154" y="267" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="275">990*</text>
+<text class="bar-value-label" x="198.0" y="275">990</text>
 <rect class="bar-track" x="286" y="255" width="88" height="34" rx="2"/>
-<rect x="286" y="255" width="83.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="263">725/760*</text>
+<rect x="286" y="255" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="263">760/760</text>
 <rect x="286" y="267" width="64.4" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="275">725/990*</text>
+<text class="bar-value-label" x="330.0" y="275">725/990</text>
+<circle cx="390.0" cy="272.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="275.0">G</text>
 <rect class="bar-track" x="418" y="255" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="255" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="255" width="88" height="34" rx="2"/>
@@ -1065,10 +1067,10 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 23 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 24 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 6 (26%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 7 (29%)</text>
 <circle cx="209.6" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="209.6" y="2187">T</text>
 <text class="legend-label" x="222.6" y="2188">tree-sitter best: 1 (4%)</text>
@@ -1076,6 +1078,6 @@
 <text class="badge-label" x="402.4" y="2187">C</text>
 <text class="legend-label" x="415.4" y="2188">ctags best: 0 (0%)</text>
 <circle cx="558.0" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="571.0" y="2188">Ties: 16 (70%)</text>
+<text class="legend-label" x="571.0" y="2188">Ties: 16 (67%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -10,10 +10,10 @@
         "gitgalaxy"
       ],
       "first_seen_at": "2026-08-19T23:28:20Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-20T00:00:00Z",
+      "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T18:18:38Z",
+      "last_reconciled_at": "2026-08-20T18:44:16Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -98,25 +98,27 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Mixed-cause shape, fully accounted for via a corpus-wide cross-reference of ctags' actual output against GitGalaxy's raw func_start regex matches and its real pipeline/DB output (215 + 50 = 265, no unexplained residual). (1) 215/265 (81%): ctags' Asm \"l\" kind tags EVERY line-start label unconditionally, including pure data/constant-definition labels (e.g. ERASCON1 OCTAL 00061, S10BITS, LSTBNKCH -- AGC_BLOCK_TWO_SELF-CHECK.agc:133 and nearby) that are never followed by an executable instruction. GitGalaxy's func_start regex deliberately requires the label be followed by a real instruction mnemonic from a fixed whitelist, so it does not count these as functions -- a genuine, intentional precision distinction (code label vs. data label), not a GitGalaxy defect; ctags' generic Asm parser has no way to make this distinction at all. (2) 50/265 (19%): a real, confirmed GitGalaxy engine defect in detector.py's _slice_by_labels (Mode A), independently root-caused to two separate bugs: (a) `RELINT` is incorrectly included in `self.assembly_returns`'s early-termination keyword list (detector.py:572-575) -- in real AGC assembly RELINT means \"release interrupt inhibit\" and commonly opens a long interrupt-handler routine rather than closing one, so it truncates the real body to one line (confirmed: ELOOPFIN, AGC_BLOCK_TWO_SELF-CHECK.agc:303, a 20+-line real routine collapsed to just its own label line); (b) the `len(block.splitlines()) < 2` guard (detector.py:1973) unconditionally discards legitimate single-instruction assembly subroutines when the next func_start match sits on the very next line (confirmed: SOPTION1-SOPTION5+, AGC_BLOCK_TWO_SELF-CHECK.agc:210-214, each a real one-instruction label). Filed as a GitHub issue; see that issue for the confirmed fix scope. No credit/debit -- the 215 portion is an honest scope difference (not two tools independently wrong about the same fact), and the 50 portion is GitGalaxy's own unresolved bug, not something ctags corroborates or contradicts."
     },
     "agc_assembly/function/existence/agree[gitgalaxy]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy"
       ],
-      "credit_tools": [],
+      "credit_tools": [
+        "gitgalaxy"
+      ],
       "debit_tools": [],
       "dissenting_tools": [
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:15Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-20T00:00:00Z",
+      "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T18:18:38Z",
+      "last_reconciled_at": "2026-08-20T18:44:16Z",
       "last_seen_count": 35,
       "last_seen_examples": [
         {
@@ -201,10 +203,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed: all 35 occurrences are real AGC labels that GitGalaxy correctly extracts and Universal Ctags' generic Asm parser structurally cannot tag, due to AGC assembly's non-standard label-naming conventions. Two sub-patterns, both confirmed corpus-wide (14/35 + 21/35 = 35/35, not just the sample): (1) labels with an embedded hyphen -- AGC's own convention of naming a point relative to an event, e.g. TIG-35/TIG-30/CALLT-35 in BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc:250/292/222 (\"35/30 seconds before Time of Ignition\"); (2) labels starting with a digit or a leading minus sign, e.g. 1CHK/2EBANK/-1CHK in AGC_BLOCK_TWO_SELF-CHECK.agc:184 (real label text is \"-1CHK\"). Directly verified via `ctags --language-force=Asm --kinds-Asm=l` against the real corpus files: ctags emits zero tags for any of these names (confirmed by grepping its actual output for the exact names and their surrounding CHK-suffixed siblings, which ARE tagged when they don't start with a hyphen/digit) -- ctags' Asm parser requires a tag name to start with a letter and contain no hyphen, neither of which is a real constraint in AGC assembly's own label syntax. GitGalaxy's func_start regex ([A-Z0-9_-]+ at line start) has no such restriction. This is a confirmed, structural ctags/Asm-parser limitation, not corroboration of anything wrong on GitGalaxy's side -- logged to docs/why_gitgalaxy_beats_ast_here.md."
     },
     "apex/function/existence/agree[gitgalaxy]_vs[tree_sitter]": {
       "agreeing_tools": [
@@ -219,7 +221,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "apex",
-      "last_reconciled_at": "2026-08-20T18:18:40Z",
+      "last_reconciled_at": "2026-08-20T18:44:17Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -258,7 +260,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T18:18:42Z",
+      "last_reconciled_at": "2026-08-20T18:44:20Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -353,7 +355,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T18:18:42Z",
+      "last_reconciled_at": "2026-08-20T18:44:20Z",
       "last_seen_count": 20,
       "last_seen_examples": [
         {
@@ -457,7 +459,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -571,7 +573,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -676,7 +678,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -790,7 +792,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -823,7 +825,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -856,7 +858,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -973,7 +975,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1024,7 +1026,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1111,7 +1113,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1164,7 +1166,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1224,7 +1226,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T18:18:47Z",
+      "last_reconciled_at": "2026-08-20T18:44:25Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1339,7 +1341,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T18:18:53Z",
+      "last_reconciled_at": "2026-08-20T18:44:30Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1442,7 +1444,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T18:18:53Z",
+      "last_reconciled_at": "2026-08-20T18:44:30Z",
       "last_seen_count": 133,
       "last_seen_examples": [
         {
@@ -1545,7 +1547,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T18:18:53Z",
+      "last_reconciled_at": "2026-08-20T18:44:30Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -1649,7 +1651,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1691,7 +1693,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 95,
       "last_seen_examples": [
         {
@@ -1805,7 +1807,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1919,7 +1921,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2033,7 +2035,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -2147,7 +2149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2179,7 +2181,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2212,7 +2214,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -2308,7 +2310,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2341,7 +2343,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 1074,
       "last_seen_examples": [
         {
@@ -2455,7 +2457,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 1097,
       "last_seen_examples": [
         {
@@ -2569,7 +2571,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 62,
       "last_seen_examples": [
         {
@@ -2683,7 +2685,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T18:18:57Z",
+      "last_reconciled_at": "2026-08-20T18:44:34Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2797,7 +2799,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2848,7 +2850,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2917,7 +2919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -2995,7 +2997,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3028,7 +3030,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3115,7 +3117,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3174,7 +3176,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3207,7 +3209,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3321,7 +3323,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3381,7 +3383,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3414,7 +3416,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 107,
       "last_seen_examples": [
         {
@@ -3528,7 +3530,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3642,7 +3644,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T18:19:03Z",
+      "last_reconciled_at": "2026-08-20T18:44:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3675,7 +3677,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-20T18:19:04Z",
+      "last_reconciled_at": "2026-08-20T18:44:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3724,7 +3726,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T18:19:08Z",
+      "last_reconciled_at": "2026-08-20T18:44:46Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3827,7 +3829,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T18:19:08Z",
+      "last_reconciled_at": "2026-08-20T18:44:46Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3930,7 +3932,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T18:19:08Z",
+      "last_reconciled_at": "2026-08-20T18:44:46Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4034,7 +4036,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T18:19:14Z",
+      "last_reconciled_at": "2026-08-20T18:44:51Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4129,7 +4131,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T18:19:14Z",
+      "last_reconciled_at": "2026-08-20T18:44:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4162,7 +4164,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T18:19:14Z",
+      "last_reconciled_at": "2026-08-20T18:44:51Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4276,7 +4278,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T18:19:14Z",
+      "last_reconciled_at": "2026-08-20T18:44:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4318,7 +4320,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T18:19:14Z",
+      "last_reconciled_at": "2026-08-20T18:44:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4360,7 +4362,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-20T18:19:17Z",
+      "last_reconciled_at": "2026-08-20T18:44:54Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4474,7 +4476,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4586,7 +4588,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4691,7 +4693,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4805,7 +4807,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -4919,7 +4921,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5033,7 +5035,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5074,7 +5076,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5114,7 +5116,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T18:19:19Z",
+      "last_reconciled_at": "2026-08-20T18:44:57Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5228,7 +5230,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5342,7 +5344,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5456,7 +5458,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5569,7 +5571,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5602,7 +5604,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5653,7 +5655,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5767,7 +5769,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T18:19:22Z",
+      "last_reconciled_at": "2026-08-20T18:45:00Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5818,7 +5820,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -5932,7 +5934,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6019,7 +6021,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6061,7 +6063,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6175,7 +6177,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6289,7 +6291,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6403,7 +6405,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6517,7 +6519,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T18:19:25Z",
+      "last_reconciled_at": "2026-08-20T18:45:03Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6631,7 +6633,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T18:19:28Z",
+      "last_reconciled_at": "2026-08-20T18:45:06Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6682,7 +6684,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T18:19:28Z",
+      "last_reconciled_at": "2026-08-20T18:45:06Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6796,7 +6798,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T18:19:28Z",
+      "last_reconciled_at": "2026-08-20T18:45:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6828,7 +6830,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T18:19:34Z",
+      "last_reconciled_at": "2026-08-20T18:45:12Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6883,7 +6885,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T18:19:34Z",
+      "last_reconciled_at": "2026-08-20T18:45:12Z",
       "last_seen_count": 79,
       "last_seen_examples": [
         {
@@ -6986,7 +6988,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T18:19:34Z",
+      "last_reconciled_at": "2026-08-20T18:45:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7018,7 +7020,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-20T18:19:35Z",
+      "last_reconciled_at": "2026-08-20T18:45:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7049,7 +7051,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-20T18:19:37Z",
+      "last_reconciled_at": "2026-08-20T18:45:15Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7082,7 +7084,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T18:19:38Z",
+      "last_reconciled_at": "2026-08-20T18:45:17Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7196,7 +7198,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T18:19:38Z",
+      "last_reconciled_at": "2026-08-20T18:45:17Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7310,7 +7312,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T18:19:38Z",
+      "last_reconciled_at": "2026-08-20T18:45:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7343,7 +7345,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T18:19:38Z",
+      "last_reconciled_at": "2026-08-20T18:45:17Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7385,7 +7387,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7418,7 +7420,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7449,7 +7451,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7563,7 +7565,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7650,7 +7652,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7737,7 +7739,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7770,7 +7772,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T18:19:44Z",
+      "last_reconciled_at": "2026-08-20T18:45:23Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7884,7 +7886,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T18:19:49Z",
+      "last_reconciled_at": "2026-08-20T18:45:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7917,7 +7919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T18:19:49Z",
+      "last_reconciled_at": "2026-08-20T18:45:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7950,7 +7952,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T18:19:49Z",
+      "last_reconciled_at": "2026-08-20T18:45:28Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8064,7 +8066,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T18:19:51Z",
+      "last_reconciled_at": "2026-08-20T18:45:30Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8149,7 +8151,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T18:19:51Z",
+      "last_reconciled_at": "2026-08-20T18:45:30Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8218,7 +8220,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T18:19:51Z",
+      "last_reconciled_at": "2026-08-20T18:45:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8251,7 +8253,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T18:19:51Z",
+      "last_reconciled_at": "2026-08-20T18:45:30Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8365,7 +8367,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T18:20:01Z",
+      "last_reconciled_at": "2026-08-20T18:45:40Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8425,7 +8427,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T18:20:01Z",
+      "last_reconciled_at": "2026-08-20T18:45:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8458,7 +8460,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T18:20:01Z",
+      "last_reconciled_at": "2026-08-20T18:45:40Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -8572,7 +8574,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T18:20:01Z",
+      "last_reconciled_at": "2026-08-20T18:45:40Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8686,7 +8688,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T18:20:02Z",
+      "last_reconciled_at": "2026-08-20T18:45:41Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8728,7 +8730,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T18:20:02Z",
+      "last_reconciled_at": "2026-08-20T18:45:41Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8806,7 +8808,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T18:20:02Z",
+      "last_reconciled_at": "2026-08-20T18:45:41Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8857,7 +8859,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T18:20:02Z",
+      "last_reconciled_at": "2026-08-20T18:45:41Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8935,7 +8937,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T18:20:07Z",
+      "last_reconciled_at": "2026-08-20T18:45:45Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8988,7 +8990,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T18:20:07Z",
+      "last_reconciled_at": "2026-08-20T18:45:45Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9102,7 +9104,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T18:20:07Z",
+      "last_reconciled_at": "2026-08-20T18:45:45Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9214,7 +9216,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T18:20:07Z",
+      "last_reconciled_at": "2026-08-20T18:45:45Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9328,7 +9330,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T18:20:07Z",
+      "last_reconciled_at": "2026-08-20T18:45:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9363,7 +9365,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T18:20:07Z",
+      "last_reconciled_at": "2026-08-20T18:45:45Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9475,7 +9477,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-20T18:20:09Z",
+      "last_reconciled_at": "2026-08-20T18:45:47Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9578,7 +9580,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T18:20:13Z",
+      "last_reconciled_at": "2026-08-20T18:45:52Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -9680,7 +9682,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T18:20:13Z",
+      "last_reconciled_at": "2026-08-20T18:45:52Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -9784,7 +9786,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-20T18:20:14Z",
+      "last_reconciled_at": "2026-08-20T18:45:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9816,7 +9818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-20T18:20:16Z",
+      "last_reconciled_at": "2026-08-20T18:45:55Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9886,7 +9888,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T18:20:17Z",
+      "last_reconciled_at": "2026-08-20T18:45:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9917,7 +9919,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T18:20:17Z",
+      "last_reconciled_at": "2026-08-20T18:45:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9948,7 +9950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T18:20:17Z",
+      "last_reconciled_at": "2026-08-20T18:45:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9980,7 +9982,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T18:20:19Z",
+      "last_reconciled_at": "2026-08-20T18:45:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10013,7 +10015,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T18:20:19Z",
+      "last_reconciled_at": "2026-08-20T18:45:58Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10055,7 +10057,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T18:20:19Z",
+      "last_reconciled_at": "2026-08-20T18:45:58Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10115,7 +10117,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T18:20:19Z",
+      "last_reconciled_at": "2026-08-20T18:45:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10148,7 +10150,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10190,7 +10192,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10302,7 +10304,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10362,7 +10364,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10467,7 +10469,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10581,7 +10583,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -10695,7 +10697,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10737,7 +10739,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T18:20:40Z",
+      "last_reconciled_at": "2026-08-20T18:46:19Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -10850,7 +10852,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T18:20:48Z",
+      "last_reconciled_at": "2026-08-20T18:46:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10881,7 +10883,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T18:20:48Z",
+      "last_reconciled_at": "2026-08-20T18:46:27Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -10984,7 +10986,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T18:20:48Z",
+      "last_reconciled_at": "2026-08-20T18:46:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/why_gitgalaxy_beats_ast_here.md
+++ b/docs/why_gitgalaxy_beats_ast_here.md
@@ -584,6 +584,56 @@ still resolves the real parameter list.
 scanner confused by the bound's internal `->`/parens would either miscount or fail to find the
 real parameter list at all.
 
+## Claim 12: recognizing dialect-specific label syntax a generic ctags parser's identifier convention excludes
+
+For a language/dialect whose real identifier syntax is broader than the conventional
+letter-first, no-punctuation identifier shape most parsers assume, GitGalaxy's regex-based
+`func_start` recognizes it correctly (because its character class is written for the actual
+dialect) while a generic ctags language parser — built for the common case, not this specific
+historical dialect — silently declines to tag it at all. This is a *lexical-coverage* claim,
+distinct from every other claim in this doc: it isn't about macro opacity (Claim 6), CPP noise
+(Claims 7/8), node granularity (Claim 4), or a nested wrapper node (Claim 5) — the construct isn't
+hidden inside anything; ctags' parser looks straight at the label and rejects the token shape
+itself.
+
+**The evidence:** AGC (Apollo Guidance Computer) assembly — the real Apollo 11 flight software in
+`language-crucible/data/agc_assembly/apollo-11/` — uses two label conventions no generic assembler
+identifier syntax anticipates: (1) an embedded hyphen naming a point relative to an event, e.g.
+`TIG-35`/`TIG-30`/`CALLT-35` in `BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc:250,292,222` ("35/30
+seconds before Time of Ignition" — a real, common AGC idiom, not a one-off); (2) a label starting
+with a digit or a leading minus sign, e.g. `1CHK`/`2EBANK`/`-1CHK` in
+`AGC_BLOCK_TWO_SELF-CHECK.agc:184` (the real label text is `-1CHK`, one of several numbered
+variants of a `CHK`-suffixed check routine). GitGalaxy's `func_start` regex for this language
+matches on `^([A-Z0-9_-]+)` at line start, deliberately including digits and hyphens because
+that's what real AGC label syntax allows. `ctags_reader.py` maps `agc_assembly` to Universal
+Ctags' generic `Asm` parser (there is no dedicated AGC ctags parser) with kind `l` (labels) as the
+function-analog. Directly confirmed by running `ctags --language-force=Asm --kinds-Asm=l` against
+the real corpus files: it emits **zero** tags for any hyphenated or digit/minus-leading label
+sampled, while emitting tags normally for every plain-alphanumeric sibling in the same file (e.g.
+`CNTRCHK`, `ERASCHK`, `SELFCHK` are all tagged; `-1CHK` is not) — a corpus-wide cross-reference
+found this holds for the full discrepancy set, not just the sample (14/35 hyphenated + 21/35
+digit/minus-leading = 35/35, tri-comparison ledger
+`agc_assembly/function/existence/agree[gitgalaxy]_vs[ctags]`, validated 2026-08-20). Ctags' `Asm`
+parser's tag-name validation requires a leading letter and no internal hyphen — a completely
+reasonable default for the assembly dialects it was actually built against, just not for AGC's.
+
+## Where Claim 12 does NOT apply
+
+- This is specific to a dialect whose real lexical grammar (what counts as a valid identifier)
+  diverges from the generic parser's assumption, not a general claim that GitGalaxy out-recalls
+  ctags on assembly. The *majority* of this same ledger shape's sibling
+  (`agc_assembly/function/existence/agree[ctags]_vs[gitgalaxy]`, 265 occurrences) is the opposite
+  situation: ctags' `Asm` parser tags every line-start label unconditionally (including pure
+  data/constant-definition labels GitGalaxy's `func_start` deliberately excludes because they're
+  never followed by a real instruction), so ctags is the more *recall*-permissive of the two there
+  — a genuine, honest granularity difference, not evidence for this claim. Don't read Claim 12 as
+  "GitGalaxy beats ctags on AGC assembly" in general; it's narrow to the specific label-punctuation
+  shapes ctags' identifier convention structurally cannot admit.
+- A real subset of GitGalaxy's own miss side of that same shape (50/265) is a confirmed GitGalaxy
+  defect in `detector.py`'s `_slice_by_labels`, not something this claim covers — see the filed
+  GitHub issue for the `RELINT`-as-terminator and single-line-block-discard bugs. Two independent
+  root causes, both real bugs, tracked separately from this claim.
+
 ## Where this doc is used
 
 - README.md's "One Graph, Not Five Separate Tools" section links here as the narrow exceptions to


### PR DESCRIPTION
## Summary
- Validated both agc_assembly tri-comparison ledger shapes (function existence, 265 + 35 occurrences), fully root-caused with real file:line evidence -- see the ledger entries' `verdict` fields for the full writeup.
- `agree[gitgalaxy]_vs[ctags]` (35): confirmed GitGalaxy correctly finds real AGC labels (hyphenated offset-names, digit/minus-leading names) that ctags' generic Asm parser structurally can't tag. Credited to GitGalaxy; logged as Claim 12 in `docs/why_gitgalaxy_beats_ast_here.md`.
- `agree[ctags]_vs[gitgalaxy]` (265): mixed-cause. 215/265 is a legitimate code-label-vs-data-label precision distinction (not a bug). 50/265 is a real GitGalaxy `detector.py` defect (`RELINT` misclassified as a function-terminator + an over-eager single-line-body discard filter) -- a follow-up issue is being filed for this separately once a sibling-language blast-radius check completes.
- Regenerated `tri_comparison_chart.py --all --write`; diff confirmed scoped to agc_assembly only (Func Precision now a clean 760/760, new GitGalaxy badge earned on that panel).
- Sanity-checked the "no classes" question: `class_start` is `None` in agc_assembly's language definition and ctags' own kind-map is empty for it too -- AGC assembly genuinely has no OOP construct, correct by design, not a gap.

## Test plan
- [x] `python tests/ruff_audit.py --ci` -- clean (baseline 78, no new findings)
- [x] `python tests/mypy_audit.py --ci` -- clean (baseline 2, no new errors)
- [x] Chart regeneration diff manually reviewed -- scoped to agc_assembly's row + summary totals only

🤖 Generated with [Claude Code](https://claude.com/claude-code)