### PR TITLE
Tri-comparison sweep: csharp args-shape validation, backlog cleared

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -227,39 +227,41 @@
 <text class="lang-label" x="20" y="539.5">csharp</text>
 <rect class="bar-track" x="154" y="519" width="88" height="34" rx="2"/>
 <rect x="154" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="527">961*</text>
-<rect x="154" y="531" width="59.2" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="539">647*</text>
-<rect x="154" y="543" width="74.3" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="551">811*</text>
+<text class="bar-value-label" x="198.0" y="527">965</text>
+<rect x="154" y="531" width="59.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="539">647</text>
+<rect x="154" y="543" width="74.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="551">811</text>
 <rect class="bar-track" x="286" y="519" width="88" height="34" rx="2"/>
-<rect x="286" y="519" width="83.6" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="527">913/961*</text>
-<rect x="286" y="531" width="87.9" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="539">646/647*</text>
-<rect x="286" y="543" width="87.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="551">810/811*</text>
+<rect x="286" y="519" width="118.3" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="527">1297/965</text>
+<rect x="286" y="531" width="102.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="539">755/647</text>
+<rect x="286" y="543" width="117.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="551">1081/811</text>
+<circle cx="390.0" cy="536.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="539.0">G</text>
 <rect class="bar-track" x="418" y="519" width="88" height="34" rx="2"/>
 <rect x="418" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="527">33*</text>
+<text class="bar-value-label" x="462.0" y="527">33</text>
 <rect x="418" y="531" width="64.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="539">24*</text>
+<text class="bar-value-label" x="462.0" y="539">24</text>
 <rect x="418" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="551">33*</text>
+<text class="bar-value-label" x="462.0" y="551">33</text>
 <rect class="bar-track" x="550" y="519" width="88" height="34" rx="2"/>
-<rect x="550" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="527">33/33*</text>
+<rect x="550" y="519" width="112.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="527">42/33</text>
 <rect x="550" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="539">24/24*</text>
-<rect x="550" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="551">33/33*</text>
+<text class="bar-value-label" x="594.0" y="539">24/24</text>
+<rect x="550" y="543" width="112.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="551">42/33</text>
 <rect class="bar-track" x="682" y="519" width="88" height="34" rx="2"/>
 <rect x="682" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="527">535*</text>
+<text class="bar-value-label" x="726.0" y="527">539*</text>
 <rect x="682" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="539">535*</text>
+<text class="bar-value-label" x="726.0" y="539">539*</text>
 <rect x="682" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="551">535*</text>
+<text class="bar-value-label" x="726.0" y="551">539*</text>
 <text class="lang-label" x="20" y="583.5">css</text>
 <rect class="bar-track" x="154" y="563" width="88" height="34" rx="2"/>
 <rect x="154" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
