### PR TITLE
fix(ci): regenerate kotlin tree-sitter accuracy baseline

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -47,7 +47,7 @@ for the same metrics tracked over time across pushes to main.
 | Html | N/A | N/A | N/A | N/A |
 | Java | 99.1% | 100.0% | 100.0% | 100.0% |
 | Javascript | 99.8% | 98.4% | 100.0% | 100.0% |
-| Kotlin | 100.0% | 96.4% | 100.0% | 100.0% |
+| Kotlin | 100.0% | 100.0% | 100.0% | 100.0% |
 | Lua | N/A | N/A | N/A | N/A |
 | Makefile | 100.0% | 100.0% | N/A | N/A |
 | Matlab | 100.0% | 100.0% | N/A | N/A |

--- a/tests/tree_sitter_accuracy_baseline_kotlin.json
+++ b/tests/tree_sitter_accuracy_baseline_kotlin.json
@@ -1,12 +1,12 @@
 {
-  "args_comparable": 27,
-  "args_exact_match": 27,
+  "args_comparable": 28,
+  "args_exact_match": 28,
   "corpus_path": "language-crucible/data/kotlin",
   "extra_classes": 0,
-  "extra_functions": 1,
+  "extra_functions": 0,
   "files_scanned": 5,
   "found_classes": 7,
-  "found_functions": 27,
+  "found_functions": 28,
   "real_classes": 7,
-  "real_functions": 27
+  "real_functions": 28
 }


### PR DESCRIPTION
## Summary
- Follow-up to #2102, which merged despite a `tree-sitter-accuracy-audit` CI failure (a merge-race between auto-merge and a non-required-but-still-run check).
- That PR's `func_node_types` fix (adding `secondary_constructor`/`anonymous_initializer` so tree-sitter correctly counts Kotlin secondary constructors) legitimately changed kotlin's pinned ground-truth `real_functions` count from 27 to 28. CI's baseline-gated check can't distinguish "corpus changed" from "ground truth measurement improved" — it just flags any drift, per its own message.
- Regenerated via `tree_sitter_accuracy_audit.py --lang kotlin --regenerate`, which also updated kotlin's summary row in `language_standards.py` from 96.4% to 100.0% func_start recall/precision.
- The other CI failure on that run (`javascript`, 600→599) is unrelated pre-existing drift, not touched by #2102 or this PR.

## Test plan
- [x] `tree_sitter_accuracy_audit.py --lang kotlin --ci` — passes against the regenerated baseline
- [x] `ruff_audit.py --ci` / `mypy_audit.py --ci` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)