### PR TITLE
tri-comparison sweep: apex

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -78,14 +78,16 @@
 <text class="lang-label" x="20" y="319.5">apex</text>
 <rect class="bar-track" x="154" y="299" width="88" height="34" rx="2"/>
 <rect x="154" y="299" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="307">40*</text>
+<text class="bar-value-label" x="198.0" y="307">40</text>
 <rect x="154" y="311" width="83.6" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="319">38*</text>
+<text class="bar-value-label" x="198.0" y="319">38</text>
 <rect class="bar-track" x="286" y="299" width="88" height="34" rx="2"/>
 <rect x="286" y="299" width="83.6" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="307">38/40*</text>
+<text class="bar-value-label" x="330.0" y="307">38/40</text>
 <rect x="286" y="311" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="319">38/38*</text>
+<text class="bar-value-label" x="330.0" y="319">38/38</text>
+<circle cx="390.0" cy="316.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="319.0">T</text>
 <rect class="bar-track" x="418" y="299" width="88" height="34" rx="2"/>
 <rect x="418" y="299" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="307">4</text>
@@ -228,15 +230,15 @@
 <text class="bar-value-label" x="198.0" y="527">961*</text>
 <rect x="154" y="531" width="59.2" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="539">647*</text>
-<rect x="154" y="543" width="76.8" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="551">839*</text>
+<rect x="154" y="543" width="74.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="551">811*</text>
 <rect class="bar-track" x="286" y="519" width="88" height="34" rx="2"/>
 <rect x="286" y="519" width="83.6" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="527">913/961*</text>
-<rect x="286" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="539">647/647*</text>
-<rect x="286" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="551">839/839*</text>
+<rect x="286" y="531" width="87.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="539">646/647*</text>
+<rect x="286" y="543" width="87.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="551">810/811*</text>
 <rect class="bar-track" x="418" y="519" width="88" height="34" rx="2"/>
 <rect x="418" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="527">33*</text>
@@ -253,11 +255,11 @@
 <text class="bar-value-label" x="594.0" y="551">22/22*</text>
 <rect class="bar-track" x="682" y="519" width="88" height="34" rx="2"/>
 <rect x="682" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="527">563*</text>
+<text class="bar-value-label" x="726.0" y="527">535*</text>
 <rect x="682" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="539">563*</text>
+<text class="bar-value-label" x="726.0" y="539">535*</text>
 <rect x="682" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="551">563*</text>
+<text class="bar-value-label" x="726.0" y="551">535*</text>
 <text class="lang-label" x="20" y="583.5">css</text>
 <rect class="bar-track" x="154" y="563" width="88" height="34" rx="2"/>
 <rect x="154" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
@@ -392,19 +394,19 @@
 <rect class="stripe" x="16" y="866" width="780" height="44"/>
 <text class="lang-label" x="20" y="891.5">haskell</text>
 <rect class="bar-track" x="154" y="871" width="88" height="34" rx="2"/>
-<rect x="154" y="871" width="72.8" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="871" width="72.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="879">148</text>
-<rect x="154" y="883" width="71.8" height="10" rx="2" fill="#eb6834"/>
+<rect x="154" y="883" width="71.4" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="891">146</text>
 <rect x="154" y="895" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="903">179</text>
+<text class="bar-value-label" x="198.0" y="903">180</text>
 <rect class="bar-track" x="286" y="871" width="88" height="34" rx="2"/>
 <rect x="286" y="871" width="86.8" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="879">146/148</text>
 <rect x="286" y="883" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="891">146/146</text>
-<rect x="286" y="895" width="37.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="903">77/179</text>
+<rect x="286" y="895" width="37.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="903">77/180</text>
 <circle cx="390.0" cy="888.0" r="8" fill="#eb6834"/>
 <text class="badge-label" x="390.0" y="891.0">T</text>
 <rect class="bar-track" x="418" y="871" width="88" height="34" rx="2"/>
@@ -469,36 +471,36 @@
 <text class="bar-value-label" x="198.0" y="1011">793*</text>
 <rect x="154" y="1015" width="78.1" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1023">704*</text>
-<rect x="154" y="1027" width="61.5" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1035">554*</text>
+<rect x="154" y="1027" width="54.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1035">495*</text>
 <rect class="bar-track" x="286" y="1003" width="88" height="34" rx="2"/>
-<rect x="286" y="1003" width="67.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1011">612/793*</text>
+<rect x="286" y="1003" width="67.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1011">611/793*</text>
 <rect x="286" y="1015" width="75.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1023">600/704*</text>
-<rect x="286" y="1027" width="66.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1035">421/554*</text>
+<rect x="286" y="1027" width="61.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1035">345/495*</text>
 <rect class="bar-track" x="418" y="1003" width="88" height="34" rx="2"/>
-<rect x="418" y="1003" width="67.2" height="10" rx="2" fill="#2a78d6"/>
+<rect x="418" y="1003" width="20.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1011">29*</text>
-<rect x="418" y="1015" width="67.2" height="10" rx="2" fill="#eb6834"/>
+<rect x="418" y="1015" width="20.4" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1023">29*</text>
 <rect x="418" y="1027" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1035">38*</text>
+<text class="bar-value-label" x="462.0" y="1035">125*</text>
 <rect class="bar-track" x="550" y="1003" width="88" height="34" rx="2"/>
 <rect x="550" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1011">29/29*</text>
 <rect x="550" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1023">29/29*</text>
-<rect x="550" y="1027" width="67.2" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1035">29/38*</text>
+<rect x="550" y="1027" width="20.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1035">29/125*</text>
 <rect class="bar-track" x="682" y="1003" width="88" height="34" rx="2"/>
 <rect x="682" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1011">409*</text>
+<text class="bar-value-label" x="726.0" y="1011">334*</text>
 <rect x="682" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1023">409*</text>
+<text class="bar-value-label" x="726.0" y="1023">334*</text>
 <rect x="682" y="1027" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="1035">409*</text>
+<text class="bar-value-label" x="726.0" y="1035">334*</text>
 <rect class="stripe" x="16" y="1042" width="780" height="44"/>
 <text class="lang-label" x="20" y="1067.5">jcl</text>
 <text class="awaiting" x="154" y="1067.5">no functions/classes found in this corpus by any tool</text>
@@ -547,12 +549,12 @@
 <rect x="154" y="1223" width="2.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1231">1</text>
 <rect x="154" y="1235" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1243">205</text>
+<text class="bar-value-label" x="198.0" y="1243">79</text>
 <rect class="bar-track" x="286" y="1223" width="88" height="34" rx="2"/>
 <rect x="286" y="1223" width="2.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1231">0/1</text>
 <rect x="286" y="1235" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1243">0/205</text>
+<text class="bar-value-label" x="330.0" y="1243">0/79</text>
 <rect class="bar-track" x="418" y="1223" width="88" height="34" rx="2"/>
 <rect x="418" y="1223" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1231">4</text>
@@ -658,15 +660,15 @@
 <text class="bar-value-label" x="462.0" y="1407">21*</text>
 <rect x="418" y="1411" width="83.8" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1419">20*</text>
-<rect x="418" y="1423" width="83.8" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1431">20*</text>
+<rect x="418" y="1423" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1431">21*</text>
 <rect class="bar-track" x="550" y="1399" width="88" height="34" rx="2"/>
-<rect x="550" y="1399" width="83.8" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1407">20/21*</text>
+<rect x="550" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1407">21/21*</text>
 <rect x="550" y="1411" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1419">20/20*</text>
 <rect x="550" y="1423" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1431">20/20*</text>
+<text class="bar-value-label" x="594.0" y="1431">21/21*</text>
 <rect class="bar-track" x="682" y="1399" width="88" height="34" rx="2"/>
 <rect x="682" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1407">934*</text>
@@ -715,34 +717,32 @@
 <text class="bar-value-label" x="198.0" y="1495">111*</text>
 <rect x="154" y="1499" width="87.2" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1507">110*</text>
-<rect x="154" y="1511" width="84.8" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1519">107*</text>
+<rect x="154" y="1511" width="75.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1519">95*</text>
 <rect class="bar-track" x="286" y="1487" width="88" height="34" rx="2"/>
 <rect x="286" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1495">111/111*</text>
 <rect x="286" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1507">110/110*</text>
 <rect x="286" y="1511" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1519">107/107*</text>
+<text class="bar-value-label" x="330.0" y="1519">95/95*</text>
 <rect class="bar-track" x="418" y="1487" width="88" height="34" rx="2"/>
 <rect x="418" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1495">7*</text>
 <rect x="418" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1507">7*</text>
-<rect x="418" y="1511" width="62.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1519">5*</text>
+<rect x="418" y="1511" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1519">0*</text>
 <rect class="bar-track" x="550" y="1487" width="88" height="34" rx="2"/>
 <rect x="550" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1495">7/7*</text>
 <rect x="550" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1507">7/7*</text>
-<rect x="550" y="1511" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1519">5/5*</text>
 <rect class="bar-track" x="682" y="1487" width="88" height="34" rx="2"/>
 <rect x="682" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1495">106*</text>
+<text class="bar-value-label" x="726.0" y="1495">94*</text>
 <rect x="682" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1507">106*</text>
+<text class="bar-value-label" x="726.0" y="1507">94*</text>
 <rect x="682" y="1511" width="2.0" height="10" rx="2" fill="#1baf7a"/>
 <text class="bar-value-label" x="726.0" y="1519">2*</text>
 <text class="lang-label" x="20" y="1551.5">python</text>
@@ -821,32 +821,36 @@
 <text class="lang-label" x="20" y="1639.5">rust</text>
 <rect class="bar-track" x="154" y="1619" width="88" height="34" rx="2"/>
 <rect x="154" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1627">1927*</text>
+<text class="bar-value-label" x="198.0" y="1627">1927</text>
 <rect x="154" y="1631" width="81.1" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1639">1775*</text>
-<rect x="154" y="1643" width="84.8" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1651">1858*</text>
+<text class="bar-value-label" x="198.0" y="1639">1775</text>
+<rect x="154" y="1643" width="81.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1651">1774</text>
 <rect class="bar-track" x="286" y="1619" width="88" height="34" rx="2"/>
 <rect x="286" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1627">1927/1927*</text>
+<text class="bar-value-label" x="330.0" y="1627">1927/1927</text>
 <rect x="286" y="1631" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1639">1775/1775*</text>
+<text class="bar-value-label" x="330.0" y="1639">1775/1775</text>
 <rect x="286" y="1643" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1651">1857/1858*</text>
+<text class="bar-value-label" x="330.0" y="1651">1774/1774</text>
+<circle cx="390.0" cy="1636.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1639.0">G</text>
 <rect class="bar-track" x="418" y="1619" width="88" height="34" rx="2"/>
 <rect x="418" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1627">312*</text>
+<text class="bar-value-label" x="462.0" y="1627">312</text>
 <rect x="418" y="1631" width="80.9" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1639">287*</text>
-<rect x="418" y="1643" width="84.1" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1651">298*</text>
+<text class="bar-value-label" x="462.0" y="1639">287</text>
+<rect x="418" y="1643" width="80.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1651">284</text>
 <rect class="bar-track" x="550" y="1619" width="88" height="34" rx="2"/>
 <rect x="550" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1627">312/312*</text>
+<text class="bar-value-label" x="594.0" y="1627">312/312</text>
 <rect x="550" y="1631" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1639">287/287*</text>
+<text class="bar-value-label" x="594.0" y="1639">287/287</text>
 <rect x="550" y="1643" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1651">298/298*</text>
+<text class="bar-value-label" x="594.0" y="1651">284/284</text>
+<circle cx="654.0" cy="1636.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="1639.0">G</text>
 <rect class="bar-track" x="682" y="1619" width="88" height="34" rx="2"/>
 <rect x="682" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1627">1774</text>
@@ -883,34 +887,34 @@
 <text class="bar-value-label" x="726.0" y="1683">541*</text>
 <text class="lang-label" x="20" y="1727.5">scheme</text>
 <rect class="bar-track" x="154" y="1707" width="88" height="34" rx="2"/>
-<rect x="154" y="1707" width="68.1" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="1707" width="55.5" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1715">58*</text>
 <rect x="154" y="1719" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1727">75*</text>
+<text class="bar-value-label" x="198.0" y="1727">92*</text>
 <rect class="bar-track" x="286" y="1707" width="88" height="34" rx="2"/>
 <rect x="286" y="1707" width="12.1" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1715">8/58*</text>
-<rect x="286" y="1719" width="9.4" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1727">8/75*</text>
+<rect x="286" y="1719" width="7.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1727">8/92*</text>
 <rect class="bar-track" x="418" y="1707" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1707" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1707" width="88" height="34" rx="2"/>
 <rect class="stripe" x="16" y="1746" width="780" height="44"/>
 <text class="lang-label" x="20" y="1771.5">shell</text>
 <rect class="bar-track" x="154" y="1751" width="88" height="34" rx="2"/>
-<rect x="154" y="1751" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1759">3</text>
-<rect x="154" y="1763" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1771">3</text>
+<rect x="154" y="1751" width="66.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1759">3*</text>
+<rect x="154" y="1763" width="66.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1771">3*</text>
 <rect x="154" y="1775" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1783">3</text>
+<text class="bar-value-label" x="198.0" y="1783">4*</text>
 <rect class="bar-track" x="286" y="1751" width="88" height="34" rx="2"/>
 <rect x="286" y="1751" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1759">3/3</text>
+<text class="bar-value-label" x="330.0" y="1759">3/3*</text>
 <rect x="286" y="1763" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1771">3/3</text>
-<rect x="286" y="1775" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1783">3/3</text>
+<text class="bar-value-label" x="330.0" y="1771">3/3*</text>
+<rect x="286" y="1775" width="66.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1783">3/4*</text>
 <rect class="bar-track" x="418" y="1751" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1751" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1751" width="88" height="34" rx="2"/>
@@ -980,56 +984,56 @@
 <text class="bar-value-label" x="198.0" y="1935">144*</text>
 <rect x="154" y="1939" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1947">144*</text>
-<rect x="154" y="1951" width="66.6" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1959">109*</text>
+<rect x="154" y="1951" width="86.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1959">141*</text>
 <rect class="bar-track" x="286" y="1927" width="88" height="34" rx="2"/>
 <rect x="286" y="1927" width="87.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1935">143/144*</text>
-<rect x="286" y="1939" width="86.8" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1947">142/144*</text>
+<rect x="286" y="1939" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1947">144/144*</text>
 <rect x="286" y="1951" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1959">109/109*</text>
+<text class="bar-value-label" x="330.0" y="1959">141/141*</text>
 <rect class="bar-track" x="418" y="1927" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1927" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1927" width="88" height="34" rx="2"/>
 <rect x="682" y="1927" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1935">108</text>
+<text class="bar-value-label" x="726.0" y="1935">138</text>
 <rect x="682" y="1939" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1947">108</text>
+<text class="bar-value-label" x="726.0" y="1947">138</text>
 <text class="lang-label" x="20" y="1991.5">typescript</text>
 <rect class="bar-track" x="154" y="1971" width="88" height="34" rx="2"/>
 <rect x="154" y="1971" width="82.5" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1979">2733*</text>
 <rect x="154" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1991">2914*</text>
-<rect x="154" y="1995" width="39.3" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="2003">1302*</text>
+<rect x="154" y="1995" width="27.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="2003">894*</text>
 <rect class="bar-track" x="286" y="1971" width="88" height="34" rx="2"/>
-<rect x="286" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1979">2732/2733*</text>
+<rect x="286" y="1971" width="87.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1979">2731/2733*</text>
 <rect x="286" y="1983" width="82.7" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1991">2740/2914*</text>
-<rect x="286" y="1995" width="83.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="2003">1241/1302*</text>
+<rect x="286" y="1995" width="82.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="2003">833/894*</text>
 <rect class="bar-track" x="418" y="1971" width="88" height="34" rx="2"/>
 <rect x="418" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1979">842*</text>
 <rect x="418" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1991">842*</text>
-<rect x="418" y="1995" width="34.7" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="2003">332*</text>
+<rect x="418" y="1995" width="35.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="2003">343*</text>
 <rect class="bar-track" x="550" y="1971" width="88" height="34" rx="2"/>
 <rect x="550" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1979">842/842*</text>
 <rect x="550" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1991">842/842*</text>
-<rect x="550" y="1995" width="87.7" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="2003">331/332*</text>
+<rect x="550" y="1995" width="87.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="2003">341/343*</text>
 <rect class="bar-track" x="682" y="1971" width="88" height="34" rx="2"/>
 <rect x="682" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1979">1231*</text>
+<text class="bar-value-label" x="726.0" y="1979">824*</text>
 <rect x="682" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1991">1231*</text>
+<text class="bar-value-label" x="726.0" y="1991">824*</text>
 <rect class="stripe" x="16" y="2010" width="780" height="44"/>
 <text class="lang-label" x="20" y="2035.5">yacc</text>
 <text class="awaiting" x="154" y="2035.5">awaiting language-crucible corpus</text>
