### PR TITLE
Tri-comparison sweep: kotlin (4/4 shapes validated, 2 audit-tool defects fixed)

### DIFF
--- a/docs/language_status/README.md
+++ b/docs/language_status/README.md
@@ -76,7 +76,7 @@ epic #813), not that no cases exist.
 | **[java](java.md)** | production | standard_block | 50/52 | 70 | 91 | **written** |
 | **[javascript](javascript.md)** | production | standard_block | 61/64 | 53 | 73 | **written** |
 | jcl | production | line_exclusive | 11/24 | 41 | 51 | not written |
-| kotlin | production | standard_block | 51/52 | 42 | 90 | not written |
+| **[kotlin](kotlin.md)** | production | standard_block | 51/52 | 43 | 90 | **written** |
 | livecode | production | multi_style_live | 47/52 | 4* | 108 | not written |
 | lua | production | multi_style_dash | 50/52 | 41 | 78 | not written |
 | m4 | production | line_exclusive | 31/47 | 21 | 73 | not written |

--- a/docs/language_status/kotlin.md
+++ b/docs/language_status/kotlin.md
@@ -1,0 +1,215 @@
+# Kotlin — Structural Signature Coverage
+
+Snapshot generated 2026-08-22 against `main`. Source: `LANGUAGE_DEFINITIONS["kotlin"]` in
+`gitgalaxy/standards/language_standards.py`, `tests/extraction/languages/test_kotlin.py` /
+`test_kotlin_strict.py`, closed GitHub issues, and
+[`gitgalaxy-raw-output`](https://github.com/squid-protocol/gitgalaxy-raw-output). Re-run the
+`language-status` skill's data-gathering commands before trusting these numbers if this doc looks
+old relative to `last_updated` below.
+
+## 1. At a glance
+
+| Field | Value |
+|---|---|
+| `_meta.status` | `production` |
+| `_meta.target_version` | Kotlin 2.3.10 (K2 Compiler / Wasm / Java 25 Support) |
+| `_meta.blueprint_version` | *(unset)* |
+| `_meta.last_updated` | 2026-03-12 |
+| `lexical_family` | `standard_block` (`//` and nestable `/* /* */ */` block comments — Kotlin explicitly allows nesting, so C-family single-level block-comment handling would terminate early) |
+| Structural signature keys wired | 51 / 52 (1 explicit `None`, see §4) |
+| Extraction-gauntlet + strict-signature tests (`test_kotlin.py` + `test_kotlin_strict.py`) | 133 |
+| Tri-comparison sweep (GitGalaxy vs. tree-sitter vs. ctags) | 4/4 discrepancy shapes validated, 2 real audit-tool bugs fixed — see §9 |
+
+## 2. Identification surface
+
+- **Extensions:** `.kt .kts .ktm` — standard sources, Kotlin script files (heavily used in modern Gradle build logic), and module declarations.
+- **Exact filenames:** none — Kotlin rarely uses extensionless execution scripts.
+- **Discriminators:** `.kt`, `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties` — Kotlin-DSL Gradle build files used as ecosystem anchors.
+- **Shebangs:** `kotlin`, `kotlinc`, `kscript`.
+
+## 3. What GitGalaxy detects
+
+Grouped by the phase headers `language_standards.py` and `how_to_add_a_language.md` use.
+Description is what Kotlin's *actual* regex matches, not the generic cross-language definition.
+
+**Topology & structure**
+| Key | What it captures for Kotlin |
+|---|---|
+| `branch` | `if else when for while do try catch finally break continue return`, plus the Elvis operator (`?:`) and `&&`/`\|\|` |
+| `args` | `fun`/`constructor` parameter lists, with a dedicated "lambda parameter shield" (one-level parenthesis nesting) for default-argument/lambda-typed parameters, bounded generic step-over (`<T, U : Comparable<U>>`), backtick-quoted arbitrary identifiers, and a second alternative for bare trailing-lambda syntax (`list.forEach { item -> ... }`) |
+| `structural_boundaries` | `package import return class interface object fun typealias` |
+| `func_start` | Anchors `fun`, `init`, or `constructor`, stepping over up to 10 annotation lines and 5 modifier keywords (`public private protected internal open override abstract final suspend inline tailrec infix operator external expect actual`), an optional `context(...)` receiver, and bounded generics — captures the literal name for the `init`/`constructor` forms since neither has a user-chosen identifier |
+| `class_start` | `class interface object enum class`, plus a dedicated (usually-anonymous, optionally-named) `companion object` alternative — `fun` is itself a valid modifier here for `fun interface Foo` (SAM/functional-interface declarations) |
+
+**Safety & risk**
+| Key | What it captures for Kotlin |
+|---|---|
+| `safety` | Safe-call chains ending the line (`?.` at end), `as?`, `require requireNotNull check checkNotNull error sealed is !is Result onSuccess onFailure fold runCatching`, Elvis (`?:`) |
+| `safety_bypasses` | Force-unwrap (`!!`), unsafe cast (`as` without `?`), `lateinit var`, `@Suppress` |
+| `high_risk_execution` | `System.exit exitProcess Runtime.getRuntime Thread.stop` |
+| `io` | `File InputStream OutputStream Retrofit OkHttpClient Ktor HttpClient RoomDatabase Dao SharedPreferences DataStore java.nio` |
+| `api` | `public`/`internal` visibility keywords, Ktor/Spring route annotations (`@RestController @Controller @Service @Component @RequestMapping @GetMapping @PostMapping @Route`) |
+| `state_mutation` | `var`, mutable collection/state types (`MutableList MutableMap MutableSet MutableState MutableStateFlow Atomic*`), line-start assignment expressions, mutator calls (`.add/.addAll/.remove/.put/.set/.update`) |
+| `dead_code` | Commented-out `// val/var/fun/class/interface/object/if/when/for/return` |
+| `doc` | `/** @param @return @property @receiver @constructor @throws @see @since` |
+| `test` | JUnit-style (`@Test @ParameterizedTest @BeforeTest @AfterTest`), `assert*(`, MockK (`mockk spyk every{ verify{`), Kotest (`shouldBe shouldNotBe`) |
+
+**Architecture & domain sensors**
+| Key | What it captures for Kotlin |
+|---|---|
+| `concurrency` | `suspend launch async CoroutineScope GlobalScope Dispatchers Flow StateFlow SharedFlow Channel yield runBlocking withContext Mutex` |
+| `ui_framework` | Jetpack Compose (`@Composable Modifier Column Row Box Text Image Button Scaffold LazyColumn LazyRow Surface remember mutableStateOf`) and classic Android views (`findViewById View Activity Fragment`) |
+| `closures` | Bare trailing-lambda shape (`{ x -> ...`, up to a 150-char parameter clause) |
+| `globals` | `object`/`companion object`, top-level `const val SCREAMING_CASE =` |
+| `decorators` | Any `@`-prefixed annotation, with a bounded 300-char argument list |
+| `generics` | Uppercase-bound generic parameters (`<T>`, `<in T>`, `<out T>`), `reified`, `where` clauses |
+| `comprehensions` | Functional collection transforms (`.map .mapNotNull .filter .filterNot .reduce .fold .flatMap .zip .associate .groupBy .forEach .any .all .none .find`) |
+| `scientific` | `kotlin.math. java.lang.Math. StrictMath. Random.` and common math function names, `BigDecimal BigInteger` |
+| `reflection_metaprogramming` | `::class`, `javaClass`, `@JvmOverloads @JvmStatic @JvmField @JvmName`, `inline crossinline noinline invoke context tailrec` |
+| `import` / `_dependency_capture` | `import [static] pkg.path` (Java-interop-style `import static` included) |
+| `ownership` | `@author`/`@since` KDoc tags, `// Created by:`/`Maintainer:`/`Copyright:` comments |
+
+**Specialized subsystems**
+| Key | What it captures for Kotlin |
+|---|---|
+| `planned_debt` / `fragile_debt` | Shared `GLOBAL_` TODO/FIXME-family markers |
+| `spec_exposure` | `[SPEC-123]`, `[spec ...]`, `[audit ...]` traceability tags |
+| `ssr_boundaries` | `ApplicationCall call.respond call.respondText call.respondHtml ServerResponse ModelAndView` |
+| `events` | `.collect .collectLatest .observe .subscribe .onNext` called with either `(` or a bare trailing `{` (Flow's idiomatic SAM-conversion collector style), `LiveData Observer Observable FlowCollector` |
+| `dependency_injection` | `@Inject @Module @Provides @Binds @HiltViewModel @AndroidEntryPoint @Component @Autowired`, Koin's `get()`/`inject()` |
+| `macros` | `@OptIn @RequiresOptIn @Suppress @SuppressWarnings` |
+| `pointers` | Kotlin/Native FFI types (`CPointer COpaquePointer CFunction CValue CPointed`) |
+| `memory_alloc` | Kotlin/Native manual memory (`memScoped alloc allocArray nativeHeap.alloc nativeHeap.free`) |
+| `telemetry` | `Timber Log Logger LoggerFactory` log-level calls, `@Slf4j` |
+| `debug_prints` | `println(`/`print(` |
+| `explicit_casts` | `as`/`as?` to a capitalized type, `.toInt() .toLong() .toShort() .toByte() .toDouble() .toFloat() .toString() .toBoolean() .toUInt() .toULong() .toUShort() .toUByte()` |
+| `panics_and_aborts` | `throw raise exitProcess return panic` |
+| `thread_sleeps` | `delay Thread.sleep yield` |
+| `bitwise_ops` | `.shl() .shr() .ushr() .and() .or() .xor() .inv()`, bare `shl shr ushr xor` |
+| `sync_locks` | `mutex lock synchronized Semaphore Atomic*` (case-insensitive) |
+| `immutability_locks` | `val const immutable readonly` |
+| `cleanup` | `close() dispose() shutdown() use() cleanup()` |
+| `encapsulation` | `private protected internal` |
+| `listeners` | `.collect .observe .subscribe .on<Event> .set<X>Listener` called with either `(` or a bare trailing `{` (same SAM-conversion idiom as `events`) |
+| `test_skip` | `@Ignore @Disabled`, `test.skip(`, `mockk spyK fake(` |
+| `serialization_parsing` | `Json.decodeFromString Json.encodeToString Moshi ObjectMapper`, `Gson()` |
+| `regex_execution` | `Regex(`, `.toRegex()`, `.matches(`, `.find(` |
+| `time_date_logic` | `Clock.System.now Instant.now System.currentTimeMillis Duration.minutes LocalDate` |
+| `ipc_rpc_bridges` | `BroadcastReceiver ProcessBuilder bindService`, `Intent(`, `HttpClient(` |
+
+## 4. What GitGalaxy explicitly does not track
+
+- **`inline_asm`** — `None`. Kotlin has no native inline-assembly syntax; Kotlin/Native FFI bridges to raw assembly go through C headers instead (covered indirectly by `pointers`/`memory_alloc`).
+
+## 5. Known limitations (accepted, not fixed)
+
+One documented `known_limitation` test (`test_kotlin.py`):
+
+- **`func_start` has no string/comment awareness.** Function-shaped text sitting inside a Kotlin raw (triple-quoted) string literal that happens to land at true line start still matches at the regex level (e.g. a `"""...fun TargetFunc() {...."""` string). This is the same architectural gap already confirmed on six other languages (JS/TS template literals, Java text blocks, Go/Rust raw strings, C# verbatim/raw strings — recurring bug class 3 in `how_to_harden_extraction.md`), now a seventh confirmed instance for Kotlin. Not fixed at the regex level — Kotlin routes through `detector.py`'s Mode B (`_slice_by_braces`), which is currently only string-shielded for JavaScript/TypeScript; extending that shielding to Kotlin is tracked as a future audited follow-up in the epic, not addressed here.
+
+## 6. Test depth
+
+`test_kotlin.py` + `test_kotlin_strict.py`: **133 collected test cases** (pytest `--collect-only`,
+counts parametrized cases individually). Includes a dedicated ReDoS regression sweep
+(`test_kotlin_redos_immunity_sweep`, added by #1070) and two cross-signature false-collision
+guards (`test`/`regex_execution`, `explicit_casts`/`pointers`).
+
+## 7. Relevant closed work
+
+**Epic-level hardening passes**
+- [#823](https://github.com/squid-protocol/gitgalaxy/issues/823) — Extraction hardening: kotlin (epic #813 sub-issue). Fixed the generic-parameter nesting gap (Rule 11), added backtick-identifier support to `func_start`/`args`, and the `companion object`/`fun interface` recall gaps in `class_start`.
+- [#592](https://github.com/squid-protocol/gitgalaxy/issues/592) — Strict parsing tests: `kotlin` structural signatures (epic #1069 sub-issue).
+- [#1070](https://github.com/squid-protocol/gitgalaxy/issues/1070) — Added ReDoS regression tests for 6 languages with zero prior coverage, including kotlin.
+- [#1295](https://github.com/squid-protocol/gitgalaxy/issues/1295) — Extended per-language `class_start` named-entity extraction to kotlin (companion objects, `object`/`enum class` declarations resolve to real names instead of a generic "Anonymous_Class" placeholder).
+
+**Real engine bugs found and fixed**
+- [#899](https://github.com/squid-protocol/gitgalaxy/issues/899) — `func_start`/`args` missing backtick-identifier support (found during #825).
+- [#1209](https://github.com/squid-protocol/gitgalaxy/issues/1209) — `args`' capture group was missing in 25 languages including kotlin (regression from the #1199 Python fix) — every zero/one-arg signature, including a bare trailing lambda, was overcounted by +1.
+- [#1405](https://github.com/squid-protocol/gitgalaxy/issues/1405) (PR [#1413](https://github.com/squid-protocol/gitgalaxy/pull/1413)) — `func_start` missed expression-bodied and bodyless interface method declarations, measured at 39.1% recall against the real okhttp corpus before the fix.
+
+**Measurement-tooling bugs (not engine bugs, but shaped what could be measured)**
+- [#1313](https://github.com/squid-protocol/gitgalaxy/issues/1313) / PR [#1315](https://github.com/squid-protocol/gitgalaxy/pull/1315) — `tree_sitter_accuracy_audit.py` reported kotlin's `real_functions`/`real_classes` as 0 despite confirmed function-shaped nodes in real corpus files — a `_get_node_name` no-"name"-field gap (kotlin's `function_declaration`/`class_declaration`/`object_declaration` nodes carry the identifier as a plainly-typed child, not a tree-sitter field), not an extraction gap. This masked #1405's real gap until fixed.
+
+**This session (tri-comparison-ledger-sweep, 2026-08-22)** — see §9 for the full writeup:
+- `tests/tools/ctags_reader.py`'s kotlin `CLASS_KINDS` was missing `"o"` (objects), silently excluding every `object Foo { ... }` singleton declaration from the ctags-side class comparison.
+- `tests/tools/tree_sitter_accuracy_audit.py`'s kotlin `func_node_types` was missing `secondary_constructor` (and, proactively, `anonymous_initializer`), so tree-sitter's own real-function count silently excluded every Kotlin secondary constructor.
+
+## 8. Real-world evidence (`gitgalaxy-raw-output`)
+
+- **[`kotlin`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/kotlin/kotlin_galaxy_llm.md)** — the Kotlin compiler's own reference implementation ([JetBrains/kotlin](https://github.com/JetBrains/kotlin)). The most adversarial Kotlin codebase available: self-hosting compiler internals, every language-generation era, heavy multiplatform/`expect`/`actual` usage. Scanned in 148.9s.
+- **[`okhttp`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/okhttp/okhttp_galaxy_llm.md)** — [square/okhttp](https://github.com/square/okhttp), a mid-size, long-lived production networking library — the same corpus §9's tri-comparison sweep investigated directly. Scanned in 2.36s.
+- **[`retrofit`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/retrofit/retrofit_galaxy_llm.md)** — [square/retrofit](https://github.com/square/retrofit), a small, canonical single-purpose REST client library — a useful low-noise baseline. Scanned in 1.68s.
+
+## 9. Tri-comparison: GitGalaxy vs. tree-sitter vs. ctags
+
+This section is a different shape from a §9 that diffs GitGalaxy against one privileged
+ground-truth parser (see python.md's/javascript.md's §9): Kotlin has two independent,
+non-privileged comparison tools available (`tree-sitter-kotlin` and `universal-ctags`) and
+neither is treated as ground truth — see `tests/tools/tri_comparison_reconcile.py`'s own module
+docstring for why. Every discrepancy the three tools produced was investigated by reading real
+source (`docs/self_scan/how_to_investigate_a_discrepancy.md`'s process), not assumed — the full
+record is `docs/self_scan/tri_comparison_ledger.json`, filterable to `"language": "kotlin"`.
+
+**Result: 4/4 discrepancy shapes validated, 2 confirmed real audit-tool defects found and fixed in
+this pass** (`tests/tools/ctags_reader.py` and `tests/tools/tree_sitter_accuracy_audit.py` —
+GitGalaxy's own engine had zero confirmed defects among the discrepancies this methodology
+surfaced). All 5 language-crucible/data/kotlin/okhttp corpus files. Current measured numbers
+(`tests/tools/tri_comparison_chart.py --languages kotlin`):
+
+| Signal | GitGalaxy | tree-sitter | ctags | Read as |
+|---|---|---|---|---|
+| Functions found (of 43 total claimed by any tool) | 28 | 28 | 42 | ctags' higher count is mostly noise (false positives), not real recall — see precision row |
+| Function precision (of what each tool claimed, how much corroborates) | **100%** (28/28) | **100%** (28/28) | 28.6% (12/42)\* | tied GitGalaxy/tree-sitter win; ctags' precision reflects a confirmed, permanent over-detection bug (see below) |
+| Class recall/precision | **100%** (7/7) | **100%** (7/7) | **100%** (7/7) | fully reconciled after this pass's fix — see below |
+| Args exact-match | **100%** (27/27) | **100%** (27/27) | N/A (0/0) | ctags emits no per-function parameter-count data for Kotlin at all |
+
+\* ctags' function precision reflects `tri_comparison_ledger.py`'s verified debit mechanism — its
+raw agreement-based precision (before this pass) would have been higher only in the sense that
+those 15 occurrences were still counted as "claimed"; the debit doesn't change what ctags claimed,
+only whether the claim should count as corroborated (it shouldn't — see below).
+
+### Where GitGalaxy (and tree-sitter) win outright
+
+- **Kotlin secondary constructors.** `okhttp/Dispatcher.kt:119`'s `constructor(executorService:
+  ExecutorService?) : this() { ... }` is a real, named-by-keyword Kotlin construct. GitGalaxy's
+  `func_start` regex already had a dedicated `(constructor)` alternative for it. tree-sitter-kotlin
+  gives it its own `secondary_constructor` node type, distinct from `function_declaration` — real,
+  just invisible to `tree_sitter_accuracy_audit.py` pre-fix (see below). ctags' own Kotlin parser
+  does not recognize this construct as a symbol at all, under any kind — a genuine parser gap, not
+  a kind-mapping one (confirmed via `ctags -x --languages=Kotlin` emitting no entry whatsoever for
+  line 119).
+- **`object` singleton declarations as classes.** `okhttp/OkHttp.kt`/`OkHttp.android.kt`/
+  `OkHttp.jvm.kt` each declare `(actual|expect) object OkHttp { ... }`. GitGalaxy's `class_start`
+  regex and tree-sitter-kotlin's `object_declaration` node both already correctly treat `object`
+  as class-shaped. ctags' own parser tags it too, just under its own distinct `object` kind
+  (`o`) rather than `class` (`c`) — invisible to the comparison only because
+  `ctags_reader.py`'s kotlin `CLASS_KINDS` set was missing `"o"` (fixed this pass).
+
+### Confirmed audit-tool bugs found and fixed this pass
+
+- **`tests/tools/ctags_reader.py`'s kotlin `CLASS_KINDS`** was `{"c", "i"}`, missing `"o"`
+  (objects) — the exact same shape as this file's already-documented cpp/fortran `CLASS_KINDS`
+  gaps. Fixed by adding `"o"`.
+- **`tests/tools/tree_sitter_accuracy_audit.py`'s kotlin `func_node_types`** was missing
+  `secondary_constructor` (and, proactively, `anonymous_initializer` for `init { }` blocks — same
+  no-name-field shape, same regex's `(init)` sibling alternative, no live occurrence in this
+  corpus but the identical underlying gap). Fixed by adding both node types plus matching
+  `_get_node_name`/`_get_param_count` branches (the literal keyword text is the name — neither
+  construct has a user-chosen identifier in Kotlin).
+
+### Confirmed ctags-side limitation (not fixable via this repo's tooling)
+
+- **ctags' own Kotlin parser tags two non-function shapes with the same generic `method` kind as
+  real functions**, and — unlike the object/class gap above — this isn't a kind-mapping omission;
+  ctags simply gives Kotlin no separate kind for either shape in the first place. Confirmed via
+  direct `ctags -x --languages=Kotlin` inspection of `okhttp/Dispatcher.kt`, 15 occurrences: (1)
+  10 trailing-lambda blocks passed as call arguments (`require(x >= 1) { "..." }`,
+  `synchronized(this) { ... }`, `.also { ... }`, `.map { it.call }`) tag as a synthetic `<lambda>`
+  symbol; (2) 5 `for (x in collection)` loop iteration variables tag as a method literally named
+  after the variable (`call`, `existingCall`). GitGalaxy's `func_start` regex and tree-sitter's
+  grammar both correctly require a real `fun`/constructor declaration, so their agreement here is
+  real corroboration, not a shared miss — ctags' own claim on this shape is debited in the ledger
+  (documented in `ctags_reader.py`'s kotlin `FUNCTION_KINDS` comment for future reference).
+  Separately, and in the opposite direction: ctags' Kotlin parser also fails to recognize
+  secondary constructors as symbols at all (see above) — a real, permanent ctags parser
+  limitation this repo's tooling cannot work around.

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -534,31 +534,31 @@
 <rect class="bar-track" x="154" y="1091" width="88" height="34" rx="2"/>
 <rect x="154" y="1091" width="58.7" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1099">28*</text>
-<rect x="154" y="1103" width="56.6" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1111">27*</text>
+<rect x="154" y="1103" width="58.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1111">28*</text>
 <rect x="154" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
 <text class="bar-value-label" x="198.0" y="1123">42*</text>
 <rect class="bar-track" x="286" y="1091" width="88" height="34" rx="2"/>
-<rect x="286" y="1091" width="84.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1099">27/28*</text>
+<rect x="286" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1099">28/28*</text>
 <rect x="286" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1111">27/27*</text>
-<rect x="286" y="1115" width="56.6" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1123">27/42*</text>
+<text class="bar-value-label" x="330.0" y="1111">28/28*</text>
+<rect x="286" y="1115" width="25.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1123">12/42*</text>
 <rect class="bar-track" x="418" y="1091" width="88" height="34" rx="2"/>
 <rect x="418" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1099">7*</text>
+<text class="bar-value-label" x="462.0" y="1099">7</text>
 <rect x="418" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1111">7*</text>
-<rect x="418" y="1115" width="50.3" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1123">4*</text>
+<text class="bar-value-label" x="462.0" y="1111">7</text>
+<rect x="418" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1123">7</text>
 <rect class="bar-track" x="550" y="1091" width="88" height="34" rx="2"/>
 <rect x="550" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1099">7/7*</text>
+<text class="bar-value-label" x="594.0" y="1099">7/7</text>
 <rect x="550" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1111">7/7*</text>
+<text class="bar-value-label" x="594.0" y="1111">7/7</text>
 <rect x="550" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="594.0" y="1123">4/4*</text>
+<text class="bar-value-label" x="594.0" y="1123">7/7</text>
 <rect class="bar-track" x="682" y="1091" width="88" height="34" rx="2"/>
 <rect x="682" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1099">27</text>
@@ -1095,10 +1095,10 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 41 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 42 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (39%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (38%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
 <text class="legend-label" x="228.8" y="2188">tree-sitter best: 1 (2%)</text>
@@ -1106,6 +1106,6 @@
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
 <circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="577.2" y="2188">Ties: 24 (59%)</text>
+<text class="legend-label" x="577.2" y="2188">Ties: 25 (60%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T01:53:56Z",
+      "last_reconciled_at": "2026-08-22T11:40:58Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T01:53:56Z",
+      "last_reconciled_at": "2026-08-22T11:40:58Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-22T01:53:57Z",
+      "last_reconciled_at": "2026-08-22T11:41:00Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T01:53:58Z",
+      "last_reconciled_at": "2026-08-22T11:41:01Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T01:53:58Z",
+      "last_reconciled_at": "2026-08-22T11:41:01Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1273,7 +1273,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T01:54:04Z",
+      "last_reconciled_at": "2026-08-22T11:41:07Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1388,7 +1388,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T01:54:09Z",
+      "last_reconciled_at": "2026-08-22T11:41:12Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1491,7 +1491,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T01:54:09Z",
+      "last_reconciled_at": "2026-08-22T11:41:12Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1594,7 +1594,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T01:54:09Z",
+      "last_reconciled_at": "2026-08-22T11:41:12Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1698,7 +1698,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1740,7 +1740,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1782,7 +1782,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -1896,7 +1896,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2010,7 +2010,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2124,7 +2124,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2238,7 +2238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2270,7 +2270,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2303,7 +2303,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2417,7 +2417,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2450,7 +2450,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2564,7 +2564,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2669,7 +2669,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2729,7 +2729,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T01:54:13Z",
+      "last_reconciled_at": "2026-08-22T11:41:17Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -2843,7 +2843,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2948,7 +2948,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3017,7 +3017,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3098,7 +3098,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3131,7 +3131,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3221,7 +3221,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3280,7 +3280,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3313,7 +3313,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3427,7 +3427,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3487,7 +3487,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3520,7 +3520,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -3636,7 +3636,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -3750,7 +3750,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T01:54:20Z",
+      "last_reconciled_at": "2026-08-22T11:41:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3783,7 +3783,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-22T01:54:21Z",
+      "last_reconciled_at": "2026-08-22T11:41:24Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3832,7 +3832,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T01:54:25Z",
+      "last_reconciled_at": "2026-08-22T11:41:29Z",
       "last_seen_count": 218,
       "last_seen_examples": [
         {
@@ -3935,7 +3935,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T01:54:25Z",
+      "last_reconciled_at": "2026-08-22T11:41:29Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4030,7 +4030,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T01:54:25Z",
+      "last_reconciled_at": "2026-08-22T11:41:29Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4134,7 +4134,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:54:31Z",
+      "last_reconciled_at": "2026-08-22T11:41:35Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4229,7 +4229,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:54:31Z",
+      "last_reconciled_at": "2026-08-22T11:41:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4261,7 +4261,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:54:31Z",
+      "last_reconciled_at": "2026-08-22T11:41:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4294,7 +4294,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:54:31Z",
+      "last_reconciled_at": "2026-08-22T11:41:35Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -4408,7 +4408,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:54:31Z",
+      "last_reconciled_at": "2026-08-22T11:41:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4452,7 +4452,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T01:54:31Z",
+      "last_reconciled_at": "2026-08-22T11:41:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4485,7 +4485,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-22T01:54:34Z",
+      "last_reconciled_at": "2026-08-22T11:41:37Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4599,7 +4599,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4711,7 +4711,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4816,7 +4816,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4930,7 +4930,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -5044,7 +5044,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5160,7 +5160,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5192,7 +5192,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5232,7 +5232,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T01:54:36Z",
+      "last_reconciled_at": "2026-08-22T11:41:40Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5346,7 +5346,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5460,7 +5460,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5574,7 +5574,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5687,7 +5687,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5720,7 +5720,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5771,7 +5771,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5885,7 +5885,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T01:54:39Z",
+      "last_reconciled_at": "2026-08-22T11:41:43Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5936,7 +5936,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -6050,7 +6050,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6137,7 +6137,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6179,7 +6179,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6293,7 +6293,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -6389,7 +6389,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -6503,7 +6503,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -6617,7 +6617,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T01:54:42Z",
+      "last_reconciled_at": "2026-08-22T11:41:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6647,10 +6647,10 @@
         "ctags"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-22T11:40:48Z",
+      "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T01:54:45Z",
+      "last_reconciled_at": "2026-08-22T11:48:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6682,26 +6682,28 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
+      "status": "validated",
+      "still_reproduces": false,
       "symbol_type": "class",
-      "verdict": null
+      "verdict": "Confirmed real ctags_reader.py kind-map gap, same shape as the cpp/fortran CLASS_KINDS precedents. All 3 flagged files (okhttp/OkHttp.kt, OkHttp.android.kt, OkHttp.jvm.kt) declare `(actual|expect) object OkHttp { ... }` -- a genuine Kotlin singleton object declaration. `ctags -x --languages=Kotlin` confirms ctags' own Kotlin parser DOES recognize and tag it, with its own distinct 'object' kind (letter 'o'), separate from 'class' (letter 'c') -- but ctags_reader.py's kotlin CLASS_KINDS set only included {'c', 'i'}, silently excluding 'o'. GitGalaxy's class_start regex and tree-sitter-kotlin's grammar (`object_declaration` node, already in class_node_types since #1295) both already correctly treat `object` as class-shaped. Fixed by adding 'o' to ctags_reader.py's kotlin CLASS_KINDS -- verified post-fix via a fresh gather_language('kotlin') run that ctags' class-name set now includes 'OkHttp' for all 3 files, matching gitgalaxy/tree-sitter exactly. No credit/debit needed: this was a reader-side kind-map bug now fixed, not an irreconcilable 3-way disagreement -- the raw ctags reading itself is now correct going forward, so the shape stops reproducing rather than needing a manual score adjustment."
     },
     "kotlin/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]": {
       "agreeing_tools": [
         "ctags"
       ],
       "credit_tools": [],
-      "debit_tools": [],
+      "debit_tools": [
+        "ctags"
+      ],
       "dissenting_tools": [
         "gitgalaxy",
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-22T11:40:48Z",
+      "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T01:54:45Z",
+      "last_reconciled_at": "2026-08-22T11:48:59Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6796,10 +6798,43 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
+      "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed ctags-side over-detection, not a GitGalaxy/tree-sitter recall gap. Direct `ctags -x --languages=Kotlin` on okhttp/Dispatcher.kt shows all 15 occurrences split into two false-positive shapes ctags' Kotlin parser tags with the same 'method' kind as real functions: (1) 10 trailing-lambda blocks passed as call arguments -- `require(x >= 1) { \"...\" }` (lines 48/68), `synchronized(this) { ... }` (49/69/178), `check(...) { ... }` (180/185), `.also { readyAsyncCalls.clear() }` (210), and `.map { it.call }` (279/283) -- each tagged as a synthetic `<lambda>` symbol; (2) 5 `for (x in collection)` loop iteration variables tagged as methods literally named after the variable (`call` at 143/146/149 in cancelAll(), `existingCall` at 128/131 in findExistingCallWithHost()). GitGalaxy's own func_start regex and tree-sitter-kotlin's grammar both correctly require a real `fun`/constructor declaration, so their agreement (neither claims these 15) is real corroboration, not a shared miss. Not fixable via ctags_reader.py's FUNCTION_KINDS map -- ctags gives Kotlin no separate kind for 'anonymous lambda literal' or 'for-loop binding' vs. a real named function in the first place (confirmed: both false-positive shapes tag plain 'method', identical to genuine functions). Documented in ctags_reader.py's kotlin FUNCTION_KINDS comment. ctags' own claim on this shape is confirmed wrong, so it's debited."
+    },
+    "kotlin/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]": {
+      "agreeing_tools": [
+        "gitgalaxy",
+        "tree_sitter"
+      ],
+      "credit_tools": [],
+      "debit_tools": [],
+      "dissenting_tools": [
+        "ctags"
+      ],
+      "first_seen_at": "2026-08-22T11:41:49Z",
+      "investigated_at": "2026-08-22T11:45:48Z",
+      "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch)",
+      "language": "kotlin",
+      "last_reconciled_at": "2026-08-22T11:48:59Z",
+      "last_seen_count": 1,
+      "last_seen_examples": [
+        {
+          "file_path": "okhttp/Dispatcher.kt",
+          "name": "constructor",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 119,
+            "tree_sitter": 119
+          }
+        }
+      ],
+      "metric": "existence",
+      "status": "validated",
+      "still_reproduces": true,
+      "symbol_type": "function",
+      "verdict": "Direct continuation of the already-investigated constructor shape (see the now-still_reproduces=False agree[gitgalaxy]_vs[ctags,tree_sitter] entry's verdict for the full investigation): fixing tree_sitter_accuracy_audit.py's kotlin func_node_types to include `secondary_constructor` made tree-sitter agree with GitGalaxy on okhttp/Dispatcher.kt line 119's `constructor(executorService: ExecutorService?) : this() { ... }`, which regrouped this exact occurrence into a NEW 2-vs-1 shape. ctags' own Kotlin parser was independently confirmed (via `ctags -x --languages=Kotlin`) to emit no entry at all for line 119, under any kind -- a genuine ctags parser limitation (it doesn't recognize secondary-constructor syntax as a symbol in the first place), not a ctags_reader.py kind-mapping gap (there is nothing to remap; ctags never sees this construct as a taggable symbol). No credit/debit: ctags never claimed this occurrence at all (a miss, not a wrong claim), so there is nothing in its matched_consensus to debit, and gitgalaxy/tree_sitter's own claims were already correctly counted independent of this adjustment mechanism."
     },
     "kotlin/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]": {
       "agreeing_tools": [
@@ -6812,10 +6847,10 @@
         "tree_sitter"
       ],
       "first_seen_at": "2026-08-18T22:44:32Z",
-      "investigated_at": null,
-      "investigated_by": null,
+      "investigated_at": "2026-08-22T11:40:48Z",
+      "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T01:54:45Z",
+      "last_reconciled_at": "2026-08-22T11:48:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6829,10 +6864,10 @@
         }
       ],
       "metric": "existence",
-      "status": "unvalidated",
-      "still_reproduces": true,
+      "status": "validated",
+      "still_reproduces": false,
       "symbol_type": "function",
-      "verdict": null
+      "verdict": "Confirmed real tree_sitter_accuracy_audit.py NODE_MAPS gap, same shape as swift's init_declaration/dart's constructor-node precedents. Line 119 of okhttp/Dispatcher.kt is `constructor(executorService: ExecutorService?) : this() { ... }` -- a genuine Kotlin secondary constructor. GitGalaxy's own func_start regex already correctly matches it (its dedicated `(constructor)` alternative). Direct tree-sitter-kotlin parse confirms this construct gets its own `secondary_constructor` node type, distinct from `function_declaration` -- absent from kotlin's func_node_types pre-fix, so tree-sitter's real_functions silently excluded every secondary constructor. Fixed by adding 'secondary_constructor' (and, proactively, 'anonymous_initializer' for `init { }` blocks -- same no-name-field shape, same regex's `(init)` sibling alternative, no live occurrence in this corpus but same underlying gap) to func_node_types, plus a _get_node_name branch returning the literal 'constructor'/'init' keyword text (there is no other name to capture -- Kotlin gives secondary constructors and init blocks no user-chosen identifier), plus a _get_param_count branch reusing function_declaration's existing function_value_parameters-wrapper logic for secondary_constructor. Verified post-fix: tree-sitter's real_functions for Dispatcher.kt now includes 'constructor', matching GitGalaxy. Separately confirmed ctags' own Kotlin parser does NOT recognize secondary constructors at all -- `ctags -x --languages=Kotlin` on this file emits no entry for line 119 whatsoever, not even under a different kind -- a genuine ctags parser limitation, not a kind-mapping gap (nothing to remap; ctags never sees it as a symbol in the first place). No credit/debit on this exact shape: post-fix, tree-sitter now agrees with gitgalaxy, so this specific agree[gitgalaxy]_vs[ctags,tree_sitter] grouping stops reproducing; the residual gitgalaxy+tree_sitter-vs-ctags gap (a real, confirmed ctags parser limitation) will surface as its own shape on the next reconcile and gets its own verdict then."
     },
     "m4/class/existence/agree[gitgalaxy]_vs[ctags]": {
       "agreeing_tools": [
@@ -6847,7 +6882,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T01:54:51Z",
+      "last_reconciled_at": "2026-08-22T11:41:55Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6902,7 +6937,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T01:54:51Z",
+      "last_reconciled_at": "2026-08-22T11:41:55Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -7005,7 +7040,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T01:54:51Z",
+      "last_reconciled_at": "2026-08-22T11:41:55Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -7109,7 +7144,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-22T01:54:52Z",
+      "last_reconciled_at": "2026-08-22T11:41:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7140,7 +7175,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-22T01:54:54Z",
+      "last_reconciled_at": "2026-08-22T11:41:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7173,7 +7208,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:54:55Z",
+      "last_reconciled_at": "2026-08-22T11:42:00Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7287,7 +7322,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:54:55Z",
+      "last_reconciled_at": "2026-08-22T11:42:00Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7401,7 +7436,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:54:55Z",
+      "last_reconciled_at": "2026-08-22T11:42:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7434,7 +7469,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T01:54:55Z",
+      "last_reconciled_at": "2026-08-22T11:42:00Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7476,7 +7511,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7509,7 +7544,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7540,7 +7575,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7654,7 +7689,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7741,7 +7776,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7828,7 +7863,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7861,7 +7896,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T01:55:01Z",
+      "last_reconciled_at": "2026-08-22T11:42:06Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -7975,7 +8010,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T01:55:06Z",
+      "last_reconciled_at": "2026-08-22T11:42:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8008,7 +8043,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T01:55:06Z",
+      "last_reconciled_at": "2026-08-22T11:42:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8041,7 +8076,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T01:55:06Z",
+      "last_reconciled_at": "2026-08-22T11:42:11Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8155,7 +8190,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:55:08Z",
+      "last_reconciled_at": "2026-08-22T11:42:13Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8240,7 +8275,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:55:08Z",
+      "last_reconciled_at": "2026-08-22T11:42:13Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8309,7 +8344,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:55:08Z",
+      "last_reconciled_at": "2026-08-22T11:42:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8342,7 +8377,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T01:55:08Z",
+      "last_reconciled_at": "2026-08-22T11:42:13Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8456,7 +8491,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:55:18Z",
+      "last_reconciled_at": "2026-08-22T11:42:23Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8516,7 +8551,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:55:18Z",
+      "last_reconciled_at": "2026-08-22T11:42:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8549,7 +8584,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:55:18Z",
+      "last_reconciled_at": "2026-08-22T11:42:23Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -8665,7 +8700,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T01:55:18Z",
+      "last_reconciled_at": "2026-08-22T11:42:23Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8698,7 +8733,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:55:19Z",
+      "last_reconciled_at": "2026-08-22T11:42:24Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8740,7 +8775,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:55:19Z",
+      "last_reconciled_at": "2026-08-22T11:42:24Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8818,7 +8853,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:55:19Z",
+      "last_reconciled_at": "2026-08-22T11:42:24Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8869,7 +8904,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T01:55:19Z",
+      "last_reconciled_at": "2026-08-22T11:42:24Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8946,7 +8981,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -9060,7 +9095,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9113,7 +9148,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9226,7 +9261,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9277,7 +9312,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9389,7 +9424,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9502,7 +9537,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9615,7 +9650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9648,7 +9683,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9683,7 +9718,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T01:55:23Z",
+      "last_reconciled_at": "2026-08-22T11:42:28Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9795,7 +9830,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-22T01:55:25Z",
+      "last_reconciled_at": "2026-08-22T11:42:31Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9898,7 +9933,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T01:55:29Z",
+      "last_reconciled_at": "2026-08-22T11:42:35Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -10000,7 +10035,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T01:55:29Z",
+      "last_reconciled_at": "2026-08-22T11:42:35Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10104,7 +10139,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-22T01:55:31Z",
+      "last_reconciled_at": "2026-08-22T11:42:36Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10136,7 +10171,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-22T01:55:32Z",
+      "last_reconciled_at": "2026-08-22T11:42:38Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10206,7 +10241,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T01:55:34Z",
+      "last_reconciled_at": "2026-08-22T11:42:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10237,7 +10272,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T01:55:34Z",
+      "last_reconciled_at": "2026-08-22T11:42:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10268,7 +10303,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T01:55:34Z",
+      "last_reconciled_at": "2026-08-22T11:42:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10300,7 +10335,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:55:35Z",
+      "last_reconciled_at": "2026-08-22T11:42:41Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10333,7 +10368,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:55:35Z",
+      "last_reconciled_at": "2026-08-22T11:42:41Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10375,7 +10410,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:55:35Z",
+      "last_reconciled_at": "2026-08-22T11:42:41Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10435,7 +10470,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:55:35Z",
+      "last_reconciled_at": "2026-08-22T11:42:41Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10467,7 +10502,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T01:55:35Z",
+      "last_reconciled_at": "2026-08-22T11:42:41Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10509,7 +10544,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10551,7 +10586,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10663,7 +10698,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10722,7 +10757,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10755,7 +10790,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10860,7 +10895,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -10974,7 +11009,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -11088,7 +11123,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11130,7 +11165,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T01:55:56Z",
+      "last_reconciled_at": "2026-08-22T11:43:02Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11243,7 +11278,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T01:56:05Z",
+      "last_reconciled_at": "2026-08-22T11:43:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11274,7 +11309,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T01:56:05Z",
+      "last_reconciled_at": "2026-08-22T11:43:10Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11377,7 +11412,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T01:56:05Z",
+      "last_reconciled_at": "2026-08-22T11:43:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_points_of_interest.md
+++ b/docs/self_scan/tri_comparison_points_of_interest.md
@@ -8,7 +8,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `agc_assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 215 occurrences as of 2026-08-22T01:53:56Z*
+*2-vs-1 -- 215 occurrences as of 2026-08-22T11:40:58Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed-cause shape, fully accounted for via a corpus-wide cross-reference of ctags' actual output against GitGalaxy's raw func_start regex matches and its real pipeline/DB output (215 + 50 = 265, no unexplained residual). (1) 215/265 (81%): ctags' Asm "l" kind tags EVERY line-start label unconditionally, including pure data/constant-definition labels (e.g. ERASCON1 OCTAL 00061, S10BITS, LSTBNKCH -- AGC_BLOCK_TWO_SELF-CHECK.agc:133 and nearby) that are never followed by an executable instruction. GitGalaxy's func_start regex deliberately requires the label be followed by a real instruction mnemonic from a fixed whitelist, so it does not count these as functions -- a genuine, intentional precision distinction (code label vs. data label), not a GitGalaxy defect; ctags' generic Asm parser has no way to make this distinction at all. (2) 50/265 (19%): a real, confirmed GitGalaxy engine defect in detector.py's _slice_by_labels (Mode A), independently root-caused to two separate bugs: (a) `RELINT` is incorrectly included in `self.assembly_returns`'s early-termination keyword list (detector.py:572-575) -- in real AGC assembly RELINT means "release interrupt inhibit" and commonly opens a long interrupt-handler routine rather than closing one, so it truncates the real body to one line (confirmed: ELOOPFIN, AGC_BLOCK_TWO_SELF-CHECK.agc:303, a 20+-line real routine collapsed to just its own label line); (b) the `len(block.splitlines()) < 2` guard (detector.py:1973) unconditionally discards legitimate single-instruction assembly subroutines when the next func_start match sits on the very next line (confirmed: SOPTION1-SOPTION5+, AGC_BLOCK_TWO_SELF-CHECK.agc:210-214, each a real one-instruction label). Filed as #1949 -- a follow-up read-only Gemini/agy dispatch confirmed both root causes generalize beyond agc_assembly to the shared Mode A mechanism (assembly, cobol, fortran, abap all independently exhibit bug 1; assembly and cobol also exhibit bug 2), plus two further bug-1 variants not visible from agc_assembly alone: the terminator regex also false-matches inside comments (assembly) and inside hyphenated identifier names (cobol), not just legitimate-but-misclassified instructions. See #1949 for the full cross-language evidence and fix scope. No credit/debit -- the 215 portion is an honest scope difference (not two tools independently wrong about the same fact), and the 50 portion is GitGalaxy's own unresolved bug, not something ctags corroborates or contradicts.
@@ -28,7 +28,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `agc_assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 37 occurrences as of 2026-08-22T01:53:56Z*
+*2-vs-1 -- 37 occurrences as of 2026-08-22T11:40:58Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Confirmed: all 35 occurrences are real AGC labels that GitGalaxy correctly extracts and Universal Ctags' generic Asm parser structurally cannot tag, due to AGC assembly's non-standard label-naming conventions. Two sub-patterns, both confirmed corpus-wide (14/35 + 21/35 = 35/35, not just the sample): (1) labels with an embedded hyphen -- AGC's own convention of naming a point relative to an event, e.g. TIG-35/TIG-30/CALLT-35 in BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc:250/292/222 ("35/30 seconds before Time of Ignition"); (2) labels starting with a digit or a leading minus sign, e.g. 1CHK/2EBANK/-1CHK in AGC_BLOCK_TWO_SELF-CHECK.agc:184 (real label text is "-1CHK"). Directly verified via `ctags --language-force=Asm --kinds-Asm=l` against the real corpus files: ctags emits zero tags for any of these names (confirmed by grepping its actual output for the exact names and their surrounding CHK-suffixed siblings, which ARE tagged when they don't start with a hyphen/digit) -- ctags' Asm parser requires a tag name to start with a letter and contain no hyphen, neither of which is a real constraint in AGC assembly's own label syntax. GitGalaxy's func_start regex ([A-Z0-9_-]+ at line start) has no such restriction. This is a confirmed, structural ctags/Asm-parser limitation, not corroboration of anything wrong on GitGalaxy's side -- logged to docs/why_gitgalaxy_beats_ast_here.md.
@@ -50,7 +50,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 26 occurrences as of 2026-08-22T01:53:58Z*
+*2-vs-1 -- 26 occurrences as of 2026-08-22T11:41:01Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed shape, no clean credit/debit call. (1) A real, confirmed GitGalaxy defect: the same detector.py `_slice_by_labels` bug filed for agc_assembly as #1949 (RELINT-style early truncation and single-line/blank-collapsed body discard) independently confirmed live for generic assembly too -- `del_command:` (bootos/os.asm:269) sits immediately before the next label `os22:` with nothing between, collapsing to a one-line block and getting discarded; `C:`/`prtstr:` (hellosilicon/matrixmultneon.s:90,92) are each followed only by a data directive (`.fill`, `.asciz`) then a blank line before the next label, same one-line-after-strip() collapse. All three are real regex matches (confirmed via direct func_start.finditer against the raw text) that never reach the final function list -- tracked under #1949, not a new issue. (2) A correct-by-design GitGalaxy exclusion: `.Lenv0:`/`.Largv0:` (cosmopolitan/ape.S:1784-1785) start with the `.L` prefix func_start's own negative lookahead deliberately excludes (GCC's own convention for compiler-generated local/temporary labels) -- both are genuinely data labels (`.asciz` string constants) here, not real subroutines; ctags' generic Asm parser has no such convention-awareness and tags them anyway. (3) ctags itself over-tags some non-callable constructs GitGalaxy correctly excludes -- C-preprocessor `#define` macro constants (`GRUB_MAGIC`/`GRUB_EAX`/`GRUB_AOUT`/`GRUB_CHECKSUM`/`USE_SYMBOL_HACK`, cosmopolitan/ape.S:49,1679-1682) are not real assembly labels at all (no trailing `:`), but ctags' Asm parser tags them regardless. No credit/debit -- the shape mixes a real unresolved GitGalaxy recall gap (#1949) with cases where ctags is the one over-tagging, not a clean corroboration story either direction.
@@ -70,7 +70,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:53:58Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:01Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed shape, three distinct confirmed mechanisms, no clean credit/debit call (real wins and real gaps in both directions within the same shape). (1) A dot-prefix naming-convention split -- NASM/GAS local labels scoped to the preceding global label are written with a leading `.` (e.g. `.load_vec:`, `.loop:` in bootos/os.asm:197,306), which GitGalaxy's func_start regex captures verbatim but ctags' Asm parser strips before emitting the tag (confirmed: ctags reports the SAME real label as `load_vec`/`loop`, no dot -- both tools genuinely found the same real construct, they just serialize the name differently). This is a name-string artifact of exact-string ledger grouping, not a detection difference on either side. (2) A genuine ctags gap: purely numeric local labels (`.1:`, `.2:` in bootos/counter.asm:52,67) are not tagged by ctags' Asm parser under ANY name (confirmed: neither `1`/`2` nor `.1`/`.2` appear in its output at all) -- GitGalaxy correctly finds these. (3) A genuine GitGalaxy precision gap, the mirror image of agc_assembly's own win: unlike agc_assembly's func_start (which requires a label be followed by a real instruction opcode), generic assembly's func_start has no such requirement -- ANY `identifier:` at line start matches, so it also matches pure data/constant declaration labels ctags' comparatively more conservative reading skips: `max_entries: equ sector_size/entry_size` (bootos/os.asm:166, a compile-time constant, not a subroutine), and several string/metadata labels in cosmopolitan/ape.S followed only by `.asciz`/data directives (`ape.ident`, `freebsd.ident`, `netbsd.ident`, `openbsd.ident`, `str.error`, `str.crlf`, `str.e820`, `str.oldcpu`). Not filed as a bug -- generic assembly's func_start is intentionally permissive because it has to span wildly different, informally-specified dialects (x86/ARM/legacy real-mode) where a fixed per-opcode whitelist like agc_assembly's isn't practical; worth a future harden-language-extraction look at whether a narrower heuristic (e.g. excluding labels followed only by known data-directive pseudo-ops like .asciz/.long/.byte/equ) could recover some of this precision without losing real dialect coverage, but that's a design tradeoff, not a clear regression to fix urgently.
@@ -89,7 +89,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 74 occurrences as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 74 occurrences as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed, independently verified all 6 sampled names against real source -- GitGalaxy and ctags both correct, tree-sitter over-recalling from two related but distinct preprocessor-driven mechanisms, both already covered by existing infrastructure: (1) keyword/macro misparse -- 'if' (dictobject.c:522-527, an `#if SIZEOF_VOID_P > 4` / `else if` sequence desyncs the parse) and 'DICT___REVERSED___METHODDEF' (dictobject.c:5102, a PyMethodDef array-initializer macro, not a definition) are both ALREADY in tree_sitter_accuracy_audit.py's `_C_KNOWN_MACRO_HALLUCINATIONS` exclusion set (confirmed by reading it directly) -- this tri-comparison tool's raw walk deliberately doesn't apply that list (it's a curated, ground-truth-shaped judgment call, appropriately left to reconciliation per this module's own stated design, not baked into the walk). (2) dead #if 0 code -- '_PyObject_ManagedDictValidityCheck' (dictobject.c:7396) and 'tos_char'/'print_stack'/'print_stacks' (frameobject.c:1264-1313) are genuinely well-formed function definitions sitting entirely inside `#if 0 ... #endif` guards; tree-sitter has no preprocessor model and parses the dead branch as live code. Both mechanisms are already the exact shape docs/why_gitgalaxy_beats_ast_here.md's Claim 8 names generically ('a dead #if 0 block... macro definitions... that merely look structural') -- added these 4 new concrete citations to Claim 8's evidence section rather than treating this as a new finding. No GitHub issue -- both tools already behave as intended; this is expected, already-documented tree-sitter preprocessor-blindness surfacing under the new tri-comparison reconciliation, not a fresh defect.
@@ -109,7 +109,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 14 occurrences as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 14 occurrences as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed.
@@ -129,7 +129,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > 3 distinct causes, all genuine tree-sitter-c grammar limitations (GitGalaxy and ctags both correct in all 10 sampled cases) -- confirmed via dispatched investigation (which ran tree-sitter's C grammar directly and found ERROR nodes in every case) plus independent source-level spot-checks of all 3 trigger shapes. This is a C-scale instance of Claim 7 (CPP-directive-driven recall loss) -- added to that claim's evidence section. (1) 4 samples: an #if/#else pair splitting a single `if` condition inside a function body (ceval.c:33, _Py_ReachedRecursionLimitWithMargin). (2) 5 samples: bare, un-semicoloned macro invocations the grammar can't cleanly recover from, losing the next real function (object.c:1269-1271's _Py_COMP_DIAG_PUSH/IGNORE_DEPR_DECLS/POP before _PyObject_SetAttributeErrorContext; similar shape for the typeobject.c slot-getattr cluster). (3) 1 sample: #if/#endif wrapping only the `static` storage-class specifier, separated from the rest of the signature (micropython/compile.c:3473-3476, mp_compile_to_raw_code). Unlike Fortran's existing Claim 7 evidence (entire trailing sections lost), C's version is local -- one function lost per trigger, not a cascading region. No GitHub issue -- documented as new Claim 7 evidence, not a fixable tooling bug (this repo doesn't control tree-sitter-c's grammar).
@@ -149,7 +149,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes.
@@ -166,7 +166,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up.
@@ -180,7 +180,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > UPDATED after a real production fix (the same fix documented in cpp's agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- c and cpp share the mechanism, `lang_id in ("c", "cpp")` in detector.py's `_slice_by_braces`). GitGalaxy now scans each file for `#define NAME(...)` function-like macro definitions and excludes any func_start match whose captured name is a known macro -- confirmed to eliminate the already-documented `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL`/`DICT___REVERSED___METHODDEF` cpython/typeobject.c false positives entirely (a direct `SELECT func_name ... WHERE func_name IN (...)` query against a fresh scan returned zero rows). The small residual (3 occurrences: `slot_nb_power`, `slot_nb_bool`, `wrap_next`, all cpython/typeobject.c) is a DIFFERENT, unrelated finding, not yet individually root-caused -- GitGalaxy and tree-sitter both correctly find these real functions and ctags doesn't; plausibly the same category of ctags miss documented in cpp's sibling entry (an ordinary function ctags' C++ parser fails to tag for reasons unrelated to macros) but not directly confirmed for these three specific names. No credit_tools adjustment applies -- already a naturally-corroborated 2-of-3 agreeing pair.
@@ -193,7 +193,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:04Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:07Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a GitGalaxy or ctags defect -- a bug in this tool's OWN _count_ctags_signature_params (tri_comparison_gatherer.py), now fixed. Confirmed directly: ran ctags against cpython/ceval.c, PyEval_GetLocals(void)'s raw signature field is literally the text '(void)'. GitGalaxy and tree-sitter both already special-case C's explicit empty-parameter-list idiom (0 real args, matching detector.py's own _count_top_level_args docstring) -- _count_ctags_signature_params did not, splitting '(void)' into one non-empty segment and counting it as 1 real parameter (the same class of bug its own docstring already describes fixing twice for Python's trailing-comma and bare * / marker cases). Added 'void' to the segment-exclusion set alongside the existing '*'/'/'/'**' -- verified fix: _count_ctags_signature_params('(void)') now returns 0. This corpus (cpython) uses the (void) idiom extremely heavily, plausibly explaining most/all of the 104 occurrences; not independently re-verified beyond the sample, but the mechanism is unconditional (any '(void)' signature was miscounted the same way, corpus-wide) so high confidence it generalizes. No GitHub issue needed -- fixed directly in this same commit, not a repo-code defect.
@@ -206,7 +206,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cobol` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 136 occurrences as of 2026-08-22T01:54:09Z*
+*2-vs-1 -- 136 occurrences as of 2026-08-22T11:41:12Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-19):
 > Mixed-cause shape, majority ctags-side false positives plus a smaller hidden GitGalaxy defect. (1) Majority (all 10 capped examples, all named END-IF): Universal Ctags' COBOL parser tags ANY period-terminated word as a 'paragraph' (kind p), including scope terminators like END-IF./END-PERFORM. that are not paragraph definitions -- confirmed by a live ctags run on cics-banking-sample-application-cbsa/BANKDATA.cbl showing dozens of plain 'END-IF.' lines (e.g. lines 455, 600) tagged as paragraphs. GitGalaxy correctly excludes these via its END-[A-Za-z0-9_-]+ reserved-word shield. This is a permanent, structural ctags limitation (documented in tests/tools/ctags_reader.py), not a GitGalaxy defect. (2) A smaller (~20 of 133), genuine GitGalaxy false-negative hiding underneath: cics-genapp/lgdpol01.cbl:139 'DELETE-POLICY-DB2-INFO.' and lgapol01.cbl:137 'WRITE-ERROR-MESSAGE.' are real, called (PERFORM'd) paragraph definitions that GitGalaxy's own func_start regex wrongly excludes -- its reserved-word negative lookahead ends in a bare \b, and since '-' is a non-word character in Python re, any real paragraph name that happens to start with a banned keyword followed by a hyphen (a common COBOL verb-prefixed naming convention: WRITE-*, READ-*, SET-*, DELETE-*, ...) is wrongly rejected. Verified directly against the compiled regex (both return no match) and confirmed ~20 such real paragraphs exist corpus-wide via grep. Filed as GitHub issue #1892. Investigated via gemini-3.1-pro-high (agy), file:line citations and regex behavior independently re-verified by Claude before applying.
@@ -226,7 +226,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cobol` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 43 occurrences as of 2026-08-22T01:54:09Z*
+*2-vs-1 -- 43 occurrences as of 2026-08-22T11:41:12Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-19):
 > Mixed-cause shape, two independent confirmed defects, neither in GitGalaxy's core function detection being right or wrong as a whole. (1) MAINLINE/TIMESTAMP and most of the 18 cases: these are real COBOL SECTION headers in the PROCEDURE DIVISION (e.g. cics-genapp/lgacdb01.cbl:128 "MAINLINE SECTION.", cics-banking-sample-application-cbsa/BANKDATA.cbl:1441 "TIMESTAMP SECTION." followed by executable CALL statements) that GitGalaxy correctly captures per its own documented func_start scope ("Paragraphs and Sections") -- and ctags ALSO correctly tags them, as kind 'section' (verified via live ), not as the 'paragraph' kind. The disagreement is manufactured by tests/tools/ctags_reader.py's CTAGS_FUNC_KINDS["cobol"] = {"p"}, which drops section-kind tags before comparison -- a test-harness bug, not a real ctags-vs-GitGalaxy disagreement. Filed as GitHub issue #1891. (2) LOCAL-STORAGE (cics-banking-sample-application-cbsa/XFRFUN.cbl:107 "LOCAL-STORAGE SECTION." immediately followed by 01-level data item declarations, no executable logic): this is a genuine GitGalaxy false positive -- the func_start regex's reserved-word negative lookahead bans WORKING-STORAGE and LINKAGE as Data Division section names but omits LOCAL-STORAGE, so it slips through and gets miscounted as a paragraph. ctags correctly reports nothing here. Filed as GitHub issue #1890. Investigated via gemini-3.1-pro-high (agy), file:line citations independently re-verified by Claude against language_standards.py and a live ctags run before applying.
@@ -248,7 +248,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 194 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 194 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > UPDATED: count grew (98 -> 194) as a direct, correct consequence of the OPCODE-macro fix documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- tree-sitter's OWN OPCODE-family misparse (godot/gdscript_vm.cpp's bytecode-dispatch macro) was previously MASKED by GitGalaxy sharing the identical mistake (both wrong == they 'agreed', landing in the other shape instead of this one). Now that GitGalaxy correctly excludes known macro invocations, tree-sitter's own grammar limitation on this exact pattern is cleanly isolated here instead, confirmed via the shape's own examples (repeated `OPCODE` entries at godot/gdscript_vm.cpp, tree_sitter line set, ctags/gitgalaxy both None). The remaining, previously-documented causes (bare control-flow-keyword/`void` hallucination, conversion-operator naming-suffix convention) are unchanged and still contribute the bulk of the original 98. No credit/debit applies -- tree-sitter is the one that's wrong here, alone.
@@ -268,7 +268,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 60 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 60 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy args-counting defect, filed as https://github.com/squid-protocol/gitgalaxy/issues/2012 . Two distinct sub-patterns visible in the sample: (1) zero-undercounting for out-of-class method definitions with real parameters (VBufStorage_buffer_t::replaceSubtrees, Translator::BuildBuffer, Translator::BuildVhloCompositeV1Op, and every `operator()` call-operator overload in godot/node.h) where ctags and tree-sitter both correctly count real, non-zero parameter lists and GitGalaxy reads 0; (2) an off-by-one OVERcount for a constructor with a member-initializer-list but zero real parameters (VBufStorage_buffer_t's default constructor -- ctags/tree-sitter correctly read 0 params, GitGalaxy reads 1). Not the same shape as the func_start recall gaps in #2009/#2010 -- these are all functions GitGalaxy already finds, just with the wrong parameter count. Needs its own dedicated investigation per the issue (may be one or two root causes).
@@ -288,7 +288,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 60 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 60 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real tree-sitter-cpp grammar limitation, not a GitGalaxy or ctags defect. Every sampled case (GDScriptFunction::call, Main::setup, Main::setup2, Main::start, Object::Connection::operator Variant) is a large, complex function -- GDScriptFunction::call in particular (godot/gdscript_vm.cpp:499) is a bytecode interpreter's main dispatch loop using GNU 'labels as values' computed-goto syntax (`&&OPCODE_LABEL`) via the same OPCODES_TABLE/OPCODE macro family documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- a non-standard GNU extension tree-sitter-cpp's grammar does not support, which plausibly causes a parse error cascade that loses the enclosing function_definition node entirely rather than just misreading the body. ctags and GitGalaxy both correctly find and name these functions regardless of body content, since neither one needs to fully parse the function body to recognize its signature. tree-sitter's non-detection is a confirmed limitation in tree-sitter itself -- but no credit_tools adjustment applies: ctags and GitGalaxy are already a 2-of-3 AGREEING PAIR on this shape (agreeing_tools has 2 members), which already satisfies reconcile_symbols' own `len(present) >= 2` precision-credit condition naturally with no ledger adjustment needed. credit_tools exists for a LONE, single-tool claim (agreeing_tools with exactly 1 member) the base algorithm can't otherwise corroborate -- applying it to an already-mutually-corroborating pair would double-count (confirmed: this exact mistake briefly pushed ctags' precision past 100% before being caught and reverted in this same session).
@@ -308,7 +308,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 30 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 30 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed ctags-only limitation: ctags parses INSIDE C++ macro DEFINITION bodies as if they were real, already-expanded code. godot/object.h's GDCLASS/_FORCE_INLINE_-based macros (`#define GDCLASS(m_class, m_inherits) ... _FORCE_INLINE_ bool (Object::*_get_get() const)(...) {...} ...`) never run as written -- they only produce real code once expanded at a `GDCLASS(SomeClass, Base)` call site elsewhere -- but ctags tags `_get_get`/`_get_set`/`_get_bind_methods`/`_get_bind_compatibility_methods`/`_get_notification`/`_get_property_can_revert`/`_get_property_get_revert`/`_get_validate_property`/`_get_get_property_list` (all 9 sampled cases, all from this same macro) as if they were ordinary member functions. Neither GitGalaxy nor tree-sitter are fooled by this. Documented in ctags_reader.py's KIND MAPS section (cpp bullet) rather than fixed -- this is ctags' own parser behavior, nothing in this repo's tooling can distinguish a macro-definition body from real code without reimplementing preprocessing.
@@ -328,7 +328,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real tree-sitter accuracy-tool limitation, filed separately (see the sibling agree[none]_vs[ctags,gitgalaxy,tree_sitter] args entry and its referenced issue for the full writeup). tree-sitter's own parameter count (via the shared `_get_param_count` helper in tree_sitter_accuracy_audit.py, reused by tri_comparison_gatherer.py) undercounts by exactly 1 whenever a function has a parameter with a default value -- confirmed 6/6 sampled cases (save_scene_to_path, step, get_index, atr_n, atr, ObjectSignalLock), all off by exactly 1, all involving a `= default_value` parameter, ctags and GitGalaxy both correctly counting the real total. No credit_tools/debit_tools adjustment applies -- this is an args-metric shape, and apply_verified_adjustments only ever touches existence-metric precision (args scores have no equivalent verified-adjustment mechanism in this ledger's own code, see tri_comparison_ledger.py's apply_verified_adjustments docstring), so these fields would be a pure no-op here regardless of value -- left empty rather than set-but-inert, for an accurate record.
@@ -348,7 +348,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > UPDATED after a real production fix. The OPCODE-family shared mistake documented in this shape's prior verdict (~96 of the original 105 occurrences) is now FIXED: GitGalaxy's func_start (and by the same mechanism, C's) now scans each file for `#define NAME(...)` function-like macro definitions and excludes any match whose captured name is a known macro -- the exact same fact universal-ctags itself already used (confirmed via a direct `ctags -f -` run: ctags tags `OPCODE` only once, at its own #define line, kind `d`, and produces zero tags at any invocation site -- it isn't smarter about the invocation's shape, it just already knows the name is a macro and never re-tags it). This also fixed the already-documented C `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL`/`DICT___REVERSED___METHODDEF` false positives as a bonus (same mechanism, `lang_id in ("c", "cpp")`). Verified via 3 repeated full-corpus scans producing byte-identical function lists, the full extraction gauntlet, and both golden masters re-blessed. The remaining residual (9 occurrences, previously miscounted as more of the same shared mistake in the earlier verdict's blanket debit -- corrected here) is a DIFFERENT, unrelated finding: GitGalaxy and tree-sitter are CORRECT here, ctags is wrong. Two sub-patterns confirmed: (1) the already-documented macro-as-return-type-prefix pattern (`IFACEMETHODIMP_(void)` immediately before the real `FancyZones::Run() noexcept` -- ctags tags the macro invocation itself and loses the real name, powertoys/FancyZones.cpp, 4 occurrences); (2) a newly-confirmed, NOT yet root-caused ctags miss on an ordinary virtual method with no macro involvement at all (`virtual RID mesh_create_from_surfaces(const Vector<RenderingServerTypes::SurfaceData> &p_surfaces, int p_blend_shape_count = 0) override { ... }`, godot/rendering_server_default.h -- ctags produces zero tags anywhere near this real method, 5 occurrences). No credit_tools adjustment applies: GitGalaxy and tree-sitter are already a 2-of-3 agreeing pair here, which already satisfies reconcile_symbols' own natural precision-credit condition.
@@ -367,7 +367,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Compound shape, three distinct causes confirmed via source, not one. (1) Most of the sample (OPCODE_WHILE x2, OPCODE_SWITCH, OPCODE) is the same GG+tree-sitter shared macro-misparse family documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry (godot/gdscript_vm.cpp's OPCODE/OPCODE_WHILE/OPCODE_SWITCH dispatch macros) -- here landing as 'GitGalaxy alone' because tree-sitter's own error recovery on this repeated macro pattern isn't fully deterministic across every occurrence, not because the underlying cause differs. GitGalaxy is WRONG for this portion (same debit as the sibling entry, not double-counted here since debit_tools is per-shape). (2) `attribute_buffer_applier_factories_`/`m_draggingState`/`std::thread` are a separate, real GitGalaxy FALSE POSITIVE: a lambda passed as a constructor argument or member-initializer-list entry (`m_draggingState([this]() {...}),`, `std::thread([...]() {...}).detach();`) is misread as a function definition. Filed as https://github.com/squid-protocol/gitgalaxy/issues/2013 . (3) `Variant::operator ::RID`/`Variant::operator ::AABB`/`Variant::operator Object *` are real functions GitGalaxy correctly finds (confirmed via godot/variant.cpp source) that didn't rank-match ctags/tree-sitter's own readings of the same functions by exact name string -- a residual, low-priority naming-comparison edge case (global-scope `::`-prefixed conversion-operator return types) not chased further in this pass. No credit/debit applied given the mixed, three-cause nature of this shape.
@@ -381,7 +381,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Not a real existence disagreement -- a template-argument name-formatting difference in the comparison tooling. `godot/variant.h`'s `HashMapComparatorDefault<Variant>` and `is_zero_constructible<Variant>` are template CLASS specializations; GitGalaxy and tree-sitter both read the name WITH its template argument baked in (matching the instantiation as written in source), while ctags strips the `<...>` template-argument suffix from its own class tag name. All three tools found the exact same class definition at the exact same line -- confirmed via the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry, which is the same pair of classes from the opposite direction. Low magnitude (2 occurrences) -- not chased to a code fix in this pass, but a plausible future micro-fix would strip a trailing `<...>` from gg/tree-sitter's class name before matching, mirroring how ctags_reader.py's operator-name normalization already handles a similar formatting mismatch.
@@ -393,7 +393,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Same template-argument name-formatting difference as the sibling agree[ctags]_vs[gitgalaxy,tree_sitter] class entry, viewed from the opposite direction -- `HashMapComparatorDefault`/`is_zero_constructible` (ctags' bare names) vs. `HashMapComparatorDefault<Variant>`/`is_zero_constructible<Variant>` (GitGalaxy/tree-sitter's names, template argument included). Not a real disagreement about whether these classes exist -- see the sibling entry for the full explanation.
@@ -405,7 +405,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:13Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > The single sampled occurrence (mlir/flatbuffer_export.cc:654, the `Translator` class's constructor) is exactly the bug filed as https://github.com/squid-protocol/gitgalaxy/issues/2009 -- a member-initializer-list spanning 906 characters exceeds GitGalaxy's func_start regex's 500-character cap for that clause, so the whole constructor is invisible to GitGalaxy despite ctags and tree-sitter both finding it correctly. GitGalaxy's non-detection is a confirmed, filed limitation -- but no credit_tools adjustment applies: ctags and tree-sitter are already a 2-of-3 AGREEING PAIR on this shape, which already satisfies reconcile_symbols' own `len(present) >= 2` precision-credit condition naturally. See the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] entry for the full explanation of why credit_tools only applies to a LONE, single-tool claim, never an already-agreeing pair.
@@ -416,7 +416,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T01:54:13Z*
+*3-way split -- 1 occurrence as of 2026-08-22T11:41:17Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > A single function (NVDA/storage.cpp's `outputEscapedAttribute`, `size_t outputEscapedAttribute(wostringstream& out, const wstring& text, size_t maxLength=0)`, 3 real parameters) where all three tools disagree for two already-independently-confirmed reasons, not a new one: ctags reads the correct count (3); GitGalaxy reads 0, matching the args-undercounting defect filed as https://github.com/squid-protocol/gitgalaxy/issues/2012 ; tree-sitter reads 2, matching the default-value-parameter undercount filed as https://github.com/squid-protocol/gitgalaxy/issues/2014 (this function's third parameter, `maxLength`, has a default value -- exactly the trigger condition for that bug). Both referenced issues cover the general pattern; no new finding here beyond confirming they can compound on the same function.
@@ -429,7 +429,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 271 occurrences as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 271 occurrences as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:27Z):
 > Confirmed: this shape is entirely tree-sitter-c-sharp's own known parse-error cascade in roslyn/LanguageParser.cs, already root-caused and evidence-backed as Claim 3 in docs/why_gitgalaxy_beats_ast_here.md (issues #1427/#1567). A syntax construct at line ~5198 triggers a parse error whose recovery fails to resynchronize for the rest of the (14,680-line) file -- tree.root_node.type itself becomes ERROR, so tree-sitter's own recall for this file collapses to near-zero past that point. GitGalaxy's regex and ctags' text-based parser are both unaffected and correctly find these functions (all sampled: ParseVariableDeclarator, GetPrecedence, ParsePrimaryExpression, ScanType x3 -- real, ordinary private methods, exact line-number agreement between ctags and gitgalaxy on every one). This is the tri-comparison ledger's own version of a phenomenon already fully diagnosed for the 2-way tree_sitter_accuracy_audit.py tool via its cascade_promotable logic -- that logic was never ported to tri_comparison_gatherer.py/tri_comparison_reconcile.py, which is why this shows as an unvalidated ledger shape despite being a known, closed question. Not a GitGalaxy or ctags defect. CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct.
@@ -449,7 +449,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 108 occurrences as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 108 occurrences as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:44Z):
 > Confirmed real ctags parser limitations, not a GitGalaxy or tree-sitter defect, via direct source reading and raw `ctags -x` runs against the flagged files. Two distinct mechanisms: (1) Local/nested functions -- roslyn/CSharpCompilation.cs's `validateSignature` (nested inside a larger method) and `isSupportedType` (a `static bool isSupportedType(...)` local function) are both structurally invisible to ctags, whose csharp kind map is only 'm' (top-level methods; "C# has no free functions" per ctags_reader.py's own comment) with no local-function concept at all -- this generalizes to every local function in the corpus, not just the sampled two. (2) Complex-signature misses and overload collisions on ordinary top-level private methods -- `FindEntryPoint` (nullable return/param types plus a generic `out` parameter) and `GetSourceDeclarationDiagnostics` (5 params, two with default values, one a `Func<...>` generic delegate) get no ctags tag at all, confirmed via `ctags -x` showing tags immediately before/after but not at their own lines -- isolated misses, not a wider blind region (unlike the tree-sitter cascade in the sibling ledger shape). `ReportUnusedImports` has two overloads at different lines; ctags tags only the first, silently dropping the second. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet. Credited on the strength of mechanism (1) generalizing structurally to the whole shape (ctags cannot see ANY local function, by construction) even though only ~5 of 107 occurrences were individually read -- mechanism (2)'s complex-signature misses are a smaller, less certain-to-generalize contributor to the same shape but point the same direction (ctags-side, not GitGalaxy/tree-sitter). CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct.
@@ -469,7 +469,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 46 occurrences as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 46 occurrences as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T21:45:53Z):
 > Mixed shape, confirmed via a full name-diff against gather_language('csharp') rather than the capped sample alone: 44 of 48 are genuine local (nested) functions inside roslyn/LanguageParser.cs's tree-sitter parse-error cascade region (line >= ~5198, same mechanism as the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] shape / Claim 3) -- tree-sitter is fully blind there, and ctags additionally has no concept of a local/nested function at all (only top-level 'm' method tags), so GitGalaxy is the only tool that can see these. The remaining 2 are genuine GitGalaxy false positives with a confirmed, unrelated root cause: roslyn/CSharpCompilation.cs:2282's GetWellKnownType( (a call, no declaration exists anywhere in the file) and roslyn/LanguageParser.cs:2338's this.EatToken( (a call inside a switch-expression arm) are both mis-captured because func_start's return-type-loop character class allows unbalanced parens/commas in a single 'token', letting it swallow a real call-expression fragment as if it were part of a return type and land on the wrong identifier as the 'function name'. Filed as GitHub issue #2035 with root cause and fix direction; fix in progress in an isolated worktree as of this writing. Not crediting/debiting any tool on this shape since it's genuinely mixed (44 real local-function finds, 2 real false positives) -- re-visit once #2035 merges and re-run to confirm the shape drops to 44 (or fewer, if further false positives of the same class surface once #2035's fix generalizes across the full corpus). FOLLOW-UP (2026-08-21, post-#2035/#2036 re-verification): re-checked this shape with a full, uncapped corpus diff rather than the capped example sample. The 2 originally-confirmed false positives (GetWellKnownType, this.EatToken) are gone as expected. However 2 MORE confirmed false positives remain, distinct mechanisms from #2035's fix: CSharpCompilation.cs's `ref mdName, ..., CreateReflectionTypeNotFoundError(` (a real call site mistaken for a declaration because `ref` is a legitimate Branch A modifier keyword when used in a real declaration, but here it's a call-argument prefix) and LanguageParser.cs:2336's `_syntaxFactory.TypeConstraint(this.ParseType())` (a ternary `?` operator consumed by the return-type loop's nullable-type-marker allowance, same general shape as this.EatToken but not covered by #2035's specific fix). Filed as issue #2054. This shape remains genuinely mixed (the overwhelming majority are real cascade-region local functions, but a small residual of false positives keeps surfacing) -- still correctly left uncredited pending #2054. CLOSED (2026-08-21): this shape is now fully clean. Both remaining false-positive mechanisms (issue #2054: bare-comma call-argument absorption, ternary-? consumption, and the nested-generic-return-type regression its own fix introduced and #2061 corrected) are fixed and merged. A full uncapped re-diff confirms all 44 remaining occurrences are genuine local functions inside LanguageParser.cs's tree-sitter parse-error cascade region (Claim 3), zero non-cascade residue. credit_tools is now correctly applicable -- gitgalaxy is alone on this shape (no tool to share the credit-double-counting error this session already found and fixed on the sibling agree[ctags,gitgalaxy]/agree[gitgalaxy,tree_sitter] shapes with), and every one of its 44 claims here is confirmed real with the reason ctags (no local-function concept) and tree-sitter (parse cascade) don't corroborate it being a confirmed limitation in THEM, not an open question about GitGalaxy.
@@ -489,7 +489,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:27Z):
 > Same root cause and file as the sibling function-existence shape (roslyn/LanguageParser.cs's tree-sitter parse-error cascade from line ~5198, Claim 3 in why_gitgalaxy_beats_ast_here.md, #1427/#1567) -- with the parse tree corrupted into a single ERROR node, tree-sitter can't resolve any class_declaration structure in the corrupted region either, including the outer LanguageParser class itself (whose body spans the entire cascade) and every enum/nested class declared inside it (VariableFlags, NameOptions, ScanTypeArgumentListKind, ScanTypeFlags, ParseTypeMode, etc.). ctags and GitGalaxy both correctly find these via text-based parsing, unaffected by tree-sitter's own AST failure. Not a GitGalaxy or ctags defect. CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct.
@@ -508,7 +508,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Confirmed GitGalaxy defect for 6 of 7 occurrences, root-caused to 3 distinct mechanisms in the csharp args regex, none of which func_start's own (already-hardened) regex shares: (1) Branch 1's return-type-loop character class has no parens, so any tuple-shaped or generic-wrapped-tuple return type fails to match at all (HasEntryPointSignature: real=2, GitGalaxy=0; SetCurrentSolutionEx: real=1, GitGalaxy=2; SetCurrentSolutionAsync both overloads: real=6/GitGalaxy=2, real=7/GitGalaxy=0); (2) the shared args capture group `(\([^)]*\))` truncates at the first unbalanced `)`, breaking on any parameter whose own type contains parens (ProcessEventHandlerWorkQueueAsync's ImmutableSegmentedList<(tuple)> param: real=2, GitGalaxy=1); (3) the name-capture has no generic-type-parameter stepper (func_start's already does), so a generic method's <T> before the real parens fails to match (OnAnyDocumentTextChanged<TArg>: real=7, GitGalaxy=2; ScheduleTask<T>: real=2, GitGalaxy=1). Filed as issue #2051 with full evidence per mechanism. The 7th occurrence (GetModifierExcludingScoped) is NOT a real defect on either side: both of its overloads (1 param and 2 params) are correctly counted by GitGalaxy; the apparent ctags=2/gitgalaxy=1 mismatch is the reconciler's rank-based (not name/overload-based) pairing comparing two DIFFERENT real overloads against each other, not a genuine disagreement about the same declaration -- confirmed by reading both real declarations directly. No credit/debit: GitGalaxy is genuinely wrong on 6/7, and the reconciler-pairing noise on the 7th isn't a tool defect at all.
@@ -525,7 +525,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Mixed shape. 1 of 4 is a confirmed genuine ctags defect: GetHashCode's tuple-parameter overload (`GetHashCode((ImmutableArray<byte> ContentHash, int Position) obj)`, 1 real param) -- ctags reports 2, mis-splitting the tuple-typed parameter's own internal comma as a second top-level parameter, the same family as the already-documented tuple-related ctags limitations in tests/tools/ctags_reader.py's csharp bullet. The other 3 (GetModifierExcludingScoped and two SetCurrentSolution rows) are NOT real tool disagreements at all -- SetCurrentSolution has 4 real overloads (1/6/4/5 real params respectively) in roslyn/Workspace.cs; every individual reading from every tool across both rows (ctags=6, gitgalaxy=1, tree_sitter=1, ctags=4, gitgalaxy=6, tree_sitter=6) independently matches SOME real overload's true count exactly when checked against the source -- the ledger shape only exists because the reconciler's rank-based pairing compared different tools' readings of DIFFERENT overloads against each other, not because any tool actually miscounted anything. Confirmed via direct line-by-line source reading of all 4 overloads. Credit gitgalaxy+tree_sitter for the 1 real ctags defect only; the shape as a whole is left without a clean credit/debit since 3 of 4 occurrences aren't a real disagreement to adjudicate.
@@ -539,7 +539,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Confirmed: both ctags and GitGalaxy are wrong here, tree-sitter alone is right. roslyn/CSharpCompilation.cs:2539's `Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` has 2 real parameters (both tuple-typed); tree_sitter correctly reports 2. GitGalaxy's args capture group truncates at the first unbalanced `)` inside the first tuple parameter's own type, reporting 1 (mechanism 2 of issue #2051, confirmed via direct regex testing). ctags independently also reports 1, for its own unrelated reason (the same tuple-parameter-splitting limitation documented elsewhere in this file for GetHashCode/Equals-with-bool-tuple-param) -- both tools land on the identical wrong number by coincidence, not real corroboration of each other.
@@ -550,7 +550,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:20Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:27Z):
 > Confirmed genuine ctags false positive, not a GitGalaxy or tree-sitter gap. roslyn/CSharpCompilation.cs:2539's real declaration is `public bool Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` -- an Equals overload with tuple-typed parameters. ctags' lightweight C# parser misreads the return-type/tuple-parameter boundary and tags the match under the name `bool` instead of `Equals`. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet alongside this shape's sibling ctags limitations (local-function blindness, complex-signature misses, overload-name collision -- see the agree[gitgalaxy,tree_sitter]_vs[ctags] shape). Not crediting/debiting: a single-tool false positive from an otherwise-unaffected precision baseline, no shared-mistake mechanism applies.
@@ -561,7 +561,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T01:54:20Z*
+*3-way split -- 1 occurrence as of 2026-08-22T11:41:23Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Tangled: partly the same reconciler rank-pairing artifact as the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] shape (SetCurrentSolution's 4 real overloads, 1/6/4/5 params), partly a genuine GitGalaxy defect underneath. ctags=5 and tree_sitter=4 each correctly match a DIFFERENT real overload's true count (line 444's 5 params, line 230's 4 params respectively) -- not wrong, just paired against each other by rank rather than by which declaration they actually read. GitGalaxy=0 traces to the SAME occurrence tree_sitter's 4 reading corresponds to (line 230, a bare tuple return type `(bool updated, Solution newSolution)` before the method name) -- a confirmed instance of issue #2051's mechanism 1 (GitGalaxy's args regex fails to match tuple return types at all). No credit/debit: too tangled between real defect and pairing noise to cleanly adjudicate at the shape level.
@@ -574,7 +574,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `css` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T01:54:21Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T11:41:24Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed ctags-side structural limitation, not a GitGalaxy defect. GitGalaxy's own func_start regex (language_standards.py) deliberately matches CSS at-rule keywords (@media/@supports/@container/@layer/@keyframes/@-webkit-keyframes) as the closest function-shaped construct CSS has, since CSS has no true function-definition/call syntax. tree-sitter's CSS grammar independently corroborates this: media_statement/supports_statement/keyframes_statement are real, distinct node types, already mapped 1:1 onto GitGalaxy's own at-rule set per issue #1313 (see tree_sitter_accuracy_audit.py's css NODE_MAPS entry and its media_statement/supports_statement name-extraction branches). Re-ran gather_language('css') directly against the full 4-file corpus (not just the ledger's capped 3-example sample): GitGalaxy and tree-sitter agree exactly on function count in every file (3/3 total, zero diff files) -- the agreement generalizes completely, it is not a partial/mixed sample. ctags' own FUNCTION_KIND_MAP already documents 'css': set()  # no function-equivalent (ctags_reader.py) -- confirmed empty (ctags_funcs: []) across all 4 corpus files too. ctags structurally cannot tag CSS at-rules as anything function-like; it isn't wrong about a claim, it has no claim to make here at all. No new doc note needed -- both the GitGalaxy/tree-sitter convention (#1313) and the ctags limitation are already documented in code. GitGalaxy+tree-sitter's agreement is real corroboration, not a shared mistake, so no credit/debit adjustment applies; ctags' lack of a comparable slot here is already handled correctly by the reconciler's own total_slots mechanics.
@@ -589,7 +589,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `dart` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-22T01:54:25Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-22T11:41:29Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy recall gaps (tree-sitter is correct), several distinct causes found via direct source investigation against language-crucible/data/dart. Some entries in this shape's original capped example list were incidentally resolved as a side effect of the func_start fix in gitgalaxy#2071 (e.g. EditableText's own multi-line constructor, generic-return-type getters like `Iterable<Element> get children =>`, and dotted-name getters like `T? get currentState => switch (...) {...}` all now regex-match correctly and reach the final pipeline output). A post-fix full-corpus name-diff still shows 12 residual missing_from_gg cases across 5 distinct confirmed root causes, none yet fixed: (1) EditableText's constructor and a private named constructor (_DiscreteKeyFrameSimulation._(...)) regex-match (confirmed via direct probe) but don't reach the final pipeline output -- a detector.py-level extraction bug downstream of the regex, not yet traced; (2) static getters with a dotted/prefixed-import return type (`static ui.BoxHeightStyle get defaultSelectionHeightStyle {`) never regex-match at all, because the return-type-prefix character class excludes `.`; (3) bodyless default constructors (`_EditableTextTapOutsideAction();`) don't regex-match; (4-5) several more names (recorder, ChildSemanticsConfigurationsResultBuilder, OrdinalSortKey, SemanticsData, SemanticsProperties, extension) not yet individually root-caused. All tracked as a consolidated follow-up in gitgalaxy#2072 -- deliberately not rushed, since the sibling existence shape's investigation already found one naive fix (broadening the return-type charclass or the keyword-exclusion list) can silently break a much more common legitimate pattern elsewhere, so each of these needs its own regression check before shipping.
@@ -609,7 +609,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `dart` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T01:54:25Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T11:41:29Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy engine defect, not a tree-sitter limitation. Root-caused two distinct false-positive bugs in dart's func_start regex's zero-prefix branch, both in gitgalaxy/standards/language_standards.py: (1) Dart 3 switch-expression arms (`Pattern => result,` including bare `_ => result,`) matched as getter definitions, because the branch's bare-`=>` lookahead alternative was unconditional (no `get` keyword required) even though Dart's real grammar has no parameterless `=> expr` construct without `get`. (2) Call statements with a lambda argument (`obj.method((x) => ...)`, `setState(() {...})`, bare self-calls like `visitChildren((Element child) {...})`) matched as function definitions, because the paren-lookahead used a naive non-balanced-paren check (`\([^)]*\)`) that stopped at the lambda's own closing paren instead of the outer call's. A full corpus-wide before/after diff (language-crucible/data/dart, 7 Flutter framework files) confirmed 126 false-positive matches removed and only 1 new match gained (a genuine recall fix for EditableText's own multi-line constructor) -- every one of the 126 manually spot-checked as a real false positive (dotted call receiver, or a statement ending `);`, or a switch-expression arm), none a lost real definition. Fixed in gitgalaxy#2071 (merged via this ledger-sweep PR) by gating the bare-arrow alternative behind the existing `get`-group conditional and switching to the same balanced-paren pattern already used elsewhere in this regex. A smaller, related false positive (multi-line class headers with with/implements clauses absorbed as a phantom function's return-type prefix, e.g. `implements AutofillClient {` matching as a function named AutofillClient) was found in the same investigation but is NOT fixed -- the straightforward fix (excluding implements/with/extends from the return-type-prefix vocabulary) was tested and confirmed to break a much more common legitimate pattern, generic method type-parameter bounds (`static Future<T?> pushNamed<T extends Object?>(...)`), which also uses `extends`. Tracked in gitgalaxy#2072 along with several other confirmed-but-deferred recall gaps found in the same pass.
@@ -628,7 +628,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `dart` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 218 occurrences as of 2026-08-22T01:54:25Z*
+*3-way split -- 218 occurrences as of 2026-08-22T11:41:29Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy defect on args counts for class/constructor names, root cause distinct from (but likely overlapping with) the func_start existence bugs fixed in gitgalaxy#2071. Spot-checked via language-crucible/data/dart, e.g. flutter/editable_text.dart's `_DeleteTextAction` class (`class _DeleteTextAction<T extends DirectionalTextEditingIntent> extends ContextAction<T> {` at line 6352, real constructor `_DeleteTextAction(this.state, this.getTextBoundary, this._applyTextBoundary);` at line 6353 taking 3 args) -- tree-sitter correctly reports args=3 for the constructor, GitGalaxy reports args=0, most likely because GitGalaxy's func_start is matching the class declaration header itself under the same name (no explicit `(...)` immediately after the class name, since it's followed by `<T extends ...>` then `extends ContextAction<T> {`) rather than the real constructor line. This looks like the same underlying class-header-vs-function-signature ambiguity as gitgalaxy#2072 item 1 (multi-line class headers with generic type-parameter bounds), not yet isolated or fixed -- a full re-diff after this ledger sweep's existence fix still shows 302 name-matched args disagreements, most following this same class/constructor-name shape. Deliberately not fixed in this pass: root-causing exactly which of the func_start branches is misattributing these needs its own investigation with the same regression discipline the existence fix required (a naive class-header exclusion already proved unsafe once in this same investigation). Tracked as a named follow-up under gitgalaxy#2072's scope.
@@ -650,7 +650,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `fortran` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-22T01:54:31Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-22T11:41:35Z*
 
 **Verdict** (by Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T23:35:49Z):
 > Confirmed already-documented tree-sitter-fortran limitation (#1709/Claim 7 in docs/why_gitgalaxy_beats_ast_here.md), re-verified directly against this exact shape's 14 occurrences (11 in wrf/module_physics_init.F: bl_init, ra_init, landuse_init, mp_init, cu_init, shcu_init, CAM_INIT, z2sigma, fdob_init, fg_init, ALLOCATE_CAM_ARRAYS; 3 in wrf/wrf_timeseries.F: calc_p8w, calc_ts, write_ts). Directly ran tree_sitter_accuracy_audit.py's own _find_blind_spot_ranges() against both files' real parse trees: every one of the 14 occurrences' start lines falls inside a tree-sitter ERROR/preproc_* blind-spot range (e.g. bl_init/mp_init/cu_init/shcu_init all sit inside one continuous (2203,4393) span; all 3 wrf_timeseries.F occurrences fall inside a (1,1200) span). ctags and GitGalaxy are both correct; tree-sitter-fortran's own grammar cascades into ERROR nodes on the CPP #if/#endif guards surrounding these subroutines. Added as new evidence to the existing Claim 7 in docs/why_gitgalaxy_beats_ast_here.md (this ledger shape is independently sourced from the original accuracy-audit finding -- a raw per-file name diff via tri_comparison_gatherer.py, not the audit tool's promotion logic).
@@ -670,7 +670,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `fortran` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:31Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:35Z*
 
 **Verdict** (by Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985), 2026-08-21T00:00:00Z):
 > Confirmed GitGalaxy engine defect, ctags and tree-sitter both correct. init_domain (module_initialize_real.F:41, `SUBROUTINE init_domain ( grid )`) genuinely takes 1 parameter. GitGalaxy's own args regex correctly matches '( grid )' when tested in isolation against the real declaration line -- the bug is upstream of the args regex entirely: fortran's func_start regex's optional return-TYPE-prefix group (`(?:INTEGER|REAL|...)[A-Za-z0-9_ \t\n&*,()=:]{0,40}?`) allows up to 40 characters including newlines between the TYPE keyword and the following FUNCTION/SUBROUTINE/etc keyword, with no requirement that they belong to the same statement. In this file, an unrelated, already-terminated `INTEGER :: internal_time_loop` declaration sits ~30 characters (4 blank lines) before `SUBROUTINE init_domain`, so the regex's own match.start() lands on that earlier, unrelated line instead of the real declaration -- corrupting every downstream computation anchored to it (start_line, body span, and -- since #1973's fix correctly bounds the args search to the label's OWN statement span -- the args search window too, which can no longer reach the real '( grid )' text several lines later). Filed as #1982 (not yet fixed). No credit/debit -- ctags and tree-sitter aren't corroborating each other by coincidence here, they're both just correctly parsing real Fortran grammar that GitGalaxy's func_start regex currently mis-anchors.
@@ -681,7 +681,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `fortran` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:31Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:35Z*
 
 **Verdict** (by Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T23:35:49Z):
 > Confirmed GitGalaxy correct on both. 'vint' (module_initialize_real.F:5375, inside #ifdef VERT_UNIT) and 'foo' (module_initialize_real.F:7519, inside #if 0) are both real, syntactically valid `PROGRAM name` declarations. tree-sitter misses both via the already-documented #1709 ERROR/preproc_* blind-spot mechanism (both sit inside #if/#ifdef-guarded regions). ctags misses 'foo' only because CTAGS_FUNC_KINDS['fortran'] was {'f','s'} (functions/subroutines only) -- ctags itself DOES correctly tag `foo` as a 'p' (program) kind (confirmed via `ctags -x --kinds-Fortran=p`), just invisible to this comparison. Fixed in tests/tools/ctags_reader.py: CTAGS_FUNC_KINDS['fortran'] now {'f','s','p','e'} (added program, entry -- matching GitGalaxy's own func_start scope of FUNCTION|SUBROUTINE|PROGRAM|ENTRY). ctags separately, genuinely fails to tag 'vint' at all under any kind in this specific file (confirmed it tags an isolated test file with identical #ifdef-wrapped `program vint` syntax fine, so it's a real, unexplained ctags-fortran-parser corruption specific to this file's content, not a preprocessor-conditional-skip decision) -- a genuine, narrow ctags limitation, not chased further for a single occurrence.
@@ -692,7 +692,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `fortran` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T01:54:31Z*
+*3-way split -- 1 occurrence as of 2026-08-22T11:41:35Z*
 
 **Verdict** (by Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T23:35:49Z):
 > Confirmed real GitGalaxy engine defect (filed, not fixed -- needs real design work). wrf/module_physics_init.F's phy_init is a genuine 677-parameter subroutine (confirmed via `ctags --fields=+S`, which correctly reports all 677 comma-separated dummy args). GitGalaxy (40) and tree-sitter (39) both wrong, for different, independently confirmed reasons: GitGalaxy's args regex first alternative `\([^)]*\)` has no paren-depth awareness and stops at the FIRST literal ')' anywhere in the window -- which, in this signature, is the ')' closing an embedded `#if ( EM_CORE == 1 )` guard ~12 lines into the parameter list, not the real closing paren ~245 lines later (directly traced: the window-bounding fix from #1973 correctly extends to the real closing paren at line 276, but the args regex itself still truncates early). Tree-sitter's undercount is the same already-documented #1709 ERROR/preproc_* cascade applied to its own parse of this signature. ctags alone gets this right because its signature accumulation isn't a single bounded regex. This is a genuine 3-way split (no two tools agree with each other at all), so no credit/debit pair applies. Filed as https://github.com/squid-protocol/gitgalaxy/issues/2077 -- fixing it needs a real depth-aware paren scanner (mirroring dart's _count_top_level_args / cpp's _cpp_class_has_body pattern) over the already-correctly-bounded args_search_text, not a one-line regex tweak, so left for its own follow-up PR rather than shipped inline.
@@ -705,7 +705,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `go` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 75 occurrences as of 2026-08-22T01:54:34Z*
+*2-vs-1 -- 75 occurrences as of 2026-08-22T11:41:37Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`go/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -726,7 +726,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 103 occurrences as of 2026-08-22T01:54:36Z*
+*2-vs-1 -- 103 occurrences as of 2026-08-22T11:41:40Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > All 10 sampled cases are ctags-side artifacts, not real GitGalaxy/tree-sitter misses -- confirmed via direct `ctags -x` output against the corpus. Three distinct ctags Haskell-parser weaknesses cover the sample: (1) multi-clause double/triple-tagging -- ctags tags every pattern-matched equation line as its own occurrence of the name (writerFn/writeFnBinary/expandFilterPath: confirmed 2-3 raw ctags tags per function, one per clause; a file-wide count found 45 such extra same-name tags across the 7-file corpus, e.g. blockToInlines alone has 14). GitGalaxy/tree-sitter both correctly anchor to the FIRST clause only, leaving ctags' later-clause tags as the ones unpaired. (2) keyword-as-identifier misparsing -- `class`/`where`/`pattern` (from PatternSynonyms) get tagged as function names when ctags fails to parse past the keyword; confirmed at Options.hs:62 (`class HasSyntaxExtensions`), Parsing.hs:184 (module-header `where`), and 3 PatternSynonyms declarations in Options.hs. (3) CAF/value-vs-function kind collapse -- defaultAbbrevs/defaultKaTeXURL/defaultMathJaxURL/defaultWebTeXURL are zero-arg top-level VALUES (non-arrow type signatures), not functions; ctags has no value/variable kind at all (`ctags --list-kinds-full=Haskell` shows only constructor/function/module/type) so it lumps every `name = expr` binding into "function". GitGalaxy (language_standards.py haskell rules, #1312) and tree-sitter's own audit tooling (_find_haskell_signature_for_bind, #1566) both independently make the same value-vs-function distinction correctly -- real cross-tool corroboration, not coincidence. (4) TH-splice call sites misread as definitions -- deriveJSON at Options.hs:454/458 is a Template Haskell splice INVOKING an imported function, not defining one; ctags misparses the call as a definition. No GitGalaxy/tree-sitter defect anywhere in this shape; purely a ctags parser limitation, same category as the already-documented empty CTAGS_CLASS_KINDS['haskell'].
@@ -746,7 +746,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 69 occurrences as of 2026-08-22T01:54:36Z*
+*2-vs-1 -- 69 occurrences as of 2026-08-22T11:41:40Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > Confirmed: all 10 sampled misses (and, by cross-check against additional non-sampled instances in Options.hs/Shared.hs, plausibly all 69) are locally-scoped function definitions -- `instance ... where` methods, `where`-clause helpers, or `let`-bound names inside `do` blocks -- never top-level module definitions. ctags' Haskell parser has no layout-rule/scope awareness and only tags equations anchored at column 1; it correctly handles multi-clause TOP-LEVEL definitions (verified via expandFilterPath, writeFnBinary, writerFn -- all tag fine, clauses and all), so this is a pure scope blind spot, not a clause-counting bug (distinct from the tree-sitter clause-splitting bug fixed earlier in this same effort, which shares 2 of the 10 sample names by coincidence of subject matter, not root cause). GitGalaxy and tree-sitter are both correct; ctags is not wrong so much as structurally incapable of seeing these. Known, expected limitation of ctags' Haskell parser, now documented alongside its existing Haskell notes in tests/tools/ctags_reader.py -- not a GitHub issue, nothing in this repo to fix.
@@ -766,7 +766,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-22T01:54:36Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-22T11:41:40Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Not a real discrepancy -- structural tooling gap, already documented in the codebase. tests/tools/ctags_reader.py:39-40,228 sets CTAGS_CLASS_KINDS['haskell'] = set() on purpose: "ctags' Haskell parser has no class-shaped kind at all (constructor/function/module/type only)". Every example in this shape (data/newtype/class declarations -- ReaderOptions, CiteMethod, HasSyntaxExtensions, etc.) is real; ctags structurally cannot report any of them for this language, not a sample-specific miss. No action needed beyond this note.
@@ -786,7 +786,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:36Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:40Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Mixed shape as originally investigated (2 occurrences): (1) Options.hs:438 getExtensions -- real function, `instance HasSyntaxExtensions WriterOptions where getExtensions opts = writerExtensions opts`. A sibling instance for ReaderOptions at Options.hs:80 has the identical shape. Tree-sitter's Haskell grammar doesn't expose typeclass-instance-method clause bodies the way it does top-level bindings, and ctags' Haskell parser has no instance-method kind either -- GitGalaxy is correct, both other tools have a real recall gap on typeclass instance methods. (2) Shared.hs:475 extensionEnabled -- was NOT a real function (imported from Text.Pandoc.Extensions, only ever appears as a guard-clause call inside a multi-line `||` condition) -- a genuine GitGalaxy false positive, filed as #2082 and fixed in PR #2083 (2026-08-22): `_slice_by_indentation` now skips an equation-form func_start match whose immediately preceding line ends in `||`/`&&`. Reconciled post-fix: only the getExtensions occurrence remains, so this shape is now a clean, unambiguous GitGalaxy win -- credited accordingly.
@@ -797,7 +797,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 9 occurrences as of 2026-08-22T01:54:36Z*
+*3-way split -- 9 occurrences as of 2026-08-22T11:41:40Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > One systematic cause, confirmed by reading source for 3 of the 9 (getMetadataFromFiles App.hs:395-397, splitTextByIndices Shared.hs:142-143, tabFilter Shared.hs:256-259) and consistent with the shape of the remaining 6. Every case is a point-free/eta-reduced Haskell equation: the type signature declares N params, but the specific clause GitGalaxy and tree-sitter both align to only explicitly binds N-1 of them, handling the trailing argument via composition (`.`) or `\case`. GitGalaxy counts arity from the full type signature (the true logical arity); tree-sitter's declaration-only reading counts only the clause's explicitly-bound patterns (correct for that one equation, but undercounts true arity). Neither reader is wrong about what it's measuring -- same shape as Claim 1 in docs/why_gitgalaxy_beats_ast_here.md. GitGalaxy's answer is arguably the more useful coupling signal; recommend documenting as a candidate Claim rather than treating as an engine defect to fix toward matching tree-sitter.
@@ -818,7 +818,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 265 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 265 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner loses the real property-key name for a function-valued object-literal property specifically when that literal is a CALL ARGUMENT rather than a direct assignment -- confirmed via jquery/ajax.js's `jQuery.extend(jQuery, {ajaxSetup: function(target, settings){...}, ajax: function(url, options){...}})`: ctags emits a synthetic 'AnonymousFunction<hex>' tag for both instead of using the real 'ajaxSetup'/'ajax' key text, while GitGalaxy and tree-sitter both correctly attribute the property key as the name. Generalizes across the whole corpus, not a one-file fluke -- the identical shape recurs in jquery/css.js (css/get/set/style), jquery/deferred.js (Deferred/catch/pipe/promise/then/when), jquery/event.js (Event/handler/off/one/postDispatch/set), jquery/core.js (20+ utility methods, reducing ctags' whole-file function count from 26 to 1), and threejs's Editor.js/GLTFLoader.js/WebGLRenderer.js/WebGLProgram.js. Doc note added to ctags_reader.py's javascript CTAGS_FUNC_KINDS entry.
@@ -838,7 +838,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 183 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 183 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed GitGalaxy correct; both ctags and tree-sitter structurally can't, for two INDEPENDENT reasons. All four affected react/*.js corpus files carry the `@flow` pragma. tree-sitter-javascript's grammar can't parse Flow's parenthesized type-cast syntax (`(expr: Type)`, e.g. `(workInProgress.child: any)`), producing an ERROR node that swallows a large trailing region of the file -- confirmed directly: ReactFiberBeginWork.js's ERROR spans lines 3221-4448 (1227 of 4448 lines), and ReactFiberWorkLoop.js/ReactFlightServer.js each produce ONE error node spanning the ENTIRE file (line 1 to EOF). Real, ordinary functions inside these regions (beginWork, attemptEarlyBailoutIfNoScheduledUpdate, mountLazyComponent, and 18 others sampled) have no tree-sitter node at all. Separately, ctags' own hand-written JS scanner hits an independent cascade triggered by a Flow RETURN-type annotation (`): Fiber | null {`) -- confirmed via a minimal isolated repro (a 4-function test file where the function with a Flow return-type annotation and everything textually after it produce zero ctags output), and confirmed against the real corpus (beginWork itself, which has exactly this return-type shape, produces zero ctags tags). GitGalaxy's regex has no dependency on either tool's parse state and finds every one of these correctly. Documented in docs/why_gitgalaxy_beats_ast_here.md (Claim 3, new subsection completing/extending the existing 'Second instance: javascript' write-up with the recall-loss half plus the newly-confirmed ctags cascade).
@@ -858,7 +858,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 93 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 93 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner tags its 'class' kind on ANY bare object-literal assignment (`var X = {...}`) or function-expression assignment (`var X = function(){}`, `obj.prop = function(){}`), a blanket heuristic for 'might be used as a pre-ES6 constructor' that fires regardless of whether `new` is ever used on it. Confirmed via a minimal isolated repro (plainObj/ctorLike/obj.Thing all tagged 'class' alongside a real ES6 class) and directly against the corpus: jqXHR (jquery/ajax.js, a plain config object), cssHooks/cssNormalTransform/cssShow (jquery/css.js), promise (jquery/deferred.js), Event/event/special (jquery/event.js, one of which -- Event -- IS a pre-ES6 constructor-style function, correctly ambiguous under ctags' heuristic but still not a real ES6 class), and the ALPHA_MODES/WEBGL_CONSTANTS/etc. config objects in threejs/GLTFLoader.js. GitGalaxy's class_start regex and tree-sitter's class_declaration node both correctly require the literal `class` keyword. Doc note added to ctags_reader.py's javascript CTAGS_CLASS_KINDS entry.
@@ -878,7 +878,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 11 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 11 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed tree-sitter-alone recall gap, same Flow-cascade family as agree[gitgalaxy]_vs[ctags,tree_sitter] above but from the other side: for these specific names (updateContextProvider, reconcileChildren, updateScopeComponent, markWorkInProgressReceivedUpdate, shouldForceFlushFallbacksInDEV, patchConsole, abortIterable, abortStream, error, throwTaintViolation), ctags' own Flow-return-type cascade trigger point happens to sit AFTER these functions (or never fires in that file), so ctags finds them correctly and agrees with GitGalaxy at the exact same line number, while tree-sitter's independent (earlier-triggering, different-construct) ERROR cascade has already swallowed them. Because the two tools' cascades trigger on different Flow constructs starting at different lines, they lose different, non-identical sets of functions -- this is why the ledger shows several distinct 3-way shapes instead of one clean 'both non-GitGalaxy tools agree on what they missed' shape. Documented alongside the fuller write-up in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension.
@@ -898,7 +898,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed ctags-side synthetic-placeholder artifact, not a real discrepancy -- ctags' JavaScript scanner emits a synthetic 'AnonymousFunction<hex><seq>' tag for every genuinely anonymous function expression (a bare inline callback with no attributable name, e.g. `jQuery.ajaxPrefilter(function(s) {...})`), and GitGalaxy/tree-sitter both correctly agree these aren't named functions worth counting. Fixed by extending `tri_comparison_gatherer.py`'s existing `_is_ctags_synthetic_anon_name` (previously only matched the C-parser's `__anon<hex>` scheme) with a second regex for JavaScript's differently-shaped 'AnonymousFunction'/'AnonymousClass' scheme -- verified this removes every 'Anonymous*' entry across the full 18-file corpus with zero regressions (ruff/mypy audits clean).
@@ -916,7 +916,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed tree-sitter-alone argument-count corruption, a third facet of the same Flow-parsing family. Even where tree-sitter DOES still produce a real function_declaration node (outside any ERROR-swallowed region), a Flow parameter type with a union (`current: Fiber | null`) corrupts that node's own formal_parameters child list. Confirmed directly via react/ReactFiberBeginWork.js:405 `updateForwardRef(current: Fiber | null, workInProgress: Fiber, Component: any, nextProps: any, renderLanes: Lanes)` -- 5 real parameters (GitGalaxy=5, ctags=5, both correct) but tree-sitter's own formal_parameters node contains a single ERROR child swallowing 'current: Fiber | null,\n  workInProgress:' whole (merging two real parameters into one unstructured blob), followed by a bare identifier node reading 'Fiber' -- the type name of the swallowed second parameter, left behind by the same ERROR recovery and miscounted as if it were itself a parameter. Net effect: 4 instead of 5, an off-by-one undercount rather than total loss. Documented in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension as the 'third facet.'
@@ -933,7 +933,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:54:42Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:41:46Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed comparison-methodology artifact (name-based reconciliation colliding on a reused property name), not a real defect in any of the three tools. jquery/event.js defines TWO separate object-literal properties both named 'setup' (line 441, taking 1 param `function(data)`) and 'trigger' (line 458, 1 param) inside one plugin-hook object, and a SECOND, unrelated pair of 'setup'/'trigger' properties (lines 759/774, taking 0 params) inside a different object later in the same file. This module's/the ledger's reconciliation pairs occurrences by NAME across the whole file, with no scope/position disambiguation, so a same-name collision between two genuinely different functions can produce a spurious per-name args mismatch depending on which occurrence each tool's internal ordering happens to surface first. Both readings (1 param and 0 params) are independently real and correct for their respective definition sites -- there is no actual counting defect here, just a reconciliation limitation inherent to comparing by name only. No credit/debit; no code fix warranted for 2 occurrences arising from a rare same-name collision.
@@ -945,11 +945,12 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ## kotlin
 
-### ❓ `kotlin` function existence: ctags agree, GitGalaxy, tree-sitter differ
+### ✅ `kotlin` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-22T01:54:45Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-22T11:41:49Z*
 
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
+**Verdict** (by claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable), 2026-08-22T11:40:48Z):
+> Confirmed ctags-side over-detection, not a GitGalaxy/tree-sitter recall gap. Direct `ctags -x --languages=Kotlin` on okhttp/Dispatcher.kt shows all 15 occurrences split into two false-positive shapes ctags' Kotlin parser tags with the same 'method' kind as real functions: (1) 10 trailing-lambda blocks passed as call arguments -- `require(x >= 1) { "..." }` (lines 48/68), `synchronized(this) { ... }` (49/69/178), `check(...) { ... }` (180/185), `.also { readyAsyncCalls.clear() }` (210), and `.map { it.call }` (279/283) -- each tagged as a synthetic `<lambda>` symbol; (2) 5 `for (x in collection)` loop iteration variables tagged as methods literally named after the variable (`call` at 143/146/149 in cancelAll(), `existingCall` at 128/131 in findExistingCallWithHost()). GitGalaxy's own func_start regex and tree-sitter-kotlin's grammar both correctly require a real `fun`/constructor declaration, so their agreement (neither claims these 15) is real corroboration, not a shared miss. Not fixable via ctags_reader.py's FUNCTION_KINDS map -- ctags gives Kotlin no separate kind for 'anonymous lambda literal' or 'for-loop binding' vs. a real named function in the first place (confirmed: both false-positive shapes tag plain 'method', identical to genuine functions). Documented in ctags_reader.py's kotlin FUNCTION_KINDS comment. ctags' own claim on this shape is confirmed wrong, so it's debited.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
@@ -964,33 +965,22 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | okhttp/Dispatcher.kt | `<lambda>` | *(n/a)* | *(n/a)* | 279 |
 | okhttp/Dispatcher.kt | `<lambda>` | *(n/a)* | *(n/a)* | 283 |
 
-### ❓ `kotlin` class existence: GitGalaxy, tree-sitter agree, ctags differ
+### ✅ `kotlin` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T01:54:45Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:49Z*
 
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| okhttp/OkHttp.android.kt | `OkHttp` | *(n/a)* | 22 | *(n/a)* |
-| okhttp/OkHttp.jvm.kt | `OkHttp` | *(n/a)* | 20 | *(n/a)* |
-| okhttp/OkHttp.kt | `OkHttp` | *(n/a)* | 18 | *(n/a)* |
-
-### ❓ `kotlin` function existence: GitGalaxy agree, tree-sitter, ctags differ
-
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:45Z*
-
-**Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`kotlin/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
+**Verdict** (by claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch), 2026-08-22T11:45:48Z):
+> Direct continuation of the already-investigated constructor shape (see the now-still_reproduces=False agree[gitgalaxy]_vs[ctags,tree_sitter] entry's verdict for the full investigation): fixing tree_sitter_accuracy_audit.py's kotlin func_node_types to include `secondary_constructor` made tree-sitter agree with GitGalaxy on okhttp/Dispatcher.kt line 119's `constructor(executorService: ExecutorService?) : this() { ... }`, which regrouped this exact occurrence into a NEW 2-vs-1 shape. ctags' own Kotlin parser was independently confirmed (via `ctags -x --languages=Kotlin`) to emit no entry at all for line 119, under any kind -- a genuine ctags parser limitation (it doesn't recognize secondary-constructor syntax as a symbol in the first place), not a ctags_reader.py kind-mapping gap (there is nothing to remap; ctags never sees this construct as a taggable symbol). No credit/debit: ctags never claimed this occurrence at all (a miss, not a wrong claim), so there is nothing in its matched_consensus to debit, and gitgalaxy/tree_sitter's own claims were already correctly counted independent of this adjustment mechanism.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
-| okhttp/Dispatcher.kt | `constructor` | 119 | *(n/a)* | *(n/a)* |
+| okhttp/Dispatcher.kt | `constructor` | 119 | 119 | *(n/a)* |
 
 ## m4
 
 ### ✅ `m4` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 76 occurrences as of 2026-08-22T01:54:51Z*
+*2-vs-1 -- 76 occurrences as of 2026-08-22T11:41:55Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-20):
 > Clean, single-cause shape (all 10 sampled cases), not a GitGalaxy defect. Every sampled occurrence (curl/configure.ac lines 967-4994) is a real AC_DEFINE or AC_DEFINE_UNQUOTED call (e.g. line 2112: AC_DEFINE_UNQUOTED([CURL_DEFAULT_SSL_BACKEND], [...], [...])) -- an autoconf helper that emits a C preprocessor #define into the generated config.h at build time, NOT a new callable M4 macro definition. GitGalaxy's own func_start regex for m4 deliberately excludes AC_DEFINE/AC_DEFINE_UNQUOTED from its keyword set (m4_define|define|AC_DEFUN|AC_DEFUN_ONCE|AU_DEFUN|m4_defun only), so its silence here is correct. ctags' M4 parser heuristically tags any AC_DEFINE*-family call with a bracketed/plain first argument as a macro definition -- same macro-invocation-vs-definition confusion already documented for C's RICHCMP_WRAPPER pattern, now also documented in tests/tools/ctags_reader.py's m4 note. No GitHub issue against GitGalaxy -- this is a real, confirmed ctags-side limitation. (Separately, unrelated to this shape: a deeper live-pipeline recall gap causing GitGalaxy to extract only 1 m4 function total across the whole corpus, despite its func_start regex matching dozens of genuine AC_DEFUN/m4_define calls when run standalone, was found and fixed in part -- see PR #1927 for the func_start capture-group fix; the remaining pipeline-level gap is tracked separately, not part of this shape's verdict.) Investigated via gemini-3.1-pro-high (agy), all 10 sampled file:line citations independently verified.
@@ -1010,7 +1000,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 36 occurrences as of 2026-08-22T01:54:51Z*
+*2-vs-1 -- 36 occurrences as of 2026-08-22T11:41:55Z*
 
 **Verdict** (by claude-sonnet-5 (direct source read, no dispatch needed), 2026-08-20):
 > Confirmed real GitGalaxy false positive, now fixed. The old func_start regex had no capture group over the macro-name argument, so it matched the AC_DEFUN keyword itself as the 'function name' -- structurally identical to matching 'def' as a Python function's name instead of what follows it. gnucobol/configure.ac:658 'AC_DEFUN([AC_PROG_F77], [])' was reported as a function literally named 'AC_DEFUN'; ctags correctly reports nothing here since this call defines an empty macro body (a no-op placeholder, common autoconf idiom for stubbing out a check). Fixed in PR #1927: func_start now captures the real macro-name argument (AC_PROG_F77), handling m4's three real quoting conventions (backtick/apostrophe, bracket, double-bracket). Verified directly: the pipeline now reports 'AC_PROG_F77' at line 658, not 'AC_DEFUN'.
@@ -1030,7 +1020,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` class existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T01:54:51Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:55Z*
 
 **Verdict** (by claude-sonnet-5 (direct source read, no dispatch needed), 2026-08-20):
 > Confirmed real GitGalaxy false positive, not yet fixed (tracked separately). m4's own class_start rule is explicitly None (m4 has no class/OOP concept) -- but detector.py's class extraction branch only checks _CLASS_START_NAMED_EXTRACTION_LANGS allowlist membership, not whether the language's own class_start is None, so m4 (and 18 other class_start=None languages) falls through to the generic 'class|struct|interface|trait|enum NAME' fallback regex regardless. That fallback has no awareness of m4 document structure, so it matches raw C struct declarations embedded as literal text inside autoconf feature-test macro arguments (e.g. curl/configure.ac:1358's 'struct SocketIFace *ISocket = NULL;' inside an AC_LANG_PROGRAM([[ ... ]]) block) as if they were real m4 classes. Verified directly against the live gatherer: gg_classes for curl/configure.ac returns ['SocketIFace', 'Library', 'sockaddr_in6'], none of which are real m4 constructs; ctags correctly reports none (no class-shaped kind for m4 at all). Filed as GitHub issue #1925 (broader architectural gap, confirmed for m4, 18 other class_start=None languages not yet checked) -- not fixed in this sweep.
@@ -1046,7 +1036,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `makefile` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:52Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:56Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`makefile/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1058,7 +1048,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `matlab` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T01:54:54Z*
+*3-way split -- 1 occurrence as of 2026-08-22T11:41:58Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`matlab/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1070,7 +1060,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 104 occurrences as of 2026-08-22T01:54:55Z*
+*2-vs-1 -- 104 occurrences as of 2026-08-22T11:42:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1089,7 +1079,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 91 occurrences as of 2026-08-22T01:54:55Z*
+*2-vs-1 -- 91 occurrences as of 2026-08-22T11:42:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1108,7 +1098,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:54:55Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:42:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1119,7 +1109,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:54:55Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1131,7 +1121,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 122 occurrences as of 2026-08-22T01:55:01Z*
+*2-vs-1 -- 122 occurrences as of 2026-08-22T11:42:06Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1150,7 +1140,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:55:01Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:42:06Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1166,7 +1156,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:55:01Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:42:06Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1182,7 +1172,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:01Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:06Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1192,7 +1182,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:01Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:06Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1202,7 +1192,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 64 occurrences as of 2026-08-22T01:55:01Z*
+*3-way split -- 64 occurrences as of 2026-08-22T11:42:06Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1223,7 +1213,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:06Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:11Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1233,7 +1223,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:06Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:11Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1245,7 +1235,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-22T01:55:08Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-22T11:42:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1264,7 +1254,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T01:55:08Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T11:42:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1280,7 +1270,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:08Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1290,7 +1280,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 5 occurrences as of 2026-08-22T01:55:08Z*
+*3-way split -- 5 occurrences as of 2026-08-22T11:42:13Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1306,7 +1296,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `python` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 100 occurrences as of 2026-08-22T01:55:18Z*
+*2-vs-1 -- 100 occurrences as of 2026-08-22T11:42:23Z*
 
 **Verdict** (by claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed), 2026-08-21T12:03:03Z):
 > Already documented as Claim 2 in docs/why_gitgalaxy_beats_ast_here.md: tree-sitter-python has no concept of Cython's cdef class/cdef/cpdef syntax at all and loses track of scope at each cdef class boundary, so it finds 0 functions in cython/MemoryView.pyx and cython/MemoryView.pxd (0/0 vs GitGalaxy+ctags' 72/16, full agreement as of the 2026-08-21 get_slice_from_memview follow-up fix -- see the sibling agree[ctags]_vs[gitgalaxy,tree_sitter] shape's verdict for that fix's details). This shape's count grew from 32 to 99 to 100 across this PR's two fixes: it originally covered only the 32 'def'-based methods inside cdef class blocks; each cdef/cpdef func_start fix moved newly-recognized occurrences into THIS shape too, since they still disagree with tree-sitter for the identical underlying reason. GitGalaxy now has zero recall gaps on this corpus for Cython functions -- the only remaining disagreement with tree-sitter is tree-sitter's own structural blindness to the Cython dialect, not a GitGalaxy defect. No GitGalaxy fix needed for tree-sitter's own recall here -- grammar limitation, not an engine defect.
@@ -1326,7 +1316,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `python` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T01:55:18Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T11:42:23Z*
 
 **Verdict** (by claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed), 2026-08-21T03:23:52Z):
 > Extends Claim 2 (docs/why_gitgalaxy_beats_ast_here.md) one syntactic level up: tree-sitter-python doesn't just lose track of scope inside a cdef class block, it fails to recognize the 'cdef class' declaration itself as a class at all -- 0 class nodes reported for cython/MemoryView.pyx, missing all 4 real classes (array, Enum, memoryview, _memoryviewslice). GitGalaxy's class_start regex and ctags both correctly identify all 4 by name, confirmed via direct gather_language() check. Note: GitGalaxy's own class_data schema has no start_line column (documented in tri_comparison_gatherer.py's own module docstring), so the ledger's stored example shows a None 'reading' for GitGalaxy on this shape -- that's the (structurally absent) line number field, not an indication GitGalaxy missed the class; by NAME it matches ctags exactly. No GitGalaxy fix needed -- tree-sitter-python grammar limitation. docs/why_gitgalaxy_beats_ast_here.md's Claim 2 updated with this class-level evidence in the same PR.
@@ -1342,7 +1332,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-22T01:55:19Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-22T11:42:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1357,7 +1347,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-22T01:55:19Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-22T11:42:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1372,7 +1362,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T01:55:19Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T11:42:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1384,7 +1374,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:55:19Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:42:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1397,7 +1387,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 152 occurrences as of 2026-08-22T01:55:23Z*
+*2-vs-1 -- 152 occurrences as of 2026-08-22T11:42:28Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch), 2026-08-19T00:00:00Z):
 > Not a new question -- already-documented, evidence-backed rust behavior (Claim 6, docs/why_gitgalaxy_beats_ast_here.md: 'structure recall inside opaque macro bodies'). Confirmed directly: all 5 sampled names (get_param, init_access, get_components, from_components, apply) are in bevy/bevy_ecs_macros.rs, inside a `quote! { ... }` proc-macro body (confirmed at source lines 444-460 -- `#path`/`#fields_alias` interpolation syntax is the classic quote! token-generation pattern). These are real Rust function definitions being code-generated by a proc macro; GitGalaxy's regex correctly parses real function syntax wherever it textually appears, including inside macro bodies. tree-sitter-rust and ctags' Rust parser both treat macro_rules!/macro-invocation bodies as opaque token trees and structurally cannot emit function nodes for anything inside one -- not a bug in either, a real grammar limitation. This is exactly why rust is one of the 3 languages (with csharp/fortran) already promoted into ground truth via blind-spot-region detection in the OLD bi-comparison tool (tree_sitter_accuracy_audit.py's _find_blind_spot_ranges) -- this tri-comparison ledger entry is that same, already-understood gap surfacing again under the new 3-tool reconciliation. GitGalaxy is correct; no engine defect, no issue needed. Resolved directly from existing documentation, no fresh dispatch required (tri-comparison-ledger-sweep skill step 1.3).
@@ -1417,7 +1407,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 25 occurrences as of 2026-08-22T01:55:23Z*
+*2-vs-1 -- 25 occurrences as of 2026-08-22T11:42:28Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Same mechanism as the already-resolved rust/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter] shape (Claim 6, docs/why_gitgalaxy_beats_ast_here.md) -- extended from `fn` definitions inside `quote!{}` invocation bodies to `struct` definitions inside `macro_rules!` DEFINITION bodies. All 6 sampled names confirmed, independently re-verified against source (not just the dispatched agent's own read): NonZeroVisitor (line 90), SaturatingVisitor (112), PrimitiveVisitor (136) inside serde/serde_core_de_impls.rs's `impl_deserialize_num!` macro (def starts line 81); SeqVisitor (998), SeqInPlaceVisitor (1036) inside `seq_impl!` (def starts 978); TupleVisitor (1403) inside `tuple_impl_body!` (nested in `tuple_impls!`, def starts 1396). All 6 are real, complete `struct` declarations, each immediately followed by a genuine `impl<'de,...> Visitor<'de> for <Name>` block -- generated once per macro invocation, not fragments or hallucinated matches. tree-sitter and ctags both treat a macro_rules! arm's body as an opaque, unexpanded token tree and structurally cannot emit struct nodes from inside one, for the identical reason they can't see function definitions inside quote!{} bodies. GitGalaxy is correct in all 6 sampled cases; judged (not independently re-confirmed beyond the sample) to generalize to the full 25, all same-shaped serde-crate occurrences. No new tool defect -- Claim 6's doc text already covered this generically (`struct_item` was already named) but had no concrete cited example for this specific shape; added one (docs/why_gitgalaxy_beats_ast_here.md) rather than filing an issue.
@@ -1437,7 +1427,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 21 occurrences as of 2026-08-22T01:55:23Z*
+*2-vs-1 -- 21 occurrences as of 2026-08-22T11:42:28Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together.
@@ -1457,7 +1447,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T01:55:23Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T11:42:28Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed structural ctags limitation, not a bug -- resolved directly (no dispatch needed). All 3 sampled names (XRegUnion, FRegUnion, VRegUnion) are real Rust `union { }` declarations (confirmed at wasmtime/wasmtime_pulley_interp.rs:404,529,604), distinct from `struct` -- Rust's less-common C-style unsafe union construct. Ran `ctags --list-kinds-full=Rust` directly: its Rust parser's kind list is macro/method/implementation/enumerator/function/enum/interface/field/module/struct/typedef/variable -- there is NO union kind at all. Confirmed via direct ctags run against this exact file: it correctly finds the wrapping `struct FRegVal(FRegUnion)`-shaped types right next to each missed union, so this isn't a general miss, specifically a missing Rust-union kind. Same category as the already-documented ctags Haskell class-kind gap (tests/tools/ctags_reader.py) -- worth a similar doc note there, not a GitHub issue (nothing to fix, ctags upstream has no union support for this language).
@@ -1470,7 +1460,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:23Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:28Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed via direct ctags run and sibling comparison, resolved directly (no dispatch needed). `done_decode` (wasmtime/wasmtime_pulley_interp.rs:964) has a destructuring-pattern parameter -- `Done { _priv }: Done`, not a simple `name: Type` binding. Ran ctags directly against the file: its IMMEDIATE SIBLING in the same impl block, `debug_assert_done_reason_none` (line 960, same visibility/receiver shape, ordinary `&mut self`-only signature), IS correctly found as a ctags 'method'. done_decode alone is missing from ctags' output. Isolates the cause precisely to the destructuring-pattern parameter -- ctags' regex-based Rust parser appears to fail/skip the whole function when a parameter is a struct pattern rather than a plain identifier binding. GitGalaxy and tree-sitter both handle this fine (both agree on line 964). N=1 in this corpus, plausibly a real, narrow ctags parser gap (not GitGalaxy's) -- not chasing further given the tiny sample, noting rather than filing an issue since there's nothing in this repo to fix.
@@ -1481,7 +1471,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 21 occurrences as of 2026-08-22T01:55:23Z*
+*3-way split -- 21 occurrences as of 2026-08-22T11:42:28Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, not a modeling disagreement -- tree-sitter is correct in all 8 sampled cases (and this generalizes to the full 21: every sampled name is a deserialize_*/spawn_*_caller-shaped signature carrying a rust lifetime annotation, the exact trigger). Root cause, independently confirmed via two methods (dispatched agent read the code path; a second grep pass confirmed the attribute is dead): `gitgalaxy/core/detector.py::StructuralExtractor._count_top_level_args` has a guard meant to exempt rust/scala lifetime marks (`'_`, `'static`) from its string-literal scanner -- `getattr(self, 'language', '') in ('rust', 'scala')` around line 3766 -- but the class stores the language as `self.primary_lang_id` (set at line 497), never `self.language`. `self.language` is referenced NOWHERE ELSE in the file, confirmed by grep. The getattr always silently falls back to `''`, so the exemption guard never fires for any language, ever -- every lifetime `'` gets treated as an unterminated string-literal opener, swallowing all subsequent top-level commas until a real closing quote or end-of-string, fusing 2+ parameters into 1. A signature with 3 lifetime marks (odd count) never exits string mode at all and undercounts every remaining parameter. Real signatures confirmed at source: bevy/bevy_ecs_world.rs:1106,1121,1270 (`MovingPtr<'_, B>` swallows the next comma, 3 vs real 4, or 2 vs real 3); serde/serde_core_de_mod.rs:1105,1115 (`&'static str` swallows the next comma, 2 vs real 3); serde_core_de_mod.rs:1136 (two lifetimes, both trailing commas swallowed, 2 vs real 4); serde_core_de_mod.rs:1152,1163 (three lifetime marks, odd count means string mode never exits, 2 vs real 4). ctags has null coverage for these specific occurrences because they're bodyless trait-method declarations (ending in `;` inside a `trait` block) -- unrelated to the args bug, ctags appears to skip signature-only declarations generally. Filed as its own GitHub issue (attribute-name mismatch, one-line fix: `self.language` -> `self.primary_lang_id`, or equivalent), separate from this ledger record.
@@ -1503,7 +1493,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scala` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 16 occurrences as of 2026-08-22T01:55:25Z*
+*3-way split -- 16 occurrences as of 2026-08-22T11:42:31Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scala/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1524,7 +1514,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scheme` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 50 occurrences as of 2026-08-22T01:55:29Z*
+*2-vs-1 -- 50 occurrences as of 2026-08-22T11:42:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scheme/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1543,7 +1533,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `scheme` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 84 occurrences as of 2026-08-22T01:55:29Z*
+*2-vs-1 -- 84 occurrences as of 2026-08-22T11:42:35Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5, 2026-08-20):
 > Confirmed real, catastrophic GitGalaxy engine defect, generalizes to the full 92 occurrences (and beyond -- this was a 100% recall drop for the whole language, not specific to the sampled cases). Root cause isolated to detector.py's StructuralExtractor._slice_by_braces (Integration Mode B): its scope-delimiter selection checked `lang_id == "lisp"` to choose parenthesis delimiters over the curly-brace default -- but "lisp" has never been a real key in LANGUAGE_DEFINITIONS (only "scheme" is), so that branch was unreachable dead code in production. Every real scheme file fell through to the curly-brace default; since scheme is entirely parenthesis-delimited, the downstream scope-body search never found an opener and silently discarded every func_start match. GitGalaxy's own func_start regex was never the problem -- confirmed matching correctly standalone (31/31 hits on one file) and prism.py's comment stripping confirmed clean (raw (define count unchanged pre/post-prism). Fixed: delimiter choice now keys off lexical_family ("recursive_block_lisp") instead of the dead lang_id string, verified directly against the gatherer (0 -> 58 real functions found; ctags finds 92, so a smaller residual recall gap remains for a future pass, tracked as a follow-on, not blocking this fix). Filed as GitHub issue #1928. A pre-existing unit test (test_detector_mode_b_lisp_family) had been passing for the wrong reason (its mock language was literally named "lisp", matching the dead string check by construction) -- corrected to use scheme's real lexical_family value so it now validates the actual production mechanism. Investigated via gemini-3.1-pro-high (agy): live-pipeline isolation with a monkey-patch before/after proof (0 -> 14 functions when lang_id coerced to match the old check), independently re-verified by Claude against the exact cited source lines before applying.
@@ -1565,7 +1555,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `shell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:31Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:36Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`shell/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1577,7 +1567,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `solidity` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-22T01:55:32Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-22T11:42:38Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`solidity/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1594,7 +1584,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:34Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1604,7 +1594,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:34Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1614,7 +1604,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T01:55:34Z*
+*3-way split -- 1 occurrence as of 2026-08-22T11:42:39Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1626,7 +1616,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T01:55:35Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T11:42:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1639,7 +1629,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:55:35Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:42:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1650,7 +1640,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:35Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1660,7 +1650,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:55:35Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:41Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1672,7 +1662,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1907 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 1907 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1691,7 +1681,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 501 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 501 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1710,7 +1700,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 174 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 174 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1729,7 +1719,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 61 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 61 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1748,7 +1738,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1766,7 +1756,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1777,7 +1767,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T01:55:56Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1788,7 +1778,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 4 occurrences as of 2026-08-22T01:55:56Z*
+*3-way split -- 4 occurrences as of 2026-08-22T11:43:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1803,7 +1793,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-22T01:56:05Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-22T11:43:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1822,7 +1812,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:56:05Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:43:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1832,7 +1822,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T01:56:05Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T11:43:10Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 

--- a/tests/tools/ctags_reader.py
+++ b/tests/tools/ctags_reader.py
@@ -336,6 +336,26 @@ CTAGS_FUNC_KINDS: dict[str, set[str]] = {
     # kotlin: ctags has no separate free-function kind -- top-level functions tag "m" too
     # (verified via probe file: a file-scope `fun` with no enclosing class still tags "m",
     # just without a `class:` field), so "m" alone already covers both cases.
+    # Also NOT fixable by adjusting this kind set: ctags' Kotlin parser tags two shapes that
+    # aren't real function declarations with the SAME "m" kind as genuine ones (found via
+    # tri-comparison-ledger-sweep, kotlin/function/existence/agree[ctags]_vs[gitgalaxy,
+    # tree_sitter], 15 occurrences, 2026-08-22, okhttp/Dispatcher.kt): (1) any trailing-lambda
+    # block passed as a call argument (`require(x >= 1) { "..." }`, `synchronized(this) { ... }`,
+    # `.also { ... }`, `.map { it.call }`) tags as a synthetic `<lambda>` symbol -- confirmed via
+    # `ctags -x --languages=Kotlin`, 10 of the 15 occurrences; (2) a `for (x in collection)` loop's
+    # iteration variable tags as a method literally named after the variable (`call`, `existingCall`)
+    # -- the remaining 5. GitGalaxy's own func_start regex and tree-sitter's grammar both correctly
+    # require a real `fun`/constructor declaration, so every one of these is a ctags-side
+    # over-count, not a GitGalaxy gap -- same shape as the javascript object-literal note above:
+    # ctags gives no separate kind for "anonymous lambda literal" or "for-loop binding" vs. a real
+    # named function/method in the first place.
+    # Separately, the opposite direction: ctags' Kotlin parser doesn't recognize a secondary
+    # constructor (`constructor(...) : this() { ... }`) as a symbol at all -- confirmed via
+    # `ctags -x --languages=Kotlin` on the same Dispatcher.kt emitting no entry whatsoever for
+    # its line-119 constructor, under any kind. Not a kind-map gap (nothing to remap; ctags never
+    # tags it in the first place) -- a genuine parser recall gap, kept as a real, permanent
+    # disagreement (kotlin/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]) rather than
+    # something this reader can work around.
     "kotlin": {"m"},
     "lua": {"f"},
     "makefile": {"t"},  # targets are the closest func-analog
@@ -419,7 +439,15 @@ CTAGS_CLASS_KINDS: dict[str, set[str]] = {
     # keyword, so every one of these is a real ctags-side over-count, not a GitGalaxy gap -- no
     # kind-set change fixes it since ctags gives no separate kind for "object literal" vs.
     # "class-shaped assignment" in the first place.
-    "kotlin": {"c", "i"},  # class, interface
+    "kotlin": {"c", "i", "o"},  # class, interface, object -- "o" was simply absent from this
+    # map, same shape as the cpp/fortran gaps above (found via tri-comparison-ledger-sweep,
+    # kotlin/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags], 2026-08-22): ctags tags a
+    # Kotlin `object Foo { ... }` singleton declaration with its own distinct "o" (objects) kind,
+    # separate from "c" (classes) -- confirmed directly via `ctags -x --languages=Kotlin` on
+    # okhttp/OkHttp.kt, which tags `expect object OkHttp` as kind "object", not "class". GitGalaxy's
+    # own class_start regex and tree-sitter's grammar both already treat `object` as class-shaped
+    # (gitgalaxy/standards/language_standards.py's kotlin class_start includes the literal `object`
+    # keyword), just invisible to this ctags-side comparison until now.
     "lua": set(),
     "makefile": set(),
     "matlab": {"c"},

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -499,7 +499,21 @@ NODE_MAPS = {
         # this grammar -- the identifier is a plainly-typed `simple_identifier`/`type_identifier`
         # child instead, so every match silently resolved to None pre-fix. See _get_node_name's
         # kotlin branch.
-        "func_node_types": {"function_declaration", "anonymous_function"},
+        # (found via tri-comparison-ledger-sweep, kotlin/function/existence/agree[gitgalaxy]_vs
+        # [ctags,tree_sitter], 2026-08-22): a secondary constructor (`constructor(...) : this()
+        # { ... }`) gets its own `secondary_constructor` node type, distinct from
+        # `function_declaration` -- confirmed via okhttp/Dispatcher.kt's `constructor
+        # (executorService: ExecutorService?)`, which GitGalaxy's own func_start regex already
+        # correctly matches (its `(constructor)` alternative), invisible to real_functions here
+        # pre-fix. `anonymous_initializer` (an `init { ... }` block, the regex's sibling `(init)`
+        # alternative) has the identical no-name-field shape and is added alongside it even though
+        # this corpus has no live example -- same underlying gap, not worth a second round-trip.
+        "func_node_types": {
+            "function_declaration",
+            "anonymous_function",
+            "secondary_constructor",
+            "anonymous_initializer",
+        },
         # #1295: kotlin's `object` declarations (including `actual`/`expect` multiplatform
         # variants) get their own `object_declaration` node type, distinct from
         # `class_declaration` -- a real, named class-like entity GitGalaxy's own class_start
@@ -1081,6 +1095,14 @@ def _get_node_name(node: Any) -> Optional[str]:
             if child.type == "type_identifier":
                 return child.text.decode("utf8")
         return None
+    # kotlin secondary constructors/init blocks have no user-chosen name at all -- the literal
+    # keyword IS the name, matching GitGalaxy's own func_start regex, which captures the bare
+    # "constructor"/"init" keyword text for these two alternatives (there is nothing else to
+    # capture: a `constructor(...)`/`init { ... }` is never given a distinct identifier in Kotlin).
+    if node.type == "secondary_constructor":
+        return "constructor"
+    if node.type == "anonymous_initializer":
+        return "init"
 
     # #1313: powershell's function_statement/class_statement/class_method_definition have no
     # "name" field -- the identifier is a plainly-typed "function_name"/"simple_name" child.
@@ -1492,8 +1514,11 @@ def _get_param_count(node: Any, lang: str = "") -> int:
                     if wrapper.type == "optional_formal_parameters":
                         count += sum(1 for p in wrapper.children if p.type == "formal_parameter")
                 return count
-    elif node.type == "function_declaration":
-        # kotlin: params live inside a "function_value_parameters" wrapper.
+    elif node.type in ("function_declaration", "secondary_constructor"):
+        # kotlin: params live inside a "function_value_parameters" wrapper. `secondary_constructor`
+        # shares the identical wrapper shape (confirmed via okhttp/Dispatcher.kt's `constructor
+        # (executorService: ExecutorService?)`) -- added alongside function_declaration rather
+        # than as its own elif since the extraction is identical.
         for child in node.children:
             if child.type == "function_value_parameters":
                 return sum(1 for p in child.children if p.type == "parameter")


### PR DESCRIPTION
## Summary
- Investigated all 4 open kotlin discrepancy shapes in `tri_comparison_ledger.json` against the okhttp corpus (`language-crucible/data/kotlin`), following the `tri-comparison-ledger-sweep` skill.
- Found and fixed 2 real, confirmed bugs in this repo's own comparison tooling (not GitGalaxy's engine):
  - `ctags_reader.py`: kotlin's `CLASS_KINDS` was missing `"o"` (objects), silently excluding every `object Foo { ... }` singleton declaration from the ctags-side class comparison — same shape as the existing cpp/fortran gaps.
  - `tree_sitter_accuracy_audit.py`: kotlin's `func_node_types` was missing `secondary_constructor` (plus, proactively, `anonymous_initializer` — same underlying gap, no live corpus occurrence), so tree-sitter's own real-function count silently excluded every Kotlin secondary constructor.
- The remaining shape (ctags tagging trailing-lambda blocks / for-loop iteration variables as functions) is a genuine, permanent ctags parser limitation — documented, not fixable via a kind-map change, and debited in the ledger.
- Adds `docs/language_status/kotlin.md` (sections 1-8 from primary sources + a §9 tri-comparison write-up) and updates the language-status README index.

## Test plan
- [x] `python tests/ruff_audit.py --ci` — clean
- [x] `python tests/mypy_audit.py --ci` — clean
- [x] Verified both audit-tool fixes directly against `tri_comparison_gatherer.gather_language('kotlin')` before/after
- [x] `tri_comparison_chart.py --all --write` regenerated, diff confirmed scoped to kotlin plus expected timestamp churn elsewhere
- Not applicable: this PR only touches test/audit tooling and docs, not `language_standards.py`/`detector.py`/`prism.py`, so `crucible_check.py`/golden-master re-blessing isn't required (CLAUDE.md's Differential Scan protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)