### PR TITLE
Validate all 8 javascript tri-comparison ledger shapes, fix 2 tool bugs

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -482,39 +482,41 @@
 <text class="lang-label" x="20" y="1023.5">javascript</text>
 <rect class="bar-track" x="154" y="1003" width="88" height="34" rx="2"/>
 <rect x="154" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1011">793*</text>
-<rect x="154" y="1015" width="78.1" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1023">704*</text>
-<rect x="154" y="1027" width="54.9" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1035">495*</text>
+<text class="bar-value-label" x="198.0" y="1011">793</text>
+<rect x="154" y="1015" width="66.5" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1023">599</text>
+<rect x="154" y="1027" width="39.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1035">353</text>
 <rect class="bar-track" x="286" y="1003" width="88" height="34" rx="2"/>
-<rect x="286" y="1003" width="67.8" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1011">611/793*</text>
-<rect x="286" y="1015" width="75.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1023">600/704*</text>
-<rect x="286" y="1027" width="61.3" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1035">345/495*</text>
+<rect x="286" y="1003" width="67.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1011">610/793</text>
+<rect x="286" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1023">599/599</text>
+<rect x="286" y="1027" width="86.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1035">345/353</text>
+<circle cx="390.0" cy="1020.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="1023.0">T</text>
 <rect class="bar-track" x="418" y="1003" width="88" height="34" rx="2"/>
-<rect x="418" y="1003" width="20.4" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1011">29*</text>
-<rect x="418" y="1015" width="20.4" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1023">29*</text>
+<rect x="418" y="1003" width="20.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1011">29</text>
+<rect x="418" y="1015" width="20.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1023">29</text>
 <rect x="418" y="1027" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1035">125*</text>
+<text class="bar-value-label" x="462.0" y="1035">122</text>
 <rect class="bar-track" x="550" y="1003" width="88" height="34" rx="2"/>
 <rect x="550" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1011">29/29*</text>
+<text class="bar-value-label" x="594.0" y="1011">29/29</text>
 <rect x="550" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1023">29/29*</text>
-<rect x="550" y="1027" width="20.4" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1035">29/125*</text>
+<text class="bar-value-label" x="594.0" y="1023">29/29</text>
+<rect x="550" y="1027" width="20.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1035">29/122</text>
 <rect class="bar-track" x="682" y="1003" width="88" height="34" rx="2"/>
 <rect x="682" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1011">334*</text>
+<text class="bar-value-label" x="726.0" y="1011">334</text>
 <rect x="682" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1023">334*</text>
+<text class="bar-value-label" x="726.0" y="1023">334</text>
 <rect x="682" y="1027" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="726.0" y="1035">334*</text>
+<text class="bar-value-label" x="726.0" y="1035">334</text>
 <rect class="stripe" x="16" y="1042" width="780" height="44"/>
 <text class="lang-label" x="20" y="1067.5">jcl</text>
 <rect class="bar-track" x="154" y="1047" width="88" height="34" rx="2"/>
