### PR TITLE
Suppress checkov false-positive on docs/language_status/dockerfile.md

### DIFF
--- a/muninn.yml
+++ b/muninn.yml
@@ -76,6 +76,17 @@ suppressions:
     tool: poutine
     rule-id: untrusted-checkout
     reason: >
-      Repository architecture requires automated documentation and state 
+      Repository architecture requires automated documentation and state
       rehydration. Workflows intentionally utilize elevated checkout credentials.
+    expires: ""
+  - id: docs/language_status/dockerfile.md
+    tool: checkov
+    reason: >
+      checkov's Dockerfile checks (CKV_DOCKER_2/3/7 -- missing HEALTHCHECK,
+      no non-root USER, base image uses :latest) match this file purely
+      because its name contains "dockerfile", then parse plain English
+      documentation prose (describing what GitGalaxy's regex detects,
+      e.g. "HEALTHCHECK", "USER") as if it were literal Dockerfile
+      instructions. It is a Markdown coverage doc with no fenced code
+      blocks at all, not a real Dockerfile.
     expires: ""


### PR DESCRIPTION
## Summary

`muninn` (this repo's security scan CI check) has been failing on **every** push to `main` since `#1976` merged (last green run: `68c2b013` at 23:03:49; first red run: `b7a93963`, #1976's own merge commit, at 00:44:19). Root-caused this while investigating why two dockerfile-tri-comparison-sweep fix PRs auto-merged despite red checks.

## Root cause

checkov's Dockerfile checks (`CKV_DOCKER_2`/`3`/`7` -- missing `HEALTHCHECK`, no non-root `USER`, base image uses `:latest`) match `docs/language_status/dockerfile.md` purely because its filename contains "dockerfile" -- then parse plain English documentation prose (describing what GitGalaxy's own regex detects, e.g. literally containing the words "HEALTHCHECK"/"USER" as text) as if it were real Dockerfile instructions. It's a Markdown coverage doc with **no fenced code blocks at all**, not a real Dockerfile -- confirmed via `gh api repos/.../code-scanning/alerts`, which shows all 3 blocking findings pointing at this exact file.

## Fix

Adds a `muninn.yml` suppression entry for this specific file + tool, following the exact same pattern already used for `mkdocs.yml`'s "API Exposure" false positive elsewhere in this file.

## Note

This was caught mid-session because I'd been treating `muninn`'s failure as a pre-existing, unrelated issue (it "fails on every recent push, including unrelated automated docs commits") and was about to proceed past it -- turned out the "unrelated" commits were unrelated in diff content but not in root cause, since checkov re-scans the whole repo on every run, not just the PR's own diff. Confirmed via `gh run list` history that the failure started exactly at #1976's merge, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)