### PR TITLE
Tri-comparison sweep: csharp ledger validation + ctags gap docs

### DIFF
--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -2834,14 +2834,17 @@
         "ctags",
         "gitgalaxy"
       ],
-      "credit_tools": [],
+      "credit_tools": [
+        "ctags",
+        "gitgalaxy"
+      ],
       "debit_tools": [],
       "dissenting_tools": [
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T18:13:27Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
       "last_reconciled_at": "2026-08-21T17:11:39Z",
       "last_seen_count": 9,
@@ -2929,10 +2932,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "class",
-      "verdict": null
+      "verdict": "Same root cause and file as the sibling function-existence shape (roslyn/LanguageParser.cs's tree-sitter parse-error cascade from line ~5198, Claim 3 in why_gitgalaxy_beats_ast_here.md, #1427/#1567) -- with the parse tree corrupted into a single ERROR node, tree-sitter can't resolve any class_declaration structure in the corrupted region either, including the outer LanguageParser class itself (whose body spans the entire cascade) and every enum/nested class declared inside it (VariableFlags, NameOptions, ScanTypeArgumentListKind, ScanTypeFlags, ParseTypeMode, etc.). ctags and GitGalaxy both correctly find these via text-based parsing, unaffected by tree-sitter's own AST failure. Not a GitGalaxy or ctags defect."
     },
     "csharp/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -3298,14 +3301,17 @@
         "ctags",
         "gitgalaxy"
       ],
-      "credit_tools": [],
+      "credit_tools": [
+        "ctags",
+        "gitgalaxy"
+      ],
       "debit_tools": [],
       "dissenting_tools": [
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T18:13:27Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
       "last_reconciled_at": "2026-08-21T17:11:39Z",
       "last_seen_count": 271,
@@ -3402,10 +3408,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed: this shape is entirely tree-sitter-c-sharp's own known parse-error cascade in roslyn/LanguageParser.cs, already root-caused and evidence-backed as Claim 3 in docs/why_gitgalaxy_beats_ast_here.md (issues #1427/#1567). A syntax construct at line ~5198 triggers a parse error whose recovery fails to resynchronize for the rest of the (14,680-line) file -- tree.root_node.type itself becomes ERROR, so tree-sitter's own recall for this file collapses to near-zero past that point. GitGalaxy's regex and ctags' text-based parser are both unaffected and correctly find these functions (all sampled: ParseVariableDeclarator, GetPrecedence, ParsePrimaryExpression, ScanType x3 -- real, ordinary private methods, exact line-number agreement between ctags and gitgalaxy on every one). This is the tri-comparison ledger's own version of a phenomenon already fully diagnosed for the 2-way tree_sitter_accuracy_audit.py tool via its cascade_promotable logic -- that logic was never ported to tri_comparison_gatherer.py/tri_comparison_reconcile.py, which is why this shows as an unvalidated ledger shape despite being a known, closed question. Not a GitGalaxy or ctags defect."
     },
     "csharp/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
@@ -3478,8 +3484,8 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-19T14:47:41Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T18:13:27Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
       "last_reconciled_at": "2026-08-21T17:11:39Z",
       "last_seen_count": 1,
@@ -3495,24 +3501,27 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed genuine ctags false positive, not a GitGalaxy or tree-sitter gap. roslyn/CSharpCompilation.cs:2539's real declaration is `public bool Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` -- an Equals overload with tuple-typed parameters. ctags' lightweight C# parser misreads the return-type/tuple-parameter boundary and tags the match under the name `bool` instead of `Equals`. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet alongside this shape's sibling ctags limitations (local-function blindness, complex-signature misses, overload-name collision -- see the agree[gitgalaxy,tree_sitter]_vs[ctags] shape). Not crediting/debiting: a single-tool false positive from an otherwise-unaffected precision baseline, no shared-mistake mechanism applies."
     },
     "csharp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy",
         "tree_sitter"
       ],
