### PR TITLE
Validate css function/existence tri-comparison ledger shape

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -265,16 +265,16 @@
 <text class="lang-label" x="20" y="583.5">css</text>
 <rect class="bar-track" x="154" y="563" width="88" height="34" rx="2"/>
 <rect x="154" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="571">3*</text>
+<text class="bar-value-label" x="198.0" y="571">3</text>
 <rect x="154" y="575" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="583">3*</text>
+<text class="bar-value-label" x="198.0" y="583">3</text>
 <rect x="154" y="587" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="595">0*</text>
+<text class="bar-value-label" x="198.0" y="595">0</text>
 <rect class="bar-track" x="286" y="563" width="88" height="34" rx="2"/>
 <rect x="286" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="571">3/3*</text>
+<text class="bar-value-label" x="330.0" y="571">3/3</text>
 <rect x="286" y="575" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="583">3/3*</text>
+<text class="bar-value-label" x="330.0" y="583">3/3</text>
 <rect class="bar-track" x="682" y="563" width="88" height="34" rx="2"/>
 <rect class="stripe" x="16" y="602" width="780" height="44"/>
 <text class="lang-label" x="20" y="627.5">dart</text>
@@ -1089,10 +1089,10 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 34 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 35 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 13 (38%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 13 (37%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
 <text class="legend-label" x="228.8" y="2188">tree-sitter best: 1 (3%)</text>
@@ -1100,6 +1100,6 @@
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
 <circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="577.2" y="2188">Ties: 20 (59%)</text>
+<text class="legend-label" x="577.2" y="2188">Ties: 21 (60%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-21T21:46:04Z",
+      "last_reconciled_at": "2026-08-21T22:00:14Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-21T21:46:04Z",
+      "last_reconciled_at": "2026-08-21T22:00:14Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-21T21:46:06Z",
+      "last_reconciled_at": "2026-08-21T22:00:16Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-21T21:46:07Z",
+      "last_reconciled_at": "2026-08-21T22:00:18Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-21T21:46:07Z",
+      "last_reconciled_at": "2026-08-21T22:00:18Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1273,7 +1273,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-21T21:46:13Z",
+      "last_reconciled_at": "2026-08-21T22:00:23Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1388,7 +1388,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T21:46:18Z",
+      "last_reconciled_at": "2026-08-21T22:00:28Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1491,7 +1491,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T21:46:18Z",
+      "last_reconciled_at": "2026-08-21T22:00:28Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1594,7 +1594,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-21T21:46:18Z",
+      "last_reconciled_at": "2026-08-21T22:00:28Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1698,7 +1698,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1740,7 +1740,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1782,7 +1782,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -1896,7 +1896,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2010,7 +2010,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2124,7 +2124,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2238,7 +2238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2270,7 +2270,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2303,7 +2303,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2417,7 +2417,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2450,7 +2450,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2564,7 +2564,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2669,7 +2669,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2729,7 +2729,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-21T21:46:23Z",
+      "last_reconciled_at": "2026-08-21T22:00:33Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -2843,7 +2843,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2948,7 +2948,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3017,7 +3017,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3098,7 +3098,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3131,7 +3131,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3221,7 +3221,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3280,7 +3280,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3313,7 +3313,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3427,7 +3427,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3487,7 +3487,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3520,7 +3520,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -3636,7 +3636,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -3750,7 +3750,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-21T21:48:33Z",
+      "last_reconciled_at": "2026-08-21T22:00:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3780,10 +3780,10 @@
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:25Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21T00:00:00Z",
+      "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-21T21:46:30Z",
+      "last_reconciled_at": "2026-08-21T22:00:40Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3815,10 +3815,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed ctags-side structural limitation, not a GitGalaxy defect. GitGalaxy's own func_start regex (language_standards.py) deliberately matches CSS at-rule keywords (@media/@supports/@container/@layer/@keyframes/@-webkit-keyframes) as the closest function-shaped construct CSS has, since CSS has no true function-definition/call syntax. tree-sitter's CSS grammar independently corroborates this: media_statement/supports_statement/keyframes_statement are real, distinct node types, already mapped 1:1 onto GitGalaxy's own at-rule set per issue #1313 (see tree_sitter_accuracy_audit.py's css NODE_MAPS entry and its media_statement/supports_statement name-extraction branches). Re-ran gather_language('css') directly against the full 4-file corpus (not just the ledger's capped 3-example sample): GitGalaxy and tree-sitter agree exactly on function count in every file (3/3 total, zero diff files) -- the agreement generalizes completely, it is not a partial/mixed sample. ctags' own FUNCTION_KIND_MAP already documents 'css': set()  # no function-equivalent (ctags_reader.py) -- confirmed empty (ctags_funcs: []) across all 4 corpus files too. ctags structurally cannot tag CSS at-rules as anything function-like; it isn't wrong about a claim, it has no claim to make here at all. No new doc note needed -- both the GitGalaxy/tree-sitter convention (#1313) and the ctags limitation are already documented in code. GitGalaxy+tree-sitter's agreement is real corroboration, not a shared mistake, so no credit/debit adjustment applies; ctags' lack of a comparable slot here is already handled correctly by the reconciler's own total_slots mechanics."
     },
     "dart/function/args/agree[none]_vs[gitgalaxy,tree_sitter]": {
       "agreeing_tools": [],
@@ -3832,7 +3832,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T21:46:34Z",
+      "last_reconciled_at": "2026-08-21T22:00:44Z",
       "last_seen_count": 216,
       "last_seen_examples": [
         {
@@ -3935,7 +3935,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T21:46:34Z",
+      "last_reconciled_at": "2026-08-21T22:00:44Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -4038,7 +4038,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "dart",
-      "last_reconciled_at": "2026-08-21T21:46:34Z",
+      "last_reconciled_at": "2026-08-21T22:00:44Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -4142,7 +4142,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T21:46:40Z",
+      "last_reconciled_at": "2026-08-21T22:00:50Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4237,7 +4237,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T21:46:40Z",
+      "last_reconciled_at": "2026-08-21T22:00:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4269,7 +4269,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T21:46:40Z",
+      "last_reconciled_at": "2026-08-21T22:00:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4302,7 +4302,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T21:46:40Z",
+      "last_reconciled_at": "2026-08-21T22:00:50Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -4416,7 +4416,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T21:46:40Z",
+      "last_reconciled_at": "2026-08-21T22:00:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4458,7 +4458,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-21T21:46:40Z",
+      "last_reconciled_at": "2026-08-21T22:00:50Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4500,7 +4500,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-21T21:46:42Z",
+      "last_reconciled_at": "2026-08-21T22:00:53Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4614,7 +4614,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4726,7 +4726,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4831,7 +4831,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4945,7 +4945,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -5059,7 +5059,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5173,7 +5173,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5214,7 +5214,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5254,7 +5254,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-21T21:46:45Z",
+      "last_reconciled_at": "2026-08-21T22:00:56Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5368,7 +5368,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5482,7 +5482,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5596,7 +5596,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5709,7 +5709,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5742,7 +5742,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5793,7 +5793,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5907,7 +5907,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-21T21:46:48Z",
+      "last_reconciled_at": "2026-08-21T22:00:58Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5958,7 +5958,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 96,
       "last_seen_examples": [
         {
@@ -6072,7 +6072,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6159,7 +6159,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6201,7 +6201,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6315,7 +6315,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 150,
       "last_seen_examples": [
         {
@@ -6429,7 +6429,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 266,
       "last_seen_examples": [
         {
@@ -6543,7 +6543,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 182,
       "last_seen_examples": [
         {
@@ -6657,7 +6657,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-21T21:46:51Z",
+      "last_reconciled_at": "2026-08-21T22:01:01Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -6771,7 +6771,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T21:46:53Z",
+      "last_reconciled_at": "2026-08-21T22:01:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6822,7 +6822,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T21:46:53Z",
+      "last_reconciled_at": "2026-08-21T22:01:04Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6936,7 +6936,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-21T21:46:53Z",
+      "last_reconciled_at": "2026-08-21T22:01:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6968,7 +6968,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T21:46:59Z",
+      "last_reconciled_at": "2026-08-21T22:01:10Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7023,7 +7023,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T21:46:59Z",
+      "last_reconciled_at": "2026-08-21T22:01:10Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -7126,7 +7126,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-21T21:46:59Z",
+      "last_reconciled_at": "2026-08-21T22:01:10Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -7230,7 +7230,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-21T21:47:00Z",
+      "last_reconciled_at": "2026-08-21T22:01:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7261,7 +7261,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-21T21:47:02Z",
+      "last_reconciled_at": "2026-08-21T22:01:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7294,7 +7294,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T21:47:04Z",
+      "last_reconciled_at": "2026-08-21T22:01:14Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7408,7 +7408,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T21:47:04Z",
+      "last_reconciled_at": "2026-08-21T22:01:14Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7522,7 +7522,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T21:47:04Z",
+      "last_reconciled_at": "2026-08-21T22:01:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7555,7 +7555,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-21T21:47:04Z",
+      "last_reconciled_at": "2026-08-21T22:01:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7597,7 +7597,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7630,7 +7630,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7661,7 +7661,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7775,7 +7775,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7862,7 +7862,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7949,7 +7949,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7982,7 +7982,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-21T21:47:10Z",
+      "last_reconciled_at": "2026-08-21T22:01:20Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -8096,7 +8096,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T21:47:15Z",
+      "last_reconciled_at": "2026-08-21T22:01:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8129,7 +8129,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T21:47:15Z",
+      "last_reconciled_at": "2026-08-21T22:01:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8162,7 +8162,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-21T21:47:15Z",
+      "last_reconciled_at": "2026-08-21T22:01:25Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8276,7 +8276,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T21:47:17Z",
+      "last_reconciled_at": "2026-08-21T22:01:27Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8361,7 +8361,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T21:47:17Z",
+      "last_reconciled_at": "2026-08-21T22:01:27Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8430,7 +8430,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T21:47:17Z",
+      "last_reconciled_at": "2026-08-21T22:01:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8463,7 +8463,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-21T21:47:17Z",
+      "last_reconciled_at": "2026-08-21T22:01:27Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8577,7 +8577,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T21:47:27Z",
+      "last_reconciled_at": "2026-08-21T22:01:37Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8637,7 +8637,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T21:47:27Z",
+      "last_reconciled_at": "2026-08-21T22:01:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8670,7 +8670,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T21:47:27Z",
+      "last_reconciled_at": "2026-08-21T22:01:37Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -8786,7 +8786,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-21T21:47:27Z",
+      "last_reconciled_at": "2026-08-21T22:01:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8819,7 +8819,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T21:47:28Z",
+      "last_reconciled_at": "2026-08-21T22:01:38Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8861,7 +8861,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T21:47:28Z",
+      "last_reconciled_at": "2026-08-21T22:01:38Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8939,7 +8939,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T21:47:28Z",
+      "last_reconciled_at": "2026-08-21T22:01:38Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8990,7 +8990,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-21T21:47:28Z",
+      "last_reconciled_at": "2026-08-21T22:01:38Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9067,7 +9067,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -9181,7 +9181,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9234,7 +9234,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9347,7 +9347,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9398,7 +9398,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9510,7 +9510,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9623,7 +9623,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9736,7 +9736,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9769,7 +9769,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9804,7 +9804,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-21T21:47:32Z",
+      "last_reconciled_at": "2026-08-21T22:01:42Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9916,7 +9916,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-21T21:47:34Z",
+      "last_reconciled_at": "2026-08-21T22:01:44Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -10019,7 +10019,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-21T21:47:39Z",
+      "last_reconciled_at": "2026-08-21T22:01:49Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -10121,7 +10121,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-21T21:47:39Z",
+      "last_reconciled_at": "2026-08-21T22:01:49Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10225,7 +10225,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-21T21:47:40Z",
+      "last_reconciled_at": "2026-08-21T22:01:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10257,7 +10257,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-21T21:47:41Z",
+      "last_reconciled_at": "2026-08-21T22:01:51Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10327,7 +10327,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T21:47:43Z",
+      "last_reconciled_at": "2026-08-21T22:01:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10358,7 +10358,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T21:47:43Z",
+      "last_reconciled_at": "2026-08-21T22:01:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10389,7 +10389,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-21T21:47:43Z",
+      "last_reconciled_at": "2026-08-21T22:01:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10421,7 +10421,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T21:47:44Z",
+      "last_reconciled_at": "2026-08-21T22:01:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10454,7 +10454,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T21:47:44Z",
+      "last_reconciled_at": "2026-08-21T22:01:54Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10496,7 +10496,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T21:47:44Z",
+      "last_reconciled_at": "2026-08-21T22:01:54Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10556,7 +10556,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T21:47:44Z",
+      "last_reconciled_at": "2026-08-21T22:01:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10588,7 +10588,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-21T21:47:44Z",
+      "last_reconciled_at": "2026-08-21T22:01:54Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10630,7 +10630,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10672,7 +10672,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10784,7 +10784,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10843,7 +10843,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10876,7 +10876,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10981,7 +10981,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -11095,7 +11095,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -11209,7 +11209,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11251,7 +11251,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-21T21:48:05Z",
+      "last_reconciled_at": "2026-08-21T22:02:15Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11364,7 +11364,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T21:48:13Z",
+      "last_reconciled_at": "2026-08-21T22:02:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11395,7 +11395,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T21:48:13Z",
+      "last_reconciled_at": "2026-08-21T22:02:23Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11498,7 +11498,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-21T21:48:13Z",
+      "last_reconciled_at": "2026-08-21T22:02:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {


### PR DESCRIPTION
## Summary
- Validated the one open css ledger shape (`css/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`): confirmed ctags-side limitation, not a GitGalaxy defect.
- GitGalaxy's `func_start` regex and tree-sitter's CSS grammar agree exactly on treating `@media`/`@supports`/`@container`/`@layer`/`@keyframes`/`@-webkit-keyframes` at-rules as function-shaped (CSS has no true function syntax) -- this matches the already-documented #1313 convention. Re-ran `gather_language("css")` against the full 4-file corpus directly (not just the ledger's capped sample): 3/3 functions match exactly, zero diffs.
- ctags has no function-equivalent concept for CSS at all (`FUNCTION_KIND_MAP["css"] = set()`, already documented in `ctags_reader.py`), confirmed empty across all 4 corpus files.
- No credit/debit adjustment applies -- GitGalaxy+tree-sitter's agreement is real corroboration, and ctags has no comparable claim to be wrong about.
- Regenerated `tri_comparison_chart.svg` (`--all --write`); css now shows a resolved badge.

## Test plan
- [x] `python tests/ruff_audit.py --ci` -- clean (78-finding baseline, no new)
- [x] `python tests/mypy_audit.py --ci` -- clean (2-error baseline, no new)
- [x] Confirmed ledger diff is scoped to the css entry plus expected `last_reconciled_at` timestamp churn from the regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)