### PR TITLE
Fix file_data.class_count to use the real named class list

### DIFF
--- a/gitgalaxy/recorders/record_keeper.py
+++ b/gitgalaxy/recorders/record_keeper.py
@@ -554,8 +554,7 @@ class RecordKeeper:
                 producer_ratio = net_mets.get("producer_ratio", 0.0)
                 ecosystem_role = net_mets.get("ecosystem_role", "Unknown")
 
-            class_idx = self.SIGNAL_SCHEMA.index("class_start") if "class_start" in self.SIGNAL_SCHEMA else -1
-            class_count = hv[class_idx] if class_idx >= 0 and class_idx < len(hv) else 0
+            class_count = len(file_data.get("classes", []))
 
             repo_macro = tel.get("repo_macro_species", "Unknown")
             repo_z = tel.get("repo_z_score", 0.0)

--- a/tests/tools_recorders/test_record_keeper.py
+++ b/tests/tools_recorders/test_record_keeper.py
@@ -195,6 +195,9 @@ def test_record_keeper_data_insertion(keeper, mock_pipeline_state, tmp_path):
     assert file_row["ecosystem_role"] == "Core Hub"
     assert file_row["state_danger"] == 2  # The hit_vector value for danger
 
+    assert file_row["class_count"] == 1
+    assert file_row["function_count"] == 1
+
     file_id = file_row["id"]
 
     # 3. Verify Class & Function Relationships (Foreign Keys)


### PR DESCRIPTION
## Summary

`file_data.class_count` was sourced from the raw `class_start` SIGNAL vector (`hv[class_idx]`, the same value stored as `struct_class_start`), not `len(classes)` -- the actual named class list that also backs the `class_data` table. `function_count` already correctly used `len(functions)`; this brings `class_count` in line with the same pattern.

## How this was found

Found while manually verifying dockerfile's tri-comparison numbers (`tri-comparison-ledger-sweep` skill's manual-verification fallback -- dockerfile has no tree-sitter/ctags comparison tool). `file_data.class_count` reported 69 for a Dockerfile with 69 real `FROM` build stages, but `class_data` had 0 rows -- dockerfile has no named class extraction wired yet (tracked separately as #1974, not this PR). `class_count` should honestly report `len(classes)` regardless of which language it's counting for -- this is a general bug affecting `class_count`'s accuracy for every language, not dockerfile-specific.

## Fix

`gitgalaxy/recorders/record_keeper.py`: one-line change, `class_count = len(file_data.get("classes", []))`.

## Regression test

Added to `test_record_keeper_data_insertion` (`tests/tools_recorders/test_record_keeper.py`): the existing `mock_pipeline_state` fixture already had 1 real class with `"class_start"` not even present in its mock `SIGNAL_SCHEMA` -- so the bug was silently producing `class_count == 0` there even though nothing asserted it. Added `assert file_row["class_count"] == 1` and `assert file_row["function_count"] == 1`.

## Verification

- `pytest tests/tools_recorders/test_record_keeper.py -v`: 4/4 passed
- `ruff_audit.py --ci` / `mypy_audit.py --ci`: clean against baseline
- Not a parsing-logic change (`detector.py`/`prism.py`/`language_standards.py` untouched) -- `crucible_check.py`/golden master reblessing not needed.

Implemented via a Gemini/agy dispatch from a fully diagnosed issue, independently re-verified (diff read, tests/audits re-run from scratch) before this PR.

Fixes #1972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)