@@ -1087,10 +1089,10 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 32 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 34 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 12 (38%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 13 (38%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
 <text class="legend-label" x="228.8" y="2188">tree-sitter best: 1 (3%)</text>
@@ -1098,6 +1100,6 @@
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
 <circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="577.2" y="2188">Ties: 19 (59%)</text>
+<text class="legend-label" x="577.2" y="2188">Ties: 20 (59%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -257,11 +257,11 @@
 <text class="bar-value-label" x="594.0" y="551">42/33</text>
 <rect class="bar-track" x="682" y="519" width="88" height="34" rx="2"/>
 <rect x="682" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="527">539*</text>
+<text class="bar-value-label" x="726.0" y="527">539</text>
 <rect x="682" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="539">539*</text>
+<text class="bar-value-label" x="726.0" y="539">539</text>
 <rect x="682" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="551">539*</text>
+<text class="bar-value-label" x="726.0" y="551">539</text>
 <text class="lang-label" x="20" y="583.5">css</text>
 <rect class="bar-track" x="154" y="563" width="88" height="34" rx="2"/>
 <rect x="154" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-21T18:51:08Z",
+      "last_reconciled_at": "2026-08-21T20:06:54Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-21T18:51:08Z",
+      "last_reconciled_at": "2026-08-21T20:06:54Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-21T18:51:10Z",
+      "last_reconciled_at": "2026-08-21T20:06:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-21T18:51:12Z",
+      "last_reconciled_at": "2026-08-21T20:06:57Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-21T18:51:12Z",
+      "last_reconciled_at": "2026-08-21T20:06:57Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1273,7 +1273,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T18:51:17Z",
+      "last_reconciled_at": "2026-08-21T20:07:02Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1388,7 +1388,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T18:51:23Z",
+      "last_reconciled_at": "2026-08-21T20:07:07Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1491,7 +1491,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T18:51:23Z",
+      "last_reconciled_at": "2026-08-21T20:07:07Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1594,7 +1594,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T18:51:23Z",
+      "last_reconciled_at": "2026-08-21T20:07:07Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1698,7 +1698,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1740,7 +1740,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1782,7 +1782,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -1896,7 +1896,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2010,7 +2010,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2124,7 +2124,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2238,7 +2238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2270,7 +2270,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2303,7 +2303,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2417,7 +2417,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2450,7 +2450,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2564,7 +2564,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2669,7 +2669,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2729,7 +2729,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T18:51:27Z",
+      "last_reconciled_at": "2026-08-21T20:07:12Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -2846,7 +2846,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2951,7 +2951,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3020,7 +3020,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3090,15 +3090,18 @@
         "gitgalaxy"
       ],
       "credit_tools": [],
-      "debit_tools": [],
+      "debit_tools": [
+        "ctags",
+        "gitgalaxy"
+      ],
       "dissenting_tools": [
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T20:06:45Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3112,10 +3115,10 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed: both ctags and GitGalaxy are wrong here, tree-sitter alone is right. roslyn/CSharpCompilation.cs:2539's `Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` has 2 real parameters (both tuple-typed); tree_sitter correctly reports 2. GitGalaxy's args capture group truncates at the first unbalanced `)` inside the first tuple parameter's own type, reporting 1 (mechanism 2 of issue #2051, confirmed via direct regex testing). ctags independently also reports 1, for its own unrelated reason (the same tuple-parameter-splitting limitation documented elsewhere in this file for GetHashCode/Equals-with-bool-tuple-param) -- both tools land on the identical wrong number by coincidence, not real corroboration of each other."
     },
     "csharp/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
@@ -3128,10 +3131,10 @@
         "gitgalaxy"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T20:06:45Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3199,26 +3202,29 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed GitGalaxy defect for 6 of 7 occurrences, root-caused to 3 distinct mechanisms in the csharp args regex, none of which func_start's own (already-hardened) regex shares: (1) Branch 1's return-type-loop character class has no parens, so any tuple-shaped or generic-wrapped-tuple return type fails to match at all (HasEntryPointSignature: real=2, GitGalaxy=0; SetCurrentSolutionEx: real=1, GitGalaxy=2; SetCurrentSolutionAsync both overloads: real=6/GitGalaxy=2, real=7/GitGalaxy=0); (2) the shared args capture group `(\\([^)]*\\))` truncates at the first unbalanced `)`, breaking on any parameter whose own type contains parens (ProcessEventHandlerWorkQueueAsync's ImmutableSegmentedList<(tuple)> param: real=2, GitGalaxy=1); (3) the name-capture has no generic-type-parameter stepper (func_start's already does), so a generic method's <T> before the real parens fails to match (OnAnyDocumentTextChanged<TArg>: real=7, GitGalaxy=2; ScheduleTask<T>: real=2, GitGalaxy=1). Filed as issue #2051 with full evidence per mechanism. The 7th occurrence (GetModifierExcludingScoped) is NOT a real defect on either side: both of its overloads (1 param and 2 params) are correctly counted by GitGalaxy; the apparent ctags=2/gitgalaxy=1 mismatch is the reconciler's rank-based (not name/overload-based) pairing comparing two DIFFERENT real overloads against each other, not a genuine disagreement about the same declaration -- confirmed by reading both real declarations directly. No credit/debit: GitGalaxy is genuinely wrong on 6/7, and the reconciler-pairing noise on the 7th isn't a tool defect at all."
     },
     "csharp/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
         "gitgalaxy",
         "tree_sitter"
       ],