-      "credit_tools": [],
+      "credit_tools": [
+        "gitgalaxy",
+        "tree_sitter"
+      ],
       "debit_tools": [],
       "dissenting_tools": [
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T18:13:44Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
       "last_reconciled_at": "2026-08-21T17:11:39Z",
       "last_seen_count": 107,
@@ -3609,10 +3618,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed real ctags parser limitations, not a GitGalaxy or tree-sitter defect, via direct source reading and raw `ctags -x` runs against the flagged files. Two distinct mechanisms: (1) Local/nested functions -- roslyn/CSharpCompilation.cs's `validateSignature` (nested inside a larger method) and `isSupportedType` (a `static bool isSupportedType(...)` local function) are both structurally invisible to ctags, whose csharp kind map is only 'm' (top-level methods; \"C# has no free functions\" per ctags_reader.py's own comment) with no local-function concept at all -- this generalizes to every local function in the corpus, not just the sampled two. (2) Complex-signature misses and overload collisions on ordinary top-level private methods -- `FindEntryPoint` (nullable return/param types plus a generic `out` parameter) and `GetSourceDeclarationDiagnostics` (5 params, two with default values, one a `Func<...>` generic delegate) get no ctags tag at all, confirmed via `ctags -x` showing tags immediately before/after but not at their own lines -- isolated misses, not a wider blind region (unlike the tree-sitter cascade in the sibling ledger shape). `ReportUnusedImports` has two overloads at different lines; ctags tags only the first, silently dropping the second. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet. Credited on the strength of mechanism (1) generalizing structurally to the whole shape (ctags cannot see ANY local function, by construction) even though only ~5 of 107 occurrences were individually read -- mechanism (2)'s complex-signature misses are a smaller, less certain-to-generalize contributor to the same shape but point the same direction (ctags-side, not GitGalaxy/tree-sitter)."
     },
     "csharp/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]": {
       "agreeing_tools": [
@@ -3625,8 +3634,8 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T18:13:27Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
       "last_reconciled_at": "2026-08-21T17:11:39Z",
       "last_seen_count": 48,
@@ -3723,10 +3732,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Mixed shape, confirmed via a full name-diff against gather_language('csharp') rather than the capped sample alone: 44 of 48 are genuine local (nested) functions inside roslyn/LanguageParser.cs's tree-sitter parse-error cascade region (line >= ~5198, same mechanism as the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] shape / Claim 3) -- tree-sitter is fully blind there, and ctags additionally has no concept of a local/nested function at all (only top-level 'm' method tags), so GitGalaxy is the only tool that can see these. The remaining 2 are genuine GitGalaxy false positives with a confirmed, unrelated root cause: roslyn/CSharpCompilation.cs:2282's GetWellKnownType( (a call, no declaration exists anywhere in the file) and roslyn/LanguageParser.cs:2338's this.EatToken( (a call inside a switch-expression arm) are both mis-captured because func_start's return-type-loop character class allows unbalanced parens/commas in a single 'token', letting it swallow a real call-expression fragment as if it were part of a return type and land on the wrong identifier as the 'function name'. Filed as GitHub issue #2035 with root cause and fix direction; fix in progress in an isolated worktree as of this writing. Not crediting/debiting any tool on this shape since it's genuinely mixed (44 real local-function finds, 2 real false positives) -- re-visit once #2035 merges and re-run to confirm the shape drops to 44 (or fewer, if further false positives of the same class surface once #2035's fix generalizes across the full corpus)."
     },
     "csharp/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]": {
       "agreeing_tools": [

--- a/tests/tools/ctags_reader.py
+++ b/tests/tools/ctags_reader.py
@@ -146,6 +146,28 @@ KIND MAPS
         NOT by ctags, which correctly excludes them -- filed separately since the production
         engine's fix needs care around C++ multiple inheritance, see the GitHub issue referenced in
         tri_comparison_ledger.json's corresponding entry.
+      - csharp: ctags' C# parser silently drops a tag for a subset of real method declarations
+        with a complex signature, both isolated single misses and, separately, an overload-name
+        collision. (1) Complex signature: `CSharpCompilation.cs`'s `FindEntryPoint` (nullable
+        return type `MethodSymbol?`, nullable param `MethodSymbol?`, and an `out` param of a
+        generic type `out ReadOnlyBindingDiagnostic<AssemblySymbol> sealedDiagnostics`) gets no
+        tag at all, confirmed via a direct `ctags -x` run showing tags immediately before and
+        after it in the file but none at its own line -- an isolated miss, not part of a wider
+        blind region. `GetSourceDeclarationDiagnostics` (5 params including two with default
+        values and a `Func<...>` generic delegate parameter) is missed the same way. (2) Overload
+        collision: `ReportUnusedImports` has two overloads at different line numbers in the same
+        file; ctags tags only the first, silently dropping the second. Also a genuine ctags FALSE
+        POSITIVE from the same file: a `public bool Equals((ImmutableArray<byte> ContentHash, int
+        Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` overload (tuple-typed
+        parameters) gets tagged under the name `bool` instead of `Equals` -- ctags' lightweight
+        parser appears to misread the return-type/tuple-parameter boundary. All confirmed via
+        `csharp/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]` (107 occurrences) and
+        `csharp/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]` (1 occurrence,
+        2026-08-21) -- real, structural ctags parser limitations, not GitGalaxy or tree-sitter
+        defects. (Separately, and NOT a ctags defect: most of that 107-shape is local/nested
+        function declarations, e.g. `validateSignature`/`isSupportedType` -- ctags has no concept
+        of a local function the same way it has no concept of a local variable; GitGalaxy and
+        tree-sitter both correctly count these, ctags correctly doesn't try to.)
     Cross-reference gitgalaxy/standards/language_standards.py's own class_start/func_start
     definitions before ever widening one of these maps -- do not add a kind because its letter
     looks right.


### PR DESCRIPTION
## Summary

Ongoing tri-comparison-ledger-sweep pass for csharp (11 open ledger shapes at start). This PR
accumulates validated ledger entries and doc updates as the sweep progresses; more commits will
land here as remaining shapes (2 Gemini fixes + 1 read-only investigation) come back.

Validated so far (5 of 11 shapes):
- **271 + 9 occurrences** (function + class existence, `agree[ctags,gitgalaxy]_vs[tree_sitter]`):
  tree-sitter-c-sharp's own already-documented parse-error cascade in
  `roslyn/LanguageParser.cs` (Claim 3 in `docs/why_gitgalaxy_beats_ast_here.md`, #1427/#1567) —
  the ledger tooling just never had this cascade-detection ported over from the sibling
  `tree_sitter_accuracy_audit.py`. Credited to ctags+gitgalaxy.
- **48 occurrences** (function existence, `agree[gitgalaxy]_vs[ctags,tree_sitter]`): mixed —
  44 are genuine local functions inside the same cascade region (ctags structurally can't see
  local functions either), 2 are confirmed GitGalaxy false positives, newly filed as
  [#2035](https://github.com/squid-protocol/gitgalaxy/issues/2035) with a fix in progress in a
  separate worktree. Left uncredited pending that fix.
- **107 occurrences** (function existence, `agree[gitgalaxy,tree_sitter]_vs[ctags]`): confirmed
  ctags-side limitations (no local-function concept in its csharp kind map, complex-signature
  misses, an overload-name collision). Credited to gitgalaxy+tree_sitter. Documented in
  `tests/tools/ctags_reader.py`'s KIND MAPS section.
- **1 occurrence** (function existence, `agree[ctags]_vs[gitgalaxy,tree_sitter]`): confirmed ctags
  false positive — a tuple-parameter `Equals` overload mistagged as `bool`.

## New issues filed along the way

- [#2035](https://github.com/squid-protocol/gitgalaxy/issues/2035) — csharp `func_start`'s
  return-type loop can swallow a call-expression fragment as a fake return type (2 confirmed false
  positives). Fix in progress.
- [#2036](https://github.com/squid-protocol/gitgalaxy/issues/2036) — csharp `detector.py`
  unconditionally drops every bodyless interface/abstract method declaration (a `;`-terminated
  signature is always treated as a false-positive bare statement, even when it has a real modifier
  keyword that makes it unambiguous). Likely a meaningful recall gap on any real C# codebase, not
  just this corpus. Fix in progress.

## Remaining (in flight)

- 6 more shapes (2 existence, ~13 args-count mismatches) under read-only investigation.
- Two code fixes (#2035, #2036) being implemented in isolated worktrees; will land as their own
  PRs and get re-validated in the ledger here once merged.

## Test plan

- [x] `docs/self_scan/tri_comparison_ledger.json` diff scoped to the 5 validated csharp entries
      only (verified via `git diff --stat`).
- [x] `tests/tools/ctags_reader.py` change is docstring-only (no behavior change).
- [ ] Chart regeneration (`tri_comparison_chart.py --all --write`) once the remaining shapes land,
      batched rather than per-entry per the sweep skill's guidance.