### PR TITLE
fix: regenerate stale tri_comparison_chart.svg (kotlin asterisks)

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -533,18 +533,18 @@
 <text class="lang-label" x="20" y="1111.5">kotlin</text>
 <rect class="bar-track" x="154" y="1091" width="88" height="34" rx="2"/>
 <rect x="154" y="1091" width="58.7" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1099">28*</text>
+<text class="bar-value-label" x="198.0" y="1099">28</text>
 <rect x="154" y="1103" width="58.7" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1111">28*</text>
+<text class="bar-value-label" x="198.0" y="1111">28</text>
 <rect x="154" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="198.0" y="1123">42*</text>
+<text class="bar-value-label" x="198.0" y="1123">42</text>
 <rect class="bar-track" x="286" y="1091" width="88" height="34" rx="2"/>
 <rect x="286" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1099">28/28*</text>
+<text class="bar-value-label" x="330.0" y="1099">28/28</text>
 <rect x="286" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1111">28/28*</text>
+<text class="bar-value-label" x="330.0" y="1111">28/28</text>
 <rect x="286" y="1115" width="25.1" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1123">12/42*</text>
+<text class="bar-value-label" x="330.0" y="1123">12/42</text>
 <rect class="bar-track" x="418" y="1091" width="88" height="34" rx="2"/>
 <rect x="418" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1099">7</text>