@@ -1063,17 +1067,17 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 24 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 26 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 6 (25%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 8 (31%)</text>
 <circle cx="209.6" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="209.6" y="2187">T</text>
-<text class="legend-label" x="222.6" y="2188">tree-sitter best: 1 (4%)</text>
+<text class="legend-label" x="222.6" y="2188">tree-sitter best: 2 (8%)</text>
 <circle cx="402.4" cy="2184" r="7" fill="#1baf7a"/>
 <text class="badge-label" x="402.4" y="2187">C</text>
 <text class="legend-label" x="415.4" y="2188">ctags best: 0 (0%)</text>
 <circle cx="558.0" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="571.0" y="2188">Ties: 17 (71%)</text>
+<text class="legend-label" x="571.0" y="2188">Ties: 16 (62%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T21:51:32Z",
+      "last_reconciled_at": "2026-08-20T22:18:34Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-20T21:51:32Z",
+      "last_reconciled_at": "2026-08-20T22:18:34Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -218,10 +218,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:15Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-20T22:17:39Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-20T21:51:33Z",
+      "last_reconciled_at": "2026-08-20T22:21:09Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -242,10 +242,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed GitGalaxy engine defect, not a tree-sitter gap. Both sampled occurrences (apex-recipes/AuraEnabledRecipes_Tests.cls:25 and :43) are `new Account(name = ...)` object-instantiation expressions inside a multi-line SObject-builder call, not real method/constructor definitions -- confirmed by reading the source directly. Root cause: the func_start regex (language_standards.py, apex rules) treats any `[a-zA-Z_][\\w.]*[ \\t\\n]+` token at start-of-line as an eligible optional return-type/modifier prefix before the captured function name, with no exclusion for the `new` keyword -- so `new Account(` parses as \"returnType=new, name=Account\", passing the #1221 gating fix (which only requires the line START with one of annotation/modifier/return-type-shaped token, not that the token be a real type). tree_sitter correctly does not report these as functions since its grammar distinguishes object_creation_expression from method_declaration structurally. Verified this generalizes beyond the 2-occurrence ledger sample: running the regex directly against the whole apex corpus found 6 total false-positive matches across 2 files (AuraEnabledRecipes_Tests.cls:6,25,43 and SOQLRecipes_Tests.cls:226,235,504), all the identical `new ClassName(` shape. Filed as GitHub issue #1963 (exclude `new` from the eligible return-type/modifier prefix token). No credit_tools/debit_tools adjustment needed: since only gitgalaxy is in agreeing_tools here (len(present)==1), the reconciler already excludes this from gitgalaxy matched_consensus by default while still counting it in total_slots -- the default precision score already reflects this correctly as an unconfirmed/wrong claim."
     },
     "assembly/function/existence/agree[ctags]_vs[gitgalaxy]": {
       "agreeing_tools": [
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T21:51:35Z",
+      "last_reconciled_at": "2026-08-20T22:18:37Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-20T21:51:35Z",
+      "last_reconciled_at": "2026-08-20T22:18:37Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -992,7 +992,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed."
     },
@@ -1010,8 +1010,8 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
-      "last_seen_count": 10,
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
+      "last_seen_count": 7,
       "last_seen_examples": [
         {
           "file_path": "cpython/typeobject.c",
@@ -1075,33 +1075,6 @@
             "gitgalaxy": null,
             "tree_sitter": null
           }
-        },
-        {
-          "file_path": "micropython/emitnative.c",
-          "name": "free",
-          "readings": {
-            "ctags": 320,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "micropython/emitnative.c",
-          "name": "new",
-          "readings": {
-            "ctags": 300,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "micropython/vm.c",
-          "name": "mp_execute_bytecode",
-          "readings": {
-            "ctags": 220,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
         }
       ],
       "metric": "existence",
@@ -1124,7 +1097,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1177,7 +1150,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1237,8 +1210,8 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-20T21:51:40Z",
-      "last_seen_count": 77,
+      "last_reconciled_at": "2026-08-20T22:18:42Z",
+      "last_seen_count": 74,
       "last_seen_examples": [
         {
           "file_path": "cpython/dictobject.c",
@@ -1322,12 +1295,12 @@
           }
         },
         {
-          "file_path": "micropython/emitnative.c",
-          "name": "EXPORT_FUN",
+          "file_path": "micropython/gc.c",
+          "name": "if",
           "readings": {
             "ctags": null,
             "gitgalaxy": null,
-            "tree_sitter": 300
+            "tree_sitter": 1353
           }
         }
       ],
@@ -1352,7 +1325,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T21:51:45Z",
+      "last_reconciled_at": "2026-08-20T22:18:48Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1455,7 +1428,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T21:51:45Z",
+      "last_reconciled_at": "2026-08-20T22:18:48Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1558,7 +1531,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-20T21:51:45Z",
+      "last_reconciled_at": "2026-08-20T22:18:48Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1662,7 +1635,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1704,7 +1677,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 95,
       "last_seen_examples": [
         {
@@ -1818,7 +1791,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -1932,7 +1905,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2046,7 +2019,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -2160,7 +2133,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2192,7 +2165,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2225,7 +2198,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -2321,7 +2294,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2354,7 +2327,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 1074,
       "last_seen_examples": [
         {
@@ -2468,7 +2441,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 1097,
       "last_seen_examples": [
         {
@@ -2582,7 +2555,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 62,
       "last_seen_examples": [
         {
@@ -2696,7 +2669,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-20T21:51:49Z",
+      "last_reconciled_at": "2026-08-20T22:18:52Z",
       "last_seen_count": 98,
       "last_seen_examples": [
         {
@@ -2810,7 +2783,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -2861,7 +2834,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -2930,7 +2903,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3008,7 +2981,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3041,8 +3014,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
-      "last_seen_count": 10,
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
+      "last_seen_count": 7,
       "last_seen_examples": [
         {
           "file_path": "roslyn/CSharpCompilation.cs",
@@ -3051,33 +3024,6 @@
             "ctags": 2,
             "gitgalaxy": 0,
             "tree_sitter": 2
-          }
-        },
-        {
-          "file_path": "roslyn/CSharpCompilation.cs",
-          "name": "TryGetInterceptor",
-          "readings": {
-            "ctags": 1,
-            "gitgalaxy": 0,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "roslyn/LanguageParser.cs",
-          "name": "ParseNamespaceBodyWorker",
-          "readings": {
-            "ctags": 5,
-            "gitgalaxy": 2,
-            "tree_sitter": 5
-          }
-        },
-        {
-          "file_path": "roslyn/LanguageParser.cs",
-          "name": "ParseNamespaceBody",
-          "readings": {
-            "ctags": 4,
-            "gitgalaxy": 2,
-            "tree_sitter": 4
           }
         },
         {
@@ -3155,14 +3101,14 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
           "file_path": "roslyn/CSharpCompilation.cs",
           "name": "GetHashCode",
           "readings": {
-            "ctags": 0,
+            "ctags": 2,
             "gitgalaxy": 1,
             "tree_sitter": 1
           }
@@ -3214,7 +3160,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3247,7 +3193,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3361,8 +3307,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
-      "last_seen_count": 5,
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
+      "last_seen_count": 4,
       "last_seen_examples": [
         {
           "file_path": "roslyn/CSharpCompilation.cs",
@@ -3389,15 +3335,6 @@
             "ctags": 86,
             "gitgalaxy": null,
             "tree_sitter": 86
-          }
-        },
-        {
-          "file_path": "roslyn/CSharpSyntaxTree.cs",
-          "name": "TryGetRoot",
-          "readings": {
-            "ctags": 91,
-            "gitgalaxy": null,
-            "tree_sitter": 91
           }
         },
         {
@@ -3430,7 +3367,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3445,7 +3382,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -3463,9 +3400,18 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
-      "last_seen_count": 79,
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
+      "last_seen_count": 107,
       "last_seen_examples": [
+        {
+          "file_path": "roslyn/CSharpCompilation.cs",
+          "name": "FindEntryPoint",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 1993,
+            "tree_sitter": 1993
+          }
+        },
         {
           "file_path": "roslyn/CSharpCompilation.cs",
           "name": "validateSignature",
@@ -3486,11 +3432,38 @@
         },
         {
           "file_path": "roslyn/CSharpCompilation.cs",
+          "name": "ReportUnusedImports",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2747,
+            "tree_sitter": 2747
+          }
+        },
+        {
+          "file_path": "roslyn/CSharpCompilation.cs",
+          "name": "GetSourceDeclarationDiagnostics",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 3395,
+            "tree_sitter": 3395
+          }
+        },
+        {
+          "file_path": "roslyn/CSharpCompilation.cs",
           "name": "isSupportedType",
           "readings": {
             "ctags": null,
             "gitgalaxy": 1798,
             "tree_sitter": 1798
+          }
+        },
+        {
+          "file_path": "roslyn/CSharpCompilation.cs",
+          "name": "IsRuntimeAsyncEnabledIn",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 351,
+            "tree_sitter": 351
           }
         },
         {
@@ -3519,42 +3492,6 @@
             "gitgalaxy": 3308,
             "tree_sitter": 3308
           }
-        },
-        {
-          "file_path": "roslyn/CSharpCompilation.cs",
-          "name": "checkValid",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2079,
-            "tree_sitter": 2079
-          }
-        },
-        {
-          "file_path": "roslyn/CSharpCompilation.cs",
-          "name": "getCustomModifierForType",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 4320,
-            "tree_sitter": 4320
-          }
-        },
-        {
-          "file_path": "roslyn/CSharpCompilation.cs",
-          "name": "isAllowedPointerArithmeticIntegralType",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 4654,
-            "tree_sitter": 4654
-          }
-        },
-        {
-          "file_path": "roslyn/CSharpCompilation.cs",
-          "name": "computeMappedPathToSyntaxTree",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 1151,
-            "tree_sitter": 1151
-          }
         }
       ],
       "metric": "existence",
@@ -3577,7 +3514,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 48,
       "last_seen_examples": [
         {
@@ -3691,7 +3628,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-20T21:51:55Z",
+      "last_reconciled_at": "2026-08-20T22:18:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3706,7 +3643,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -3724,7 +3661,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-20T21:51:57Z",
+      "last_reconciled_at": "2026-08-20T22:19:00Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3773,7 +3710,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T21:52:01Z",
+      "last_reconciled_at": "2026-08-20T22:19:04Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3876,7 +3813,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T21:52:01Z",
+      "last_reconciled_at": "2026-08-20T22:19:04Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -3979,7 +3916,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-20T21:52:01Z",
+      "last_reconciled_at": "2026-08-20T22:19:04Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4083,7 +4020,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T21:52:06Z",
+      "last_reconciled_at": "2026-08-20T22:19:10Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4178,7 +4115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T21:52:06Z",
+      "last_reconciled_at": "2026-08-20T22:19:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4211,7 +4148,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T21:52:06Z",
+      "last_reconciled_at": "2026-08-20T22:19:10Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4325,7 +4262,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T21:52:06Z",
+      "last_reconciled_at": "2026-08-20T22:19:10Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4367,7 +4304,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-20T21:52:06Z",
+      "last_reconciled_at": "2026-08-20T22:19:10Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4409,7 +4346,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-20T21:52:09Z",
+      "last_reconciled_at": "2026-08-20T22:19:12Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4523,7 +4460,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4635,7 +4572,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4740,7 +4677,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4854,8 +4791,8 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
-      "last_seen_count": 102,
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
+      "last_seen_count": 103,
       "last_seen_examples": [
         {
           "file_path": "pandoc/App.hs",
@@ -4968,7 +4905,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5082,7 +5019,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5123,7 +5060,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5163,7 +5100,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-20T21:52:12Z",
+      "last_reconciled_at": "2026-08-20T22:19:15Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5277,7 +5214,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5391,7 +5328,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5505,7 +5442,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5618,7 +5555,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5651,7 +5588,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5702,7 +5639,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5816,7 +5753,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-20T21:52:14Z",
+      "last_reconciled_at": "2026-08-20T22:19:18Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5867,23 +5804,50 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
-      "last_seen_count": 9,
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
+      "last_seen_count": 96,
       "last_seen_examples": [
         {
-          "file_path": "jquery/deferred.js",
-          "name": "Identity",
+          "file_path": "jquery/ajax.js",
+          "name": "jqXHR",
           "readings": {
-            "ctags": 6,
+            "ctags": 448,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/css.js",
+          "name": "cssHooks",
+          "readings": {
+            "ctags": 357,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/css.js",
+          "name": "cssNormalTransform",
+          "readings": {
+            "ctags": 22,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/css.js",
+          "name": "cssShow",
+          "readings": {
+            "ctags": 21,
             "gitgalaxy": null,
             "tree_sitter": null
           }
         },
         {
           "file_path": "jquery/deferred.js",
-          "name": "Thrower",
+          "name": "promise",
           "readings": {
-            "ctags": 9,
+            "ctags": 58,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -5898,55 +5862,37 @@
           }
         },
         {
-          "file_path": "threejs/Editor.js",
-          "name": "Editor",
+          "file_path": "jquery/event.js",
+          "name": "event",
           "readings": {
-            "ctags": 15,
+            "ctags": 89,
             "gitgalaxy": null,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "threejs/GLTFLoader.js",
-          "name": "GLTFRegistry",
+          "file_path": "jquery/event.js",
+          "name": "special",
           "readings": {
-            "ctags": 576,
+            "ctags": 756,
             "gitgalaxy": null,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "threejs/GLTFLoader.js",
-          "name": "InterpolantFactoryMethodGLTFCubicSpline",
+          "file_path": "jquery/event.js",
+          "name": "special",
           "readings": {
-            "ctags": 4643,
+            "ctags": 812,
             "gitgalaxy": null,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "threejs/GLTFLoader.js",
-          "name": "Material",
+          "file_path": "react/ReactFiberBeginWork.js",
+          "name": "cachePool",
           "readings": {
-            "ctags": 3457,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "threejs/GLTFLoader.js",
-          "name": "Object3D",
-          "readings": {
-            "ctags": 1807,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "threejs/WebGLProgram.js",
-          "name": "WebGLProgram",
-          "readings": {
-            "ctags": 412,
+            "ctags": 2281,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -5972,7 +5918,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6059,27 +6005,9 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
-      "last_seen_count": 4,
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
+      "last_seen_count": 2,
       "last_seen_examples": [
-        {
-          "file_path": "jquery/core.js",
-          "name": "each",
-          "readings": {
-            "ctags": 2,
-            "gitgalaxy": 1,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "map",
-          "readings": {
-            "ctags": 3,
-            "gitgalaxy": 1,
-            "tree_sitter": 1
-          }
-        },
         {
           "file_path": "jquery/event.js",
           "name": "setup",
@@ -6119,8 +6047,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
-      "last_seen_count": 12,
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
+      "last_seen_count": 11,
       "last_seen_examples": [
         {
           "file_path": "react/ReactFiberBeginWork.js",
@@ -6155,15 +6083,6 @@
           "readings": {
             "ctags": 3739,
             "gitgalaxy": 3739,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "react/ReactFiberWorkLoop.js",
-          "name": "onResolution",
-          "readings": {
-            "ctags": 2837,
-            "gitgalaxy": 2837,
             "tree_sitter": null
           }
         },
@@ -6211,6 +6130,15 @@
             "gitgalaxy": 1222,
             "tree_sitter": null
           }
+        },
+        {
+          "file_path": "react/ReactFlightServer.js",
+          "name": "throwTaintViolation",
+          "readings": {
+            "ctags": 618,
+            "gitgalaxy": 618,
+            "tree_sitter": null
+          }
         }
       ],
       "metric": "existence",
@@ -6233,12 +6161,12 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
-      "last_seen_count": 133,
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
+      "last_seen_count": 150,
       "last_seen_examples": [
         {
           "file_path": "jquery/ajax.js",
-          "name": "anonymousFunctionc3e813860100",
+          "name": "AnonymousFunctionc3e813860100",
           "readings": {
             "ctags": 55,
             "gitgalaxy": null,
@@ -6247,7 +6175,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "anonymousFunctionc3e813860200",
+          "name": "AnonymousFunctionc3e813860200",
           "readings": {
             "ctags": 94,
             "gitgalaxy": null,
@@ -6256,7 +6184,25 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "anonymousFunctionc3e813860600",
+          "name": "AnonymousFunctionc3e813860300",
+          "readings": {
+            "ctags": 369,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860400",
+          "readings": {
+            "ctags": 383,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860500",
           "readings": {
             "ctags": 694,
             "gitgalaxy": null,
@@ -6265,7 +6211,25 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "anonymousFunctionc3e813860800",
+          "name": "AnonymousFunctionc3e813860600",
+          "readings": {
+            "ctags": 848,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860700",
+          "readings": {
+            "ctags": 852,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "AnonymousFunctionc3e813860800",
           "readings": {
             "ctags": 857,
             "gitgalaxy": null,
@@ -6274,7 +6238,7 @@
         },
         {
           "file_path": "jquery/ajax.js",
-          "name": "anonymousFunctionc3e813860b00",
+          "name": "AnonymousFunctionc3e813860900",
           "readings": {
             "ctags": 879,
             "gitgalaxy": null,
@@ -6286,42 +6250,6 @@
           "name": "converters",
           "readings": {
             "ctags": 764,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "jQuery",
-          "readings": {
-            "ctags": 858,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "anonymousFunction6aaf8d8b0200",
-          "readings": {
-            "ctags": 38,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "anonymousFunction6aaf8d8b0300",
-          "readings": {
-            "ctags": 44,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "anonymousFunction6aaf8d8b0400",
-          "readings": {
-            "ctags": 57,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -6347,9 +6275,45 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
-      "last_seen_count": 191,
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
+      "last_seen_count": 266,
       "last_seen_examples": [
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "ajax",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 383,
+            "tree_sitter": 383
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "ajaxSetup",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 369,
+            "tree_sitter": 369
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "getJSON",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 848,
+            "tree_sitter": 848
+          }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "getScript",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 852,
+            "tree_sitter": 852
+          }
+        },
         {
           "file_path": "jquery/core.js",
           "name": "extend",
@@ -6357,6 +6321,15 @@
             "ctags": null,
             "gitgalaxy": 115,
             "tree_sitter": 115
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "each",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 70,
+            "tree_sitter": 70
           }
         },
         {
@@ -6373,71 +6346,26 @@
           "name": "map",
           "readings": {
             "ctags": null,
+            "gitgalaxy": 74,
+            "tree_sitter": 74
+          }
+        },
+        {
+          "file_path": "jquery/core.js",
+          "name": "map",
+          "readings": {
+            "ctags": null,
             "gitgalaxy": 370,
             "tree_sitter": 370
           }
         },
         {
           "file_path": "jquery/core.js",
-          "name": "eq",
+          "name": "text",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 104,
-            "tree_sitter": 104
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "get",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 44,
-            "tree_sitter": 44
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "end",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 110,
-            "tree_sitter": 110
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "pushStack",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 57,
-            "tree_sitter": 57
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "even",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 92,
-            "tree_sitter": 92
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "odd",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 98,
-            "tree_sitter": 98
-          }
-        },
-        {
-          "file_path": "jquery/core.js",
-          "name": "toArray",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 38,
-            "tree_sitter": 38
+            "gitgalaxy": 260,
+            "tree_sitter": 260
           }
         }
       ],
@@ -6461,8 +6389,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
-      "last_seen_count": 181,
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
+      "last_seen_count": 182,
       "last_seen_examples": [
         {
           "file_path": "react/ReactFiberBeginWork.js",
@@ -6575,7 +6503,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-20T21:52:17Z",
+      "last_reconciled_at": "2026-08-20T22:19:21Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6689,7 +6617,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T21:52:20Z",
+      "last_reconciled_at": "2026-08-20T22:19:24Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6740,7 +6668,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T21:52:20Z",
+      "last_reconciled_at": "2026-08-20T22:19:24Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6854,7 +6782,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-20T21:52:20Z",
+      "last_reconciled_at": "2026-08-20T22:19:24Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6886,7 +6814,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T21:52:26Z",
+      "last_reconciled_at": "2026-08-20T22:19:30Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6941,33 +6869,9 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T21:52:26Z",
-      "last_seen_count": 205,
+      "last_reconciled_at": "2026-08-20T22:19:30Z",
+      "last_seen_count": 79,
       "last_seen_examples": [
-        {
-          "file_path": "curl/configure.ac",
-          "name": "CURL_CA_NATIVE",
-          "readings": {
-            "ctags": 2127,
-            "gitgalaxy": null
-          }
-        },
-        {
-          "file_path": "curl/configure.ac",
-          "name": "CURL_CA_SEARCH_SAFE",
-          "readings": {
-            "ctags": 2199,
-            "gitgalaxy": null
-          }
-        },
-        {
-          "file_path": "curl/configure.ac",
-          "name": "CURL_DEBUG_GLOBAL_MEM",
-          "readings": {
-            "ctags": 1097,
-            "gitgalaxy": null
-          }
-        },
         {
           "file_path": "curl/configure.ac",
           "name": "CURL_DEFAULT_SSL_BACKEND",
@@ -6978,49 +6882,73 @@
         },
         {
           "file_path": "curl/configure.ac",
-          "name": "CURL_DISABLE_ALTSVC",
+          "name": "CURL_DISABLE_CA_SEARCH",
           "readings": {
-            "ctags": 762,
+            "ctags": 2183,
             "gitgalaxy": null
           }
         },
         {
           "file_path": "curl/configure.ac",
-          "name": "CURL_DISABLE_ALTSVC",
+          "name": "CURL_DISABLE_HSTS",
           "readings": {
-            "ctags": 4832,
+            "ctags": 4890,
             "gitgalaxy": null
           }
         },
         {
           "file_path": "curl/configure.ac",
-          "name": "CURL_DISABLE_AWS",
+          "name": "CURL_DISABLE_LDAP",
           "readings": {
-            "ctags": 4469,
+            "ctags": 2629,
             "gitgalaxy": null
           }
         },
         {
           "file_path": "curl/configure.ac",
-          "name": "CURL_DISABLE_BASIC_AUTH",
+          "name": "CURL_DISABLE_LDAP",
           "readings": {
-            "ctags": 4372,
+            "ctags": 2647,
             "gitgalaxy": null
           }
         },
         {
           "file_path": "curl/configure.ac",
-          "name": "CURL_DISABLE_BEARER_AUTH",
+          "name": "CURL_DISABLE_LDAPS",
           "readings": {
-            "ctags": 4391,
+            "ctags": 2631,
             "gitgalaxy": null
           }
         },
         {
           "file_path": "curl/configure.ac",
-          "name": "CURL_DISABLE_BINDLOCAL",
+          "name": "CURL_DISABLE_LDAPS",
           "readings": {
-            "ctags": 4671,
+            "ctags": 2649,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "curl/configure.ac",
+          "name": "CURL_DISABLE_TELNET",
+          "readings": {
+            "ctags": 967,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "curl/configure.ac",
+          "name": "CURL_DISABLE_WEBSOCKETS",
+          "readings": {
+            "ctags": 4994,
+            "gitgalaxy": null
+          }
+        },
+        {
+          "file_path": "curl/configure.ac",
+          "name": "CURL_KRB5_VERSION",
+          "readings": {
+            "ctags": 1986,
             "gitgalaxy": null
           }
         }
@@ -7044,7 +6972,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-20T21:52:26Z",
+      "last_reconciled_at": "2026-08-20T22:19:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7076,7 +7004,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-20T21:52:27Z",
+      "last_reconciled_at": "2026-08-20T22:19:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7107,7 +7035,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-20T21:52:29Z",
+      "last_reconciled_at": "2026-08-20T22:19:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7140,7 +7068,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T21:52:30Z",
+      "last_reconciled_at": "2026-08-20T22:19:34Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7156,7 +7084,7 @@
           "file_path": "worldwideweb/Anchor.m",
           "name": "selectDiagnostic:",
           "readings": {
-            "ctags": 277,
+            "ctags": 278,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7165,7 +7093,7 @@
           "file_path": "worldwideweb/Anchor.m",
           "name": "setAddress:",
           "readings": {
-            "ctags": 313,
+            "ctags": 314,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7174,7 +7102,7 @@
           "file_path": "worldwideweb/Anchor.m",
           "name": "setNode:",
           "readings": {
-            "ctags": 263,
+            "ctags": 264,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7183,7 +7111,7 @@
           "file_path": "worldwideweb/HyperManager.m",
           "name": "accessName:Diagnostic:",
           "readings": {
-            "ctags": 155,
+            "ctags": 157,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7192,7 +7120,7 @@
           "file_path": "worldwideweb/HyperManager.m",
           "name": "appAcceptsAnotherFile:",
           "readings": {
-            "ctags": 253,
+            "ctags": 254,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7201,7 +7129,7 @@
           "file_path": "worldwideweb/HyperManager.m",
           "name": "appDidInit:",
           "readings": {
-            "ctags": 239,
+            "ctags": 240,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7210,7 +7138,7 @@
           "file_path": "worldwideweb/HyperManager.m",
           "name": "appOpenFile:type:",
           "readings": {
-            "ctags": 260,
+            "ctags": 261,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7219,7 +7147,7 @@
           "file_path": "worldwideweb/HyperManager.m",
           "name": "appOpenTempFile:type:",
           "readings": {
-            "ctags": 272,
+            "ctags": 273,
             "gitgalaxy": null,
             "tree_sitter": null
           }
@@ -7254,7 +7182,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T21:52:30Z",
+      "last_reconciled_at": "2026-08-20T22:19:34Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7368,7 +7296,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T21:52:30Z",
+      "last_reconciled_at": "2026-08-20T22:19:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7401,7 +7329,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-20T21:52:30Z",
+      "last_reconciled_at": "2026-08-20T22:19:34Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7443,7 +7371,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7458,7 +7386,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -7476,7 +7404,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7491,7 +7419,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": null
     },
@@ -7507,7 +7435,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7621,7 +7549,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7708,7 +7636,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7795,7 +7723,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7828,7 +7756,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-20T21:52:36Z",
+      "last_reconciled_at": "2026-08-20T22:19:40Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7942,7 +7870,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T21:52:40Z",
+      "last_reconciled_at": "2026-08-20T22:19:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7975,7 +7903,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T21:52:40Z",
+      "last_reconciled_at": "2026-08-20T22:19:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8008,7 +7936,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-20T21:52:40Z",
+      "last_reconciled_at": "2026-08-20T22:19:45Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8122,9 +8050,27 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T21:52:43Z",
-      "last_seen_count": 2,
+      "last_reconciled_at": "2026-08-20T22:19:47Z",
+      "last_seen_count": 7,
       "last_seen_examples": [
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "R2RVerification",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": null,
+            "tree_sitter": 25
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "LinkInfo",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": null,
+            "tree_sitter": 1584
+          }
+        },
         {
           "file_path": "core/packaging.psm1",
           "name": "PackageManifestResultStatus",
@@ -8136,11 +8082,38 @@
         },
         {
           "file_path": "core/packaging.psm1",
+          "name": "PackageManifestResult",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": null,
+            "tree_sitter": 5366
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
           "name": "MachineOSOverride",
           "readings": {
             "ctags": null,
             "gitgalaxy": null,
             "tree_sitter": 5441
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "PsPeInfo",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": null,
+            "tree_sitter": 5451
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "BomRecord",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": null,
+            "tree_sitter": 5605
           }
         }
       ],
@@ -8162,7 +8135,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T21:52:43Z",
+      "last_reconciled_at": "2026-08-20T22:19:47Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8231,7 +8204,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T21:52:43Z",
+      "last_reconciled_at": "2026-08-20T22:19:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8264,43 +8237,97 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-20T21:52:43Z",
-      "last_seen_count": 4,
+      "last_reconciled_at": "2026-08-20T22:19:47Z",
+      "last_seen_count": 16,
       "last_seen_examples": [
         {
-          "file_path": "core/packaging.psm1",
-          "name": "New-NativeDeb",
+          "file_path": "core/ci.psm1",
+          "name": "Invoke-LinuxTestsCore",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1749,
-            "tree_sitter": 1749
+            "gitgalaxy": 749,
+            "tree_sitter": 749
+          }
+        },
+        {
+          "file_path": "core/ci.psm1",
+          "name": "Set-Path",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 701,
+            "tree_sitter": 701
+          }
+        },
+        {
+          "file_path": "core/ci.psm1",
+          "name": "Invoke-BootstrapStage",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 739,
+            "tree_sitter": 739
+          }
+        },
+        {
+          "file_path": "core/ci.psm1",
+          "name": "Show-Environment",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 731,
+            "tree_sitter": 731
           }
         },
         {
           "file_path": "core/packaging.psm1",
-          "name": "GetPattern",
+          "name": "New-GlobalToolNupkgSource",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 5619,
-            "tree_sitter": 5619
+            "gitgalaxy": 4727,
+            "tree_sitter": 4727
           }
         },
         {
           "file_path": "core/packaging.psm1",
-          "name": "EnsureArchitecture",
+          "name": "Get-DirectoryNode",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 5647,
-            "tree_sitter": 5647
+            "gitgalaxy": 4431,
+            "tree_sitter": 4431
           }
         },
         {
           "file_path": "core/packaging.psm1",
-          "name": "SetPattern",
+          "name": "ReduceFxDependentPackage",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 5633,
-            "tree_sitter": 5633
+            "gitgalaxy": 4599,
+            "tree_sitter": 4599
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "Get-PackageVersionAsMajorMinorBuildRevision",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 4544,
+            "tree_sitter": 4544
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "Get-WindowsVersion",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 4512,
+            "tree_sitter": 4512
+          }
+        },
+        {
+          "file_path": "core/packaging.psm1",
+          "name": "Start-PrepForGlobalToolNupkg",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 4676,
+            "tree_sitter": 4676
           }
         }
       ],
@@ -8324,7 +8351,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T21:52:52Z",
+      "last_reconciled_at": "2026-08-20T22:19:57Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8384,7 +8411,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T21:52:52Z",
+      "last_reconciled_at": "2026-08-20T22:19:57Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8417,7 +8444,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T21:52:52Z",
+      "last_reconciled_at": "2026-08-20T22:19:57Z",
       "last_seen_count": 32,
       "last_seen_examples": [
         {
@@ -8531,7 +8558,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-20T21:52:52Z",
+      "last_reconciled_at": "2026-08-20T22:19:57Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8645,7 +8672,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T21:52:53Z",
+      "last_reconciled_at": "2026-08-20T22:19:58Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8687,7 +8714,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T21:52:53Z",
+      "last_reconciled_at": "2026-08-20T22:19:58Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8765,7 +8792,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T21:52:53Z",
+      "last_reconciled_at": "2026-08-20T22:19:58Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8816,7 +8843,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-20T21:52:53Z",
+      "last_reconciled_at": "2026-08-20T22:19:58Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8893,7 +8920,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -8989,7 +9016,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": null
     },
@@ -9007,7 +9034,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9060,8 +9087,8 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
-      "last_seen_count": 11,
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
+      "last_seen_count": 25,
       "last_seen_examples": [
         {
           "file_path": "serde/serde_core_de_impls.rs",
@@ -9174,7 +9201,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9286,7 +9313,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9399,7 +9426,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9495,7 +9522,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9512,7 +9539,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9527,7 +9554,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9545,7 +9572,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9580,96 +9607,96 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-20T21:52:57Z",
-      "last_seen_count": 69,
+      "last_reconciled_at": "2026-08-20T22:20:02Z",
+      "last_seen_count": 152,
       "last_seen_examples": [
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "get_param",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2427,
+            "gitgalaxy": 456,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "init_access",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2447,
+            "gitgalaxy": 444,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "get_components",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2481,
+            "gitgalaxy": 158,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "from_components",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2606,
+            "gitgalaxy": 191,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "apply",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2639,
+            "gitgalaxy": 448,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "queue",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2745,
+            "gitgalaxy": 452,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "build",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2778,
+            "gitgalaxy": 406,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "map_entities",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2877,
+            "gitgalaxy": 229,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "apply_effect",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2888,
+            "gitgalaxy": 177,
             "tree_sitter": null
           }
         },
         {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "deserialize",
+          "file_path": "bevy/bevy_ecs_macros.rs",
+          "name": "component_ids",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2987,
+            "gitgalaxy": 141,
             "tree_sitter": null
           }
         }
@@ -9692,7 +9719,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-20T21:52:59Z",
+      "last_reconciled_at": "2026-08-20T22:20:04Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9795,8 +9822,8 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T21:53:03Z",
-      "last_seen_count": 67,
+      "last_reconciled_at": "2026-08-20T22:20:09Z",
+      "last_seen_count": 84,
       "last_seen_examples": [
         {
           "file_path": "racket/schemify.rkt",
@@ -9897,7 +9924,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-20T21:53:03Z",
+      "last_reconciled_at": "2026-08-20T22:20:09Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10001,7 +10028,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-20T21:53:05Z",
+      "last_reconciled_at": "2026-08-20T22:20:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10016,7 +10043,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10033,7 +10060,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-20T21:53:06Z",
+      "last_reconciled_at": "2026-08-20T22:20:11Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10103,7 +10130,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T21:53:08Z",
+      "last_reconciled_at": "2026-08-20T22:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10134,7 +10161,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T21:53:08Z",
+      "last_reconciled_at": "2026-08-20T22:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10165,7 +10192,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-20T21:53:08Z",
+      "last_reconciled_at": "2026-08-20T22:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10197,7 +10224,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T21:53:09Z",
+      "last_reconciled_at": "2026-08-20T22:20:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10230,7 +10257,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T21:53:09Z",
+      "last_reconciled_at": "2026-08-20T22:20:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10254,7 +10281,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10272,8 +10299,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T21:53:09Z",
-      "last_seen_count": 34,
+      "last_reconciled_at": "2026-08-20T22:20:14Z",
+      "last_seen_count": 4,
       "last_seen_examples": [
         {
           "file_path": "sqlite/malloc_common.tcl",
@@ -10295,42 +10322,6 @@
         },
         {
           "file_path": "sqlite/tester.tcl",
-          "name": "do_ioerr_test",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 1927,
-            "tree_sitter": 1927
-          }
-        },
-        {
-          "file_path": "sqlite/tester.tcl",
-          "name": "dbcksum",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2176,
-            "tree_sitter": 2176
-          }
-        },
-        {
-          "file_path": "sqlite/tester.tcl",
-          "name": "wal_check_journal_mode",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2316,
-            "tree_sitter": 2316
-          }
-        },
-        {
-          "file_path": "sqlite/tester.tcl",
-          "name": "test_set_config_pagecache",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2496,
-            "tree_sitter": 2496
-          }
-        },
-        {
-          "file_path": "sqlite/tester.tcl",
           "name": "sqlite3",
           "readings": {
             "ctags": null,
@@ -10340,29 +10331,11 @@
         },
         {
           "file_path": "sqlite/tester.tcl",
-          "name": "crash_on_write",
+          "name": "finish_test",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1844,
-            "tree_sitter": 1844
-          }
-        },
-        {
-          "file_path": "sqlite/tester.tcl",
-          "name": "cksum",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2124,
-            "tree_sitter": 2124
-          }
-        },
-        {
-          "file_path": "sqlite/tester.tcl",
-          "name": "allcksum",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2145,
-            "tree_sitter": 2145
+            "gitgalaxy": 1243,
+            "tree_sitter": 1243
           }
         }
       ],
@@ -10386,7 +10359,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T21:53:09Z",
+      "last_reconciled_at": "2026-08-20T22:20:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10418,7 +10391,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-20T21:53:09Z",
+      "last_reconciled_at": "2026-08-20T22:20:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10442,7 +10415,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10460,9 +10433,18 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
-      "last_seen_count": 1,
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
+      "last_seen_count": 2,
       "last_seen_examples": [
+        {
+          "file_path": "vscode/instantiationService.ts",
+          "name": "extends",
+          "readings": {
+            "ctags": 410,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
         {
           "file_path": "vscode/lifecycle.ts",
           "name": "implements",
@@ -10493,8 +10475,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
-      "last_seen_count": 511,
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
+      "last_seen_count": 501,
       "last_seen_examples": [
         {
           "file_path": "assemblyscript/ast.ts",
@@ -10605,8 +10587,8 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
-      "last_seen_count": 9,
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
+      "last_seen_count": 4,
       "last_seen_examples": [
         {
           "file_path": "vscode/async.ts",
@@ -10615,51 +10597,6 @@
             "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 0
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 1,
-            "tree_sitter": 2
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 0,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 1,
-            "tree_sitter": 2
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 1,
-            "tree_sitter": 0
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 2,
-            "tree_sitter": 1
           }
         },
         {
@@ -10709,7 +10646,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10724,7 +10661,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10742,7 +10679,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10847,7 +10784,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10961,97 +10898,97 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
-      "last_seen_count": 1500,
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
+      "last_seen_count": 1907,
       "last_seen_examples": [
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "getOrElseW",
+          "file_path": "assemblyscript/ast.ts",
+          "name": "lineAt",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1050,
-            "tree_sitter": 1051
+            "gitgalaxy": 1686,
+            "tree_sitter": 1686
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "traverseReadonlyNonEmptyArrayWithIndex",
+          "file_path": "assemblyscript/ast.ts",
+          "name": "isLibrary",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1581,
-            "tree_sitter": 1582
+            "gitgalaxy": 1674,
+            "tree_sitter": 1674
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "extend",
+          "file_path": "assemblyscript/ast.ts",
+          "name": "isNative",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 839,
-            "tree_sitter": 839
+            "gitgalaxy": 1669,
+            "tree_sitter": 1669
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "exists",
+          "file_path": "assemblyscript/ast.ts",
+          "name": "columnAt",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1497,
-            "tree_sitter": 1498
+            "gitgalaxy": 1715,
+            "tree_sitter": 1715
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "equals",
+          "file_path": "assemblyscript/compiler.ts",
+          "name": "compileBinaryExpression",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 229,
-            "tree_sitter": 229
+            "gitgalaxy": 4046,
+            "tree_sitter": 4046
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "ap",
+          "file_path": "assemblyscript/compiler.ts",
+          "name": "compileUnaryPrefixExpression",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 408,
-            "tree_sitter": 408
+            "gitgalaxy": 9522,
+            "tree_sitter": 9522
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "tryCatch",
+          "file_path": "assemblyscript/compiler.ts",
+          "name": "convertExpression",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1393,
-            "tree_sitter": 1393
+            "gitgalaxy": 3546,
+            "tree_sitter": 3546
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "apW",
+          "file_path": "assemblyscript/compiler.ts",
+          "name": "makePow",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 523,
-            "tree_sitter": 524
+            "gitgalaxy": 5088,
+            "tree_sitter": 5088
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "stringifyJSON",
+          "file_path": "assemblyscript/compiler.ts",
+          "name": "compileUnaryPostfixExpression",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 1728,
-            "tree_sitter": 1728
+            "gitgalaxy": 9278,
+            "tree_sitter": 9278
           }
         },
         {
-          "file_path": "fp-ts/Either.ts",
-          "name": "matchW",
+          "file_path": "assemblyscript/compiler.ts",
+          "name": "compileIdentifierExpression",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 985,
-            "tree_sitter": 986
+            "gitgalaxy": 7358,
+            "tree_sitter": 7358
           }
         }
       ],
@@ -11075,9 +11012,18 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
-      "last_seen_count": 1,
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
+      "last_seen_count": 2,
       "last_seen_examples": [
+        {
+          "file_path": "vscode/lifecycle.ts",
+          "name": "createReferencedObject",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 711,
+            "tree_sitter": null
+          }
+        },
         {
           "file_path": "vscode/lifecycle.ts",
           "name": "destroyReferencedObject",
@@ -11108,7 +11054,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-20T21:53:30Z",
+      "last_reconciled_at": "2026-08-20T22:20:35Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11221,7 +11167,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T21:53:38Z",
+      "last_reconciled_at": "2026-08-20T22:20:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11252,7 +11198,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T21:53:38Z",
+      "last_reconciled_at": "2026-08-20T22:20:44Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11355,7 +11301,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-20T21:53:38Z",
+      "last_reconciled_at": "2026-08-20T22:20:44Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_points_of_interest.md
+++ b/docs/self_scan/tri_comparison_points_of_interest.md
@@ -8,7 +8,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `agc_assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 215 occurrences as of 2026-08-20T21:51:32Z*
+*2-vs-1 -- 215 occurrences as of 2026-08-20T22:18:34Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed-cause shape, fully accounted for via a corpus-wide cross-reference of ctags' actual output against GitGalaxy's raw func_start regex matches and its real pipeline/DB output (215 + 50 = 265, no unexplained residual). (1) 215/265 (81%): ctags' Asm "l" kind tags EVERY line-start label unconditionally, including pure data/constant-definition labels (e.g. ERASCON1 OCTAL 00061, S10BITS, LSTBNKCH -- AGC_BLOCK_TWO_SELF-CHECK.agc:133 and nearby) that are never followed by an executable instruction. GitGalaxy's func_start regex deliberately requires the label be followed by a real instruction mnemonic from a fixed whitelist, so it does not count these as functions -- a genuine, intentional precision distinction (code label vs. data label), not a GitGalaxy defect; ctags' generic Asm parser has no way to make this distinction at all. (2) 50/265 (19%): a real, confirmed GitGalaxy engine defect in detector.py's _slice_by_labels (Mode A), independently root-caused to two separate bugs: (a) `RELINT` is incorrectly included in `self.assembly_returns`'s early-termination keyword list (detector.py:572-575) -- in real AGC assembly RELINT means "release interrupt inhibit" and commonly opens a long interrupt-handler routine rather than closing one, so it truncates the real body to one line (confirmed: ELOOPFIN, AGC_BLOCK_TWO_SELF-CHECK.agc:303, a 20+-line real routine collapsed to just its own label line); (b) the `len(block.splitlines()) < 2` guard (detector.py:1973) unconditionally discards legitimate single-instruction assembly subroutines when the next func_start match sits on the very next line (confirmed: SOPTION1-SOPTION5+, AGC_BLOCK_TWO_SELF-CHECK.agc:210-214, each a real one-instruction label). Filed as #1949 -- a follow-up read-only Gemini/agy dispatch confirmed both root causes generalize beyond agc_assembly to the shared Mode A mechanism (assembly, cobol, fortran, abap all independently exhibit bug 1; assembly and cobol also exhibit bug 2), plus two further bug-1 variants not visible from agc_assembly alone: the terminator regex also false-matches inside comments (assembly) and inside hyphenated identifier names (cobol), not just legitimate-but-misclassified instructions. See #1949 for the full cross-language evidence and fix scope. No credit/debit -- the 215 portion is an honest scope difference (not two tools independently wrong about the same fact), and the 50 portion is GitGalaxy's own unresolved bug, not something ctags corroborates or contradicts.
@@ -28,7 +28,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `agc_assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 37 occurrences as of 2026-08-20T21:51:32Z*
+*2-vs-1 -- 37 occurrences as of 2026-08-20T22:18:34Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Confirmed: all 35 occurrences are real AGC labels that GitGalaxy correctly extracts and Universal Ctags' generic Asm parser structurally cannot tag, due to AGC assembly's non-standard label-naming conventions. Two sub-patterns, both confirmed corpus-wide (14/35 + 21/35 = 35/35, not just the sample): (1) labels with an embedded hyphen -- AGC's own convention of naming a point relative to an event, e.g. TIG-35/TIG-30/CALLT-35 in BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc:250/292/222 ("35/30 seconds before Time of Ignition"); (2) labels starting with a digit or a leading minus sign, e.g. 1CHK/2EBANK/-1CHK in AGC_BLOCK_TWO_SELF-CHECK.agc:184 (real label text is "-1CHK"). Directly verified via `ctags --language-force=Asm --kinds-Asm=l` against the real corpus files: ctags emits zero tags for any of these names (confirmed by grepping its actual output for the exact names and their surrounding CHK-suffixed siblings, which ARE tagged when they don't start with a hyphen/digit) -- ctags' Asm parser requires a tag name to start with a letter and contain no hyphen, neither of which is a real constraint in AGC assembly's own label syntax. GitGalaxy's func_start regex ([A-Z0-9_-]+ at line start) has no such restriction. This is a confirmed, structural ctags/Asm-parser limitation, not corroboration of anything wrong on GitGalaxy's side -- logged to docs/why_gitgalaxy_beats_ast_here.md.
@@ -48,11 +48,12 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ## apex
 
-### ❓ `apex` function existence: GitGalaxy agree, tree-sitter differ
+### ✅ `apex` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:51:33Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:21:09Z*
 
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`apex/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
+**Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source), 2026-08-20T22:17:39Z):
+> Confirmed GitGalaxy engine defect, not a tree-sitter gap. Both sampled occurrences (apex-recipes/AuraEnabledRecipes_Tests.cls:25 and :43) are `new Account(name = ...)` object-instantiation expressions inside a multi-line SObject-builder call, not real method/constructor definitions -- confirmed by reading the source directly. Root cause: the func_start regex (language_standards.py, apex rules) treats any `[a-zA-Z_][\w.]*[ \t\n]+` token at start-of-line as an eligible optional return-type/modifier prefix before the captured function name, with no exclusion for the `new` keyword -- so `new Account(` parses as "returnType=new, name=Account", passing the #1221 gating fix (which only requires the line START with one of annotation/modifier/return-type-shaped token, not that the token be a real type). tree_sitter correctly does not report these as functions since its grammar distinguishes object_creation_expression from method_declaration structurally. Verified this generalizes beyond the 2-occurrence ledger sample: running the regex directly against the whole apex corpus found 6 total false-positive matches across 2 files (AuraEnabledRecipes_Tests.cls:6,25,43 and SOQLRecipes_Tests.cls:226,235,504), all the identical `new ClassName(` shape. Filed as GitHub issue #1963 (exclude `new` from the eligible return-type/modifier prefix token). No credit_tools/debit_tools adjustment needed: since only gitgalaxy is in agreeing_tools here (len(present)==1), the reconciler already excludes this from gitgalaxy matched_consensus by default while still counting it in total_slots -- the default precision score already reflects this correctly as an unconfirmed/wrong claim.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
@@ -63,7 +64,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 26 occurrences as of 2026-08-20T21:51:35Z*
+*2-vs-1 -- 26 occurrences as of 2026-08-20T22:18:37Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed shape, no clean credit/debit call. (1) A real, confirmed GitGalaxy defect: the same detector.py `_slice_by_labels` bug filed for agc_assembly as #1949 (RELINT-style early truncation and single-line/blank-collapsed body discard) independently confirmed live for generic assembly too -- `del_command:` (bootos/os.asm:269) sits immediately before the next label `os22:` with nothing between, collapsing to a one-line block and getting discarded; `C:`/`prtstr:` (hellosilicon/matrixmultneon.s:90,92) are each followed only by a data directive (`.fill`, `.asciz`) then a blank line before the next label, same one-line-after-strip() collapse. All three are real regex matches (confirmed via direct func_start.finditer against the raw text) that never reach the final function list -- tracked under #1949, not a new issue. (2) A correct-by-design GitGalaxy exclusion: `.Lenv0:`/`.Largv0:` (cosmopolitan/ape.S:1784-1785) start with the `.L` prefix func_start's own negative lookahead deliberately excludes (GCC's own convention for compiler-generated local/temporary labels) -- both are genuinely data labels (`.asciz` string constants) here, not real subroutines; ctags' generic Asm parser has no such convention-awareness and tags them anyway. (3) ctags itself over-tags some non-callable constructs GitGalaxy correctly excludes -- C-preprocessor `#define` macro constants (`GRUB_MAGIC`/`GRUB_EAX`/`GRUB_AOUT`/`GRUB_CHECKSUM`/`USE_SYMBOL_HACK`, cosmopolitan/ape.S:49,1679-1682) are not real assembly labels at all (no trailing `:`), but ctags' Asm parser tags them regardless. No credit/debit -- the shape mixes a real unresolved GitGalaxy recall gap (#1949) with cases where ctags is the one over-tagging, not a clean corroboration story either direction.
@@ -83,7 +84,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-20T21:51:35Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:18:37Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed shape, three distinct confirmed mechanisms, no clean credit/debit call (real wins and real gaps in both directions within the same shape). (1) A dot-prefix naming-convention split -- NASM/GAS local labels scoped to the preceding global label are written with a leading `.` (e.g. `.load_vec:`, `.loop:` in bootos/os.asm:197,306), which GitGalaxy's func_start regex captures verbatim but ctags' Asm parser strips before emitting the tag (confirmed: ctags reports the SAME real label as `load_vec`/`loop`, no dot -- both tools genuinely found the same real construct, they just serialize the name differently). This is a name-string artifact of exact-string ledger grouping, not a detection difference on either side. (2) A genuine ctags gap: purely numeric local labels (`.1:`, `.2:` in bootos/counter.asm:52,67) are not tagged by ctags' Asm parser under ANY name (confirmed: neither `1`/`2` nor `.1`/`.2` appear in its output at all) -- GitGalaxy correctly finds these. (3) A genuine GitGalaxy precision gap, the mirror image of agc_assembly's own win: unlike agc_assembly's func_start (which requires a label be followed by a real instruction opcode), generic assembly's func_start has no such requirement -- ANY `identifier:` at line start matches, so it also matches pure data/constant declaration labels ctags' comparatively more conservative reading skips: `max_entries: equ sector_size/entry_size` (bootos/os.asm:166, a compile-time constant, not a subroutine), and several string/metadata labels in cosmopolitan/ape.S followed only by `.asciz`/data directives (`ape.ident`, `freebsd.ident`, `netbsd.ident`, `openbsd.ident`, `str.error`, `str.crlf`, `str.e820`, `str.oldcpu`). Not filed as a bug -- generic assembly's func_start is intentionally permissive because it has to span wildly different, informally-specified dialects (x86/ARM/legacy real-mode) where a fixed per-opcode whitelist like agc_assembly's isn't practical; worth a future harden-language-extraction look at whether a narrower heuristic (e.g. excluding labels followed only by known data-directive pseudo-ops like .asciz/.long/.byte/equ) could recover some of this precision without losing real dialect coverage, but that's a design tradeoff, not a clear regression to fix urgently.
@@ -102,7 +103,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 77 occurrences as of 2026-08-20T21:51:40Z*
+*2-vs-1 -- 74 occurrences as of 2026-08-20T22:18:42Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed, independently verified all 6 sampled names against real source -- GitGalaxy and ctags both correct, tree-sitter over-recalling from two related but distinct preprocessor-driven mechanisms, both already covered by existing infrastructure: (1) keyword/macro misparse -- 'if' (dictobject.c:522-527, an `#if SIZEOF_VOID_P > 4` / `else if` sequence desyncs the parse) and 'DICT___REVERSED___METHODDEF' (dictobject.c:5102, a PyMethodDef array-initializer macro, not a definition) are both ALREADY in tree_sitter_accuracy_audit.py's `_C_KNOWN_MACRO_HALLUCINATIONS` exclusion set (confirmed by reading it directly) -- this tri-comparison tool's raw walk deliberately doesn't apply that list (it's a curated, ground-truth-shaped judgment call, appropriately left to reconciliation per this module's own stated design, not baked into the walk). (2) dead #if 0 code -- '_PyObject_ManagedDictValidityCheck' (dictobject.c:7396) and 'tos_char'/'print_stack'/'print_stacks' (frameobject.c:1264-1313) are genuinely well-formed function definitions sitting entirely inside `#if 0 ... #endif` guards; tree-sitter has no preprocessor model and parses the dead branch as live code. Both mechanisms are already the exact shape docs/why_gitgalaxy_beats_ast_here.md's Claim 8 names generically ('a dead #if 0 block... macro definitions... that merely look structural') -- added these 4 new concrete citations to Claim 8's evidence section rather than treating this as a new finding. No GitHub issue -- both tools already behave as intended; this is expected, already-documented tree-sitter preprocessor-blindness surfacing under the new tri-comparison reconciliation, not a fresh defect.
@@ -118,11 +119,11 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | cpython/frameobject.c | `print_stack` | *(n/a)* | 1284 | *(n/a)* |
 | cpython/frameobject.c | `print_stacks` | *(n/a)* | 1304 | *(n/a)* |
 | cpython/object.c | `if` | *(n/a)* | 1272 | *(n/a)* |
-| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 300 | *(n/a)* |
+| micropython/gc.c | `if` | *(n/a)* | 1353 | *(n/a)* |
 
 ### ✅ `c` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-20T21:51:40Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-20T22:18:42Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > 3 distinct causes, all genuine tree-sitter-c grammar limitations (GitGalaxy and ctags both correct in all 10 sampled cases) -- confirmed via dispatched investigation (which ran tree-sitter's C grammar directly and found ERROR nodes in every case) plus independent source-level spot-checks of all 3 trigger shapes. This is a C-scale instance of Claim 7 (CPP-directive-driven recall loss) -- added to that claim's evidence section. (1) 4 samples: an #if/#else pair splitting a single `if` condition inside a function body (ceval.c:33, _Py_ReachedRecursionLimitWithMargin). (2) 5 samples: bare, un-semicoloned macro invocations the grammar can't cleanly recover from, losing the next real function (object.c:1269-1271's _Py_COMP_DIAG_PUSH/IGNORE_DEPR_DECLS/POP before _PyObject_SetAttributeErrorContext; similar shape for the typeobject.c slot-getattr cluster). (3) 1 sample: #if/#endif wrapping only the `static` storage-class specifier, separated from the rest of the signature (micropython/compile.c:3473-3476, mp_compile_to_raw_code). Unlike Fortran's existing Claim 7 evidence (entire trailing sections lost), C's version is local -- one function lost per trigger, not a cascading region. No GitHub issue -- documented as new Claim 7 evidence, not a fixable tooling bug (this repo doesn't control tree-sitter-c's grammar).
@@ -142,7 +143,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-20T21:51:40Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:18:42Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes.
@@ -156,13 +157,10 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | cpython/typeobject.c | `SLOT1` | *(n/a)* | *(n/a)* | 10542 |
 | cpython/typeobject.c | `SLOT1` | *(n/a)* | *(n/a)* | 10703 |
 | cpython/typeobject.c | `SLOT1BINFULL` | *(n/a)* | *(n/a)* | 10575 |
-| micropython/emitnative.c | `free` | *(n/a)* | *(n/a)* | 320 |
-| micropython/emitnative.c | `new` | *(n/a)* | *(n/a)* | 300 |
-| micropython/vm.c | `mp_execute_bytecode` | *(n/a)* | *(n/a)* | 220 |
 
 ### ✅ `c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-20T21:51:40Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-20T22:18:42Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up.
@@ -174,9 +172,22 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | cpython/typeobject.c | `slot_tp_repr` | 10714 | *(n/a)* | *(n/a)* |
 | cpython/typeobject.c | `slot_nb_inplace_power` | 10697 | *(n/a)* | *(n/a)* |
 
+### ✅ `c` function existence: tree-sitter, ctags agree, GitGalaxy differ
+
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:18:42Z*
+
+**Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
+> Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 300 | 300 |
+| micropython/emitnative.c | `EXPORT_FUN` | *(n/a)* | 320 | 320 |
+| micropython/vm.c | `MICROPY_WRAP_MP_EXECUTE_BYTECODE` | *(n/a)* | 220 | 220 |
+
 ### ✅ `c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:51:40Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:18:42Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Two distinct causes, both confirmed by independent verification, not one -- resolved via dispatched investigation plus direct fixes. (1) 5 of 8 (I_AllocLow, I_ZoneBase, I_BaseTiccmd, R_CheckBBox, R_AddLine, all doom): a real bug in THIS tool's OWN ctags_reader.py, not a ctags limitation. Old Doom source uses literal TAB characters for column alignment (e.g. `byte*\tI_AllocLow(int length)`); ctags faithfully echoes that tab into its tag-file's address/pattern field, and read_ctags_symbols' naive line.split('\t') then misreads a fragment of the SOURCE LINE as the kind field, fails the kind-membership check, and silently drops the symbol. Confirmed by running ctags with the exact flags this code uses and inspecting the raw tab-delimited output directly -- reproduced the exact column-shift byte for byte. Fixed: parse now finds the tag-file format's guaranteed `;"` address-terminator marker instead of blind-splitting the whole line, only tab-splitting the safe trailer after it. Verified: all 5 names now correctly found. (2) 3 of 8 (slot_nb_power, slot_nb_bool, wrap_next, all cpython typeobject.c): extension of the already-documented SLOT-macro ctags limitation -- each follows a SLOT1BINFULL/SLOT0/RICHCMP_WRAPPER macro invocation ctags misreads as a function (confirmed at typeobject.c:10574/10577/10630), which also swallows the real function immediately after it. Not code-fixed (same ground-truth-judgment reasoning as the sibling 7-occurrence shape) -- already covered by ctags_reader.py's existing note on this mechanism.
@@ -189,7 +200,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:51:40Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:18:42Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a GitGalaxy or ctags defect -- a bug in this tool's OWN _count_ctags_signature_params (tri_comparison_gatherer.py), now fixed. Confirmed directly: ran ctags against cpython/ceval.c, PyEval_GetLocals(void)'s raw signature field is literally the text '(void)'. GitGalaxy and tree-sitter both already special-case C's explicit empty-parameter-list idiom (0 real args, matching detector.py's own _count_top_level_args docstring) -- _count_ctags_signature_params did not, splitting '(void)' into one non-empty segment and counting it as 1 real parameter (the same class of bug its own docstring already describes fixing twice for Python's trailing-comma and bare * / marker cases). Added 'void' to the segment-exclusion set alongside the existing '*'/'/'/'**' -- verified fix: _count_ctags_signature_params('(void)') now returns 0. This corpus (cpython) uses the (void) idiom extremely heavily, plausibly explaining most/all of the 104 occurrences; not independently re-verified beyond the sample, but the mechanism is unconditional (any '(void)' signature was miscounted the same way, corpus-wide) so high confidence it generalizes. No GitHub issue needed -- fixed directly in this same commit, not a repo-code defect.
@@ -202,7 +213,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cobol` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 136 occurrences as of 2026-08-20T21:51:45Z*
+*2-vs-1 -- 136 occurrences as of 2026-08-20T22:18:48Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-19):
 > Mixed-cause shape, majority ctags-side false positives plus a smaller hidden GitGalaxy defect. (1) Majority (all 10 capped examples, all named END-IF): Universal Ctags' COBOL parser tags ANY period-terminated word as a 'paragraph' (kind p), including scope terminators like END-IF./END-PERFORM. that are not paragraph definitions -- confirmed by a live ctags run on cics-banking-sample-application-cbsa/BANKDATA.cbl showing dozens of plain 'END-IF.' lines (e.g. lines 455, 600) tagged as paragraphs. GitGalaxy correctly excludes these via its END-[A-Za-z0-9_-]+ reserved-word shield. This is a permanent, structural ctags limitation (documented in tests/tools/ctags_reader.py), not a GitGalaxy defect. (2) A smaller (~20 of 133), genuine GitGalaxy false-negative hiding underneath: cics-genapp/lgdpol01.cbl:139 'DELETE-POLICY-DB2-INFO.' and lgapol01.cbl:137 'WRITE-ERROR-MESSAGE.' are real, called (PERFORM'd) paragraph definitions that GitGalaxy's own func_start regex wrongly excludes -- its reserved-word negative lookahead ends in a bare \b, and since '-' is a non-word character in Python re, any real paragraph name that happens to start with a banned keyword followed by a hyphen (a common COBOL verb-prefixed naming convention: WRITE-*, READ-*, SET-*, DELETE-*, ...) is wrongly rejected. Verified directly against the compiled regex (both return no match) and confirmed ~20 such real paragraphs exist corpus-wide via grep. Filed as GitHub issue #1892. Investigated via gemini-3.1-pro-high (agy), file:line citations and regex behavior independently re-verified by Claude before applying.
@@ -222,7 +233,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cobol` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 43 occurrences as of 2026-08-20T21:51:45Z*
+*2-vs-1 -- 43 occurrences as of 2026-08-20T22:18:48Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-19):
 > Mixed-cause shape, two independent confirmed defects, neither in GitGalaxy's core function detection being right or wrong as a whole. (1) MAINLINE/TIMESTAMP and most of the 18 cases: these are real COBOL SECTION headers in the PROCEDURE DIVISION (e.g. cics-genapp/lgacdb01.cbl:128 "MAINLINE SECTION.", cics-banking-sample-application-cbsa/BANKDATA.cbl:1441 "TIMESTAMP SECTION." followed by executable CALL statements) that GitGalaxy correctly captures per its own documented func_start scope ("Paragraphs and Sections") -- and ctags ALSO correctly tags them, as kind 'section' (verified via live ), not as the 'paragraph' kind. The disagreement is manufactured by tests/tools/ctags_reader.py's CTAGS_FUNC_KINDS["cobol"] = {"p"}, which drops section-kind tags before comparison -- a test-harness bug, not a real ctags-vs-GitGalaxy disagreement. Filed as GitHub issue #1891. (2) LOCAL-STORAGE (cics-banking-sample-application-cbsa/XFRFUN.cbl:107 "LOCAL-STORAGE SECTION." immediately followed by 01-level data item declarations, no executable logic): this is a genuine GitGalaxy false positive -- the func_start regex's reserved-word negative lookahead bans WORKING-STORAGE and LINKAGE as Data Division section names but omits LOCAL-STORAGE, so it slips through and gets miscounted as a paragraph. ctags correctly reports nothing here. Filed as GitHub issue #1890. Investigated via gemini-3.1-pro-high (agy), file:line citations independently re-verified by Claude against language_standards.py and a live ctags run before applying.
@@ -244,7 +255,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1097 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 1097 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -263,7 +274,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1074 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 1074 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -282,7 +293,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 98 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 98 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -301,7 +312,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 95 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 95 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -320,7 +331,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 62 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 62 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -339,7 +350,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 22 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 22 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -358,7 +369,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -377,7 +388,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -396,7 +407,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -413,7 +424,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -424,7 +435,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:51:49Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -434,7 +445,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `cpp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-20T21:51:49Z*
+*3-way split -- 1 occurrence as of 2026-08-20T22:18:52Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`cpp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -446,7 +457,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 271 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 271 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -465,26 +476,26 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 79 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 107 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
+| roslyn/CSharpCompilation.cs | `FindEntryPoint` | 1993 | 1993 | *(n/a)* |
 | roslyn/CSharpCompilation.cs | `validateSignature` | 4463 | 4463 | *(n/a)* |
 | roslyn/CSharpCompilation.cs | `validateSignature` | 4689 | 4689 | *(n/a)* |
+| roslyn/CSharpCompilation.cs | `ReportUnusedImports` | 2747 | 2747 | *(n/a)* |
+| roslyn/CSharpCompilation.cs | `GetSourceDeclarationDiagnostics` | 3395 | 3395 | *(n/a)* |
 | roslyn/CSharpCompilation.cs | `isSupportedType` | 1798 | 1798 | *(n/a)* |
+| roslyn/CSharpCompilation.cs | `IsRuntimeAsyncEnabledIn` | 351 | 351 | *(n/a)* |
 | roslyn/CSharpCompilation.cs | `registeredUsageOfUsingsInTree` | 3359 | 3359 | *(n/a)* |
 | roslyn/CSharpCompilation.cs | `getExplicitAccessibilitySymbol` | 4945 | 4945 | *(n/a)* |
 | roslyn/CSharpCompilation.cs | `updateCachedDiagnostics` | 3308 | 3308 | *(n/a)* |
-| roslyn/CSharpCompilation.cs | `checkValid` | 2079 | 2079 | *(n/a)* |
-| roslyn/CSharpCompilation.cs | `getCustomModifierForType` | 4320 | 4320 | *(n/a)* |
-| roslyn/CSharpCompilation.cs | `isAllowedPointerArithmeticIntegralType` | 4654 | 4654 | *(n/a)* |
-| roslyn/CSharpCompilation.cs | `computeMappedPathToSyntaxTree` | 1151 | 1151 | *(n/a)* |
 
 ### ❓ `csharp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 48 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 48 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -503,16 +514,13 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
 | roslyn/CSharpCompilation.cs | `HasEntryPointSignature` | 0 | 2 | 2 |
-| roslyn/CSharpCompilation.cs | `TryGetInterceptor` | 0 | 1 | 1 |
-| roslyn/LanguageParser.cs | `ParseNamespaceBodyWorker` | 2 | 5 | 5 |
-| roslyn/LanguageParser.cs | `ParseNamespaceBody` | 2 | 4 | 4 |
 | roslyn/Workspace.cs | `SetCurrentSolutionAsync` | 2 | 6 | 6 |
 | roslyn/Workspace.cs | `SetCurrentSolutionAsync` | 0 | 7 | 7 |
 | roslyn/Workspace.cs | `OnAnyDocumentTextChanged` | 2 | 7 | 7 |
@@ -522,7 +530,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -537,7 +545,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 5 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 5 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -549,9 +557,22 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | roslyn/LanguageParser.cs | `AccessorDeclaringKind` | *(n/a)* | 4342 | *(n/a)* |
 | roslyn/LanguageParser.cs | `PostSkipAction` | *(n/a)* | 4472 | *(n/a)* |
 
+### ❓ `csharp` function args: GitGalaxy, tree-sitter agree, ctags differ
+
+*2-vs-1 -- 4 occurrences as of 2026-08-20T22:18:59Z*
+
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| roslyn/CSharpCompilation.cs | `GetHashCode` | 1 | 1 | 2 |
+| roslyn/LanguageParser.cs | `GetModifierExcludingScoped` | 1 | 1 | 2 |
+| roslyn/Workspace.cs | `SetCurrentSolution` | 1 | 1 | 6 |
+| roslyn/Workspace.cs | `SetCurrentSolution` | 6 | 6 | 4 |
+
 ### ❓ `csharp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 5 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -560,25 +581,11 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | roslyn/CSharpCompilation.cs | `ShouldCheckTypeForMembers` | *(n/a)* | 5268 | 5268 |
 | roslyn/CSharpCompilation.cs | `Matches` | *(n/a)* | 5281 | 5281 |
 | roslyn/CSharpSyntaxTree.cs | `GetRoot` | *(n/a)* | 86 | 86 |
-| roslyn/CSharpSyntaxTree.cs | `TryGetRoot` | *(n/a)* | 91 | 91 |
 | roslyn/DiagnosticAnalyzer.cs | `Initialize` | *(n/a)* | 24 | 24 |
-
-### ❓ `csharp` function args: GitGalaxy, tree-sitter agree, ctags differ
-
-*2-vs-1 -- 4 occurrences as of 2026-08-20T21:51:55Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| roslyn/CSharpCompilation.cs | `GetHashCode` | 1 | 1 | 0 |
-| roslyn/LanguageParser.cs | `GetModifierExcludingScoped` | 1 | 1 | 2 |
-| roslyn/Workspace.cs | `SetCurrentSolution` | 1 | 1 | 6 |
-| roslyn/Workspace.cs | `SetCurrentSolution` | 6 | 6 | 4 |
 
 ### ❓ `csharp` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -590,7 +597,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `csharp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:51:55Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -598,9 +605,29 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 |---|---|---|---|---|
 | roslyn/CSharpCompilation.cs | `Equals` | 1 | 2 | 1 |
 
+### ❓ `csharp` function existence: ctags agree, GitGalaxy, tree-sitter differ
+
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:18:59Z*
+
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| roslyn/CSharpCompilation.cs | `bool` | *(n/a)* | *(n/a)* | 2539 |
+
+### ❓ `csharp` function existence: tree-sitter agree, GitGalaxy, ctags differ
+
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:18:59Z*
+
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| roslyn/CSharpSyntaxTree.cs | `TryGetRoot` | *(n/a)* | 91 | *(n/a)* |
+
 ### ❓ `csharp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-20T21:51:55Z*
+*3-way split -- 1 occurrence as of 2026-08-20T22:18:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`csharp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -612,7 +639,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `css` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:51:57Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:19:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`css/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -626,7 +653,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 37 occurrences as of 2026-08-20T21:52:01Z*
+*2-vs-1 -- 37 occurrences as of 2026-08-20T22:19:04Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -645,7 +672,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 18 occurrences as of 2026-08-20T21:52:01Z*
+*2-vs-1 -- 18 occurrences as of 2026-08-20T22:19:04Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -664,7 +691,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `dart` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 216 occurrences as of 2026-08-20T21:52:01Z*
+*3-way split -- 216 occurrences as of 2026-08-20T22:19:04Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`dart/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -685,7 +712,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 14 occurrences as of 2026-08-20T21:52:06Z*
+*2-vs-1 -- 14 occurrences as of 2026-08-20T22:19:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -704,7 +731,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-20T21:52:06Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-20T22:19:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -721,7 +748,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:52:06Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:19:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -732,7 +759,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:52:06Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:19:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -743,7 +770,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `fortran` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-20T21:52:06Z*
+*3-way split -- 1 occurrence as of 2026-08-20T22:19:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`fortran/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -755,7 +782,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `go` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 75 occurrences as of 2026-08-20T21:52:09Z*
+*2-vs-1 -- 75 occurrences as of 2026-08-20T22:19:12Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`go/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -776,7 +803,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 102 occurrences as of 2026-08-20T21:52:12Z*
+*2-vs-1 -- 103 occurrences as of 2026-08-20T22:19:15Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > All 10 sampled cases are ctags-side artifacts, not real GitGalaxy/tree-sitter misses -- confirmed via direct `ctags -x` output against the corpus. Three distinct ctags Haskell-parser weaknesses cover the sample: (1) multi-clause double/triple-tagging -- ctags tags every pattern-matched equation line as its own occurrence of the name (writerFn/writeFnBinary/expandFilterPath: confirmed 2-3 raw ctags tags per function, one per clause; a file-wide count found 45 such extra same-name tags across the 7-file corpus, e.g. blockToInlines alone has 14). GitGalaxy/tree-sitter both correctly anchor to the FIRST clause only, leaving ctags' later-clause tags as the ones unpaired. (2) keyword-as-identifier misparsing -- `class`/`where`/`pattern` (from PatternSynonyms) get tagged as function names when ctags fails to parse past the keyword; confirmed at Options.hs:62 (`class HasSyntaxExtensions`), Parsing.hs:184 (module-header `where`), and 3 PatternSynonyms declarations in Options.hs. (3) CAF/value-vs-function kind collapse -- defaultAbbrevs/defaultKaTeXURL/defaultMathJaxURL/defaultWebTeXURL are zero-arg top-level VALUES (non-arrow type signatures), not functions; ctags has no value/variable kind at all (`ctags --list-kinds-full=Haskell` shows only constructor/function/module/type) so it lumps every `name = expr` binding into "function". GitGalaxy (language_standards.py haskell rules, #1312) and tree-sitter's own audit tooling (_find_haskell_signature_for_bind, #1566) both independently make the same value-vs-function distinction correctly -- real cross-tool corroboration, not coincidence. (4) TH-splice call sites misread as definitions -- deriveJSON at Options.hs:454/458 is a Template Haskell splice INVOKING an imported function, not defining one; ctags misparses the call as a definition. No GitGalaxy/tree-sitter defect anywhere in this shape; purely a ctags parser limitation, same category as the already-documented empty CTAGS_CLASS_KINDS['haskell'].
@@ -796,7 +823,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 69 occurrences as of 2026-08-20T21:52:12Z*
+*2-vs-1 -- 69 occurrences as of 2026-08-20T22:19:15Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > Confirmed: all 10 sampled misses (and, by cross-check against additional non-sampled instances in Options.hs/Shared.hs, plausibly all 69) are locally-scoped function definitions -- `instance ... where` methods, `where`-clause helpers, or `let`-bound names inside `do` blocks -- never top-level module definitions. ctags' Haskell parser has no layout-rule/scope awareness and only tags equations anchored at column 1; it correctly handles multi-clause TOP-LEVEL definitions (verified via expandFilterPath, writeFnBinary, writerFn -- all tag fine, clauses and all), so this is a pure scope blind spot, not a clause-counting bug (distinct from the tree-sitter clause-splitting bug fixed earlier in this same effort, which shares 2 of the 10 sample names by coincidence of subject matter, not root cause). GitGalaxy and tree-sitter are both correct; ctags is not wrong so much as structurally incapable of seeing these. Known, expected limitation of ctags' Haskell parser, now documented alongside its existing Haskell notes in tests/tools/ctags_reader.py -- not a GitHub issue, nothing in this repo to fix.
@@ -816,7 +843,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-20T21:52:12Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-20T22:19:15Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Not a real discrepancy -- structural tooling gap, already documented in the codebase. tests/tools/ctags_reader.py:39-40,228 sets CTAGS_CLASS_KINDS['haskell'] = set() on purpose: "ctags' Haskell parser has no class-shaped kind at all (constructor/function/module/type only)". Every example in this shape (data/newtype/class declarations -- ReaderOptions, CiteMethod, HasSyntaxExtensions, etc.) is real; ctags structurally cannot report any of them for this language, not a sample-specific miss. No action needed beyond this note.
@@ -836,7 +863,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:52:12Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:19:15Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Mixed shape, resolved by reading both of the 2 occurrences directly (no larger sample needed). (1) Options.hs:438 getExtensions -- real function, `instance HasSyntaxExtensions WriterOptions where getExtensions opts = writerExtensions opts`. A sibling instance for ReaderOptions at Options.hs:80 has the identical shape. Tree-sitter's Haskell grammar doesn't expose typeclass-instance-method clause bodies the way it does top-level bindings, and ctags' Haskell parser has no instance-method kind either -- GitGalaxy is correct, both other tools have a real recall gap on typeclass instance methods. (2) Shared.hs:475 extensionEnabled -- NOT a real function. Imported from Text.Pandoc.Extensions (Shared.hs:114), only ever appears as a guard-clause call (`| extensionEnabled Ext_gfm_auto_identifiers exts = ...`). GitGalaxy's regex misreads a guard-clause invocation as a definition -- genuine GitGalaxy false positive, worth its own engine bug against language_standards.py's haskell func_start rule.
@@ -848,7 +875,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 9 occurrences as of 2026-08-20T21:52:12Z*
+*3-way split -- 9 occurrences as of 2026-08-20T22:19:15Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > One systematic cause, confirmed by reading source for 3 of the 9 (getMetadataFromFiles App.hs:395-397, splitTextByIndices Shared.hs:142-143, tabFilter Shared.hs:256-259) and consistent with the shape of the remaining 6. Every case is a point-free/eta-reduced Haskell equation: the type signature declares N params, but the specific clause GitGalaxy and tree-sitter both align to only explicitly binds N-1 of them, handling the trailing argument via composition (`.`) or `\case`. GitGalaxy counts arity from the full type signature (the true logical arity); tree-sitter's declaration-only reading counts only the clause's explicitly-bound patterns (correct for that one equation, but undercounts true arity). Neither reader is wrong about what it's measuring -- same shape as Claim 1 in docs/why_gitgalaxy_beats_ast_here.md. GitGalaxy's answer is arguably the more useful coupling signal; recommend documenting as a candidate Claim rather than treating as an engine defect to fix toward matching tree-sitter.
@@ -869,7 +896,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 28 occurrences as of 2026-08-20T21:52:14Z*
+*2-vs-1 -- 28 occurrences as of 2026-08-20T22:19:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -888,7 +915,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 12 occurrences as of 2026-08-20T21:52:14Z*
+*2-vs-1 -- 12 occurrences as of 2026-08-20T22:19:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -907,7 +934,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:52:14Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:19:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -919,7 +946,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `java` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-20T21:52:14Z*
+*3-way split -- 1 occurrence as of 2026-08-20T22:19:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`java/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -931,26 +958,26 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 191 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 266 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
+| jquery/ajax.js | `ajax` | 383 | 383 | *(n/a)* |
+| jquery/ajax.js | `ajaxSetup` | 369 | 369 | *(n/a)* |
+| jquery/ajax.js | `getJSON` | 848 | 848 | *(n/a)* |
+| jquery/ajax.js | `getScript` | 852 | 852 | *(n/a)* |
 | jquery/core.js | `extend` | 115 | 115 | *(n/a)* |
+| jquery/core.js | `each` | 70 | 70 | *(n/a)* |
 | jquery/core.js | `each` | 237 | 237 | *(n/a)* |
+| jquery/core.js | `map` | 74 | 74 | *(n/a)* |
 | jquery/core.js | `map` | 370 | 370 | *(n/a)* |
-| jquery/core.js | `eq` | 104 | 104 | *(n/a)* |
-| jquery/core.js | `get` | 44 | 44 | *(n/a)* |
-| jquery/core.js | `end` | 110 | 110 | *(n/a)* |
-| jquery/core.js | `pushStack` | 57 | 57 | *(n/a)* |
-| jquery/core.js | `even` | 92 | 92 | *(n/a)* |
-| jquery/core.js | `odd` | 98 | 98 | *(n/a)* |
-| jquery/core.js | `toArray` | 38 | 38 | *(n/a)* |
+| jquery/core.js | `text` | 260 | 260 | *(n/a)* |
 
 ### ❓ `javascript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 181 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 182 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -969,26 +996,26 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 133 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 150 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| jquery/ajax.js | `anonymousFunctionc3e813860100` | *(n/a)* | *(n/a)* | 55 |
-| jquery/ajax.js | `anonymousFunctionc3e813860200` | *(n/a)* | *(n/a)* | 94 |
-| jquery/ajax.js | `anonymousFunctionc3e813860600` | *(n/a)* | *(n/a)* | 694 |
-| jquery/ajax.js | `anonymousFunctionc3e813860800` | *(n/a)* | *(n/a)* | 857 |
-| jquery/ajax.js | `anonymousFunctionc3e813860b00` | *(n/a)* | *(n/a)* | 879 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860100` | *(n/a)* | *(n/a)* | 55 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860200` | *(n/a)* | *(n/a)* | 94 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860300` | *(n/a)* | *(n/a)* | 369 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860400` | *(n/a)* | *(n/a)* | 383 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860500` | *(n/a)* | *(n/a)* | 694 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860600` | *(n/a)* | *(n/a)* | 848 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860700` | *(n/a)* | *(n/a)* | 852 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860800` | *(n/a)* | *(n/a)* | 857 |
+| jquery/ajax.js | `AnonymousFunctionc3e813860900` | *(n/a)* | *(n/a)* | 879 |
 | jquery/ajax.js | `converters` | *(n/a)* | *(n/a)* | 764 |
-| jquery/ajax.js | `jQuery` | *(n/a)* | *(n/a)* | 858 |
-| jquery/core.js | `anonymousFunction6aaf8d8b0200` | *(n/a)* | *(n/a)* | 38 |
-| jquery/core.js | `anonymousFunction6aaf8d8b0300` | *(n/a)* | *(n/a)* | 44 |
-| jquery/core.js | `anonymousFunction6aaf8d8b0400` | *(n/a)* | *(n/a)* | 57 |
 
 ### ❓ `javascript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 104 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 104 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1005,9 +1032,28 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | react/ReactFiberBeginWork.js | `if` | *(n/a)* | 4077 | *(n/a)* |
 | react/ReactFiberBeginWork.js | `if` | *(n/a)* | 4150 | *(n/a)* |
 
+### ❓ `javascript` class existence: ctags agree, GitGalaxy, tree-sitter differ
+
+*2-vs-1 -- 96 occurrences as of 2026-08-20T22:19:21Z*
+
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| jquery/ajax.js | `jqXHR` | *(n/a)* | *(n/a)* | 448 |
+| jquery/css.js | `cssHooks` | *(n/a)* | *(n/a)* | 357 |
+| jquery/css.js | `cssNormalTransform` | *(n/a)* | *(n/a)* | 22 |
+| jquery/css.js | `cssShow` | *(n/a)* | *(n/a)* | 21 |
+| jquery/deferred.js | `promise` | *(n/a)* | *(n/a)* | 58 |
+| jquery/event.js | `Event` | *(n/a)* | *(n/a)* | 617 |
+| jquery/event.js | `event` | *(n/a)* | *(n/a)* | 89 |
+| jquery/event.js | `special` | *(n/a)* | *(n/a)* | 756 |
+| jquery/event.js | `special` | *(n/a)* | *(n/a)* | 812 |
+| react/ReactFiberBeginWork.js | `cachePool` | *(n/a)* | *(n/a)* | 2281 |
+
 ### ❓ `javascript` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 12 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 11 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1017,34 +1063,16 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | react/ReactFiberBeginWork.js | `reconcileChildren` | 340 | *(n/a)* | 340 |
 | react/ReactFiberBeginWork.js | `updateScopeComponent` | 3727 | *(n/a)* | 3727 |
 | react/ReactFiberBeginWork.js | `markWorkInProgressReceivedUpdate` | 3739 | *(n/a)* | 3739 |
-| react/ReactFiberWorkLoop.js | `onResolution` | 2837 | *(n/a)* | 2837 |
 | react/ReactFiberWorkLoop.js | `shouldForceFlushFallbacksInDEV` | 5539 | *(n/a)* | 5539 |
 | react/ReactFlightServer.js | `patchConsole` | 386 | *(n/a)* | 386 |
 | react/ReactFlightServer.js | `abortIterable` | 1367 | *(n/a)* | 1367 |
 | react/ReactFlightServer.js | `abortStream` | 1233 | *(n/a)* | 1233 |
 | react/ReactFlightServer.js | `error` | 1222 | *(n/a)* | 1222 |
-
-### ❓ `javascript` class existence: ctags agree, GitGalaxy, tree-sitter differ
-
-*2-vs-1 -- 9 occurrences as of 2026-08-20T21:52:17Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| jquery/deferred.js | `Identity` | *(n/a)* | *(n/a)* | 6 |
-| jquery/deferred.js | `Thrower` | *(n/a)* | *(n/a)* | 9 |
-| jquery/event.js | `Event` | *(n/a)* | *(n/a)* | 617 |
-| threejs/Editor.js | `Editor` | *(n/a)* | *(n/a)* | 15 |
-| threejs/GLTFLoader.js | `GLTFRegistry` | *(n/a)* | *(n/a)* | 576 |
-| threejs/GLTFLoader.js | `InterpolantFactoryMethodGLTFCubicSpline` | *(n/a)* | *(n/a)* | 4643 |
-| threejs/GLTFLoader.js | `Material` | *(n/a)* | *(n/a)* | 3457 |
-| threejs/GLTFLoader.js | `Object3D` | *(n/a)* | *(n/a)* | 1807 |
-| threejs/WebGLProgram.js | `WebGLProgram` | *(n/a)* | *(n/a)* | 412 |
+| react/ReactFlightServer.js | `throwTaintViolation` | 618 | *(n/a)* | 618 |
 
 ### ❓ `javascript` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1060,14 +1088,12 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `javascript` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-20T21:52:17Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:19:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`javascript/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| jquery/core.js | `each` | 1 | 1 | 2 |
-| jquery/core.js | `map` | 1 | 1 | 3 |
 | jquery/event.js | `setup` | 1 | 1 | 0 |
 | jquery/event.js | `trigger` | 1 | 1 | 0 |
 
@@ -1075,7 +1101,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-20T21:52:20Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-20T22:19:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1094,7 +1120,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:52:20Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:19:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1106,7 +1132,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `kotlin` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:20Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1118,27 +1144,27 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 205 occurrences as of 2026-08-20T21:52:26Z*
+*2-vs-1 -- 79 occurrences as of 2026-08-20T22:19:30Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-20):
 > Clean, single-cause shape (all 10 sampled cases), not a GitGalaxy defect. Every sampled occurrence (curl/configure.ac lines 967-4994) is a real AC_DEFINE or AC_DEFINE_UNQUOTED call (e.g. line 2112: AC_DEFINE_UNQUOTED([CURL_DEFAULT_SSL_BACKEND], [...], [...])) -- an autoconf helper that emits a C preprocessor #define into the generated config.h at build time, NOT a new callable M4 macro definition. GitGalaxy's own func_start regex for m4 deliberately excludes AC_DEFINE/AC_DEFINE_UNQUOTED from its keyword set (m4_define|define|AC_DEFUN|AC_DEFUN_ONCE|AU_DEFUN|m4_defun only), so its silence here is correct. ctags' M4 parser heuristically tags any AC_DEFINE*-family call with a bracketed/plain first argument as a macro definition -- same macro-invocation-vs-definition confusion already documented for C's RICHCMP_WRAPPER pattern, now also documented in tests/tools/ctags_reader.py's m4 note. No GitHub issue against GitGalaxy -- this is a real, confirmed ctags-side limitation. (Separately, unrelated to this shape: a deeper live-pipeline recall gap causing GitGalaxy to extract only 1 m4 function total across the whole corpus, despite its func_start regex matching dozens of genuine AC_DEFUN/m4_define calls when run standalone, was found and fixed in part -- see PR #1927 for the func_start capture-group fix; the remaining pipeline-level gap is tracked separately, not part of this shape's verdict.) Investigated via gemini-3.1-pro-high (agy), all 10 sampled file:line citations independently verified.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| curl/configure.ac | `CURL_CA_NATIVE` | *(n/a)* | *(n/a)* | 2127 |
-| curl/configure.ac | `CURL_CA_SEARCH_SAFE` | *(n/a)* | *(n/a)* | 2199 |
-| curl/configure.ac | `CURL_DEBUG_GLOBAL_MEM` | *(n/a)* | *(n/a)* | 1097 |
 | curl/configure.ac | `CURL_DEFAULT_SSL_BACKEND` | *(n/a)* | *(n/a)* | 2112 |
-| curl/configure.ac | `CURL_DISABLE_ALTSVC` | *(n/a)* | *(n/a)* | 762 |
-| curl/configure.ac | `CURL_DISABLE_ALTSVC` | *(n/a)* | *(n/a)* | 4832 |
-| curl/configure.ac | `CURL_DISABLE_AWS` | *(n/a)* | *(n/a)* | 4469 |
-| curl/configure.ac | `CURL_DISABLE_BASIC_AUTH` | *(n/a)* | *(n/a)* | 4372 |
-| curl/configure.ac | `CURL_DISABLE_BEARER_AUTH` | *(n/a)* | *(n/a)* | 4391 |
-| curl/configure.ac | `CURL_DISABLE_BINDLOCAL` | *(n/a)* | *(n/a)* | 4671 |
+| curl/configure.ac | `CURL_DISABLE_CA_SEARCH` | *(n/a)* | *(n/a)* | 2183 |
+| curl/configure.ac | `CURL_DISABLE_HSTS` | *(n/a)* | *(n/a)* | 4890 |
+| curl/configure.ac | `CURL_DISABLE_LDAP` | *(n/a)* | *(n/a)* | 2629 |
+| curl/configure.ac | `CURL_DISABLE_LDAP` | *(n/a)* | *(n/a)* | 2647 |
+| curl/configure.ac | `CURL_DISABLE_LDAPS` | *(n/a)* | *(n/a)* | 2631 |
+| curl/configure.ac | `CURL_DISABLE_LDAPS` | *(n/a)* | *(n/a)* | 2649 |
+| curl/configure.ac | `CURL_DISABLE_TELNET` | *(n/a)* | *(n/a)* | 967 |
+| curl/configure.ac | `CURL_DISABLE_WEBSOCKETS` | *(n/a)* | *(n/a)* | 4994 |
+| curl/configure.ac | `CURL_KRB5_VERSION` | *(n/a)* | *(n/a)* | 1986 |
 
 ### ✅ `m4` class existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-20T21:52:26Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-20T22:19:30Z*
 
 **Verdict** (by claude-sonnet-5 (direct source read, no dispatch needed), 2026-08-20):
 > Confirmed real GitGalaxy false positive, not yet fixed (tracked separately). m4's own class_start rule is explicitly None (m4 has no class/OOP concept) -- but detector.py's class extraction branch only checks _CLASS_START_NAMED_EXTRACTION_LANGS allowlist membership, not whether the language's own class_start is None, so m4 (and 18 other class_start=None languages) falls through to the generic 'class|struct|interface|trait|enum NAME' fallback regex regardless. That fallback has no awareness of m4 document structure, so it matches raw C struct declarations embedded as literal text inside autoconf feature-test macro arguments (e.g. curl/configure.ac:1358's 'struct SocketIFace *ISocket = NULL;' inside an AC_LANG_PROGRAM([[ ... ]]) block) as if they were real m4 classes. Verified directly against the live gatherer: gg_classes for curl/configure.ac returns ['SocketIFace', 'Library', 'sockaddr_in6'], none of which are real m4 constructs; ctags correctly reports none (no class-shaped kind for m4 at all). Filed as GitHub issue #1925 (broader architectural gap, confirmed for m4, 18 other class_start=None languages not yet checked) -- not fixed in this sweep.
@@ -1152,7 +1178,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:26Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:30Z*
 
 **Verdict** (by claude-sonnet-5 (direct source read, no dispatch needed), 2026-08-20):
 > Confirmed real GitGalaxy false positive, now fixed. The old func_start regex had no capture group over the macro-name argument, so it matched the AC_DEFUN keyword itself as the 'function name' -- structurally identical to matching 'def' as a Python function's name instead of what follows it. gnucobol/configure.ac:658 'AC_DEFUN([AC_PROG_F77], [])' was reported as a function literally named 'AC_DEFUN'; ctags correctly reports nothing here since this call defines an empty macro body (a no-op placeholder, common autoconf idiom for stubbing out a check). Fixed in PR #1927: func_start now captures the real macro-name argument (AC_PROG_F77), handling m4's three real quoting conventions (backtick/apostrophe, bracket, double-bracket). Verified directly: the pipeline now reports 'AC_PROG_F77' at line 658, not 'AC_DEFUN'.
@@ -1165,7 +1191,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `makefile` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:27Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:31Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`makefile/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1177,7 +1203,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `matlab` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-20T21:52:29Z*
+*3-way split -- 1 occurrence as of 2026-08-20T22:19:33Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`matlab/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1189,7 +1215,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 104 occurrences as of 2026-08-20T21:52:30Z*
+*2-vs-1 -- 104 occurrences as of 2026-08-20T22:19:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1208,26 +1234,26 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 91 occurrences as of 2026-08-20T21:52:30Z*
+*2-vs-1 -- 91 occurrences as of 2026-08-20T22:19:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
 | worldwideweb/Anchor.m | `linkTo:` | *(n/a)* | *(n/a)* | 331 |
-| worldwideweb/Anchor.m | `selectDiagnostic:` | *(n/a)* | *(n/a)* | 277 |
-| worldwideweb/Anchor.m | `setAddress:` | *(n/a)* | *(n/a)* | 313 |
-| worldwideweb/Anchor.m | `setNode:` | *(n/a)* | *(n/a)* | 263 |
-| worldwideweb/HyperManager.m | `accessName:Diagnostic:` | *(n/a)* | *(n/a)* | 155 |
-| worldwideweb/HyperManager.m | `appAcceptsAnotherFile:` | *(n/a)* | *(n/a)* | 253 |
-| worldwideweb/HyperManager.m | `appDidInit:` | *(n/a)* | *(n/a)* | 239 |
-| worldwideweb/HyperManager.m | `appOpenFile:type:` | *(n/a)* | *(n/a)* | 260 |
-| worldwideweb/HyperManager.m | `appOpenTempFile:type:` | *(n/a)* | *(n/a)* | 272 |
+| worldwideweb/Anchor.m | `selectDiagnostic:` | *(n/a)* | *(n/a)* | 278 |
+| worldwideweb/Anchor.m | `setAddress:` | *(n/a)* | *(n/a)* | 314 |
+| worldwideweb/Anchor.m | `setNode:` | *(n/a)* | *(n/a)* | 264 |
+| worldwideweb/HyperManager.m | `accessName:Diagnostic:` | *(n/a)* | *(n/a)* | 157 |
+| worldwideweb/HyperManager.m | `appAcceptsAnotherFile:` | *(n/a)* | *(n/a)* | 254 |
+| worldwideweb/HyperManager.m | `appDidInit:` | *(n/a)* | *(n/a)* | 240 |
+| worldwideweb/HyperManager.m | `appOpenFile:type:` | *(n/a)* | *(n/a)* | 261 |
+| worldwideweb/HyperManager.m | `appOpenTempFile:type:` | *(n/a)* | *(n/a)* | 273 |
 | worldwideweb/HyperManager.m | `back:` | *(n/a)* | *(n/a)* | 198 |
 
 ### ❓ `objective-c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:52:30Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:19:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1238,7 +1264,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:30Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1250,7 +1276,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 122 occurrences as of 2026-08-20T21:52:36Z*
+*2-vs-1 -- 122 occurrences as of 2026-08-20T22:19:40Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1269,7 +1295,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-20T21:52:36Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:19:40Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1285,7 +1311,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-20T21:52:36Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:19:40Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1299,19 +1325,19 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | spamassassin/Makefile.PL | `MY::install` | 818 | 818 | *(n/a)* |
 | spamassassin/Makefile.PL | `MY::libscan` | 802 | 802 | *(n/a)* |
 
-### ❓ `perl` class existence: GitGalaxy agree, tree-sitter, ctags differ
+### ❓ `perl` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:36Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:40Z*
 
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/class/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| spamassassin/PerMsgStatus.pm | `Mail::SpamAssassin::PerMsgStatus` | *(n/a)* | *(n/a)* | *(n/a)* |
+| spamassassin/PerMsgStatus.pm | `Mail::SpamAssassin::PerMsgStatus` | *(n/a)* | *(n/a)* | 3022 |
 
 ### ❓ `perl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:36Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:40Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1321,7 +1347,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 64 occurrences as of 2026-08-20T21:52:36Z*
+*3-way split -- 64 occurrences as of 2026-08-20T22:19:40Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1342,7 +1368,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:40Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:45Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1352,7 +1378,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:40Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:45Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1364,31 +1390,42 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-20T21:52:43Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-20T22:19:47Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| core/packaging.psm1 | `New-NativeDeb` | 1749 | 1749 | *(n/a)* |
-| core/packaging.psm1 | `GetPattern` | 5619 | 5619 | *(n/a)* |
-| core/packaging.psm1 | `EnsureArchitecture` | 5647 | 5647 | *(n/a)* |
-| core/packaging.psm1 | `SetPattern` | 5633 | 5633 | *(n/a)* |
+| core/ci.psm1 | `Invoke-LinuxTestsCore` | 749 | 749 | *(n/a)* |
+| core/ci.psm1 | `Set-Path` | 701 | 701 | *(n/a)* |
+| core/ci.psm1 | `Invoke-BootstrapStage` | 739 | 739 | *(n/a)* |
+| core/ci.psm1 | `Show-Environment` | 731 | 731 | *(n/a)* |
+| core/packaging.psm1 | `New-GlobalToolNupkgSource` | 4727 | 4727 | *(n/a)* |
+| core/packaging.psm1 | `Get-DirectoryNode` | 4431 | 4431 | *(n/a)* |
+| core/packaging.psm1 | `ReduceFxDependentPackage` | 4599 | 4599 | *(n/a)* |
+| core/packaging.psm1 | `Get-PackageVersionAsMajorMinorBuildRevision` | 4544 | 4544 | *(n/a)* |
+| core/packaging.psm1 | `Get-WindowsVersion` | 4512 | 4512 | *(n/a)* |
+| core/packaging.psm1 | `Start-PrepForGlobalToolNupkg` | 4676 | 4676 | *(n/a)* |
 
 ### ❓ `powershell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:52:43Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-20T22:19:47Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
+| core/packaging.psm1 | `R2RVerification` | *(n/a)* | 25 | *(n/a)* |
+| core/packaging.psm1 | `LinkInfo` | *(n/a)* | 1584 | *(n/a)* |
 | core/packaging.psm1 | `PackageManifestResultStatus` | *(n/a)* | 5359 | *(n/a)* |
+| core/packaging.psm1 | `PackageManifestResult` | *(n/a)* | 5366 | *(n/a)* |
 | core/packaging.psm1 | `MachineOSOverride` | *(n/a)* | 5441 | *(n/a)* |
+| core/packaging.psm1 | `PsPeInfo` | *(n/a)* | 5451 | *(n/a)* |
+| core/packaging.psm1 | `BomRecord` | *(n/a)* | 5605 | *(n/a)* |
 
 ### ❓ `powershell` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:43Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:47Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1398,7 +1435,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 5 occurrences as of 2026-08-20T21:52:43Z*
+*3-way split -- 5 occurrences as of 2026-08-20T22:19:47Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1414,7 +1451,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 68 occurrences as of 2026-08-20T21:52:52Z*
+*2-vs-1 -- 68 occurrences as of 2026-08-20T22:19:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1433,7 +1470,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 32 occurrences as of 2026-08-20T21:52:52Z*
+*2-vs-1 -- 32 occurrences as of 2026-08-20T22:19:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1452,7 +1489,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-20T21:52:52Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-20T22:19:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1465,7 +1502,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `python` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:52Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:19:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`python/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1477,7 +1514,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-20T21:52:53Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-20T22:19:58Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1492,7 +1529,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-20T21:52:53Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-20T22:19:58Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1507,7 +1544,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:52:53Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:19:58Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1519,7 +1556,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:52:53Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:19:58Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1530,97 +1567,29 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ## rust
 
-### ❓ `rust` function existence: GitGalaxy, ctags agree, tree-sitter differ
-
-*2-vs-1 -- 83 occurrences as of 2026-08-20T21:52:57Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`rust/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| bevy/bevy_ecs_macros.rs | `get_param` | 456 | *(n/a)* | 457 |
-| bevy/bevy_ecs_macros.rs | `init_access` | 444 | *(n/a)* | 444 |
-| bevy/bevy_ecs_macros.rs | `get_components` | 158 | *(n/a)* | 160 |
-| bevy/bevy_ecs_macros.rs | `from_components` | 191 | *(n/a)* | 192 |
-| bevy/bevy_ecs_macros.rs | `apply` | 448 | *(n/a)* | 448 |
-| bevy/bevy_ecs_macros.rs | `queue` | 452 | *(n/a)* | 452 |
-| bevy/bevy_ecs_macros.rs | `build` | 406 | *(n/a)* | 406 |
-| bevy/bevy_ecs_macros.rs | `map_entities` | 229 | *(n/a)* | 229 |
-| bevy/bevy_ecs_macros.rs | `apply_effect` | 177 | *(n/a)* | 179 |
-| bevy/bevy_ecs_macros.rs | `component_ids` | 141 | *(n/a)* | 141 |
-
-### ❓ `rust` class existence: GitGalaxy, ctags agree, tree-sitter differ
-
-*2-vs-1 -- 14 occurrences as of 2026-08-20T21:52:57Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`rust/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| serde/serde_derive_de.rs | `__DeserializeWith` | *(n/a)* | *(n/a)* | 684 |
-| syn/data.rs | `Variant` | *(n/a)* | *(n/a)* | 13 |
-| syn/data.rs | `Fields` | *(n/a)* | *(n/a)* | 36 |
-| syn/data.rs | `FieldsNamed` | *(n/a)* | *(n/a)* | 53 |
-| syn/data.rs | `FieldsUnnamed` | *(n/a)* | *(n/a)* | 62 |
-| syn/data.rs | `Field` | *(n/a)* | *(n/a)* | 185 |
-| syn/derive.rs | `DeriveInput` | *(n/a)* | *(n/a)* | 13 |
-| syn/derive.rs | `Data` | *(n/a)* | *(n/a)* | 31 |
-| syn/derive.rs | `DataStruct` | *(n/a)* | *(n/a)* | 41 |
-| syn/derive.rs | `DataEnum` | *(n/a)* | *(n/a)* | 51 |
-
-### ❓ `rust` function existence: ctags agree, GitGalaxy, tree-sitter differ
-
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:57Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`rust/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| serde/serde_derive_de.rs | `deserialize` | *(n/a)* | *(n/a)* | 692 |
-
 ### ✅ `rust` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 69 occurrences as of 2026-08-20T21:52:57Z*
+*2-vs-1 -- 152 occurrences as of 2026-08-20T22:20:02Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch), 2026-08-19T00:00:00Z):
 > Not a new question -- already-documented, evidence-backed rust behavior (Claim 6, docs/why_gitgalaxy_beats_ast_here.md: 'structure recall inside opaque macro bodies'). Confirmed directly: all 5 sampled names (get_param, init_access, get_components, from_components, apply) are in bevy/bevy_ecs_macros.rs, inside a `quote! { ... }` proc-macro body (confirmed at source lines 444-460 -- `#path`/`#fields_alias` interpolation syntax is the classic quote! token-generation pattern). These are real Rust function definitions being code-generated by a proc macro; GitGalaxy's regex correctly parses real function syntax wherever it textually appears, including inside macro bodies. tree-sitter-rust and ctags' Rust parser both treat macro_rules!/macro-invocation bodies as opaque token trees and structurally cannot emit function nodes for anything inside one -- not a bug in either, a real grammar limitation. This is exactly why rust is one of the 3 languages (with csharp/fortran) already promoted into ground truth via blind-spot-region detection in the OLD bi-comparison tool (tree_sitter_accuracy_audit.py's _find_blind_spot_ranges) -- this tri-comparison ledger entry is that same, already-understood gap surfacing again under the new 3-tool reconciliation. GitGalaxy is correct; no engine defect, no issue needed. Resolved directly from existing documentation, no fresh dispatch required (tri-comparison-ledger-sweep skill step 1.3).
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| serde/serde_core_de_impls.rs | `deserialize` | 2427 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2447 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2481 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2606 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2639 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2745 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2778 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2877 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2888 | *(n/a)* | *(n/a)* |
-| serde/serde_core_de_impls.rs | `deserialize` | 2987 | *(n/a)* | *(n/a)* |
-
-### ✅ `rust` function args: tree-sitter, ctags agree, GitGalaxy differ
-
-*2-vs-1 -- 21 occurrences as of 2026-08-20T21:52:57Z*
-
-**Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
-> Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| bevy/bevy_ecs_table.rs | `initialize` | 3 | 5 | 5 |
-| bevy/bevy_ecs_table.rs | `replace` | 3 | 5 | 5 |
-| bevy/bevy_ecs_world.rs | `insert_resource_by_id` | 3 | 4 | 4 |
-| bevy/bevy_ecs_world.rs | `insert_non_send_by_id` | 3 | 4 | 4 |
-| bevy/bevy_reflect_path.rs | `new` | 3 | 1 | 1 |
-| serde/serde_core_de_impls.rs | `new` | 3 | 1 | 1 |
-| serde/serde_internals_ast.rs | `from_ast` | 2 | 4 | 4 |
-| serde/serde_internals_ast.rs | `all_fields` | 2 | 1 | 1 |
-| serde/serde_internals_attr.rs | `none` | 1 | 2 | 2 |
-| serde/serde_internals_attr.rs | `none` | 1 | 2 | 2 |
+| bevy/bevy_ecs_macros.rs | `get_param` | 456 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `init_access` | 444 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `get_components` | 158 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `from_components` | 191 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `apply` | 448 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `queue` | 452 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `build` | 406 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `map_entities` | 229 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `apply_effect` | 177 | *(n/a)* | *(n/a)* |
+| bevy/bevy_ecs_macros.rs | `component_ids` | 141 | *(n/a)* | *(n/a)* |
 
 ### ✅ `rust` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 11 occurrences as of 2026-08-20T21:52:57Z*
+*2-vs-1 -- 25 occurrences as of 2026-08-20T22:20:02Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Same mechanism as the already-resolved rust/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter] shape (Claim 6, docs/why_gitgalaxy_beats_ast_here.md) -- extended from `fn` definitions inside `quote!{}` invocation bodies to `struct` definitions inside `macro_rules!` DEFINITION bodies. All 6 sampled names confirmed, independently re-verified against source (not just the dispatched agent's own read): NonZeroVisitor (line 90), SaturatingVisitor (112), PrimitiveVisitor (136) inside serde/serde_core_de_impls.rs's `impl_deserialize_num!` macro (def starts line 81); SeqVisitor (998), SeqInPlaceVisitor (1036) inside `seq_impl!` (def starts 978); TupleVisitor (1403) inside `tuple_impl_body!` (nested in `tuple_impls!`, def starts 1396). All 6 are real, complete `struct` declarations, each immediately followed by a genuine `impl<'de,...> Visitor<'de> for <Name>` block -- generated once per macro invocation, not fragments or hallucinated matches. tree-sitter and ctags both treat a macro_rules! arm's body as an opaque, unexpanded token tree and structurally cannot emit struct nodes from inside one, for the identical reason they can't see function definitions inside quote!{} bodies. GitGalaxy is correct in all 6 sampled cases; judged (not independently re-confirmed beyond the sample) to generalize to the full 25, all same-shaped serde-crate occurrences. No new tool defect -- Claim 6's doc text already covered this generically (`struct_item` was already named) but had no concrete cited example for this specific shape; added one (docs/why_gitgalaxy_beats_ast_here.md) rather than filing an issue.
@@ -1638,9 +1607,29 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | serde/serde_core_de_impls.rs | `KindVisitor` | *(n/a)* | *(n/a)* | *(n/a)* |
 | serde/serde_core_de_impls.rs | `EnumVisitor` | *(n/a)* | *(n/a)* | *(n/a)* |
 
+### ✅ `rust` function args: tree-sitter, ctags agree, GitGalaxy differ
+
+*2-vs-1 -- 21 occurrences as of 2026-08-20T22:20:02Z*
+
+**Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
+> Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| bevy/bevy_ecs_table.rs | `initialize` | 3 | 5 | 5 |
+| bevy/bevy_ecs_table.rs | `replace` | 3 | 5 | 5 |
+| bevy/bevy_ecs_world.rs | `insert_resource_by_id` | 3 | 4 | 4 |
+| bevy/bevy_ecs_world.rs | `insert_non_send_by_id` | 3 | 4 | 4 |
+| bevy/bevy_reflect_path.rs | `new` | 3 | 1 | 1 |
+| serde/serde_core_de_impls.rs | `new` | 3 | 1 | 1 |
+| serde/serde_internals_ast.rs | `from_ast` | 2 | 4 | 4 |
+| serde/serde_internals_ast.rs | `all_fields` | 2 | 1 | 1 |
+| serde/serde_internals_attr.rs | `none` | 1 | 2 | 2 |
+| serde/serde_internals_attr.rs | `none` | 1 | 2 | 2 |
+
 ### ✅ `rust` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-20T21:52:57Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-20T22:20:02Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed structural ctags limitation, not a bug -- resolved directly (no dispatch needed). All 3 sampled names (XRegUnion, FRegUnion, VRegUnion) are real Rust `union { }` declarations (confirmed at wasmtime/wasmtime_pulley_interp.rs:404,529,604), distinct from `struct` -- Rust's less-common C-style unsafe union construct. Ran `ctags --list-kinds-full=Rust` directly: its Rust parser's kind list is macro/method/implementation/enumerator/function/enum/interface/field/module/struct/typedef/variable -- there is NO union kind at all. Confirmed via direct ctags run against this exact file: it correctly finds the wrapping `struct FRegVal(FRegUnion)`-shaped types right next to each missed union, so this isn't a general miss, specifically a missing Rust-union kind. Same category as the already-documented ctags Haskell class-kind gap (tests/tools/ctags_reader.py) -- worth a similar doc note there, not a GitHub issue (nothing to fix, ctags upstream has no union support for this language).
@@ -1653,7 +1642,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:52:57Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:02Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed via direct ctags run and sibling comparison, resolved directly (no dispatch needed). `done_decode` (wasmtime/wasmtime_pulley_interp.rs:964) has a destructuring-pattern parameter -- `Done { _priv }: Done`, not a simple `name: Type` binding. Ran ctags directly against the file: its IMMEDIATE SIBLING in the same impl block, `debug_assert_done_reason_none` (line 960, same visibility/receiver shape, ordinary `&mut self`-only signature), IS correctly found as a ctags 'method'. done_decode alone is missing from ctags' output. Isolates the cause precisely to the destructuring-pattern parameter -- ctags' regex-based Rust parser appears to fail/skip the whole function when a parameter is a struct pattern rather than a plain identifier binding. GitGalaxy and tree-sitter both handle this fine (both agree on line 964). N=1 in this corpus, plausibly a real, narrow ctags parser gap (not GitGalaxy's) -- not chasing further given the tiny sample, noting rather than filing an issue since there's nothing in this repo to fix.
@@ -1664,7 +1653,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 21 occurrences as of 2026-08-20T21:52:57Z*
+*3-way split -- 21 occurrences as of 2026-08-20T22:20:02Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, not a modeling disagreement -- tree-sitter is correct in all 8 sampled cases (and this generalizes to the full 21: every sampled name is a deserialize_*/spawn_*_caller-shaped signature carrying a rust lifetime annotation, the exact trigger). Root cause, independently confirmed via two methods (dispatched agent read the code path; a second grep pass confirmed the attribute is dead): `gitgalaxy/core/detector.py::StructuralExtractor._count_top_level_args` has a guard meant to exempt rust/scala lifetime marks (`'_`, `'static`) from its string-literal scanner -- `getattr(self, 'language', '') in ('rust', 'scala')` around line 3766 -- but the class stores the language as `self.primary_lang_id` (set at line 497), never `self.language`. `self.language` is referenced NOWHERE ELSE in the file, confirmed by grep. The getattr always silently falls back to `''`, so the exemption guard never fires for any language, ever -- every lifetime `'` gets treated as an unterminated string-literal opener, swallowing all subsequent top-level commas until a real closing quote or end-of-string, fusing 2+ parameters into 1. A signature with 3 lifetime marks (odd count) never exits string mode at all and undercounts every remaining parameter. Real signatures confirmed at source: bevy/bevy_ecs_world.rs:1106,1121,1270 (`MovingPtr<'_, B>` swallows the next comma, 3 vs real 4, or 2 vs real 3); serde/serde_core_de_mod.rs:1105,1115 (`&'static str` swallows the next comma, 2 vs real 3); serde_core_de_mod.rs:1136 (two lifetimes, both trailing commas swallowed, 2 vs real 4); serde_core_de_mod.rs:1152,1163 (three lifetime marks, odd count means string mode never exits, 2 vs real 4). ctags has null coverage for these specific occurrences because they're bodyless trait-method declarations (ending in `;` inside a `trait` block) -- unrelated to the args bug, ctags appears to skip signature-only declarations generally. Filed as its own GitHub issue (attribute-name mismatch, one-line fix: `self.language` -> `self.primary_lang_id`, or equivalent), separate from this ledger record.
@@ -1686,7 +1675,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scala` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 16 occurrences as of 2026-08-20T21:52:59Z*
+*3-way split -- 16 occurrences as of 2026-08-20T22:20:04Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scala/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1707,7 +1696,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scheme` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 50 occurrences as of 2026-08-20T21:53:03Z*
+*2-vs-1 -- 50 occurrences as of 2026-08-20T22:20:09Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scheme/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1726,7 +1715,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `scheme` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 67 occurrences as of 2026-08-20T21:53:03Z*
+*2-vs-1 -- 84 occurrences as of 2026-08-20T22:20:09Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5, 2026-08-20):
 > Confirmed real, catastrophic GitGalaxy engine defect, generalizes to the full 92 occurrences (and beyond -- this was a 100% recall drop for the whole language, not specific to the sampled cases). Root cause isolated to detector.py's StructuralExtractor._slice_by_braces (Integration Mode B): its scope-delimiter selection checked `lang_id == "lisp"` to choose parenthesis delimiters over the curly-brace default -- but "lisp" has never been a real key in LANGUAGE_DEFINITIONS (only "scheme" is), so that branch was unreachable dead code in production. Every real scheme file fell through to the curly-brace default; since scheme is entirely parenthesis-delimited, the downstream scope-body search never found an opener and silently discarded every func_start match. GitGalaxy's own func_start regex was never the problem -- confirmed matching correctly standalone (31/31 hits on one file) and prism.py's comment stripping confirmed clean (raw (define count unchanged pre/post-prism). Fixed: delimiter choice now keys off lexical_family ("recursive_block_lisp") instead of the dead lang_id string, verified directly against the gatherer (0 -> 58 real functions found; ctags finds 92, so a smaller residual recall gap remains for a future pass, tracked as a follow-on, not blocking this fix). Filed as GitHub issue #1928. A pre-existing unit test (test_detector_mode_b_lisp_family) had been passing for the wrong reason (its mock language was literally named "lisp", matching the dead string check by construction) -- corrected to use scheme's real lexical_family value so it now validates the actual production mechanism. Investigated via gemini-3.1-pro-high (agy): live-pipeline isolation with a monkey-patch before/after proof (0 -> 14 functions when lang_id coerced to match the old check), independently re-verified by Claude against the exact cited source lines before applying.
@@ -1744,11 +1733,23 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | racket/thread.rkt | `add-transitive-resume-to-thread!` | *(n/a)* | *(n/a)* | 802 |
 | racket/thread.rkt | `break-enabled` | *(n/a)* | *(n/a)* | 1011 |
 
+## shell
+
+### ❓ `shell` function existence: ctags agree, GitGalaxy, tree-sitter differ
+
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:10Z*
+
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`shell/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
+
+| file | name | GitGalaxy | tree-sitter | ctags |
+|---|---|---|---|---|
+| brew/brew | `FILTERED_ENV=` | *(n/a)* | *(n/a)* | 292 |
+
 ## solidity
 
 ### ❓ `solidity` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-20T21:53:06Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-20T22:20:11Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`solidity/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1765,7 +1766,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:08Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1775,7 +1776,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:08Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1785,7 +1786,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-20T21:53:08Z*
+*3-way split -- 1 occurrence as of 2026-08-20T22:20:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1797,7 +1798,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 34 occurrences as of 2026-08-20T21:53:09Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-20T22:20:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1805,29 +1806,23 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 |---|---|---|---|---|
 | sqlite/malloc_common.tcl | `faultsim_test_proc` | 347 | 347 | *(n/a)* |
 | sqlite/tester.tcl | `set_test_counter` | 583 | 583 | *(n/a)* |
-| sqlite/tester.tcl | `do_ioerr_test` | 1927 | 1927 | *(n/a)* |
-| sqlite/tester.tcl | `dbcksum` | 2176 | 2176 | *(n/a)* |
-| sqlite/tester.tcl | `wal_check_journal_mode` | 2316 | 2316 | *(n/a)* |
-| sqlite/tester.tcl | `test_set_config_pagecache` | 2496 | 2496 | *(n/a)* |
 | sqlite/tester.tcl | `sqlite3` | 116 | 116 | *(n/a)* |
-| sqlite/tester.tcl | `crash_on_write` | 1844 | 1844 | *(n/a)* |
-| sqlite/tester.tcl | `cksum` | 2124 | 2124 | *(n/a)* |
-| sqlite/tester.tcl | `allcksum` | 2145 | 2145 | *(n/a)* |
+| sqlite/tester.tcl | `finish_test` | 1243 | 1243 | *(n/a)* |
 
-### ❓ `tcl` function existence: tree-sitter agree, GitGalaxy, ctags differ
+### ❓ `tcl` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-20T21:53:09Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:20:14Z*
 
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
+**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| sqlite/tester.tcl | `drop_all_tables` | *(n/a)* | 2254 | *(n/a)* |
-| sqlite/tester.tcl | `drop_all_indexes` | *(n/a)* | 2279 | *(n/a)* |
+| sqlite/tester.tcl | `drop_all_tables` | *(n/a)* | 2254 | 2254 |
+| sqlite/tester.tcl | `drop_all_indexes` | *(n/a)* | 2279 | 2279 |
 
 ### ❓ `tcl` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:09Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1837,7 +1832,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:09Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:14Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1849,26 +1844,26 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1500 occurrences as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 1907 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| fp-ts/Either.ts | `getOrElseW` | 1050 | 1051 | *(n/a)* |
-| fp-ts/Either.ts | `traverseReadonlyNonEmptyArrayWithIndex` | 1581 | 1582 | *(n/a)* |
-| fp-ts/Either.ts | `extend` | 839 | 839 | *(n/a)* |
-| fp-ts/Either.ts | `exists` | 1497 | 1498 | *(n/a)* |
-| fp-ts/Either.ts | `equals` | 229 | 229 | *(n/a)* |
-| fp-ts/Either.ts | `ap` | 408 | 408 | *(n/a)* |
-| fp-ts/Either.ts | `tryCatch` | 1393 | 1393 | *(n/a)* |
-| fp-ts/Either.ts | `apW` | 523 | 524 | *(n/a)* |
-| fp-ts/Either.ts | `stringifyJSON` | 1728 | 1728 | *(n/a)* |
-| fp-ts/Either.ts | `matchW` | 985 | 986 | *(n/a)* |
+| assemblyscript/ast.ts | `lineAt` | 1686 | 1686 | *(n/a)* |
+| assemblyscript/ast.ts | `isLibrary` | 1674 | 1674 | *(n/a)* |
+| assemblyscript/ast.ts | `isNative` | 1669 | 1669 | *(n/a)* |
+| assemblyscript/ast.ts | `columnAt` | 1715 | 1715 | *(n/a)* |
+| assemblyscript/compiler.ts | `compileBinaryExpression` | 4046 | 4046 | *(n/a)* |
+| assemblyscript/compiler.ts | `compileUnaryPrefixExpression` | 9522 | 9522 | *(n/a)* |
+| assemblyscript/compiler.ts | `convertExpression` | 3546 | 3546 | *(n/a)* |
+| assemblyscript/compiler.ts | `makePow` | 5088 | 5088 | *(n/a)* |
+| assemblyscript/compiler.ts | `compileUnaryPostfixExpression` | 9278 | 9278 | *(n/a)* |
+| assemblyscript/compiler.ts | `compileIdentifierExpression` | 7358 | 7358 | *(n/a)* |
 
 ### ❓ `typescript` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 511 occurrences as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 501 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1887,7 +1882,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 174 occurrences as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 174 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1906,7 +1901,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 61 occurrences as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 61 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1925,7 +1920,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1943,48 +1938,35 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
+| vscode/instantiationService.ts | `extends` | *(n/a)* | *(n/a)* | 410 |
 | vscode/lifecycle.ts | `implements` | *(n/a)* | *(n/a)* | 235 |
-
-### ❓ `typescript` function existence: GitGalaxy, ctags agree, tree-sitter differ
-
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:30Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| vscode/lifecycle.ts | `createReferencedObject` | 711 | *(n/a)* | 711 |
 
 ### ❓ `typescript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:30Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
+| vscode/lifecycle.ts | `createReferencedObject` | 711 | *(n/a)* | *(n/a)* |
 | vscode/lifecycle.ts | `destroyReferencedObject` | 712 | *(n/a)* | *(n/a)* |
 
 ### ❓ `typescript` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 9 occurrences as of 2026-08-20T21:53:30Z*
+*3-way split -- 4 occurrences as of 2026-08-20T22:20:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
 | vscode/async.ts | `constructor` | 2 | 0 | *(n/a)* |
-| vscode/async.ts | `constructor` | 1 | 2 | *(n/a)* |
-| vscode/async.ts | `constructor` | 0 | 1 | *(n/a)* |
-| vscode/async.ts | `constructor` | 1 | 2 | *(n/a)* |
-| vscode/async.ts | `constructor` | 1 | 0 | *(n/a)* |
-| vscode/async.ts | `constructor` | 2 | 1 | *(n/a)* |
 | vscode/vscode.d.ts | `constructor` | 5 | 2 | *(n/a)* |
 | vscode/vscode.d.ts | `constructor` | 1 | 2 | *(n/a)* |
 | vscode/vscode.d.ts | `constructor` | 1 | 4 | *(n/a)* |
@@ -1993,7 +1975,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-20T21:53:38Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-20T22:20:44Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -2012,7 +1994,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:38Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:44Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -2022,7 +2004,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-20T21:53:38Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-20T22:20:44Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 


### PR DESCRIPTION
## Summary

Tri-comparison ledger sweep for `apex`. Investigated the language's one open, still-reproducing
discrepancy shape directly (no Gemini dispatch needed -- root cause was clear from source):

- `apex/function/existence/agree[gitgalaxy]_vs[tree_sitter]` (2 sampled occurrences) -- confirmed
  a real GitGalaxy false positive. Filed as #1963.

Apex's backlog is now fully cleared (1/1 shapes validated). `docs/language_status/apex.md` capstone
to follow in this same PR.

## Test plan

- [x] `python tests/tools/tri_comparison_chart.py --all --write` regenerated, diff scoped to the
      apex status transition plus expected repo-wide timestamp/count refresh noise
- [x] `python tests/ruff_audit.py --ci` -- clean
- [x] `python tests/mypy_audit.py --ci` -- clean
- [x] Confirmed apex Func Precision panel now badges tree-sitter with no unvalidated-disagreement
      asterisk

🤖 Generated with [Claude Code](https://claude.com/claude-code)