-      "credit_tools": [],
+      "credit_tools": [
+        "gitgalaxy",
+        "tree_sitter"
+      ],
       "debit_tools": [],
       "dissenting_tools": [
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T20:06:45Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3259,10 +3265,10 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Mixed shape. 1 of 4 is a confirmed genuine ctags defect: GetHashCode's tuple-parameter overload (`GetHashCode((ImmutableArray<byte> ContentHash, int Position) obj)`, 1 real param) -- ctags reports 2, mis-splitting the tuple-typed parameter's own internal comma as a second top-level parameter, the same family as the already-documented tuple-related ctags limitations in tests/tools/ctags_reader.py's csharp bullet. The other 3 (GetModifierExcludingScoped and two SetCurrentSolution rows) are NOT real tool disagreements at all -- SetCurrentSolution has 4 real overloads (1/6/4/5 real params respectively) in roslyn/Workspace.cs; every individual reading from every tool across both rows (ctags=6, gitgalaxy=1, tree_sitter=1, ctags=4, gitgalaxy=6, tree_sitter=6) independently matches SOME real overload's true count exactly when checked against the source -- the ledger shape only exists because the reconciler's rank-based pairing compared different tools' readings of DIFFERENT overloads against each other, not because any tool actually miscounted anything. Confirmed via direct line-by-line source reading of all 4 overloads. Credit gitgalaxy+tree_sitter for the 1 real ctags defect only; the shape as a whole is left without a clean credit/debit since 3 of 4 occurrences aren't a real disagreement to adjudicate."
     },
     "csharp/function/args/agree[none]_vs[ctags,gitgalaxy,tree_sitter]": {
       "agreeing_tools": [],
@@ -3274,10 +3280,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T20:06:45Z",
+      "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3291,10 +3297,10 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Tangled: partly the same reconciler rank-pairing artifact as the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] shape (SetCurrentSolution's 4 real overloads, 1/6/4/5 params), partly a genuine GitGalaxy defect underneath. ctags=5 and tree_sitter=4 each correctly match a DIFFERENT real overload's true count (line 444's 5 params, line 230's 4 params respectively) -- not wrong, just paired against each other by rank rather than by which declaration they actually read. GitGalaxy=0 traces to the SAME occurrence tree_sitter's 4 reading corresponds to (line 230, a bare tuple return type `(bool updated, Solution newSolution)` before the method name) -- a confirmed instance of issue #2051's mechanism 1 (GitGalaxy's args regex fails to match tuple return types at all). No credit/debit: too tangled between real defect and pairing noise to cleanly adjudicate at the shape level."
     },
     "csharp/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
       "agreeing_tools": [
@@ -3313,7 +3319,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3427,7 +3433,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3487,7 +3493,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3523,7 +3529,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -3637,7 +3643,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 47,
       "last_seen_examples": [
         {
@@ -3751,7 +3757,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_reconciled_at": "2026-08-21T20:07:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3784,7 +3790,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-21T18:51:35Z",
+      "last_reconciled_at": "2026-08-21T20:07:19Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3833,7 +3839,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T18:51:39Z",
+      "last_reconciled_at": "2026-08-21T20:07:23Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3936,7 +3942,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T18:51:39Z",
+      "last_reconciled_at": "2026-08-21T20:07:23Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -4039,7 +4045,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T18:51:39Z",
+      "last_reconciled_at": "2026-08-21T20:07:23Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4143,7 +4149,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T18:51:45Z",
+      "last_reconciled_at": "2026-08-21T20:07:29Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4238,7 +4244,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T18:51:45Z",
+      "last_reconciled_at": "2026-08-21T20:07:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4270,7 +4276,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T18:51:45Z",
+      "last_reconciled_at": "2026-08-21T20:07:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4303,7 +4309,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T18:51:45Z",
+      "last_reconciled_at": "2026-08-21T20:07:29Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4417,7 +4423,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T18:51:45Z",
+      "last_reconciled_at": "2026-08-21T20:07:29Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4459,7 +4465,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T18:51:45Z",
+      "last_reconciled_at": "2026-08-21T20:07:29Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4501,7 +4507,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-21T18:51:48Z",
+      "last_reconciled_at": "2026-08-21T20:07:31Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4615,7 +4621,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4727,7 +4733,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4832,7 +4838,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4946,7 +4952,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -5060,7 +5066,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5174,7 +5180,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5215,7 +5221,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5255,7 +5261,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T18:51:51Z",
+      "last_reconciled_at": "2026-08-21T20:07:34Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5369,7 +5375,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5483,7 +5489,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5597,7 +5603,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5710,7 +5716,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5743,7 +5749,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5794,7 +5800,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5908,7 +5914,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T18:51:54Z",
+      "last_reconciled_at": "2026-08-21T20:07:37Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5959,7 +5965,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -6073,7 +6079,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6160,7 +6166,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6202,7 +6208,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6316,7 +6322,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6430,7 +6436,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6544,7 +6550,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6658,7 +6664,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T18:51:56Z",
+      "last_reconciled_at": "2026-08-21T20:07:40Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6772,7 +6778,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T18:51:59Z",
+      "last_reconciled_at": "2026-08-21T20:07:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6823,7 +6829,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T18:51:59Z",
+      "last_reconciled_at": "2026-08-21T20:07:42Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6937,7 +6943,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T18:51:59Z",
+      "last_reconciled_at": "2026-08-21T20:07:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6969,7 +6975,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T18:52:05Z",
+      "last_reconciled_at": "2026-08-21T20:07:48Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7024,7 +7030,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T18:52:05Z",
+      "last_reconciled_at": "2026-08-21T20:07:48Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -7127,7 +7133,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T18:52:05Z",
+      "last_reconciled_at": "2026-08-21T20:07:48Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -7231,7 +7237,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-21T18:52:07Z",
+      "last_reconciled_at": "2026-08-21T20:07:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7262,7 +7268,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-21T18:52:08Z",
+      "last_reconciled_at": "2026-08-21T20:07:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7295,7 +7301,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T18:52:10Z",
+      "last_reconciled_at": "2026-08-21T20:07:53Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7409,7 +7415,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T18:52:10Z",
+      "last_reconciled_at": "2026-08-21T20:07:53Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7523,7 +7529,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T18:52:10Z",
+      "last_reconciled_at": "2026-08-21T20:07:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7556,7 +7562,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T18:52:10Z",
+      "last_reconciled_at": "2026-08-21T20:07:53Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7598,7 +7604,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7631,7 +7637,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7662,7 +7668,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7776,7 +7782,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7863,7 +7869,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7950,7 +7956,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7983,7 +7989,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T18:52:16Z",
+      "last_reconciled_at": "2026-08-21T20:07:59Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -8097,7 +8103,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T18:52:21Z",
+      "last_reconciled_at": "2026-08-21T20:08:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8130,7 +8136,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T18:52:21Z",
+      "last_reconciled_at": "2026-08-21T20:08:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8163,7 +8169,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T18:52:21Z",
+      "last_reconciled_at": "2026-08-21T20:08:03Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8277,7 +8283,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T18:52:23Z",
+      "last_reconciled_at": "2026-08-21T20:08:06Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8362,7 +8368,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T18:52:23Z",
+      "last_reconciled_at": "2026-08-21T20:08:06Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8431,7 +8437,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T18:52:23Z",
+      "last_reconciled_at": "2026-08-21T20:08:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8464,7 +8470,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T18:52:23Z",
+      "last_reconciled_at": "2026-08-21T20:08:06Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8578,7 +8584,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T18:52:33Z",
+      "last_reconciled_at": "2026-08-21T20:08:15Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8638,7 +8644,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T18:52:33Z",
+      "last_reconciled_at": "2026-08-21T20:08:15Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8671,7 +8677,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T18:52:33Z",
+      "last_reconciled_at": "2026-08-21T20:08:15Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -8787,7 +8793,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T18:52:33Z",
+      "last_reconciled_at": "2026-08-21T20:08:15Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8820,7 +8826,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T18:52:34Z",
+      "last_reconciled_at": "2026-08-21T20:08:17Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8862,7 +8868,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T18:52:34Z",
+      "last_reconciled_at": "2026-08-21T20:08:17Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8940,7 +8946,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T18:52:34Z",
+      "last_reconciled_at": "2026-08-21T20:08:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8991,7 +8997,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T18:52:34Z",
+      "last_reconciled_at": "2026-08-21T20:08:17Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9068,7 +9074,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -9182,7 +9188,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9235,7 +9241,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9348,7 +9354,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9399,7 +9405,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9511,7 +9517,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9624,7 +9630,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9737,7 +9743,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9770,7 +9776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9805,7 +9811,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T18:52:38Z",
+      "last_reconciled_at": "2026-08-21T20:08:20Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9917,7 +9923,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-21T18:52:40Z",
+      "last_reconciled_at": "2026-08-21T20:08:23Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -10020,7 +10026,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-21T18:52:45Z",
+      "last_reconciled_at": "2026-08-21T20:08:27Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -10122,7 +10128,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-21T18:52:45Z",
+      "last_reconciled_at": "2026-08-21T20:08:27Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10226,7 +10232,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-21T18:52:46Z",
+      "last_reconciled_at": "2026-08-21T20:08:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10258,7 +10264,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-21T18:52:48Z",
+      "last_reconciled_at": "2026-08-21T20:08:30Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10328,7 +10334,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T18:52:49Z",
+      "last_reconciled_at": "2026-08-21T20:08:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10359,7 +10365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T18:52:49Z",
+      "last_reconciled_at": "2026-08-21T20:08:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10390,7 +10396,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T18:52:49Z",
+      "last_reconciled_at": "2026-08-21T20:08:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10422,7 +10428,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T18:52:51Z",
+      "last_reconciled_at": "2026-08-21T20:08:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10455,7 +10461,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T18:52:51Z",
+      "last_reconciled_at": "2026-08-21T20:08:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10497,7 +10503,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T18:52:51Z",
+      "last_reconciled_at": "2026-08-21T20:08:33Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10557,7 +10563,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T18:52:51Z",
+      "last_reconciled_at": "2026-08-21T20:08:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10589,7 +10595,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T18:52:51Z",
+      "last_reconciled_at": "2026-08-21T20:08:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10631,7 +10637,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10673,7 +10679,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10785,7 +10791,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10844,7 +10850,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10877,7 +10883,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10982,7 +10988,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -11096,7 +11102,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -11210,7 +11216,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11252,7 +11258,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T18:53:11Z",
+      "last_reconciled_at": "2026-08-21T20:08:53Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11365,7 +11371,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T18:53:20Z",
+      "last_reconciled_at": "2026-08-21T20:09:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11396,7 +11402,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T18:53:20Z",
+      "last_reconciled_at": "2026-08-21T20:09:02Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11499,7 +11505,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T18:53:20Z",
+      "last_reconciled_at": "2026-08-21T20:09:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-21T17:11:14Z",
+      "last_reconciled_at": "2026-08-21T18:51:08Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-21T17:11:14Z",
+      "last_reconciled_at": "2026-08-21T18:51:08Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-21T17:11:16Z",
+      "last_reconciled_at": "2026-08-21T18:51:10Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-21T17:11:18Z",
+      "last_reconciled_at": "2026-08-21T18:51:12Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-21T17:11:18Z",
+      "last_reconciled_at": "2026-08-21T18:51:12Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1273,7 +1273,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T17:11:23Z",
+      "last_reconciled_at": "2026-08-21T18:51:17Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1388,7 +1388,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T17:11:28Z",
+      "last_reconciled_at": "2026-08-21T18:51:23Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1491,7 +1491,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T17:11:28Z",
+      "last_reconciled_at": "2026-08-21T18:51:23Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1594,7 +1594,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T17:11:28Z",
+      "last_reconciled_at": "2026-08-21T18:51:23Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1698,7 +1698,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1740,7 +1740,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1782,7 +1782,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -1896,7 +1896,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2010,7 +2010,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2124,7 +2124,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2238,7 +2238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2270,7 +2270,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2303,7 +2303,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2417,7 +2417,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2450,7 +2450,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2564,7 +2564,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2669,7 +2669,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2729,7 +2729,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T17:11:33Z",
+      "last_reconciled_at": "2026-08-21T18:51:27Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -2846,7 +2846,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2951,7 +2951,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3020,7 +3020,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3098,7 +3098,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3131,7 +3131,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3218,7 +3218,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3277,7 +3277,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3313,7 +3313,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3427,7 +3427,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3469,7 +3469,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -3487,7 +3487,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3523,8 +3523,8 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
-      "last_seen_count": 107,
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_seen_count": 108,
       "last_seen_examples": [
         {
           "file_path": "roslyn/CSharpCompilation.cs",
@@ -3637,15 +3637,15 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
-      "last_seen_count": 48,
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
+      "last_seen_count": 47,
       "last_seen_examples": [
         {
           "file_path": "roslyn/CSharpCompilation.cs",
-          "name": "GetWellKnownType",
+          "name": "CreateReflectionTypeNotFoundError",
           "readings": {
             "ctags": null,
-            "gitgalaxy": 2282,
+            "gitgalaxy": 1883,
             "tree_sitter": null
           }
         },
@@ -3751,7 +3751,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T17:11:39Z",
+      "last_reconciled_at": "2026-08-21T18:51:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3766,7 +3766,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -3784,7 +3784,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "css",
-      "last_reconciled_at": "2026-08-21T17:11:40Z",
+      "last_reconciled_at": "2026-08-21T18:51:35Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3833,7 +3833,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T17:11:44Z",
+      "last_reconciled_at": "2026-08-21T18:51:39Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3936,7 +3936,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T17:11:44Z",
+      "last_reconciled_at": "2026-08-21T18:51:39Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -4039,7 +4039,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T17:11:44Z",
+      "last_reconciled_at": "2026-08-21T18:51:39Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4143,7 +4143,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T17:11:50Z",
+      "last_reconciled_at": "2026-08-21T18:51:45Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4238,7 +4238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T17:11:50Z",
+      "last_reconciled_at": "2026-08-21T18:51:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4270,7 +4270,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T17:11:50Z",
+      "last_reconciled_at": "2026-08-21T18:51:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4303,7 +4303,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T17:11:50Z",
+      "last_reconciled_at": "2026-08-21T18:51:45Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4417,7 +4417,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T17:11:50Z",
+      "last_reconciled_at": "2026-08-21T18:51:45Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4459,7 +4459,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T17:11:50Z",
+      "last_reconciled_at": "2026-08-21T18:51:45Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4501,7 +4501,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-21T17:11:52Z",
+      "last_reconciled_at": "2026-08-21T18:51:48Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4615,7 +4615,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4727,7 +4727,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4832,7 +4832,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4946,7 +4946,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -5060,7 +5060,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5174,7 +5174,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5215,7 +5215,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5255,7 +5255,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T17:11:55Z",
+      "last_reconciled_at": "2026-08-21T18:51:51Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5369,7 +5369,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5483,7 +5483,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5597,7 +5597,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5710,7 +5710,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5743,7 +5743,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5794,7 +5794,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5908,7 +5908,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T17:11:58Z",
+      "last_reconciled_at": "2026-08-21T18:51:54Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5959,7 +5959,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -6073,7 +6073,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6160,7 +6160,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6202,7 +6202,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6316,7 +6316,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6430,7 +6430,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6544,7 +6544,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6658,7 +6658,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T17:12:01Z",
+      "last_reconciled_at": "2026-08-21T18:51:56Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6772,7 +6772,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T17:12:04Z",
+      "last_reconciled_at": "2026-08-21T18:51:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6823,7 +6823,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T17:12:04Z",
+      "last_reconciled_at": "2026-08-21T18:51:59Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6937,7 +6937,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T17:12:04Z",
+      "last_reconciled_at": "2026-08-21T18:51:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6969,7 +6969,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T17:12:10Z",
+      "last_reconciled_at": "2026-08-21T18:52:05Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7024,7 +7024,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T17:12:10Z",
+      "last_reconciled_at": "2026-08-21T18:52:05Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -7127,7 +7127,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T17:12:10Z",
+      "last_reconciled_at": "2026-08-21T18:52:05Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -7231,7 +7231,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-21T17:12:11Z",
+      "last_reconciled_at": "2026-08-21T18:52:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7262,7 +7262,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-21T17:12:13Z",
+      "last_reconciled_at": "2026-08-21T18:52:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7295,7 +7295,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T17:12:14Z",
+      "last_reconciled_at": "2026-08-21T18:52:10Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7409,7 +7409,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T17:12:14Z",
+      "last_reconciled_at": "2026-08-21T18:52:10Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7523,7 +7523,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T17:12:14Z",
+      "last_reconciled_at": "2026-08-21T18:52:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7556,7 +7556,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T17:12:14Z",
+      "last_reconciled_at": "2026-08-21T18:52:10Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7598,7 +7598,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7631,7 +7631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7662,7 +7662,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7776,7 +7776,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7863,7 +7863,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7983,7 +7983,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T17:12:20Z",
+      "last_reconciled_at": "2026-08-21T18:52:16Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -8097,7 +8097,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T17:12:25Z",
+      "last_reconciled_at": "2026-08-21T18:52:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8130,7 +8130,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T17:12:25Z",
+      "last_reconciled_at": "2026-08-21T18:52:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8163,7 +8163,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T17:12:25Z",
+      "last_reconciled_at": "2026-08-21T18:52:21Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8277,7 +8277,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T17:12:27Z",
+      "last_reconciled_at": "2026-08-21T18:52:23Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8362,7 +8362,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T17:12:27Z",
+      "last_reconciled_at": "2026-08-21T18:52:23Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8431,7 +8431,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T17:12:27Z",
+      "last_reconciled_at": "2026-08-21T18:52:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8464,7 +8464,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T17:12:27Z",
+      "last_reconciled_at": "2026-08-21T18:52:23Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8578,7 +8578,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T17:12:37Z",
+      "last_reconciled_at": "2026-08-21T18:52:33Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8638,7 +8638,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T17:12:37Z",
+      "last_reconciled_at": "2026-08-21T18:52:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8671,7 +8671,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T17:12:37Z",
+      "last_reconciled_at": "2026-08-21T18:52:33Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -8787,7 +8787,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T17:12:37Z",
+      "last_reconciled_at": "2026-08-21T18:52:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8820,7 +8820,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T17:12:38Z",
+      "last_reconciled_at": "2026-08-21T18:52:34Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8862,7 +8862,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T17:12:38Z",
+      "last_reconciled_at": "2026-08-21T18:52:34Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8940,7 +8940,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T17:12:38Z",
+      "last_reconciled_at": "2026-08-21T18:52:34Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8991,7 +8991,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T17:12:38Z",
+      "last_reconciled_at": "2026-08-21T18:52:34Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9068,7 +9068,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -9182,7 +9182,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9235,7 +9235,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9348,7 +9348,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9399,7 +9399,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9511,7 +9511,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9624,7 +9624,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9737,7 +9737,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9770,7 +9770,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9805,7 +9805,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T17:12:42Z",
+      "last_reconciled_at": "2026-08-21T18:52:38Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9917,7 +9917,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-21T17:12:45Z",
+      "last_reconciled_at": "2026-08-21T18:52:40Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -10020,7 +10020,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-21T17:12:49Z",
+      "last_reconciled_at": "2026-08-21T18:52:45Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -10122,7 +10122,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-21T17:12:49Z",
+      "last_reconciled_at": "2026-08-21T18:52:45Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10226,7 +10226,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-21T17:12:50Z",
+      "last_reconciled_at": "2026-08-21T18:52:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10258,7 +10258,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-21T17:12:52Z",
+      "last_reconciled_at": "2026-08-21T18:52:48Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10328,7 +10328,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T17:12:53Z",
+      "last_reconciled_at": "2026-08-21T18:52:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10359,7 +10359,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T17:12:53Z",
+      "last_reconciled_at": "2026-08-21T18:52:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10390,7 +10390,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T17:12:53Z",
+      "last_reconciled_at": "2026-08-21T18:52:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10422,7 +10422,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T17:12:55Z",
+      "last_reconciled_at": "2026-08-21T18:52:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10455,7 +10455,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T17:12:55Z",
+      "last_reconciled_at": "2026-08-21T18:52:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10497,7 +10497,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T17:12:55Z",
+      "last_reconciled_at": "2026-08-21T18:52:51Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10557,7 +10557,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T17:12:55Z",
+      "last_reconciled_at": "2026-08-21T18:52:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10589,7 +10589,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T17:12:55Z",
+      "last_reconciled_at": "2026-08-21T18:52:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10631,7 +10631,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10673,7 +10673,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10785,7 +10785,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10844,7 +10844,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10877,7 +10877,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10982,7 +10982,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -11096,7 +11096,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -11210,7 +11210,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11252,7 +11252,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T17:13:15Z",
+      "last_reconciled_at": "2026-08-21T18:53:11Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11365,7 +11365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T17:13:24Z",
+      "last_reconciled_at": "2026-08-21T18:53:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11396,7 +11396,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T17:13:24Z",
+      "last_reconciled_at": "2026-08-21T18:53:20Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11499,7 +11499,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T17:13:24Z",
+      "last_reconciled_at": "2026-08-21T18:53:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {


### PR DESCRIPTION
## Summary

Continuation of the accumulating csharp tri-comparison sweep (part 1: #2037). Refreshes the
ledger/chart after the two merged engine fixes (#2039, #2040) and validates the 4 remaining
args-count shapes, clearing csharp's ledger backlog entirely (0 open unvalidated shapes).

**Confirmed a real GitGalaxy defect and filed [#2051](https://github.com/squid-protocol/gitgalaxy/issues/2051):**
the csharp `args` regex was never updated the way `func_start` was — it fails on tuple return
types, generic-wrapped-tuple return types, tuple-typed parameters (truncates on the first
unbalanced `)`), and generic methods (`Method<T>(...)`, no stepper to skip `<T>` before the real
parens). Three distinct, independently-reproduced mechanisms, not fixed in this pass since it
needs real design work across the regex plus full corpus verification — filed with complete
evidence per mechanism for a dedicated follow-up.

**Also confirmed one genuine ctags defect** (a tuple-typed parameter mis-split into 2 params),
credited to gitgalaxy+tree_sitter, and **one shape where both ctags and GitGalaxy are
independently wrong** (a two-tuple-param `Equals` overload), debited both.

**Several apparent "disagreements" turned out to be reconciler rank-pairing artifacts, not real
tool defects** — `SetCurrentSolution` has 4 real overloads with different arg counts in the
corpus; every individual tool reading independently matched some real overload's true count when
checked against source, the ledger shape only existed because the reconciler pairs same-named
occurrences by rank position, not by which specific overload they are (an already-documented,
deliberate design tradeoff in `tri_comparison_reconcile.py`, not a bug).

## Current standing for csharp (all validated, no open questions)

| Category | Winner |
|---|---|
| Func recall | GitGalaxy |
| Func precision | GitGalaxy |
| Class recall | tie (GitGalaxy = ctags) |
| Class precision | tie (GitGalaxy = ctags) |
| Args | tree-sitter (root-caused, #2051 open for the fix) |

## Test plan

- [x] `docs/self_scan/tri_comparison_ledger.json`/`tri_comparison_chart.svg` diff scoped to fresh
      reconcile + the 4 newly-validated csharp shapes.
- [x] `ruff_audit.py --ci` / `mypy_audit.py --ci`: no new findings.
- [x] Confirmed 0 remaining open/unvalidated csharp ledger shapes via direct query.