@@ -1095,10 +1095,10 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 42 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 43 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (38%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (37%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
 <text class="legend-label" x="228.8" y="2188">tree-sitter best: 1 (2%)</text>
@@ -1106,6 +1106,6 @@
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
 <circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="577.2" y="2188">Ties: 25 (60%)</text>
+<text class="legend-label" x="577.2" y="2188">Ties: 26 (60%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T11:40:58Z",
+      "last_reconciled_at": "2026-08-22T12:11:49Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T11:40:58Z",
+      "last_reconciled_at": "2026-08-22T12:11:49Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-22T11:41:00Z",
+      "last_reconciled_at": "2026-08-22T12:11:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T11:41:01Z",
+      "last_reconciled_at": "2026-08-22T12:11:52Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T11:41:01Z",
+      "last_reconciled_at": "2026-08-22T12:11:52Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1273,7 +1273,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T11:41:07Z",
+      "last_reconciled_at": "2026-08-22T12:11:57Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1388,7 +1388,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T11:41:12Z",
+      "last_reconciled_at": "2026-08-22T12:12:03Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1491,7 +1491,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T11:41:12Z",
+      "last_reconciled_at": "2026-08-22T12:12:03Z",
       "last_seen_count": 136,
       "last_seen_examples": [
         {
@@ -1594,7 +1594,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T11:41:12Z",
+      "last_reconciled_at": "2026-08-22T12:12:03Z",
       "last_seen_count": 43,
       "last_seen_examples": [
         {
@@ -1698,7 +1698,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1740,7 +1740,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1782,7 +1782,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -1896,7 +1896,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2010,7 +2010,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2124,7 +2124,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2238,7 +2238,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2270,7 +2270,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2303,7 +2303,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2417,7 +2417,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2450,7 +2450,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2564,7 +2564,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2669,7 +2669,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2729,7 +2729,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T11:41:17Z",
+      "last_reconciled_at": "2026-08-22T12:12:07Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -2843,7 +2843,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2948,7 +2948,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3017,7 +3017,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3098,7 +3098,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3131,7 +3131,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3221,7 +3221,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3280,7 +3280,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3313,7 +3313,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -3427,7 +3427,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3487,7 +3487,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3520,7 +3520,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -3636,7 +3636,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -3750,7 +3750,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T11:41:23Z",
+      "last_reconciled_at": "2026-08-22T12:12:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3783,7 +3783,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-22T11:41:24Z",
+      "last_reconciled_at": "2026-08-22T12:12:15Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -3832,7 +3832,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T11:41:29Z",
+      "last_reconciled_at": "2026-08-22T12:12:19Z",
       "last_seen_count": 218,
       "last_seen_examples": [
         {
@@ -3935,7 +3935,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T11:41:29Z",
+      "last_reconciled_at": "2026-08-22T12:12:19Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4030,7 +4030,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T11:41:29Z",
+      "last_reconciled_at": "2026-08-22T12:12:19Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4134,7 +4134,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T11:41:35Z",
+      "last_reconciled_at": "2026-08-22T12:12:25Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4229,7 +4229,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T11:41:35Z",
+      "last_reconciled_at": "2026-08-22T12:12:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4261,7 +4261,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T11:41:35Z",
+      "last_reconciled_at": "2026-08-22T12:12:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4294,7 +4294,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T11:41:35Z",
+      "last_reconciled_at": "2026-08-22T12:12:25Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -4408,7 +4408,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T11:41:35Z",
+      "last_reconciled_at": "2026-08-22T12:12:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -4452,7 +4452,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T11:41:35Z",
+      "last_reconciled_at": "2026-08-22T12:12:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4485,7 +4485,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-22T11:41:37Z",
+      "last_reconciled_at": "2026-08-22T12:12:27Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -4599,7 +4599,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4711,7 +4711,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4816,7 +4816,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -4930,7 +4930,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -5044,7 +5044,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5160,7 +5160,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5192,7 +5192,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5232,7 +5232,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T11:41:40Z",
+      "last_reconciled_at": "2026-08-22T12:12:30Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -5346,7 +5346,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5460,7 +5460,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -5574,7 +5574,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -5687,7 +5687,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5720,7 +5720,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5771,7 +5771,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -5885,7 +5885,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T11:41:43Z",
+      "last_reconciled_at": "2026-08-22T12:12:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -5936,7 +5936,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -6050,7 +6050,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -6137,7 +6137,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6179,7 +6179,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -6293,7 +6293,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -6389,7 +6389,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -6503,7 +6503,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -6617,7 +6617,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T11:41:46Z",
+      "last_reconciled_at": "2026-08-22T12:12:36Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6650,7 +6650,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T11:48:59Z",
+      "last_reconciled_at": "2026-08-22T12:12:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6703,7 +6703,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T11:48:59Z",
+      "last_reconciled_at": "2026-08-22T12:12:39Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -6817,7 +6817,7 @@
       "investigated_at": "2026-08-22T11:45:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T11:48:59Z",
+      "last_reconciled_at": "2026-08-22T12:12:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6850,7 +6850,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T11:48:59Z",
+      "last_reconciled_at": "2026-08-22T12:12:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6882,7 +6882,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T11:41:55Z",
+      "last_reconciled_at": "2026-08-22T12:12:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -6937,7 +6937,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T11:41:55Z",
+      "last_reconciled_at": "2026-08-22T12:12:45Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -7040,7 +7040,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T11:41:55Z",
+      "last_reconciled_at": "2026-08-22T12:12:45Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -7144,7 +7144,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-22T11:41:56Z",
+      "last_reconciled_at": "2026-08-22T12:12:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7175,7 +7175,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-22T11:41:58Z",
+      "last_reconciled_at": "2026-08-22T12:12:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7208,7 +7208,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T11:42:00Z",
+      "last_reconciled_at": "2026-08-22T12:12:49Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -7322,7 +7322,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T11:42:00Z",
+      "last_reconciled_at": "2026-08-22T12:12:49Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -7436,7 +7436,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T11:42:00Z",
+      "last_reconciled_at": "2026-08-22T12:12:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7469,7 +7469,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T11:42:00Z",
+      "last_reconciled_at": "2026-08-22T12:12:49Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7511,7 +7511,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7544,7 +7544,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7575,7 +7575,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -7689,7 +7689,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7776,7 +7776,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7863,7 +7863,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7896,7 +7896,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T11:42:06Z",
+      "last_reconciled_at": "2026-08-22T12:12:55Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -8010,7 +8010,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T11:42:11Z",
+      "last_reconciled_at": "2026-08-22T12:13:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8043,7 +8043,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T11:42:11Z",
+      "last_reconciled_at": "2026-08-22T12:13:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8076,7 +8076,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T11:42:11Z",
+      "last_reconciled_at": "2026-08-22T12:13:00Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -8190,7 +8190,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T11:42:13Z",
+      "last_reconciled_at": "2026-08-22T12:13:03Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -8275,7 +8275,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T11:42:13Z",
+      "last_reconciled_at": "2026-08-22T12:13:03Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -8344,7 +8344,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T11:42:13Z",
+      "last_reconciled_at": "2026-08-22T12:13:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8377,7 +8377,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T11:42:13Z",
+      "last_reconciled_at": "2026-08-22T12:13:03Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -8491,7 +8491,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T11:42:23Z",
+      "last_reconciled_at": "2026-08-22T12:13:12Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8551,7 +8551,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T11:42:23Z",
+      "last_reconciled_at": "2026-08-22T12:13:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8584,7 +8584,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T11:42:23Z",
+      "last_reconciled_at": "2026-08-22T12:13:12Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -8700,7 +8700,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T11:42:23Z",
+      "last_reconciled_at": "2026-08-22T12:13:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8733,7 +8733,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T11:42:24Z",
+      "last_reconciled_at": "2026-08-22T12:13:14Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8775,7 +8775,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T11:42:24Z",
+      "last_reconciled_at": "2026-08-22T12:13:14Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8853,7 +8853,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T11:42:24Z",
+      "last_reconciled_at": "2026-08-22T12:13:14Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8904,7 +8904,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T11:42:24Z",
+      "last_reconciled_at": "2026-08-22T12:13:14Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8981,7 +8981,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -9095,7 +9095,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9148,7 +9148,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -9261,7 +9261,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -9312,7 +9312,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9424,7 +9424,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -9537,7 +9537,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -9650,7 +9650,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9683,7 +9683,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9718,7 +9718,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T11:42:28Z",
+      "last_reconciled_at": "2026-08-22T12:13:17Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -9830,7 +9830,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-22T11:42:31Z",
+      "last_reconciled_at": "2026-08-22T12:13:20Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9933,7 +9933,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T11:42:35Z",
+      "last_reconciled_at": "2026-08-22T12:13:24Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -10035,7 +10035,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T11:42:35Z",
+      "last_reconciled_at": "2026-08-22T12:13:24Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -10139,7 +10139,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-22T11:42:36Z",
+      "last_reconciled_at": "2026-08-22T12:13:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10171,7 +10171,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-22T11:42:38Z",
+      "last_reconciled_at": "2026-08-22T12:13:27Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10241,7 +10241,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T11:42:39Z",
+      "last_reconciled_at": "2026-08-22T12:13:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10272,7 +10272,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T11:42:39Z",
+      "last_reconciled_at": "2026-08-22T12:13:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10303,7 +10303,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T11:42:39Z",
+      "last_reconciled_at": "2026-08-22T12:13:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10335,7 +10335,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T11:42:41Z",
+      "last_reconciled_at": "2026-08-22T12:13:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10368,7 +10368,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T11:42:41Z",
+      "last_reconciled_at": "2026-08-22T12:13:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10410,7 +10410,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T11:42:41Z",
+      "last_reconciled_at": "2026-08-22T12:13:30Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10470,7 +10470,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T11:42:41Z",
+      "last_reconciled_at": "2026-08-22T12:13:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10502,7 +10502,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T11:42:41Z",
+      "last_reconciled_at": "2026-08-22T12:13:30Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10544,7 +10544,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10586,7 +10586,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -10698,7 +10698,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10757,7 +10757,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10790,7 +10790,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10895,7 +10895,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -11009,7 +11009,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -11123,7 +11123,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11165,7 +11165,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T11:43:02Z",
+      "last_reconciled_at": "2026-08-22T12:13:52Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -11278,7 +11278,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T11:43:10Z",
+      "last_reconciled_at": "2026-08-22T12:14:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11309,7 +11309,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T11:43:10Z",
+      "last_reconciled_at": "2026-08-22T12:14:01Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -11412,7 +11412,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T11:43:10Z",
+      "last_reconciled_at": "2026-08-22T12:14:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {


### PR DESCRIPTION
## Summary
- #2102 validated kotlin's 4th ledger shape but never re-ran `tri_comparison_chart.py --all --write` afterward, so the committed SVG kept showing `*` on kotlin's Functions Found/Function Precision panels even though every kotlin ledger entry is `status=validated` (`has_open_question()` returns `False` for both function/existence and class/existence).
- Caught by the user spotting the stale asterisks in the published chart. Regenerated — confirmed via diff that only kotlin's 6 asterisked labels changed, plus the summary legend's ranked-comparison count/percentages (43 vs. 42 real comparisons, since kotlin's function-precision panel now counts as resolved).

## Test plan
- [x] Confirmed `has_open_question('kotlin', 'function', 'existence')` and `('kotlin', 'class', 'existence')` both return `False` against the current ledger
- [x] Diffed the regenerated SVG — only kotlin's asterisked labels and the aggregate summary legend changed, no other language's cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)