@@ -1093,17 +1095,17 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 39 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 41 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (41%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (39%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
-<text class="legend-label" x="228.8" y="2188">tree-sitter best: 0 (0%)</text>
+<text class="legend-label" x="228.8" y="2188">tree-sitter best: 1 (2%)</text>
 <circle cx="408.6" cy="2184" r="7" fill="#1baf7a"/>
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
 <circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="577.2" y="2188">Ties: 23 (59%)</text>
+<text class="legend-label" x="577.2" y="2188">Ties: 24 (59%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T01:16:10Z",
+      "last_reconciled_at": "2026-08-22T01:53:56Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T01:16:10Z",
+      "last_reconciled_at": "2026-08-22T01:53:56Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-22T01:16:11Z",
+      "last_reconciled_at": "2026-08-22T01:53:57Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T01:16:13Z",
+      "last_reconciled_at": "2026-08-22T01:53:58Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T01:16:13Z",
+      "last_reconciled_at": "2026-08-22T01:53:58Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1273,7 +1273,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:16:18Z",
+      "last_reconciled_at": "2026-08-22T01:54:04Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1388,7 +1388,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T01:16:23Z",
+      "last_reconciled_at": "2026-08-22T01:54:09Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1491,7 +1491,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T01:16:23Z",
+      "last_reconciled_at": "2026-08-22T01:54:09Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1594,7 +1594,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T01:16:23Z",
+      "last_reconciled_at": "2026-08-22T01:54:09Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1698,7 +1698,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1740,7 +1740,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1782,7 +1782,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -1896,7 +1896,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2010,7 +2010,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2124,7 +2124,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2238,7 +2238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2270,7 +2270,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2303,7 +2303,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2417,7 +2417,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2450,7 +2450,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2564,7 +2564,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2669,7 +2669,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2729,7 +2729,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:16:28Z",
+      "last_reconciled_at": "2026-08-22T01:54:13Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -2843,7 +2843,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2948,7 +2948,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3017,7 +3017,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3098,7 +3098,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3131,7 +3131,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3221,7 +3221,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3280,7 +3280,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3313,7 +3313,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3427,7 +3427,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3487,7 +3487,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3520,7 +3520,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -3636,7 +3636,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -3750,7 +3750,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:16:34Z",
+      "last_reconciled_at": "2026-08-22T01:54:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3783,7 +3783,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-22T01:16:35Z",
+      "last_reconciled_at": "2026-08-22T01:54:21Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3832,7 +3832,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T01:16:39Z",
+      "last_reconciled_at": "2026-08-22T01:54:25Z",
       "last_seen_count": 218,
       "last_seen_examples": [
         {
@@ -3935,7 +3935,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T01:16:39Z",
+      "last_reconciled_at": "2026-08-22T01:54:25Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4030,7 +4030,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T01:16:39Z",
+      "last_reconciled_at": "2026-08-22T01:54:25Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4134,7 +4134,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:16:45Z",
+      "last_reconciled_at": "2026-08-22T01:54:31Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4229,7 +4229,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:16:45Z",
+      "last_reconciled_at": "2026-08-22T01:54:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4261,7 +4261,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:16:45Z",
+      "last_reconciled_at": "2026-08-22T01:54:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4294,7 +4294,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:16:45Z",
+      "last_reconciled_at": "2026-08-22T01:54:31Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -4408,7 +4408,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:16:45Z",
+      "last_reconciled_at": "2026-08-22T01:54:31Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4452,7 +4452,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:16:45Z",
+      "last_reconciled_at": "2026-08-22T01:54:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4485,7 +4485,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-22T01:16:48Z",
+      "last_reconciled_at": "2026-08-22T01:54:34Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4599,7 +4599,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4711,7 +4711,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4816,7 +4816,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4930,7 +4930,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -5044,7 +5044,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5160,7 +5160,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5192,7 +5192,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5232,7 +5232,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:16:50Z",
+      "last_reconciled_at": "2026-08-22T01:54:36Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5346,7 +5346,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5460,7 +5460,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5574,7 +5574,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5687,7 +5687,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5720,7 +5720,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5771,7 +5771,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5885,7 +5885,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:18:29Z",
+      "last_reconciled_at": "2026-08-22T01:54:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5933,11 +5933,11 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
-      "last_seen_count": 96,
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_seen_count": 93,
       "last_seen_examples": [
         {
           "file_path": "jquery/ajax.js",
@@ -6031,10 +6031,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "class",
-      "verdict": null
+      "verdict": "Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner tags its 'class' kind on ANY bare object-literal assignment (`var X = {...}`) or function-expression assignment (`var X = function(){}`, `obj.prop = function(){}`), a blanket heuristic for 'might be used as a pre-ES6 constructor' that fires regardless of whether `new` is ever used on it. Confirmed via a minimal isolated repro (plainObj/ctorLike/obj.Thing all tagged 'class' alongside a real ES6 class) and directly against the corpus: jqXHR (jquery/ajax.js, a plain config object), cssHooks/cssNormalTransform/cssShow (jquery/css.js), promise (jquery/deferred.js), Event/event/special (jquery/event.js, one of which -- Event -- IS a pre-ES6 constructor-style function, correctly ambiguous under ctags' heuristic but still not a real ES6 class), and the ALPHA_MODES/WEBGL_CONSTANTS/etc. config objects in threejs/GLTFLoader.js. GitGalaxy's class_start regex and tree-sitter's class_declaration node both correctly require the literal `class` keyword. Doc note added to ctags_reader.py's javascript CTAGS_CLASS_KINDS entry."
     },
     "javascript/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
       "agreeing_tools": [
@@ -6047,10 +6047,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6118,10 +6118,10 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed tree-sitter-alone argument-count corruption, a third facet of the same Flow-parsing family. Even where tree-sitter DOES still produce a real function_declaration node (outside any ERROR-swallowed region), a Flow parameter type with a union (`current: Fiber | null`) corrupts that node's own formal_parameters child list. Confirmed directly via react/ReactFiberBeginWork.js:405 `updateForwardRef(current: Fiber | null, workInProgress: Fiber, Component: any, nextProps: any, renderLanes: Lanes)` -- 5 real parameters (GitGalaxy=5, ctags=5, both correct) but tree-sitter's own formal_parameters node contains a single ERROR child swallowing 'current: Fiber | null,\\n  workInProgress:' whole (merging two real parameters into one unstructured blob), followed by a bare identifier node reading 'Fiber' -- the type name of the swallowed second parameter, left behind by the same ERROR recovery and miscounted as if it were itself a parameter. Net effect: 4 instead of 5, an off-by-one undercount rather than total loss. Documented in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension as the 'third facet.'"
     },
     "javascript/function/args/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -6134,10 +6134,10 @@
         "ctags"
       ],
       "first_seen_at": "2026-08-19T23:29:07Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6160,10 +6160,10 @@
         }
       ],
       "metric": "args",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed comparison-methodology artifact (name-based reconciliation colliding on a reused property name), not a real defect in any of the three tools. jquery/event.js defines TWO separate object-literal properties both named 'setup' (line 441, taking 1 param `function(data)`) and 'trigger' (line 458, 1 param) inside one plugin-hook object, and a SECOND, unrelated pair of 'setup'/'trigger' properties (lines 759/774, taking 0 params) inside a different object later in the same file. This module's/the ledger's reconciliation pairs occurrences by NAME across the whole file, with no scope/position disambiguation, so a same-name collision between two genuinely different functions can produce a spurious per-name args mismatch depending on which occurrence each tool's internal ordering happens to surface first. Both readings (1 param and 0 params) are independently real and correct for their respective definition sites -- there is no actual counting defect here, just a reconciliation limitation inherent to comparing by name only. No credit/debit; no code fix warranted for 2 occurrences arising from a rare same-name collision."
     },
     "javascript/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]": {
       "agreeing_tools": [
@@ -6176,10 +6176,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6274,10 +6274,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed tree-sitter-alone recall gap, same Flow-cascade family as agree[gitgalaxy]_vs[ctags,tree_sitter] above but from the other side: for these specific names (updateContextProvider, reconcileChildren, updateScopeComponent, markWorkInProgressReceivedUpdate, shouldForceFlushFallbacksInDEV, patchConsole, abortIterable, abortStream, error, throwTaintViolation), ctags' own Flow-return-type cascade trigger point happens to sit AFTER these functions (or never fires in that file), so ctags finds them correctly and agrees with GitGalaxy at the exact same line number, while tree-sitter's independent (earlier-triggering, different-construct) ERROR cascade has already swallowed them. Because the two tools' cascades trigger on different Flow constructs starting at different lines, they lose different, non-identical sets of functions -- this is why the ledger shows several distinct 3-way shapes instead of one clean 'both non-GitGalaxy tools agree on what they missed' shape. Documented alongside the fuller write-up in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension."
     },
     "javascript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
       "agreeing_tools": [
@@ -6290,93 +6290,12 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
-      "last_seen_count": 150,
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_seen_count": 8,
       "last_seen_examples": [
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860100",
-          "readings": {
-            "ctags": 55,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860200",
-          "readings": {
-            "ctags": 94,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860300",
-          "readings": {
-            "ctags": 369,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860400",
-          "readings": {
-            "ctags": 383,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860500",
-          "readings": {
-            "ctags": 694,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860600",
-          "readings": {
-            "ctags": 848,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860700",
-          "readings": {
-            "ctags": 852,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860800",
-          "readings": {
-            "ctags": 857,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
-        {
-          "file_path": "jquery/ajax.js",
-          "name": "AnonymousFunctionc3e813860900",
-          "readings": {
-            "ctags": 879,
-            "gitgalaxy": null,
-            "tree_sitter": null
-          }
-        },
         {
           "file_path": "jquery/ajax.js",
           "name": "converters",
@@ -6385,13 +6304,76 @@
             "gitgalaxy": null,
             "tree_sitter": null
           }
+        },
+        {
+          "file_path": "jquery/ajax.js",
+          "name": "jQuery",
+          "readings": {
+            "ctags": 858,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "jquery/deferred.js",
+          "name": "deferred",
+          "readings": {
+            "ctags": 319,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "react/ReactFlightServer.js",
+          "name": "[ASYNC_ITERATOR]",
+          "readings": {
+            "ctags": 1616,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "react/ReactFlightServer.js",
+          "name": "[Symbol.iterator]",
+          "readings": {
+            "ctags": 1576,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "threejs/GLTFLoader.js",
+          "name": "copy",
+          "readings": {
+            "ctags": 3457,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "threejs/GLTFLoader.js",
+          "name": "copy",
+          "readings": {
+            "ctags": 3477,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
+        },
+        {
+          "file_path": "threejs/GLTFLoader.js",
+          "name": "createInterpolant",
+          "readings": {
+            "ctags": 4643,
+            "gitgalaxy": null,
+            "tree_sitter": null
+          }
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed ctags-side synthetic-placeholder artifact, not a real discrepancy -- ctags' JavaScript scanner emits a synthetic 'AnonymousFunction<hex><seq>' tag for every genuinely anonymous function expression (a bare inline callback with no attributable name, e.g. `jQuery.ajaxPrefilter(function(s) {...})`), and GitGalaxy/tree-sitter both correctly agree these aren't named functions worth counting. Fixed by extending `tri_comparison_gatherer.py`'s existing `_is_ctags_synthetic_anon_name` (previously only matched the C-parser's `__anon<hex>` scheme) with a second regex for JavaScript's differently-shaped 'AnonymousFunction'/'AnonymousClass' scheme -- verified this removes every 'Anonymous*' entry across the full 18-file corpus with zero regressions (ruff/mypy audits clean)."
     },
     "javascript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -6404,11 +6386,11 @@
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
-      "last_seen_count": 266,
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_seen_count": 265,
       "last_seen_examples": [
         {
           "file_path": "jquery/ajax.js",
@@ -6502,10 +6484,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner loses the real property-key name for a function-valued object-literal property specifically when that literal is a CALL ARGUMENT rather than a direct assignment -- confirmed via jquery/ajax.js's `jQuery.extend(jQuery, {ajaxSetup: function(target, settings){...}, ajax: function(url, options){...}})`: ctags emits a synthetic 'AnonymousFunction<hex>' tag for both instead of using the real 'ajaxSetup'/'ajax' key text, while GitGalaxy and tree-sitter both correctly attribute the property key as the name. Generalizes across the whole corpus, not a one-file fluke -- the identical shape recurs in jquery/css.js (css/get/set/style), jquery/deferred.js (Deferred/catch/pipe/promise/then/when), jquery/event.js (Event/handler/off/one/postDispatch/set), jquery/core.js (20+ utility methods, reducing ctags' whole-file function count from 26 to 1), and threejs's Editor.js/GLTFLoader.js/WebGLRenderer.js/WebGLProgram.js. Doc note added to ctags_reader.py's javascript CTAGS_FUNC_KINDS entry."
     },
     "javascript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]": {
       "agreeing_tools": [
@@ -6518,11 +6500,11 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
-      "last_seen_count": 182,
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_seen_count": 183,
       "last_seen_examples": [
         {
           "file_path": "react/ReactFiberBeginWork.js",
@@ -6616,10 +6598,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed GitGalaxy correct; both ctags and tree-sitter structurally can't, for two INDEPENDENT reasons. All four affected react/*.js corpus files carry the `@flow` pragma. tree-sitter-javascript's grammar can't parse Flow's parenthesized type-cast syntax (`(expr: Type)`, e.g. `(workInProgress.child: any)`), producing an ERROR node that swallows a large trailing region of the file -- confirmed directly: ReactFiberBeginWork.js's ERROR spans lines 3221-4448 (1227 of 4448 lines), and ReactFiberWorkLoop.js/ReactFlightServer.js each produce ONE error node spanning the ENTIRE file (line 1 to EOF). Real, ordinary functions inside these regions (beginWork, attemptEarlyBailoutIfNoScheduledUpdate, mountLazyComponent, and 18 others sampled) have no tree-sitter node at all. Separately, ctags' own hand-written JS scanner hits an independent cascade triggered by a Flow RETURN-type annotation (`): Fiber | null {`) -- confirmed via a minimal isolated repro (a 4-function test file where the function with a Flow return-type annotation and everything textually after it produce zero ctags output), and confirmed against the real corpus (beginWork itself, which has exactly this return-type shape, produces zero ctags tags). GitGalaxy's regex has no dependency on either tool's parse state and finds every one of these correctly. Documented in docs/why_gitgalaxy_beats_ast_here.md (Claim 3, new subsection completing/extending the existing 'Second instance: javascript' write-up with the recall-loss half plus the newly-confirmed ctags cascade)."
     },
     "javascript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]": {
       "agreeing_tools": [
@@ -6632,108 +6614,27 @@
         "gitgalaxy"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-21",
+      "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:16:56Z",
-      "last_seen_count": 104,
+      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_seen_count": 1,
       "last_seen_examples": [
         {
           "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
+          "name": "markSkippedUpdateLanes",
           "readings": {
             "ctags": null,
             "gitgalaxy": null,
-            "tree_sitter": 346
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3243
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3305
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3668
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3770
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3775
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3811
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 3980
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 4077
-          }
-        },
-        {
-          "file_path": "react/ReactFiberBeginWork.js",
-          "name": "if",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": null,
-            "tree_sitter": 4150
+            "tree_sitter": 3780
           }
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
+      "status": "validated",
+      "still_reproduces": false,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed tri_comparison_gatherer.py measurement-tool bug (own tool, not GitGalaxy/ctags/tree-sitter-the-grammar), now fixed. This is the exact #1633/Claim-3 hallucination mechanism already fixed in tree_sitter_accuracy_audit.py's walk() -- but tri_comparison_gatherer.py's own, deliberately simpler `_walk_tree_sitter` had never been given the equivalent reserved-keyword/known-hallucination filter, so every phantom method_definition node from javascript's Flow-cascade error recovery (control-flow keywords like 'if'/'for'/'let', plus known hallucinated names) was still polluting the tri-comparison ledger's own readings. The one sampled occurrence here ('markSkippedUpdateLanes' at ReactFiberBeginWork.js:3780) is a plain call expression (invoking an imported function) hallucinated into a method_definition node -- confirmed directly via a fresh parse (node.type == 'method_definition' at that exact line). Fixed by porting tsaa._JS_RESERVED_STATEMENT_KEYWORDS/tsaa._JS_KNOWN_FLOW_HALLUCINATIONS directly into the filter (reusing the single source of truth, not duplicating), plus adding 'markSkippedUpdateLanes' itself to tsaa._JS_KNOWN_FLOW_HALLUCINATIONS so both tools benefit. Verified: this exact name no longer appears in a fresh gather_language('javascript') diff; ruff/mypy clean."
     },
     "kotlin/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
       "agreeing_tools": [
@@ -6749,7 +6650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T01:16:58Z",
+      "last_reconciled_at": "2026-08-22T01:54:45Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6800,7 +6701,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T01:16:58Z",
+      "last_reconciled_at": "2026-08-22T01:54:45Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6914,7 +6815,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T01:16:58Z",
+      "last_reconciled_at": "2026-08-22T01:54:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6946,7 +6847,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T01:17:05Z",
+      "last_reconciled_at": "2026-08-22T01:54:51Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -7001,7 +6902,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T01:17:05Z",
+      "last_reconciled_at": "2026-08-22T01:54:51Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -7104,7 +7005,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T01:17:05Z",
+      "last_reconciled_at": "2026-08-22T01:54:51Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -7208,7 +7109,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-22T01:17:06Z",
+      "last_reconciled_at": "2026-08-22T01:54:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7239,7 +7140,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-22T01:17:08Z",
+      "last_reconciled_at": "2026-08-22T01:54:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7272,7 +7173,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:17:09Z",
+      "last_reconciled_at": "2026-08-22T01:54:55Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7386,7 +7287,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:17:09Z",
+      "last_reconciled_at": "2026-08-22T01:54:55Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7500,7 +7401,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:17:09Z",
+      "last_reconciled_at": "2026-08-22T01:54:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7533,7 +7434,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:17:09Z",
+      "last_reconciled_at": "2026-08-22T01:54:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7575,7 +7476,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7608,7 +7509,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7639,7 +7540,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7753,7 +7654,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7840,7 +7741,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7927,7 +7828,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7960,7 +7861,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:17:15Z",
+      "last_reconciled_at": "2026-08-22T01:55:01Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -8074,7 +7975,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T01:17:20Z",
+      "last_reconciled_at": "2026-08-22T01:55:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8107,7 +8008,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T01:17:20Z",
+      "last_reconciled_at": "2026-08-22T01:55:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8140,7 +8041,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T01:17:20Z",
+      "last_reconciled_at": "2026-08-22T01:55:06Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8254,7 +8155,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:17:22Z",
+      "last_reconciled_at": "2026-08-22T01:55:08Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8339,7 +8240,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:17:22Z",
+      "last_reconciled_at": "2026-08-22T01:55:08Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8408,7 +8309,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:17:22Z",
+      "last_reconciled_at": "2026-08-22T01:55:08Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8441,7 +8342,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:17:22Z",
+      "last_reconciled_at": "2026-08-22T01:55:08Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8555,7 +8456,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:17:31Z",
+      "last_reconciled_at": "2026-08-22T01:55:18Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8615,7 +8516,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:17:31Z",
+      "last_reconciled_at": "2026-08-22T01:55:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8648,7 +8549,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:17:31Z",
+      "last_reconciled_at": "2026-08-22T01:55:18Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -8764,7 +8665,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:17:31Z",
+      "last_reconciled_at": "2026-08-22T01:55:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8797,7 +8698,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:17:33Z",
+      "last_reconciled_at": "2026-08-22T01:55:19Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8839,7 +8740,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:17:33Z",
+      "last_reconciled_at": "2026-08-22T01:55:19Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8917,7 +8818,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:17:33Z",
+      "last_reconciled_at": "2026-08-22T01:55:19Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8968,7 +8869,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:17:33Z",
+      "last_reconciled_at": "2026-08-22T01:55:19Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -9045,7 +8946,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -9159,7 +9060,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9212,7 +9113,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9325,7 +9226,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9376,7 +9277,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9488,7 +9389,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9601,7 +9502,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9714,7 +9615,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9747,7 +9648,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9782,7 +9683,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:17:37Z",
+      "last_reconciled_at": "2026-08-22T01:55:23Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9894,7 +9795,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-22T01:17:39Z",
+      "last_reconciled_at": "2026-08-22T01:55:25Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9997,7 +9898,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T01:17:43Z",
+      "last_reconciled_at": "2026-08-22T01:55:29Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -10099,7 +10000,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T01:17:43Z",
+      "last_reconciled_at": "2026-08-22T01:55:29Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10203,7 +10104,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-22T01:17:45Z",
+      "last_reconciled_at": "2026-08-22T01:55:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10235,7 +10136,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-22T01:17:46Z",
+      "last_reconciled_at": "2026-08-22T01:55:32Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10305,7 +10206,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T01:17:47Z",
+      "last_reconciled_at": "2026-08-22T01:55:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10336,7 +10237,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T01:17:47Z",
+      "last_reconciled_at": "2026-08-22T01:55:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10367,7 +10268,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T01:17:47Z",
+      "last_reconciled_at": "2026-08-22T01:55:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10399,7 +10300,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:17:49Z",
+      "last_reconciled_at": "2026-08-22T01:55:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10432,7 +10333,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:17:49Z",
+      "last_reconciled_at": "2026-08-22T01:55:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10474,7 +10375,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:17:49Z",
+      "last_reconciled_at": "2026-08-22T01:55:35Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10534,7 +10435,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:17:49Z",
+      "last_reconciled_at": "2026-08-22T01:55:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10566,7 +10467,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:17:49Z",
+      "last_reconciled_at": "2026-08-22T01:55:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10608,7 +10509,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10650,7 +10551,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10762,7 +10663,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10821,7 +10722,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10854,7 +10755,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10959,7 +10860,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -11073,7 +10974,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -11187,7 +11088,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11229,7 +11130,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:18:10Z",
+      "last_reconciled_at": "2026-08-22T01:55:56Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11342,7 +11243,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T01:18:18Z",
+      "last_reconciled_at": "2026-08-22T01:56:05Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11373,7 +11274,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T01:18:18Z",
+      "last_reconciled_at": "2026-08-22T01:56:05Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11476,7 +11377,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T01:18:18Z",
+      "last_reconciled_at": "2026-08-22T01:56:05Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/why_gitgalaxy_beats_ast_here.md
+++ b/docs/why_gitgalaxy_beats_ast_here.md
@@ -304,6 +304,86 @@ Fixed in `tests/tools/tree_sitter_accuracy_audit.py`'s `measure()` (`walk()` clo
 GitGalaxy's engine — this is purely a measurement-tool correction; GitGalaxy's own detected
 function set for this corpus is byte-for-byte identical before and after.
 
+### The other half of the javascript instance: real functions genuinely lost, and a second, independent tool hitting the same wall (2026-08-21, tri-comparison-ledger-sweep)
+
+The "Second instance" above fixes the *hallucination* half of `#1633` (garbage phantom names
+inflating the miss count); this is the *recall* half the earlier text gestured at without ever
+pinning down — real, ordinary named functions that tree-sitter's cascade genuinely loses, not
+phantom entries to filter. Confirmed directly across all four Flow-typed react corpus files
+(`react/ReactFiberBeginWork.js`, `ReactFiberWorkLoop.js`, `ReactFlightServer.js`, all carrying the
+`@flow` pragma): `tree.root_node.has_error` is `True` for every one, and two of the four
+(`ReactFiberWorkLoop.js`, `ReactFlightServer.js`) produce a single `ERROR` node spanning the
+*entire file*, line 1 to EOF — not a partial cascade, total. `ReactFiberBeginWork.js`'s own cascade
+spans lines 3221–4448 (1,227 of 4,448 lines) and swallows ordinary, unremarkable functions like
+`beginWork` (line 4164), `attemptEarlyBailoutIfNoScheduledUpdate`, `mountLazyComponent`, and
+eighteen others sampled directly from the ledger (`javascript/function/existence/
+agree[gitgalaxy]_vs[ctags,tree_sitter]`, 182 occurrences) — GitGalaxy's regex finds every one
+correctly; tree-sitter's tree has no node for them at all, not even a mangled one, because they
+sit inside the flattened `ERROR` region.
+
+**A second, independent tool hits an equivalent wall for a different reason.** ctags is not a
+tree-sitter grammar — it's Universal Ctags' own hand-written JavaScript scanner — so there was no
+a priori reason to expect it shares tree-sitter's blind spot. It does, via a different trigger.
+Isolated with a minimal standalone reproduction (not just observed in the large corpus file):
+```javascript
+function typedParam(a: Fiber | null, b: Fiber) {   // parses fine -- ctags tags "typedParam"
+  return a;
+}
+function retType(a): Fiber | null {                 // ctags tags NOTHING from here on
+  return a;
+}
+function afterCast() { ... }                        // permanently invisible to ctags too
+```
+A Flow parameter-type annotation alone (`a: Fiber | null`) doesn't trip ctags' scanner; a Flow
+*return-type* annotation after the closing paren (`): Fiber | null {`) does, and — same "one bad
+construct corrupts recovery for the rest of the file" shape as csharp's Claim 3 mechanism — ctags
+never resynchronizes afterward: `retType` itself and every function textually after it in the test
+file are silently dropped, no placeholder, no partial tag, nothing. This is confirmed as the real,
+generalizing cause (not a one-off) against the corpus itself: `react/ReactFiberBeginWork.js:4164`'s
+`beginWork` — an ordinary `function beginWork(current: Fiber | null, workInProgress: Fiber,
+renderLanes: Lanes): Fiber | null {` with exactly this return-type shape — produces zero ctags
+output of any kind, matching the isolated repro exactly.
+
+Because the two tools' cascades trigger on *different* Flow constructs (tree-sitter: a
+parenthesized type-cast expression, `(expr: Type)`; ctags: a function's own return-type
+annotation) and start at different lines, they don't lose the *same* set of functions — some names
+are recoverable from ctags but not tree-sitter and vice versa, which is why the ledger shows this
+as several distinct shapes (`agree[gitgalaxy]_vs[ctags,tree_sitter]`,
+`agree[ctags,gitgalaxy]_vs[tree_sitter]`) rather than one clean "ctags and tree-sitter agree on what
+they both missed" shape. The unifying fact across all of them: GitGalaxy's regex has no dependency
+on either tool's parse state and is never affected by where either cascade starts.
+
+**A third facet of the same root cause: correct functions, wrong argument counts.** Even where
+tree-sitter's grammar *does* still produce a real `function_declaration` node for a Flow-annotated
+function (i.e., outside any `ERROR`-swallowed region), a Flow parameter type with a union
+(`current: Fiber | null`) can corrupt that one node's own `formal_parameters` child list. Confirmed
+directly via `react/ReactFiberBeginWork.js:405`'s `updateForwardRef(current: Fiber | null,
+workInProgress: Fiber, Component: any, nextProps: any, renderLanes: Lanes)` (5 real parameters,
+confirmed by both GitGalaxy and ctags, `javascript/function/args/
+agree[ctags,gitgalaxy]_vs[tree_sitter]`): tree-sitter's `formal_parameters` node for this
+declaration contains a single `ERROR` child that swallows `current: Fiber | null,\n  workInProgress:`
+whole (merging what should be two separate parameters into one unstructured blob), followed by a
+bare `identifier` node reading `Fiber` — the *type name* of the second parameter, left behind by
+the same `ERROR` recovery and miscounted as if it were itself a third parameter. The two real
+losses and one bogus gain net out to an off-by-one undercount (4 instead of 5), not a total loss —
+a quieter, easier-to-miss failure mode than the existence-side cascades above, since the function
+is still "found," just measured with the wrong shape internally.
+
+**Fixed where this module's own walker (not `tree_sitter_accuracy_audit.py`) inherited the gap:**
+`tests/tools/tri_comparison_gatherer.py`'s `_walk_tree_sitter` is a deliberately simpler, separate
+walk from `tree_sitter_accuracy_audit.py`'s `measure()` (see that function's own docstring) — it
+had never been given the reserved-keyword/known-hallucination `method_definition` filter the
+"Second instance" fix above already proved necessary, so every hallucinated phantom name
+(`if`/`for`/`markSkippedUpdateLanes`/etc.) was still polluting the tri-comparison ledger's own
+javascript readings even after that fix landed in the accuracy-audit tool. Ported directly (reusing
+`tsaa._JS_RESERVED_STATEMENT_KEYWORDS`/`tsaa._JS_KNOWN_FLOW_HALLUCINATIONS` rather than a second
+copy) plus one new confirmed hallucination name (`markSkippedUpdateLanes`, a call-expression
+callee misparsed as a `method_definition`, added to `tsaa._JS_KNOWN_FLOW_HALLUCINATIONS` so both
+tools benefit). The recall losses documented above (real functions/correct-arg-counts tree-sitter
+and ctags can't produce at all) are the underlying grammar/scanner limitation itself, not a
+measurement-tool bug, and aren't "fixed" by anything in this repo — they're the evidence this
+section exists to record.
+
 ## A third confirmed instance: C, local single-function recovery (2026-08-19)
 
 A narrower version of this same mechanism, found via the tri-comparison ledger

--- a/tests/tools/ctags_reader.py
+++ b/tests/tools/ctags_reader.py
@@ -316,7 +316,23 @@ CTAGS_FUNC_KINDS: dict[str, set[str]] = {
     "haskell": {"f"},
     "html": set(),
     "java": {"m"},
-    "javascript": {"f", "m"},  # functions + methods
+    "javascript": {"f", "m"},  # functions + methods -- but see two confirmed parser-level gaps
+    # (found via tri-comparison-ledger-sweep, 2026-08-21, jquery/react corpus), neither fixable by
+    # adjusting this kind set: (1) a function-valued object-literal property loses its real
+    # property-key name and falls back to a synthetic "AnonymousFunction<hex>" tag (filtered by
+    # `_is_ctags_synthetic_anon_name` in tri_comparison_gatherer.py) specifically when that literal
+    # is a CALL ARGUMENT rather than a direct assignment -- confirmed via jquery/ajax.js's
+    # `jQuery.extend(jQuery, {ajaxSetup: function(){...}, ajax: function(){...}})`: ctags' own
+    # scope-tracking loses the `ajaxSetup`/`ajax` key names entirely inside the call, while the
+    # exact same `key: function(){}` shape assigned directly (`X.prototype = {abort: function(){}}`
+    # style) tags correctly as a "method". jquery/core.js is the extreme case -- one single
+    # `jQuery.extend(jQuery, {...})` call holding 20+ real utility methods (`each`, `extend`,
+    # `grep`, ...) reduces ctags' whole-file function count to 1. (2) Flow-typed javascript (react's
+    # `@flow` source) can trip ctags' own return-type-annotation handling (`): Type {|`) and
+    # silently drop every function textually after the trigger for the rest of the file, no
+    # placeholder emitted at all -- see docs/why_gitgalaxy_beats_ast_here.md's Claim 3 for the full
+    # writeup and a minimal repro; this is ctags' own scanner hitting an equivalent, independently-
+    # triggered version of the same cascade tree-sitter-javascript already hits there.
     # kotlin: ctags has no separate free-function kind -- top-level functions tag "m" too
     # (verified via probe file: a file-scope `fun` with no enclosing class still tags "m",
     # just without a `class:` field), so "m" alone already covers both cases.
@@ -391,7 +407,18 @@ CTAGS_CLASS_KINDS: dict[str, set[str]] = {
     "haskell": set(),  # no class-shaped kind in ctags' Haskell parser at all
     "html": set(),
     "java": {"c", "i", "g"},  # class, interface, enum
-    "javascript": {"c"},
+    "javascript": {"c"},  # real `class Foo {}` -- but ctags' JS parser also tags this SAME "c"
+    # kind on any bare object-literal assignment (`var X = {...}`) or function-expression
+    # assignment (`var X = function(){}`, `obj.prop = function(){}`), a blanket heuristic for
+    # "might be used as a pre-ES6 constructor" that fires whether or not the value is ever
+    # actually invoked with `new` (found via tri-comparison-ledger-sweep,
+    # javascript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter], 96 occurrences,
+    # 2026-08-21 -- confirmed both on the jquery/threejs corpus, e.g. jquery/css.js's plain config
+    # object `cssHooks`/`cssShow`, and via a minimal isolated repro). GitGalaxy's own class_start
+    # regex and tree-sitter's `class_declaration` node both correctly require the literal `class`
+    # keyword, so every one of these is a real ctags-side over-count, not a GitGalaxy gap -- no
+    # kind-set change fixes it since ctags gives no separate kind for "object literal" vs.
+    # "class-shaped assignment" in the first place.
     "kotlin": {"c", "i"},  # class, interface
     "lua": set(),
     "makefile": set(),

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -1666,6 +1666,15 @@ _JS_KNOWN_FLOW_HALLUCINATIONS = frozenset(
         "let",
         "logRenderPhase",
         "logStartViewTransitionYieldPhase",
+        # #1633 recurrence, found via tri-comparison-ledger-sweep on javascript (2026-08-21,
+        # `agree[tree_sitter]_vs[ctags,gitgalaxy]`, ReactFiberBeginWork.js:3780): a plain call
+        # expression (`markSkippedUpdateLanes(workInProgress.lanes);`, invoking an imported
+        # function, not defining one) inside the same ERROR-cascade region hallucinates into a
+        # `method_definition` node whose "name" resolves to the callee identifier -- confirmed
+        # directly (node.type == "method_definition" at that exact line). Same mechanism as the
+        # other entries here, just a call-expression shape instead of a reserved keyword or
+        # object property.
+        "markSkippedUpdateLanes",
         "markNestedUpdateScheduled",
         "onCommitRootTestSelector",
         "recordCommitTime",

--- a/tests/tools/tri_comparison_gatherer.py
+++ b/tests/tools/tri_comparison_gatherer.py
@@ -181,6 +181,22 @@ def _walk_tree_sitter(root, func_node_types: set[str], class_node_types: set[str
     C++ multiple inheritance (`class Foo : public A, public B {`) makes the production engine's
     generic comma/paren/equals lookahead unsafe to reuse as-is for cpp without further design work;
     this walker instead uses the grammar's own `body` field, which has no such ambiguity).
+
+    A third piece is ported for the identical reason (found via the tri-comparison-ledger-sweep on
+    javascript, 2026-08-21 -- the `javascript/function/existence/*` shapes involving `tree_sitter`
+    on the react corpus, e.g. `agree[gitgalaxy]_vs[ctags,tree_sitter]`/
+    `agree[tree_sitter]_vs[ctags,gitgalaxy]`): this is the exact same `#1633`/Claim 3 mechanism
+    already fixed in `tree_sitter_accuracy_audit.py`'s own walk() -- Flow-typed react source
+    (`@flow` pragma, `(expr: Type)` casts, `import {x, type Y}` specifiers) produces grammar
+    `ERROR` nodes tree-sitter-javascript can't parse around, and recovery hallucinates plain
+    control-flow keywords (`if`/`for`/`while`/...) and specific known names as `method_definition`
+    nodes. Confirmed directly against this module's own parse of `react/ReactFiberBeginWork.js`,
+    `ReactFiberWorkLoop.js`, and `ReactFlightServer.js`: each has `tree.root_node.has_error is
+    True`, with `ReactFiberWorkLoop.js`/`ReactFlightServer.js` each producing ONE `ERROR` node
+    spanning the entire file (line 1 to EOF) -- confirming this module's simpler walker was never
+    given the reserved-keyword/hallucination filter `tree_sitter_accuracy_audit.py` already proved
+    necessary, not a new bug in the underlying grammar. Reuses `tsaa`'s own frozensets directly
+    (not a re-derived copy) so there's exactly one place either list is maintained.
     """
     funcs: list[Occurrence] = []
     classes: list[Occurrence] = []
@@ -188,7 +204,18 @@ def _walk_tree_sitter(root, func_node_types: set[str], class_node_types: set[str
     def walk(node, is_continuation_clause=False):
         if node.type in func_node_types:
             name = tsaa._get_node_name(node)
-            if name and not (lang == "haskell" and is_continuation_clause):
+            if (
+                name
+                and not (lang == "haskell" and is_continuation_clause)
+                and not (
+                    lang == "javascript"
+                    and node.type == "method_definition"
+                    and (
+                        name in tsaa._JS_RESERVED_STATEMENT_KEYWORDS
+                        or name in tsaa._JS_KNOWN_FLOW_HALLUCINATIONS
+                    )
+                )
+            ):
                 funcs.append(
                     Occurrence(
                         name=name,
@@ -224,8 +251,30 @@ def _walk_tree_sitter(root, func_node_types: set[str], class_node_types: set[str
 
 _CTAGS_ANON_NAME_RE = re.compile(r"^__anon[0-9a-f]+$")
 
+# universal-ctags' JavaScript parser uses a DIFFERENT synthetic-placeholder scheme than the C
+# parser's "__anon<hex>" above -- "AnonymousFunction<hex><seq>"/"AnonymousClass<hex><seq>" (e.g.
+# "AnonymousFunctionff8c17c30100"), emitted for every anonymous function EXPRESSION (a bare inline
+# callback with no attributable name, `jQuery.ajaxPrefilter(function(s) {...})`) and, separately,
+# for anonymous object-literal/constructor-style assignments its "class" heuristic can't otherwise
+# key on. Found via tri-comparison-ledger-sweep on javascript (2026-08-21,
+# javascript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter], 150 occurrences): neither
+# GitGalaxy nor tree-sitter report a name for a genuinely-anonymous callback either (there isn't
+# one), so this is the exact same false-discrepancy shape as the C `__anon` case above, just a
+# differently-shaped placeholder from a different per-language ctags parser.
+#
+# Deliberately checked ONLY for lang == "javascript", NOT applied blindly to every language the
+# way the "__anon" regex above is -- confirmed directly (2026-08-21) that PHP's ctags parser
+# reuses this exact same "AnonymousClass<hex>" text for a GENUINE PHP language construct (`$obj =
+# new class { ... };`, PHP 7+ anonymous classes), which is real, valid PHP source ctags is
+# correctly tagging, not a placeholder to discard. An earlier version of this filter checked the
+# name pattern alone with no per-language gate and silently dropped a real php ctags class tag
+# (corpus-wide class found-count regression 30->29), caught before commit by re-running the full
+# `--all --write` chart and diffing every changed panel, not assumed safe from the javascript
+# corpus check alone.
+_CTAGS_JS_ANON_NAME_RE = re.compile(r"^Anonymous(?:Function|Class)[0-9a-f]+$")
 
-def _is_ctags_synthetic_anon_name(name: str) -> bool:
+
+def _is_ctags_synthetic_anon_name(name: str, lang: str) -> bool:
     """universal-ctags synthesizes a placeholder name (`__anon<hex hash>`, e.g.
     `__anon2570bd640108`) for an anonymous struct/union/enum (`typedef struct { ... } Foo;` --
     real, common C, e.g. cpython/ceval.c's platform-specific pthread attr shim) so it has
@@ -235,8 +284,13 @@ def _is_ctags_synthetic_anon_name(name: str) -> bool:
     confirmed via c/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter] (23 occurrences,
     every single sample this exact shape, spanning cpython/doom). The same exclusion GitGalaxy's
     own synthetic placeholder names already get (_SYNTHETIC_GG_FUNC_NAMES/
-    _SYNTHETIC_GG_CLASS_NAMES) applied to ctags' equivalent."""
-    return bool(_CTAGS_ANON_NAME_RE.match(name))
+    _SYNTHETIC_GG_CLASS_NAMES) applied to ctags' equivalent. Also covers javascript's own
+    "AnonymousFunction"/"AnonymousClass" placeholder scheme (_CTAGS_JS_ANON_NAME_RE above), gated
+    to `lang == "javascript"` only -- see that regex's own comment for why this one CAN'T be
+    applied language-agnostically like the "__anon" check above."""
+    if _CTAGS_ANON_NAME_RE.match(name):
+        return True
+    return lang == "javascript" and bool(_CTAGS_JS_ANON_NAME_RE.match(name))
 
 
 def gather_language(lang: str, corpus_dir: Optional[Path] = None) -> list[FileReadings]:
@@ -312,12 +366,12 @@ def gather_language(lang: str, corpus_dir: Optional[Path] = None) -> list[FileRe
                             args=_count_ctags_signature_params(s.signature),
                         )
                         for s in ct_syms
-                        if s.kind in ctags_func_kinds and not _is_ctags_synthetic_anon_name(s.name)
+                        if s.kind in ctags_func_kinds and not _is_ctags_synthetic_anon_name(s.name, lang)
                     ]
                     ctags_classes = [
                         Occurrence(name=s.name, line=s.line if s.line >= 0 else None, args=None)
                         for s in ct_syms
-                        if s.kind in ctags_class_kinds and not _is_ctags_synthetic_anon_name(s.name)
+                        if s.kind in ctags_class_kinds and not _is_ctags_synthetic_anon_name(s.name, lang)
                     ]
                 else:
                     ctags_funcs, ctags_classes = [], []


### PR DESCRIPTION
## Summary
- Investigated every open `javascript/*` shape in the tri-comparison ledger (jquery/react/threejs corpus) and validated all 8 with evidenced verdicts.
- Root causes: two ctags-side JS-scanner heuristics (call-argument object-literal name loss, blanket object-literal-as-"class" tagging), and a Flow-typed-react cascade that independently breaks both tree-sitter-javascript (type-cast syntax) and ctags' own scanner (return-type annotations) — GitGalaxy's regex is immune to both. Extended Claim 3 in `docs/why_gitgalaxy_beats_ast_here.md` with the full write-up.
- Fixed 2 real bugs in `tests/tools/tri_comparison_gatherer.py`, both mirroring patterns already proven in `tree_sitter_accuracy_audit.py`:
  - Ported the reserved-keyword/Flow-hallucination `method_definition` filter (plus one new confirmed hallucination name, added to the shared `tsaa` frozenset).
  - Extended the ctags synthetic-anon-name filter for JS's "AnonymousFunction"/"AnonymousClass" scheme — gated to `lang == "javascript"` only, after confirming an ungated version incorrectly stripped PHP's real anonymous-class ctags tags (PHP has a genuine `new class {}` anonymous-class feature using the identical tag text).
- Regenerated the full 45-language chart; diff is scoped to the javascript panel plus the aggregate summary footer only. javascript now shows a real earned tree-sitter Func Precision badge instead of all-asterisked unvalidated bars.

## Test plan
- [x] `python tests/ruff_audit.py --ci` — clean (78-finding baseline, no new)
- [x] `python tests/mypy_audit.py --ci` — clean (2-error baseline, no new)
- [x] Verified the PHP-regression fix directly: `gather_language('php')` restores the real `AnonymousClass<hex>` tag; `gather_language('javascript')` still filters all synthetic placeholders
- [x] Full `tri_comparison_chart.py --all --write` diff reviewed line-by-line — confirmed scoped to javascript + summary footer, no leak into any other language panel
- Not a `language_standards.py`/`detector.py`/`prism.py` change, so `crucible_check.py`/golden-master re-blessing doesn't apply — this PR only touches comparison tooling and docs/ledger data

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>