### PR TITLE
Fix tri-comparison chart/ledger regen that ran without real ctags

### DIFF
--- a/ANTIGRAVITY.md
+++ b/ANTIGRAVITY.md
@@ -70,7 +70,48 @@ GitGalaxy scans itself and outputs intelligence to `/docs/gitgalaxy_architecture
   - Fastest path in an active session: `python tests/tools/self_scan.py` regenerates it in place.
   - If you'd rather not run a local scan, the `gitgalaxy.yml` workflow's "Full Report" job now publishes a fresh copy as a `gitgalaxy-self-scan-db` build artifact on every merge to main -- pull the latest one from that workflow's most recent run instead.
 
-## 7. Extraction Hardening & Adversarial Testing
+## 7. Tri-Comparison Chart & Ledger (GitGalaxy vs. tree-sitter vs. ctags)
+
+Full protocol lives in `docs/self_scan/tri_comparison_README.md` -- **read it before touching**
+`docs/self_scan/tri_comparison_chart.svg`, `tri_comparison_ledger.json`, or
+`tri_comparison_points_of_interest.md`. It's the canonical regen doc for both agents (Claude reads
+it via `CLAUDE.md`); this section exists because skipping it caused a real incident (PR #2111,
+2026-08-22): a regen ran with no genuine `universal-ctags` binary on PATH, and every language
+silently degraded to a 2-tool (GitGalaxy + tree-sitter) comparison instead of erroring -- reverting
+cobol's already-validated full-precision badge, degrading fortran's, and dropping ctags data across
+every ctags-covered language in the chart, with no error message at all.
+
+- **Confirm ctags before you regenerate, every time:** `ctags --version` MUST print
+  "Universal Ctags", not error and not print an Arduino banner. Ubuntu's `arduino-ctags` package
+  installs a binary under the same name and lacks most kinds this system needs -- a silently
+  degraded regen still runs and still writes a file, so a clean exit code proves nothing here.
+  If there's no root/sudo available, build a local one without it:
+  ```bash
+  mkdir -p /tmp/gitgalaxy-scratch/ctags-local && cd /tmp/gitgalaxy-scratch/ctags-local
+  apt-get download universal-ctags && dpkg -x universal-ctags*.deb extracted/
+  mkdir -p bin && ln -sf "$PWD/extracted/usr/bin/ctags-universal" bin/ctags
+  export PATH="/tmp/gitgalaxy-scratch/ctags-local/bin:$PATH"
+  ```
+- **Always regenerate with `--all --write`, never a partial `--languages` list with `--write`** --
+  a partial write overwrites the WHOLE file with only those languages, silently deleting every
+  other language's row.
+  ```bash
+  python tests/tools/tri_comparison_chart.py --all --write
+  python tests/tools/tri_comparison_report.py --write   # regen the points-of-interest doc too
+  ```
+- **Never hand-edit `tri_comparison_ledger.json`'s `status`/`verdict`/`still_reproduces`.** Those
+  are set by a human (or an agent standing in for one) reading real source per
+  `docs/self_scan/how_to_investigate_a_discrepancy.md`, then left alone by every later regen.
+  `still_reproduces` in particular is recomputed from a live gather, not something to hand-set to
+  `false` just because part of a shape's root cause got fixed in the same PR -- a shape can have a
+  permanent, structural cause (e.g. ctags mistagging COBOL scope terminators as paragraphs) that
+  keeps reproducing even after a real GitGalaxy bug contributing to the same shape is fixed. This is
+  exactly the second, smaller bug PR #2111 introduced alongside the missing-ctags one.
+- After regenerating, diff the languages you actually touched and confirm ctags/tree-sitter bars
+  and badges are still present, not just that the file changed -- a plausible-looking diff is not
+  the same as a correct one when the failure mode is silent by design.
+
+## 8. Extraction Hardening & Adversarial Testing
 
 When tasked with "hardening extraction coverage" or similar testing epics, avoid **Self-Consistency Bias** (writing tests that merely pass against the *current implementation* instead of the *actual ground truth*). Do not cement implementation flaws by writing invalid tests just because the current regex fails. 
 
@@ -84,7 +125,7 @@ To ensure rigorous, adversarial testing, structure your work into a strict **5-s
 
 *(Tip: You can use the `/teamwork-preview` slash command to help automate and visualize complex multi-agent teams for large projects).*
 
-## 8. Submitting Pull Requests
+## 9. Submitting Pull Requests
 
 When working in this repository, **you MUST ALWAYS work on a side branch and submit a PR to `main`. NEVER merge or push your changes directly to `main` without a PR.** This strict workflow ensures that tests and multi-agent pipelines are run in isolation.
 
@@ -101,7 +142,7 @@ When generating or submitting a Pull Request for this repository, it is critical
   - **Do not leave the PR body blank, sparse, or lame.** A poor description will cause the PR to be rejected.
 - **Add relevant labels:** Ensure the PR has descriptive labels attached so it integrates correctly into the project's tracking and CI processes.
 
-## 9. Scratch Files & Working Directory
+## 10. Scratch Files & Working Directory
 
 Throwaway scripts, reproduction cases, one-off debug output, and generated test artifacts that
 aren't meant to become part of the repo do **not** belong in the repo tree, not even temporarily.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,22 @@ human or agent read real source and recorded a verdict), regardless of how lopsi
 look before that. See the tri-comparison-ledger-sweep skill for the full investigate-and-verify
 workflow this drives.
 
+**Regenerating the chart/ledger itself is a separate, operational concern from the verification
+rule above — read `docs/self_scan/tri_comparison_README.md` before running
+`tri_comparison_chart.py` or hand-editing `tri_comparison_ledger.json`.** It's the canonical
+regen doc both agents point to (this file for Claude, `ANTIGRAVITY.md` for Gemini/Antigravity), not
+something to re-derive or duplicate. A real incident (PR #2111, 2026-08-22) shows why it matters:
+that regen ran with no genuine `universal-ctags` binary on PATH — Ubuntu's `arduino-ctags` package
+shadows the `ctags` binary name and silently degrades every language to a 2-tool comparison instead
+of erroring — which reverted cobol's already-validated full-precision badge, degraded fortran's,
+and dropped ctags data repo-wide, all without a single error message. Before trusting any regen's
+output: confirm `ctags --version` in your own terminal prints "Universal Ctags", not an Arduino
+banner or a not-found error; always regenerate with `--all --write`, never a partial `--languages`
+list with `--write` (it overwrites the whole file with only those languages); and never hand-set
+`status`/`verdict`/`still_reproduces` on a ledger entry — those come from a live gather or a human
+(or agent-standing-in-for-one) reading real source, never a guess about whether a shape "should"
+still reproduce.
+
 **Once verified, a rate-only TIE needs its own tie-break — don't leave it badge-less by default
 either.** Found via a real case: GitGalaxy, tree-sitter, and ctags can each land on 100% precision
 for the same language/metric (each is simply never wrong about what it itself claims, at very

--- a/docs/self_scan/tri_comparison_README.md
+++ b/docs/self_scan/tri_comparison_README.md
@@ -236,3 +236,11 @@ already degrades to.
 - [`docs/language_status/README.md`](../language_status/README.md) — per-language coverage docs;
   some carry their own tri-comparison capstone section (search for "Tri-comparison findings")
   built from this same ledger, synthesized for that one language.
+- This file is the canonical regen/operational doc for **both** coding agents working in this
+  repo — `CLAUDE.md`'s "Comparative-correctness claims require verification" section and
+  `ANTIGRAVITY.md`'s "Tri-Comparison Chart & Ledger" section both point here rather than
+  duplicating the procedure. A regen skipping the "Reproducing or updating this locally" steps
+  above (real `ctags` on PATH, `--all --write` only) caused a real incident, PR #2111
+  (2026-08-22) — every language silently lost its ctags bars/badges, including cobol's already-
+  validated full-precision badge, with no error at any point in the run. Check
+  `ctags --version` before you trust any regen's output.

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -59,11 +59,17 @@
 <rect class="stripe" x="16" y="250" width="780" height="44"/>
 <text class="lang-label" x="20" y="275.5">agc_assembly</text>
 <rect class="bar-track" x="154" y="255" width="88" height="34" rx="2"/>
-<rect x="154" y="255" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="255" width="72.2" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="263">812</text>
+<rect x="154" y="267" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="275">990</text>
 <rect class="bar-track" x="286" y="255" width="88" height="34" rx="2"/>
-<rect x="286" y="255" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="263">0/812</text>
+<rect x="286" y="255" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="263">812/812</text>
+<rect x="286" y="267" width="68.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="275">775/990</text>
+<circle cx="390.0" cy="272.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="275.0">G</text>
 <rect class="bar-track" x="418" y="255" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="255" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="255" width="88" height="34" rx="2"/>
@@ -98,11 +104,17 @@
 <rect class="stripe" x="16" y="338" width="780" height="44"/>
 <text class="lang-label" x="20" y="363.5">assembly</text>
 <rect class="bar-track" x="154" y="343" width="88" height="34" rx="2"/>
-<rect x="154" y="343" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="343" width="74.2" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="351">102</text>
+<rect x="154" y="355" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="363">121</text>
 <rect class="bar-track" x="286" y="343" width="88" height="34" rx="2"/>
-<rect x="286" y="343" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="351">0/102</text>
+<rect x="286" y="343" width="82.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="351">95/102</text>
+<rect x="286" y="355" width="69.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="363">95/121</text>
+<circle cx="390.0" cy="360.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="363.0">G</text>
 <rect class="bar-track" x="418" y="343" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="343" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="343" width="88" height="34" rx="2"/>
@@ -111,115 +123,159 @@
 <text class="lang-label" x="20" y="407.5">c</text>
 <rect class="bar-track" x="154" y="387" width="88" height="34" rx="2"/>
 <rect x="154" y="387" width="84.5" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="395">1719*</text>
+<text class="bar-value-label" x="198.0" y="395">1719</text>
 <rect x="154" y="399" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="407">1790*</text>
+<text class="bar-value-label" x="198.0" y="407">1790</text>
+<rect x="154" y="411" width="85.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="419">1733</text>
 <rect class="bar-track" x="286" y="387" width="88" height="34" rx="2"/>
-<rect x="286" y="387" width="87.1" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="395">1702/1719*</text>
+<rect x="286" y="387" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="395">1719/1719</text>
 <rect x="286" y="399" width="83.7" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="407">1702/1790*</text>
+<text class="bar-value-label" x="330.0" y="407">1702/1790</text>
+<rect x="286" y="411" width="86.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="419">1712/1733</text>
+<circle cx="390.0" cy="404.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="407.0">G</text>
 <rect class="bar-track" x="418" y="387" width="88" height="34" rx="2"/>
 <rect x="418" y="387" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="395">61</text>
 <rect x="418" y="399" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="407">61</text>
+<rect x="418" y="411" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="419">61</text>
 <rect class="bar-track" x="550" y="387" width="88" height="34" rx="2"/>
 <rect x="550" y="387" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="395">61/61</text>
 <rect x="550" y="399" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="407">61/61</text>
+<rect x="550" y="411" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="419">61/61</text>
 <rect class="bar-track" x="682" y="387" width="88" height="34" rx="2"/>
 <rect x="682" y="387" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="395">1702</text>
+<text class="bar-value-label" x="726.0" y="395">1699</text>
 <rect x="682" y="399" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="407">1702</text>
+<text class="bar-value-label" x="726.0" y="407">1699</text>
+<rect x="682" y="411" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="419">1699</text>
 <rect class="stripe" x="16" y="426" width="780" height="44"/>
 <text class="lang-label" x="20" y="451.5">cobol</text>
 <rect class="bar-track" x="154" y="431" width="88" height="34" rx="2"/>
-<rect x="154" y="431" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="431" width="61.3" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="439">168</text>
+<rect x="154" y="443" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="451">241</text>
 <rect class="bar-track" x="286" y="431" width="88" height="34" rx="2"/>
-<rect x="286" y="431" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="439">0/168</text>
+<rect x="286" y="431" width="63.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="439">122/168</text>
+<rect x="286" y="443" width="44.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="451">122/241</text>
+<circle cx="390.0" cy="448.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="451.0">G</text>
 <rect class="bar-track" x="418" y="431" width="88" height="34" rx="2"/>
 <rect x="418" y="431" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="439">19</text>
+<rect x="418" y="443" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="451">19</text>
 <rect class="bar-track" x="550" y="431" width="88" height="34" rx="2"/>
-<rect x="550" y="431" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="439">0/19</text>
+<rect x="550" y="431" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="439">19/19</text>
+<rect x="550" y="443" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="451">19/19</text>
 <rect class="bar-track" x="682" y="431" width="88" height="34" rx="2"/>
 <rect x="682" y="431" width="88" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="439">0†</text>
 <text class="lang-label" x="20" y="495.5">cpp</text>
 <rect class="bar-track" x="154" y="475" width="88" height="34" rx="2"/>
 <rect x="154" y="475" width="80.3" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="483">1360*</text>
+<text class="bar-value-label" x="198.0" y="483">1360</text>
 <rect x="154" y="487" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="495">1491*</text>
+<text class="bar-value-label" x="198.0" y="495">1491</text>
+<rect x="154" y="499" width="81.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="507">1378</text>
 <rect class="bar-track" x="286" y="475" width="88" height="34" rx="2"/>
-<rect x="286" y="475" width="83.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="483">1296/1360*</text>
+<rect x="286" y="475" width="87.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="483">1356/1360</text>
 <rect x="286" y="487" width="76.5" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="495">1296/1491*</text>
+<text class="bar-value-label" x="330.0" y="495">1297/1491</text>
+<rect x="286" y="499" width="86.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="507">1348/1378</text>
+<circle cx="390.0" cy="492.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="495.0">G</text>
 <rect class="bar-track" x="418" y="475" width="88" height="34" rx="2"/>
 <rect x="418" y="475" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="483">65</text>
 <rect x="418" y="487" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="495">65</text>
+<rect x="418" y="499" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="507">65</text>
 <rect class="bar-track" x="550" y="475" width="88" height="34" rx="2"/>
 <rect x="550" y="475" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="483">65/65</text>
 <rect x="550" y="487" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="495">65/65</text>
+<rect x="550" y="499" width="85.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="507">63/65</text>
 <rect class="bar-track" x="682" y="475" width="88" height="34" rx="2"/>
 <rect x="682" y="475" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="483">1296*</text>
+<text class="bar-value-label" x="726.0" y="483">1287</text>
 <rect x="682" y="487" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="495">1296*</text>
+<text class="bar-value-label" x="726.0" y="495">1287</text>
+<rect x="682" y="499" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="507">1287</text>
 <rect class="stripe" x="16" y="514" width="780" height="44"/>
 <text class="lang-label" x="20" y="539.5">csharp</text>
 <rect class="bar-track" x="154" y="519" width="88" height="34" rx="2"/>
 <rect x="154" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="527">964*</text>
+<text class="bar-value-label" x="198.0" y="527">964</text>
 <rect x="154" y="531" width="59.1" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="539">647*</text>
+<text class="bar-value-label" x="198.0" y="539">647</text>
+<rect x="154" y="543" width="74.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="551">811</text>
 <rect class="bar-track" x="286" y="519" width="88" height="34" rx="2"/>
-<rect x="286" y="519" width="59.1" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="527">647/964*</text>
+<rect x="286" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="527">964/964</text>
 <rect x="286" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="539">647/647*</text>
+<text class="bar-value-label" x="330.0" y="539">647/647</text>
+<rect x="286" y="543" width="87.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="551">810/811</text>
+<circle cx="390.0" cy="536.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="539.0">G</text>
 <rect class="bar-track" x="418" y="519" width="88" height="34" rx="2"/>
 <rect x="418" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="527">33*</text>
+<text class="bar-value-label" x="462.0" y="527">33</text>
 <rect x="418" y="531" width="64.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="539">24*</text>
+<text class="bar-value-label" x="462.0" y="539">24</text>
+<rect x="418" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="551">33</text>
 <rect class="bar-track" x="550" y="519" width="88" height="34" rx="2"/>
-<rect x="550" y="519" width="64.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="527">24/33*</text>
+<rect x="550" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="527">33/33</text>
 <rect x="550" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="539">24/24*</text>
+<text class="bar-value-label" x="594.0" y="539">24/24</text>
+<rect x="550" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="551">33/33</text>
 <rect class="bar-track" x="682" y="519" width="88" height="34" rx="2"/>
 <rect x="682" y="519" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="527">647*</text>
+<text class="bar-value-label" x="726.0" y="527">539</text>
 <rect x="682" y="531" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="539">647*</text>
+<text class="bar-value-label" x="726.0" y="539">539</text>
+<rect x="682" y="543" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="551">539</text>
 <text class="lang-label" x="20" y="583.5">css</text>
 <rect class="bar-track" x="154" y="563" width="88" height="34" rx="2"/>
 <rect x="154" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="571">3</text>
 <rect x="154" y="575" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="583">3</text>
+<rect x="154" y="587" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="595">0</text>
 <rect class="bar-track" x="286" y="563" width="88" height="34" rx="2"/>
 <rect x="286" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="571">3/3</text>
 <rect x="286" y="575" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="583">3/3</text>
 <rect class="bar-track" x="682" y="563" width="88" height="34" rx="2"/>
-<rect x="682" y="563" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="571">3</text>
-<rect x="682" y="575" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="583">3</text>
 <rect class="stripe" x="16" y="602" width="780" height="44"/>
 <text class="lang-label" x="20" y="627.5">dart</text>
 <rect class="bar-track" x="154" y="607" width="88" height="34" rx="2"/>
@@ -275,29 +331,41 @@
 <text class="lang-label" x="20" y="759.5">fortran</text>
 <rect class="bar-track" x="154" y="739" width="88" height="34" rx="2"/>
 <rect x="154" y="739" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="747">139*</text>
+<text class="bar-value-label" x="198.0" y="747">139</text>
 <rect x="154" y="751" width="77.9" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="759">123*</text>
+<text class="bar-value-label" x="198.0" y="759">123</text>
+<rect x="154" y="763" width="87.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="771">138</text>
 <rect class="bar-track" x="286" y="739" width="88" height="34" rx="2"/>
-<rect x="286" y="739" width="77.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="747">123/139*</text>
+<rect x="286" y="739" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="747">139/139</text>
 <rect x="286" y="751" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="759">123/123*</text>
+<text class="bar-value-label" x="330.0" y="759">123/123</text>
+<rect x="286" y="763" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="771">138/138</text>
+<circle cx="390.0" cy="756.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="759.0">G</text>
 <rect class="bar-track" x="418" y="739" width="88" height="34" rx="2"/>
 <rect x="418" y="739" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="747">11</text>
 <rect x="418" y="751" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="759">11</text>
+<rect x="418" y="763" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="771">11</text>
 <rect class="bar-track" x="550" y="739" width="88" height="34" rx="2"/>
 <rect x="550" y="739" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="747">11/11</text>
 <rect x="550" y="751" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="759">11/11</text>
+<rect x="550" y="763" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="771">11/11</text>
 <rect class="bar-track" x="682" y="739" width="88" height="34" rx="2"/>
 <rect x="682" y="739" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="747">123*</text>
+<text class="bar-value-label" x="726.0" y="747">123</text>
 <rect x="682" y="751" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="759">123*</text>
+<text class="bar-value-label" x="726.0" y="759">123</text>
+<rect x="682" y="763" width="68.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="771">95</text>
 <rect class="stripe" x="16" y="778" width="780" height="44"/>
 <text class="lang-label" x="20" y="803.5">go</text>
 <rect class="bar-track" x="154" y="783" width="88" height="34" rx="2"/>
@@ -305,45 +373,63 @@
 <text class="bar-value-label" x="198.0" y="791">897</text>
 <rect x="154" y="795" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="803">897</text>
+<rect x="154" y="807" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="815">897</text>
 <rect class="bar-track" x="286" y="783" width="88" height="34" rx="2"/>
 <rect x="286" y="783" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="791">897/897</text>
 <rect x="286" y="795" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="803">897/897</text>
+<rect x="286" y="807" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="815">897/897</text>
 <rect class="bar-track" x="418" y="783" width="88" height="34" rx="2"/>
 <rect x="418" y="783" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="791">69</text>
 <rect x="418" y="795" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="803">69</text>
+<rect x="418" y="807" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="815">69</text>
 <rect class="bar-track" x="550" y="783" width="88" height="34" rx="2"/>
 <rect x="550" y="783" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="791">69/69</text>
 <rect x="550" y="795" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="803">69/69</text>
+<rect x="550" y="807" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="815">69/69</text>
 <rect class="bar-track" x="682" y="783" width="88" height="34" rx="2"/>
 <rect x="682" y="783" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="791">897*</text>
 <rect x="682" y="795" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="803">897*</text>
+<rect x="682" y="807" width="87.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="815">894*</text>
 <text class="lang-label" x="20" y="847.5">groovy</text>
 <text class="awaiting" x="154" y="847.5">awaiting language-crucible corpus</text>
 <rect class="stripe" x="16" y="866" width="780" height="44"/>
 <text class="lang-label" x="20" y="891.5">haskell</text>
 <rect class="bar-track" x="154" y="871" width="88" height="34" rx="2"/>
-<rect x="154" y="871" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="879">147*</text>
-<rect x="154" y="883" width="87.4" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="891">146*</text>
+<rect x="154" y="871" width="71.9" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="879">147</text>
+<rect x="154" y="883" width="71.4" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="891">146</text>
+<rect x="154" y="895" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="903">180</text>
 <rect class="bar-track" x="286" y="871" width="88" height="34" rx="2"/>
-<rect x="286" y="871" width="87.4" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="879">146/147*</text>
+<rect x="286" y="871" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="879">147/147</text>
 <rect x="286" y="883" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="891">146/146*</text>
+<text class="bar-value-label" x="330.0" y="891">146/146</text>
+<rect x="286" y="895" width="37.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="903">77/180</text>
+<circle cx="390.0" cy="888.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="891.0">G</text>
 <rect class="bar-track" x="418" y="871" width="88" height="34" rx="2"/>
 <rect x="418" y="871" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="879">16</text>
 <rect x="418" y="883" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="891">16</text>
+<rect x="418" y="895" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="903">0</text>
 <rect class="bar-track" x="550" y="871" width="88" height="34" rx="2"/>
 <rect x="550" y="871" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="879">16/16</text>
@@ -351,9 +437,9 @@
 <text class="bar-value-label" x="594.0" y="891">16/16</text>
 <rect class="bar-track" x="682" y="871" width="88" height="34" rx="2"/>
 <rect x="682" y="871" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="879">146</text>
+<text class="bar-value-label" x="726.0" y="879">77</text>
 <rect x="682" y="883" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="891">146</text>
+<text class="bar-value-label" x="726.0" y="891">77</text>
 <text class="lang-label" x="20" y="935.5">html</text>
 <text class="awaiting" x="154" y="935.5">no functions/classes found in this corpus by any tool</text>
 <rect class="stripe" x="16" y="954" width="780" height="44"/>
@@ -363,52 +449,74 @@
 <text class="bar-value-label" x="198.0" y="967">318</text>
 <rect x="154" y="971" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="979">318</text>
+<rect x="154" y="983" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="991">318</text>
 <rect class="bar-track" x="286" y="959" width="88" height="34" rx="2"/>
 <rect x="286" y="959" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="967">318/318</text>
 <rect x="286" y="971" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="979">318/318</text>
+<rect x="286" y="983" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="991">318/318</text>
 <rect class="bar-track" x="418" y="959" width="88" height="34" rx="2"/>
 <rect x="418" y="959" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="967">35</text>
 <rect x="418" y="971" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="979">35</text>
+<rect x="418" y="983" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="991">35</text>
 <rect class="bar-track" x="550" y="959" width="88" height="34" rx="2"/>
 <rect x="550" y="959" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="967">35/35</text>
 <rect x="550" y="971" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="979">35/35</text>
+<rect x="550" y="983" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="991">35/35</text>
 <rect class="bar-track" x="682" y="959" width="88" height="34" rx="2"/>
 <rect x="682" y="959" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="967">318</text>
 <rect x="682" y="971" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="979">318</text>
+<rect x="682" y="983" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="991">318</text>
 <text class="lang-label" x="20" y="1023.5">javascript</text>
 <rect class="bar-track" x="154" y="1003" width="88" height="34" rx="2"/>
 <rect x="154" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1011">793*</text>
+<text class="bar-value-label" x="198.0" y="1011">793</text>
 <rect x="154" y="1015" width="66.5" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1023">599*</text>
+<text class="bar-value-label" x="198.0" y="1023">599</text>
+<rect x="154" y="1027" width="39.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1035">353</text>
 <rect class="bar-track" x="286" y="1003" width="88" height="34" rx="2"/>
-<rect x="286" y="1003" width="66.5" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1011">599/793*</text>
+<rect x="286" y="1003" width="67.7" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1011">610/793</text>
 <rect x="286" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1023">599/599*</text>
+<text class="bar-value-label" x="330.0" y="1023">599/599</text>
+<rect x="286" y="1027" width="86.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1035">345/353</text>
+<circle cx="390.0" cy="1020.0" r="8" fill="#eb6834"/>
+<text class="badge-label" x="390.0" y="1023.0">T</text>
 <rect class="bar-track" x="418" y="1003" width="88" height="34" rx="2"/>
-<rect x="418" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="418" y="1003" width="20.9" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1011">29</text>
-<rect x="418" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<rect x="418" y="1015" width="20.9" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1023">29</text>
+<rect x="418" y="1027" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1035">122</text>
 <rect class="bar-track" x="550" y="1003" width="88" height="34" rx="2"/>
 <rect x="550" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1011">29/29</text>
 <rect x="550" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1023">29/29</text>
+<rect x="550" y="1027" width="20.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1035">29/122</text>
 <rect class="bar-track" x="682" y="1003" width="88" height="34" rx="2"/>
 <rect x="682" y="1003" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1011">599*</text>
+<text class="bar-value-label" x="726.0" y="1011">334</text>
 <rect x="682" y="1015" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1023">599*</text>
+<text class="bar-value-label" x="726.0" y="1023">334</text>
+<rect x="682" y="1027" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1035">334</text>
 <rect class="stripe" x="16" y="1042" width="780" height="44"/>
 <text class="lang-label" x="20" y="1067.5">jcl</text>
 <rect class="bar-track" x="154" y="1047" width="88" height="34" rx="2"/>
@@ -424,30 +532,38 @@
 <text class="bar-value-label" x="726.0" y="1055">1‡</text>
 <text class="lang-label" x="20" y="1111.5">kotlin</text>
 <rect class="bar-track" x="154" y="1091" width="88" height="34" rx="2"/>
-<rect x="154" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="1091" width="58.7" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1099">28</text>
-<rect x="154" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<rect x="154" y="1103" width="58.7" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1111">28</text>
+<rect x="154" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1123">42</text>
 <rect class="bar-track" x="286" y="1091" width="88" height="34" rx="2"/>
 <rect x="286" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1099">28/28</text>
 <rect x="286" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1111">28/28</text>
+<rect x="286" y="1115" width="25.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1123">12/42</text>
 <rect class="bar-track" x="418" y="1091" width="88" height="34" rx="2"/>
 <rect x="418" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1099">7</text>
 <rect x="418" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1111">7</text>
+<rect x="418" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1123">7</text>
 <rect class="bar-track" x="550" y="1091" width="88" height="34" rx="2"/>
 <rect x="550" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1099">7/7</text>
 <rect x="550" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1111">7/7</text>
+<rect x="550" y="1115" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1123">7/7</text>
 <rect class="bar-track" x="682" y="1091" width="88" height="34" rx="2"/>
 <rect x="682" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1099">28</text>
+<text class="bar-value-label" x="726.0" y="1099">27</text>
 <rect x="682" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1111">28</text>
+<text class="bar-value-label" x="726.0" y="1111">27</text>
 <rect class="stripe" x="16" y="1130" width="780" height="44"/>
 <text class="lang-label" x="20" y="1155.5">livecode</text>
 <text class="awaiting" x="154" y="1155.5">no functions/classes found in this corpus by any tool</text>
@@ -456,14 +572,22 @@
 <rect class="stripe" x="16" y="1218" width="780" height="44"/>
 <text class="lang-label" x="20" y="1243.5">m4</text>
 <rect class="bar-track" x="154" y="1223" width="88" height="34" rx="2"/>
-<rect x="154" y="1223" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<rect x="154" y="1223" width="43.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1231">39</text>
+<rect x="154" y="1235" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1243">79</text>
 <rect class="bar-track" x="286" y="1223" width="88" height="34" rx="2"/>
-<rect x="286" y="1223" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1231">0/39</text>
+<rect x="286" y="1223" width="6.8" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1231">3/39</text>
+<rect x="286" y="1235" width="3.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1243">3/79</text>
+<circle cx="390.0" cy="1240.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1243.0">G</text>
 <rect class="bar-track" x="418" y="1223" width="88" height="34" rx="2"/>
 <rect x="418" y="1223" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1231">4</text>
+<rect x="418" y="1235" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1243">0</text>
 <rect class="bar-track" x="550" y="1223" width="88" height="34" rx="2"/>
 <rect x="550" y="1223" width="2.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1231">0/4</text>
@@ -471,21 +595,19 @@
 <text class="lang-label" x="20" y="1287.5">makefile</text>
 <rect class="bar-track" x="154" y="1267" width="88" height="34" rx="2"/>
 <rect x="154" y="1267" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1275">1</text>
+<text class="bar-value-label" x="198.0" y="1275">1*</text>
 <rect x="154" y="1279" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1287">1</text>
+<text class="bar-value-label" x="198.0" y="1287">1*</text>
+<rect x="154" y="1291" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1299">0*</text>
 <rect class="bar-track" x="286" y="1267" width="88" height="34" rx="2"/>
 <rect x="286" y="1267" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1275">1/1</text>
+<text class="bar-value-label" x="330.0" y="1275">1/1*</text>
 <rect x="286" y="1279" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1287">1/1</text>
+<text class="bar-value-label" x="330.0" y="1287">1/1*</text>
 <rect class="bar-track" x="418" y="1267" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1267" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1267" width="88" height="34" rx="2"/>
-<rect x="682" y="1267" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1275">1</text>
-<rect x="682" y="1279" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1287">1</text>
 <rect class="stripe" x="16" y="1306" width="780" height="44"/>
 <text class="lang-label" x="20" y="1331.5">matlab</text>
 <rect class="bar-track" x="154" y="1311" width="88" height="34" rx="2"/>
@@ -493,11 +615,15 @@
 <text class="bar-value-label" x="198.0" y="1319">23</text>
 <rect x="154" y="1323" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1331">23</text>
+<rect x="154" y="1335" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1343">23</text>
 <rect class="bar-track" x="286" y="1311" width="88" height="34" rx="2"/>
 <rect x="286" y="1311" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1319">23/23</text>
 <rect x="286" y="1323" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1331">23/23</text>
+<rect x="286" y="1335" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1343">23/23</text>
 <rect class="bar-track" x="418" y="1311" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1311" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1311" width="88" height="34" rx="2"/>
@@ -511,26 +637,36 @@
 <text class="bar-value-label" x="198.0" y="1363">152*</text>
 <rect x="154" y="1367" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1375">153*</text>
+<rect x="154" y="1379" width="79.4" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1387">138*</text>
 <rect class="bar-track" x="286" y="1355" width="88" height="34" rx="2"/>
 <rect x="286" y="1355" width="87.4" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1363">151/152*</text>
 <rect x="286" y="1367" width="86.8" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1375">151/153*</text>
+<rect x="286" y="1379" width="30.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1387">47/138*</text>
 <rect class="bar-track" x="418" y="1355" width="88" height="34" rx="2"/>
 <rect x="418" y="1355" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1363">5</text>
 <rect x="418" y="1367" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1375">5</text>
+<rect x="418" y="1379" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1387">5</text>
 <rect class="bar-track" x="550" y="1355" width="88" height="34" rx="2"/>
 <rect x="550" y="1355" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="594.0" y="1363">5/5</text>
 <rect x="550" y="1367" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1375">5/5</text>
+<rect x="550" y="1379" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1387">5/5</text>
 <rect class="bar-track" x="682" y="1355" width="88" height="34" rx="2"/>
 <rect x="682" y="1355" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1363">151</text>
+<text class="bar-value-label" x="726.0" y="1363">47</text>
 <rect x="682" y="1367" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1375">151</text>
+<text class="bar-value-label" x="726.0" y="1375">47</text>
+<rect x="682" y="1379" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1387">47</text>
 <rect class="stripe" x="16" y="1394" width="780" height="44"/>
 <text class="lang-label" x="20" y="1419.5">perl</text>
 <rect class="bar-track" x="154" y="1399" width="88" height="34" rx="2"/>
@@ -538,52 +674,70 @@
 <text class="bar-value-label" x="198.0" y="1407">942*</text>
 <rect x="154" y="1411" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1419">1063*</text>
+<rect x="154" y="1423" width="77.9" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1431">941*</text>
 <rect class="bar-track" x="286" y="1399" width="88" height="34" rx="2"/>
 <rect x="286" y="1399" width="87.9" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1407">941/942*</text>
 <rect x="286" y="1411" width="77.9" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1419">941/1063*</text>
+<rect x="286" y="1423" width="87.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1431">934/941*</text>
 <rect class="bar-track" x="418" y="1399" width="88" height="34" rx="2"/>
 <rect x="418" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1407">21*</text>
 <rect x="418" y="1411" width="83.8" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="1419">20*</text>
+<rect x="418" y="1423" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1431">21*</text>
 <rect class="bar-track" x="550" y="1399" width="88" height="34" rx="2"/>
-<rect x="550" y="1399" width="83.8" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1407">20/21*</text>
+<rect x="550" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1407">21/21*</text>
 <rect x="550" y="1411" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="594.0" y="1419">20/20*</text>
+<rect x="550" y="1423" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1431">21/21*</text>
 <rect class="bar-track" x="682" y="1399" width="88" height="34" rx="2"/>
 <rect x="682" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1407">941*</text>
+<text class="bar-value-label" x="726.0" y="1407">934*</text>
 <rect x="682" y="1411" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1419">941*</text>
+<text class="bar-value-label" x="726.0" y="1419">934*</text>
 <text class="lang-label" x="20" y="1463.5">php</text>
 <rect class="bar-track" x="154" y="1443" width="88" height="34" rx="2"/>
 <rect x="154" y="1443" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1451">1703*</text>
 <rect x="154" y="1455" width="87.9" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1463">1702*</text>
+<rect x="154" y="1467" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1475">1703*</text>
 <rect class="bar-track" x="286" y="1443" width="88" height="34" rx="2"/>
-<rect x="286" y="1443" width="87.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1451">1702/1703*</text>
+<rect x="286" y="1443" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1451">1703/1703*</text>
 <rect x="286" y="1455" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1463">1702/1702*</text>
+<rect x="286" y="1467" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1475">1703/1703*</text>
 <rect class="bar-track" x="418" y="1443" width="88" height="34" rx="2"/>
-<rect x="418" y="1443" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1451">29</text>
-<rect x="418" y="1455" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1463">29</text>
+<rect x="418" y="1443" width="85.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="462.0" y="1451">29*</text>
+<rect x="418" y="1455" width="85.1" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="462.0" y="1463">29*</text>
+<rect x="418" y="1467" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1475">30*</text>
 <rect class="bar-track" x="550" y="1443" width="88" height="34" rx="2"/>
 <rect x="550" y="1443" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1451">29/29</text>
+<text class="bar-value-label" x="594.0" y="1451">29/29*</text>
 <rect x="550" y="1455" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1463">29/29</text>
+<text class="bar-value-label" x="594.0" y="1463">29/29*</text>
+<rect x="550" y="1467" width="85.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1475">29/30*</text>
 <rect class="bar-track" x="682" y="1443" width="88" height="34" rx="2"/>
 <rect x="682" y="1443" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1451">1702</text>
 <rect x="682" y="1455" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="1463">1702</text>
+<rect x="682" y="1467" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1475">1702</text>
 <rect class="stripe" x="16" y="1482" width="780" height="44"/>
 <text class="lang-label" x="20" y="1507.5">powershell</text>
 <rect class="bar-track" x="154" y="1487" width="88" height="34" rx="2"/>
@@ -591,52 +745,70 @@
 <text class="bar-value-label" x="198.0" y="1495">111*</text>
 <rect x="154" y="1499" width="87.2" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1507">110*</text>
+<rect x="154" y="1511" width="75.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1519">95*</text>
 <rect class="bar-track" x="286" y="1487" width="88" height="34" rx="2"/>
-<rect x="286" y="1487" width="87.2" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1495">110/111*</text>
+<rect x="286" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1495">111/111*</text>
 <rect x="286" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1507">110/110*</text>
+<rect x="286" y="1511" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1519">95/95*</text>
 <rect class="bar-track" x="418" y="1487" width="88" height="34" rx="2"/>
 <rect x="418" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1495">7</text>
+<text class="bar-value-label" x="462.0" y="1495">7*</text>
 <rect x="418" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1507">7</text>
+<text class="bar-value-label" x="462.0" y="1507">7*</text>
+<rect x="418" y="1511" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1519">0*</text>
 <rect class="bar-track" x="550" y="1487" width="88" height="34" rx="2"/>
 <rect x="550" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1495">7/7</text>
+<text class="bar-value-label" x="594.0" y="1495">7/7*</text>
 <rect x="550" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1507">7/7</text>
+<text class="bar-value-label" x="594.0" y="1507">7/7*</text>
 <rect class="bar-track" x="682" y="1487" width="88" height="34" rx="2"/>
 <rect x="682" y="1487" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1495">110*</text>
+<text class="bar-value-label" x="726.0" y="1495">94*</text>
 <rect x="682" y="1499" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1507">110*</text>
+<text class="bar-value-label" x="726.0" y="1507">94*</text>
+<rect x="682" y="1511" width="2.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1519">2*</text>
 <text class="lang-label" x="20" y="1551.5">python</text>
 <rect class="bar-track" x="154" y="1531" width="88" height="34" rx="2"/>
 <rect x="154" y="1531" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1539">3725*</text>
+<text class="bar-value-label" x="198.0" y="1539">3725</text>
 <rect x="154" y="1543" width="85.6" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1551">3625*</text>
+<text class="bar-value-label" x="198.0" y="1551">3625</text>
+<rect x="154" y="1555" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1563">3725</text>
 <rect class="bar-track" x="286" y="1531" width="88" height="34" rx="2"/>
-<rect x="286" y="1531" width="85.6" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1539">3625/3725*</text>
+<rect x="286" y="1531" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1539">3725/3725</text>
 <rect x="286" y="1543" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1551">3625/3625*</text>
+<text class="bar-value-label" x="330.0" y="1551">3625/3625</text>
+<rect x="286" y="1555" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1563">3725/3725</text>
 <rect class="bar-track" x="418" y="1531" width="88" height="34" rx="2"/>
 <rect x="418" y="1531" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1539">473*</text>
+<text class="bar-value-label" x="462.0" y="1539">473</text>
 <rect x="418" y="1543" width="87.3" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1551">469*</text>
+<text class="bar-value-label" x="462.0" y="1551">469</text>
+<rect x="418" y="1555" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1563">473</text>
 <rect class="bar-track" x="550" y="1531" width="88" height="34" rx="2"/>
-<rect x="550" y="1531" width="87.3" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1539">469/473*</text>
+<rect x="550" y="1531" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1539">473/473</text>
 <rect x="550" y="1543" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1551">469/469*</text>
+<text class="bar-value-label" x="594.0" y="1551">469/469</text>
+<rect x="550" y="1555" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1563">473/473</text>
 <rect class="bar-track" x="682" y="1531" width="88" height="34" rx="2"/>
 <rect x="682" y="1531" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1539">3625</text>
 <rect x="682" y="1543" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="1551">3625</text>
+<rect x="682" y="1555" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1563">3625</text>
 <rect class="stripe" x="16" y="1570" width="780" height="44"/>
 <text class="lang-label" x="20" y="1595.5">ruby</text>
 <rect class="bar-track" x="154" y="1575" width="88" height="34" rx="2"/>
@@ -644,52 +816,76 @@
 <text class="bar-value-label" x="198.0" y="1583">124</text>
 <rect x="154" y="1587" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1595">124</text>
+<rect x="154" y="1599" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1607">124</text>
 <rect class="bar-track" x="286" y="1575" width="88" height="34" rx="2"/>
 <rect x="286" y="1575" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1583">124/124</text>
 <rect x="286" y="1587" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1595">124/124</text>
+<rect x="286" y="1599" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1607">124/124</text>
 <rect class="bar-track" x="418" y="1575" width="88" height="34" rx="2"/>
 <rect x="418" y="1575" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1583">19</text>
+<text class="bar-value-label" x="462.0" y="1583">19*</text>
 <rect x="418" y="1587" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1595">19</text>
+<text class="bar-value-label" x="462.0" y="1595">19*</text>
+<rect x="418" y="1599" width="69.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1607">15*</text>
 <rect class="bar-track" x="550" y="1575" width="88" height="34" rx="2"/>
 <rect x="550" y="1575" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1583">19/19</text>
+<text class="bar-value-label" x="594.0" y="1583">19/19*</text>
 <rect x="550" y="1587" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1595">19/19</text>
+<text class="bar-value-label" x="594.0" y="1595">19/19*</text>
+<rect x="550" y="1599" width="76.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1607">13/15*</text>
 <rect class="bar-track" x="682" y="1575" width="88" height="34" rx="2"/>
 <rect x="682" y="1575" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1583">124*</text>
 <rect x="682" y="1587" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="1595">124*</text>
+<rect x="682" y="1599" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1607">124*</text>
 <text class="lang-label" x="20" y="1639.5">rust</text>
 <rect class="bar-track" x="154" y="1619" width="88" height="34" rx="2"/>
 <rect x="154" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1627">1927*</text>
+<text class="bar-value-label" x="198.0" y="1627">1927</text>
 <rect x="154" y="1631" width="81.1" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1639">1775*</text>
+<text class="bar-value-label" x="198.0" y="1639">1775</text>
+<rect x="154" y="1643" width="81.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1651">1774</text>
 <rect class="bar-track" x="286" y="1619" width="88" height="34" rx="2"/>
-<rect x="286" y="1619" width="81.1" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1627">1775/1927*</text>
+<rect x="286" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1627">1927/1927</text>
 <rect x="286" y="1631" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1639">1775/1775*</text>
+<text class="bar-value-label" x="330.0" y="1639">1775/1775</text>
+<rect x="286" y="1643" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1651">1774/1774</text>
+<circle cx="390.0" cy="1636.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1639.0">G</text>
 <rect class="bar-track" x="418" y="1619" width="88" height="34" rx="2"/>
 <rect x="418" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1627">312*</text>
+<text class="bar-value-label" x="462.0" y="1627">312</text>
 <rect x="418" y="1631" width="80.9" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1639">287*</text>
+<text class="bar-value-label" x="462.0" y="1639">287</text>
+<rect x="418" y="1643" width="80.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="1651">284</text>
 <rect class="bar-track" x="550" y="1619" width="88" height="34" rx="2"/>
-<rect x="550" y="1619" width="80.9" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1627">287/312*</text>
+<rect x="550" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1627">312/312</text>
 <rect x="550" y="1631" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1639">287/287*</text>
+<text class="bar-value-label" x="594.0" y="1639">287/287</text>
+<rect x="550" y="1643" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="1651">284/284</text>
+<circle cx="654.0" cy="1636.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="1639.0">G</text>
 <rect class="bar-track" x="682" y="1619" width="88" height="34" rx="2"/>
 <rect x="682" y="1619" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1627">1775</text>
+<text class="bar-value-label" x="726.0" y="1627">1774</text>
 <rect x="682" y="1631" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1639">1775</text>
+<text class="bar-value-label" x="726.0" y="1639">1774</text>
+<rect x="682" y="1643" width="70.1" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="726.0" y="1651">1413</text>
 <rect class="stripe" x="16" y="1658" width="780" height="44"/>
 <text class="lang-label" x="20" y="1683.5">scala</text>
 <rect class="bar-track" x="154" y="1663" width="88" height="34" rx="2"/>
@@ -719,26 +915,34 @@
 <text class="bar-value-label" x="726.0" y="1683">541*</text>
 <text class="lang-label" x="20" y="1727.5">scheme</text>
 <rect class="bar-track" x="154" y="1707" width="88" height="34" rx="2"/>
-<rect x="154" y="1707" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1715">58</text>
+<rect x="154" y="1707" width="55.5" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1715">58*</text>
+<rect x="154" y="1719" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1727">92*</text>
 <rect class="bar-track" x="286" y="1707" width="88" height="34" rx="2"/>
-<rect x="286" y="1707" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1715">0/58</text>
+<rect x="286" y="1707" width="12.1" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1715">8/58*</text>
+<rect x="286" y="1719" width="7.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1727">8/92*</text>
 <rect class="bar-track" x="418" y="1707" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1707" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1707" width="88" height="34" rx="2"/>
 <rect class="stripe" x="16" y="1746" width="780" height="44"/>
 <text class="lang-label" x="20" y="1771.5">shell</text>
 <rect class="bar-track" x="154" y="1751" width="88" height="34" rx="2"/>
-<rect x="154" y="1751" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="198.0" y="1759">3</text>
-<rect x="154" y="1763" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="198.0" y="1771">3</text>
+<rect x="154" y="1751" width="66.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="198.0" y="1759">3*</text>
+<rect x="154" y="1763" width="66.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="198.0" y="1771">3*</text>
+<rect x="154" y="1775" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1783">4*</text>
 <rect class="bar-track" x="286" y="1751" width="88" height="34" rx="2"/>
 <rect x="286" y="1751" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1759">3/3</text>
+<text class="bar-value-label" x="330.0" y="1759">3/3*</text>
 <rect x="286" y="1763" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1771">3/3</text>
+<text class="bar-value-label" x="330.0" y="1771">3/3*</text>
+<rect x="286" y="1775" width="66.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1783">3/4*</text>
 <rect class="bar-track" x="418" y="1751" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1751" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1751" width="88" height="34" rx="2"/>
@@ -808,44 +1012,56 @@
 <text class="bar-value-label" x="198.0" y="1935">144*</text>
 <rect x="154" y="1939" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1947">144*</text>
+<rect x="154" y="1951" width="86.2" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="1959">141*</text>
 <rect class="bar-track" x="286" y="1927" width="88" height="34" rx="2"/>
-<rect x="286" y="1927" width="86.8" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1935">142/144*</text>
-<rect x="286" y="1939" width="86.8" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1947">142/144*</text>
+<rect x="286" y="1927" width="87.4" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1935">143/144*</text>
+<rect x="286" y="1939" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1947">144/144*</text>
+<rect x="286" y="1951" width="88.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1959">141/141*</text>
 <rect class="bar-track" x="418" y="1927" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="550" y="1927" width="88" height="34" rx="2"/>
 <rect class="bar-track" x="682" y="1927" width="88" height="34" rx="2"/>
 <rect x="682" y="1927" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1935">142</text>
+<text class="bar-value-label" x="726.0" y="1935">138</text>
 <rect x="682" y="1939" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1947">142</text>
+<text class="bar-value-label" x="726.0" y="1947">138</text>
 <text class="lang-label" x="20" y="1991.5">typescript</text>
 <rect class="bar-track" x="154" y="1971" width="88" height="34" rx="2"/>
 <rect x="154" y="1971" width="82.5" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1979">2733*</text>
 <rect x="154" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="198.0" y="1991">2914*</text>
+<rect x="154" y="1995" width="27.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="198.0" y="2003">894*</text>
 <rect class="bar-track" x="286" y="1971" width="88" height="34" rx="2"/>
 <rect x="286" y="1971" width="87.9" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1979">2731/2733*</text>
-<rect x="286" y="1983" width="82.5" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1991">2731/2914*</text>
+<rect x="286" y="1983" width="82.7" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1991">2740/2914*</text>
+<rect x="286" y="1995" width="82.0" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="2003">833/894*</text>
 <rect class="bar-track" x="418" y="1971" width="88" height="34" rx="2"/>
 <rect x="418" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1979">842</text>
+<text class="bar-value-label" x="462.0" y="1979">842*</text>
 <rect x="418" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="462.0" y="1991">842</text>
+<text class="bar-value-label" x="462.0" y="1991">842*</text>
+<rect x="418" y="1995" width="35.8" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="462.0" y="2003">343*</text>
 <rect class="bar-track" x="550" y="1971" width="88" height="34" rx="2"/>
 <rect x="550" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1979">842/842</text>
+<text class="bar-value-label" x="594.0" y="1979">842/842*</text>
 <rect x="550" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="1991">842/842</text>
+<text class="bar-value-label" x="594.0" y="1991">842/842*</text>
+<rect x="550" y="1995" width="87.5" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="594.0" y="2003">341/343*</text>
 <rect class="bar-track" x="682" y="1971" width="88" height="34" rx="2"/>
 <rect x="682" y="1971" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="726.0" y="1979">2731*</text>
+<text class="bar-value-label" x="726.0" y="1979">824*</text>
 <rect x="682" y="1983" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="726.0" y="1991">2731*</text>
+<text class="bar-value-label" x="726.0" y="1991">824*</text>
 <rect class="stripe" x="16" y="2010" width="780" height="44"/>
 <text class="lang-label" x="20" y="2035.5">yacc</text>
 <text class="awaiting" x="154" y="2035.5">awaiting language-crucible corpus</text>
@@ -879,17 +1095,17 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2750</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 33 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 43 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 5 (15%)</text>
-<circle cx="209.6" cy="2184" r="7" fill="#eb6834"/>
-<text class="badge-label" x="209.6" y="2187">T</text>
-<text class="legend-label" x="222.6" y="2188">tree-sitter best: 0 (0%)</text>
-<circle cx="402.4" cy="2184" r="7" fill="#1baf7a"/>
-<text class="badge-label" x="402.4" y="2187">C</text>
-<text class="legend-label" x="415.4" y="2188">ctags best: 0 (0%)</text>
-<circle cx="558.0" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="571.0" y="2188">Ties: 28 (85%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 16 (37%)</text>
+<circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
+<text class="badge-label" x="215.8" y="2187">T</text>
+<text class="legend-label" x="228.8" y="2188">tree-sitter best: 1 (2%)</text>
+<circle cx="408.6" cy="2184" r="7" fill="#1baf7a"/>
+<text class="badge-label" x="408.6" y="2187">C</text>
+<text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
+<circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
+<text class="legend-label" x="577.2" y="2188">Ties: 26 (60%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T13:45:03Z",
+      "last_reconciled_at": "2026-08-22T14:08:18Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -99,7 +99,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed-cause shape, fully accounted for via a corpus-wide cross-reference of ctags' actual output against GitGalaxy's raw func_start regex matches and its real pipeline/DB output (215 + 50 = 265, no unexplained residual). (1) 215/265 (81%): ctags' Asm \"l\" kind tags EVERY line-start label unconditionally, including pure data/constant-definition labels (e.g. ERASCON1 OCTAL 00061, S10BITS, LSTBNKCH -- AGC_BLOCK_TWO_SELF-CHECK.agc:133 and nearby) that are never followed by an executable instruction. GitGalaxy's func_start regex deliberately requires the label be followed by a real instruction mnemonic from a fixed whitelist, so it does not count these as functions -- a genuine, intentional precision distinction (code label vs. data label), not a GitGalaxy defect; ctags' generic Asm parser has no way to make this distinction at all. (2) 50/265 (19%): a real, confirmed GitGalaxy engine defect in detector.py's _slice_by_labels (Mode A), independently root-caused to two separate bugs: (a) `RELINT` is incorrectly included in `self.assembly_returns`'s early-termination keyword list (detector.py:572-575) -- in real AGC assembly RELINT means \"release interrupt inhibit\" and commonly opens a long interrupt-handler routine rather than closing one, so it truncates the real body to one line (confirmed: ELOOPFIN, AGC_BLOCK_TWO_SELF-CHECK.agc:303, a 20+-line real routine collapsed to just its own label line); (b) the `len(block.splitlines()) < 2` guard (detector.py:1973) unconditionally discards legitimate single-instruction assembly subroutines when the next func_start match sits on the very next line (confirmed: SOPTION1-SOPTION5+, AGC_BLOCK_TWO_SELF-CHECK.agc:210-214, each a real one-instruction label). Filed as #1949 -- a follow-up read-only Gemini/agy dispatch confirmed both root causes generalize beyond agc_assembly to the shared Mode A mechanism (assembly, cobol, fortran, abap all independently exhibit bug 1; assembly and cobol also exhibit bug 2), plus two further bug-1 variants not visible from agc_assembly alone: the terminator regex also false-matches inside comments (assembly) and inside hyphenated identifier names (cobol), not just legitimate-but-misclassified instructions. See #1949 for the full cross-language evidence and fix scope. No credit/debit -- the 215 portion is an honest scope difference (not two tools independently wrong about the same fact), and the 50 portion is GitGalaxy's own unresolved bug, not something ctags corroborates or contradicts."
     },
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-22T13:45:03Z",
+      "last_reconciled_at": "2026-08-22T14:08:18Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -204,7 +204,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed: all 35 occurrences are real AGC labels that GitGalaxy correctly extracts and Universal Ctags' generic Asm parser structurally cannot tag, due to AGC assembly's non-standard label-naming conventions. Two sub-patterns, both confirmed corpus-wide (14/35 + 21/35 = 35/35, not just the sample): (1) labels with an embedded hyphen -- AGC's own convention of naming a point relative to an event, e.g. TIG-35/TIG-30/CALLT-35 in BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc:250/292/222 (\"35/30 seconds before Time of Ignition\"); (2) labels starting with a digit or a leading minus sign, e.g. 1CHK/2EBANK/-1CHK in AGC_BLOCK_TWO_SELF-CHECK.agc:184 (real label text is \"-1CHK\"). Directly verified via `ctags --language-force=Asm --kinds-Asm=l` against the real corpus files: ctags emits zero tags for any of these names (confirmed by grepping its actual output for the exact names and their surrounding CHK-suffixed siblings, which ARE tagged when they don't start with a hyphen/digit) -- ctags' Asm parser requires a tag name to start with a letter and contain no hyphen, neither of which is a real constraint in AGC assembly's own label syntax. GitGalaxy's func_start regex ([A-Z0-9_-]+ at line start) has no such restriction. This is a confirmed, structural ctags/Asm-parser limitation, not corroboration of anything wrong on GitGalaxy's side -- logged to docs/why_gitgalaxy_beats_ast_here.md."
     },
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-22T13:45:05Z",
+      "last_reconciled_at": "2026-08-22T14:08:20Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T13:45:06Z",
+      "last_reconciled_at": "2026-08-22T14:08:22Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -346,7 +346,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed shape, no clean credit/debit call. (1) A real, confirmed GitGalaxy defect: the same detector.py `_slice_by_labels` bug filed for agc_assembly as #1949 (RELINT-style early truncation and single-line/blank-collapsed body discard) independently confirmed live for generic assembly too -- `del_command:` (bootos/os.asm:269) sits immediately before the next label `os22:` with nothing between, collapsing to a one-line block and getting discarded; `C:`/`prtstr:` (hellosilicon/matrixmultneon.s:90,92) are each followed only by a data directive (`.fill`, `.asciz`) then a blank line before the next label, same one-line-after-strip() collapse. All three are real regex matches (confirmed via direct func_start.finditer against the raw text) that never reach the final function list -- tracked under #1949, not a new issue. (2) A correct-by-design GitGalaxy exclusion: `.Lenv0:`/`.Largv0:` (cosmopolitan/ape.S:1784-1785) start with the `.L` prefix func_start's own negative lookahead deliberately excludes (GCC's own convention for compiler-generated local/temporary labels) -- both are genuinely data labels (`.asciz` string constants) here, not real subroutines; ctags' generic Asm parser has no such convention-awareness and tags them anyway. (3) ctags itself over-tags some non-callable constructs GitGalaxy correctly excludes -- C-preprocessor `#define` macro constants (`GRUB_MAGIC`/`GRUB_EAX`/`GRUB_AOUT`/`GRUB_CHECKSUM`/`USE_SYMBOL_HACK`, cosmopolitan/ape.S:49,1679-1682) are not real assembly labels at all (no trailing `:`), but ctags' Asm parser tags them regardless. No credit/debit -- the shape mixes a real unresolved GitGalaxy recall gap (#1949) with cases where ctags is the one over-tagging, not a clean corroboration story either direction."
     },
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-22T13:45:06Z",
+      "last_reconciled_at": "2026-08-22T14:08:22Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -425,7 +425,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed shape, three distinct confirmed mechanisms, no clean credit/debit call (real wins and real gaps in both directions within the same shape). (1) A dot-prefix naming-convention split -- NASM/GAS local labels scoped to the preceding global label are written with a leading `.` (e.g. `.load_vec:`, `.loop:` in bootos/os.asm:197,306), which GitGalaxy's func_start regex captures verbatim but ctags' Asm parser strips before emitting the tag (confirmed: ctags reports the SAME real label as `load_vec`/`loop`, no dot -- both tools genuinely found the same real construct, they just serialize the name differently). This is a name-string artifact of exact-string ledger grouping, not a detection difference on either side. (2) A genuine ctags gap: purely numeric local labels (`.1:`, `.2:` in bootos/counter.asm:52,67) are not tagged by ctags' Asm parser under ANY name (confirmed: neither `1`/`2` nor `.1`/`.2` appear in its output at all) -- GitGalaxy correctly finds these. (3) A genuine GitGalaxy precision gap, the mirror image of agc_assembly's own win: unlike agc_assembly's func_start (which requires a label be followed by a real instruction opcode), generic assembly's func_start has no such requirement -- ANY `identifier:` at line start matches, so it also matches pure data/constant declaration labels ctags' comparatively more conservative reading skips: `max_entries: equ sector_size/entry_size` (bootos/os.asm:166, a compile-time constant, not a subroutine), and several string/metadata labels in cosmopolitan/ape.S followed only by `.asciz`/data directives (`ape.ident`, `freebsd.ident`, `netbsd.ident`, `openbsd.ident`, `str.error`, `str.crlf`, `str.e820`, `str.oldcpu`). Not filed as a bug -- generic assembly's func_start is intentionally permissive because it has to span wildly different, informally-specified dialects (x86/ARM/legacy real-mode) where a fixed per-opcode whitelist like agc_assembly's isn't practical; worth a future harden-language-extraction look at whether a narrower heuristic (e.g. excluding labels followed only by known data-directive pseudo-ops like .asciz/.long/.byte/equ) could recover some of this precision without losing real dialect coverage, but that's a design tradeoff, not a clear regression to fix urgently."
     },
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -824,7 +824,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Not a GitGalaxy or ctags defect -- a bug in this tool's OWN _count_ctags_signature_params (tri_comparison_gatherer.py), now fixed. Confirmed directly: ran ctags against cpython/ceval.c, PyEval_GetLocals(void)'s raw signature field is literally the text '(void)'. GitGalaxy and tree-sitter both already special-case C's explicit empty-parameter-list idiom (0 real args, matching detector.py's own _count_top_level_args docstring) -- _count_ctags_signature_params did not, splitting '(void)' into one non-empty segment and counting it as 1 real parameter (the same class of bug its own docstring already describes fixing twice for Python's trailing-comma and bare * / marker cases). Added 'void' to the segment-exclusion set alongside the existing '*'/'/'/'**' -- verified fix: _count_ctags_signature_params('(void)') now returns 0. This corpus (cpython) uses the (void) idiom extremely heavily, plausibly explaining most/all of the 104 occurrences; not independently re-verified beyond the sample, but the mechanism is unconditional (any '(void)' signature was miscounted the same way, corpus-wide) so high confidence it generalizes. No GitHub issue needed -- fixed directly in this same commit, not a repo-code defect."
     },
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -938,7 +938,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "3 distinct causes, all genuine tree-sitter-c grammar limitations (GitGalaxy and ctags both correct in all 10 sampled cases) -- confirmed via dispatched investigation (which ran tree-sitter's C grammar directly and found ERROR nodes in every case) plus independent source-level spot-checks of all 3 trigger shapes. This is a C-scale instance of Claim 7 (CPP-directive-driven recall loss) -- added to that claim's evidence section. (1) 4 samples: an #if/#else pair splitting a single `if` condition inside a function body (ceval.c:33, _Py_ReachedRecursionLimitWithMargin). (2) 5 samples: bare, un-semicoloned macro invocations the grammar can't cleanly recover from, losing the next real function (object.c:1269-1271's _Py_COMP_DIAG_PUSH/IGNORE_DEPR_DECLS/POP before _PyObject_SetAttributeErrorContext; similar shape for the typeobject.c slot-getattr cluster). (3) 1 sample: #if/#endif wrapping only the `static` storage-class specifier, separated from the rest of the signature (micropython/compile.c:3473-3476, mp_compile_to_raw_code). Unlike Fortran's existing Claim 7 evidence (entire trailing sections lost), C's version is local -- one function lost per trigger, not a cascading region. No GitHub issue -- documented as new Claim 7 evidence, not a fixable tooling bug (this repo doesn't control tree-sitter-c's grammar)."
     },
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1055,7 +1055,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed."
     },
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1142,7 +1142,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes."
     },
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1193,7 +1193,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "UPDATED after a real production fix (the same fix documented in cpp's agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- c and cpp share the mechanism, `lang_id in (\"c\", \"cpp\")` in detector.py's `_slice_by_braces`). GitGalaxy now scans each file for `#define NAME(...)` function-like macro definitions and excludes any func_start match whose captured name is a known macro -- confirmed to eliminate the already-documented `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL`/`DICT___REVERSED___METHODDEF` cpython/typeobject.c false positives entirely (a direct `SELECT func_name ... WHERE func_name IN (...)` query against a fresh scan returned zero rows). The small residual (3 occurrences: `slot_nb_power`, `slot_nb_bool`, `wrap_next`, all cpython/typeobject.c) is a DIFFERENT, unrelated finding, not yet individually root-caused -- GitGalaxy and tree-sitter both correctly find these real functions and ctags doesn't; plausibly the same category of ctags miss documented in cpp's sibling entry (an ordinary function ctags' C++ parser fails to tag for reasons unrelated to macros) but not directly confirmed for these three specific names. No credit_tools adjustment applies -- already a naturally-corroborated 2-of-3 agreeing pair."
     },
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1255,7 +1255,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up."
     },
@@ -1271,7 +1271,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 17,
       "last_seen_examples": [
         {
@@ -1357,7 +1357,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -1375,7 +1375,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1471,7 +1471,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed, independently verified all 6 sampled names against real source -- GitGalaxy and ctags both correct, tree-sitter over-recalling from two related but distinct preprocessor-driven mechanisms, both already covered by existing infrastructure: (1) keyword/macro misparse -- 'if' (dictobject.c:522-527, an `#if SIZEOF_VOID_P > 4` / `else if` sequence desyncs the parse) and 'DICT___REVERSED___METHODDEF' (dictobject.c:5102, a PyMethodDef array-initializer macro, not a definition) are both ALREADY in tree_sitter_accuracy_audit.py's `_C_KNOWN_MACRO_HALLUCINATIONS` exclusion set (confirmed by reading it directly) -- this tri-comparison tool's raw walk deliberately doesn't apply that list (it's a curated, ground-truth-shaped judgment call, appropriately left to reconciliation per this module's own stated design, not baked into the walk). (2) dead #if 0 code -- '_PyObject_ManagedDictValidityCheck' (dictobject.c:7396) and 'tos_char'/'print_stack'/'print_stacks' (frameobject.c:1264-1313) are genuinely well-formed function definitions sitting entirely inside `#if 0 ... #endif` guards; tree-sitter has no preprocessor model and parses the dead branch as live code. Both mechanisms are already the exact shape docs/why_gitgalaxy_beats_ast_here.md's Claim 8 names generically ('a dead #if 0 block... macro definitions... that merely look structural') -- added these 4 new concrete citations to Claim 8's evidence section rather than treating this as a new finding. No GitHub issue -- both tools already behave as intended; this is expected, already-documented tree-sitter preprocessor-blindness surfacing under the new tri-comparison reconciliation, not a fresh defect."
     },
@@ -1487,7 +1487,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-22T13:45:12Z",
+      "last_reconciled_at": "2026-08-22T14:08:27Z",
       "last_seen_count": 88,
       "last_seen_examples": [
         {
@@ -1573,7 +1573,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -1592,7 +1592,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T13:45:17Z",
+      "last_reconciled_at": "2026-08-22T14:08:32Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1695,8 +1695,8 @@
       "investigated_at": "2026-08-22T00:00:00Z",
       "investigated_by": "Agent",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T13:45:17Z",
-      "last_seen_count": 136,
+      "last_reconciled_at": "2026-08-22T14:08:32Z",
+      "last_seen_count": 119,
       "last_seen_examples": [
         {
           "file_path": "cics-banking-sample-application-cbsa/BANKDATA.cbl",
@@ -1781,7 +1781,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed GitGalaxy engine defect (issue #1892). Fixed in the same pass by replacing the bare \b boundary with (?=[ \\t\\n.]) in the func_start reserved word shield, preventing hyphenated verbs like DELETE-POLICY from being incorrectly shielded."
     },
@@ -1798,8 +1798,8 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-22T13:45:17Z",
-      "last_seen_count": 43,
+      "last_reconciled_at": "2026-08-22T14:08:32Z",
+      "last_seen_count": 46,
       "last_seen_examples": [
         {
           "file_path": "cics-banking-sample-application-cbsa/BANKDATA.cbl",
@@ -1859,6 +1859,14 @@
         },
         {
           "file_path": "cics-banking-sample-application-cbsa/BANKDATA.cbl",
+          "name": "DELETE-DB2-ROWS",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 1179
+          }
+        },
+        {
+          "file_path": "cics-banking-sample-application-cbsa/BANKDATA.cbl",
           "name": "GET-TODAYS-DATE",
           "readings": {
             "ctags": null,
@@ -1872,19 +1880,11 @@
             "ctags": null,
             "gitgalaxy": 1405
           }
-        },
-        {
-          "file_path": "cics-banking-sample-application-cbsa/BNKMENU.cbl",
-          "name": "PREMIERE",
-          "readings": {
-            "ctags": null,
-            "gitgalaxy": 108
-          }
         }
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed-cause shape, two independent confirmed defects, neither in GitGalaxy's core function detection being right or wrong as a whole. (1) MAINLINE/TIMESTAMP and most of the 18 cases: these are real COBOL SECTION headers in the PROCEDURE DIVISION (e.g. cics-genapp/lgacdb01.cbl:128 \"MAINLINE SECTION.\", cics-banking-sample-application-cbsa/BANKDATA.cbl:1441 \"TIMESTAMP SECTION.\" followed by executable CALL statements) that GitGalaxy correctly captures per its own documented func_start scope (\"Paragraphs and Sections\") -- and ctags ALSO correctly tags them, as kind 'section' (verified via live ), not as the 'paragraph' kind. The disagreement is manufactured by tests/tools/ctags_reader.py's CTAGS_FUNC_KINDS[\"cobol\"] = {\"p\"}, which drops section-kind tags before comparison -- a test-harness bug, not a real ctags-vs-GitGalaxy disagreement. Filed as GitHub issue #1891. (2) LOCAL-STORAGE (cics-banking-sample-application-cbsa/XFRFUN.cbl:107 \"LOCAL-STORAGE SECTION.\" immediately followed by 01-level data item declarations, no executable logic): this is a genuine GitGalaxy false positive -- the func_start regex's reserved-word negative lookahead bans WORKING-STORAGE and LINKAGE as Data Division section names but omits LOCAL-STORAGE, so it slips through and gets miscounted as a paragraph. ctags correctly reports nothing here. Filed as GitHub issue #1890. Investigated via gemini-3.1-pro-high (agy), file:line citations independently re-verified by Claude against language_standards.py and a live ctags run before applying."
     },
@@ -1902,7 +1902,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1926,7 +1926,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Not a real existence disagreement -- a template-argument name-formatting difference in the comparison tooling. `godot/variant.h`'s `HashMapComparatorDefault<Variant>` and `is_zero_constructible<Variant>` are template CLASS specializations; GitGalaxy and tree-sitter both read the name WITH its template argument baked in (matching the instantiation as written in source), while ctags strips the `<...>` template-argument suffix from its own class tag name. All three tools found the exact same class definition at the exact same line -- confirmed via the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry, which is the same pair of classes from the opposite direction. Low magnitude (2 occurrences) -- not chased to a code fix in this pass, but a plausible future micro-fix would strip a trailing `<...>` from gg/tree-sitter's class name before matching, mirroring how ctags_reader.py's operator-name normalization already handles a similar formatting mismatch."
     },
@@ -1944,7 +1944,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1968,7 +1968,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Same template-argument name-formatting difference as the sibling agree[ctags]_vs[gitgalaxy,tree_sitter] class entry, viewed from the opposite direction -- `HashMapComparatorDefault`/`is_zero_constructible` (ctags' bare names) vs. `HashMapComparatorDefault<Variant>`/`is_zero_constructible<Variant>` (GitGalaxy/tree-sitter's names, template argument included). Not a real disagreement about whether these classes exist -- see the sibling entry for the full explanation."
     },
@@ -1986,7 +1986,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -2100,7 +2100,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2214,7 +2214,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -2310,7 +2310,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real tree-sitter accuracy-tool limitation, filed separately (see the sibling agree[none]_vs[ctags,gitgalaxy,tree_sitter] args entry and its referenced issue for the full writeup). tree-sitter's own parameter count (via the shared `_get_param_count` helper in tree_sitter_accuracy_audit.py, reused by tri_comparison_gatherer.py) undercounts by exactly 1 whenever a function has a parameter with a default value -- confirmed 6/6 sampled cases (save_scene_to_path, step, get_index, atr_n, atr, ObjectSignalLock), all off by exactly 1, all involving a `= default_value` parameter, ctags and GitGalaxy both correctly counting the real total. No credit_tools/debit_tools adjustment applies -- this is an args-metric shape, and apply_verified_adjustments only ever touches existence-metric precision (args scores have no equivalent verified-adjustment mechanism in this ledger's own code, see tri_comparison_ledger.py's apply_verified_adjustments docstring), so these fields would be a pure no-op here regardless of value -- left empty rather than set-but-inert, for an accurate record."
     },
@@ -2328,7 +2328,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2424,7 +2424,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real GitGalaxy args-counting defect, filed as https://github.com/squid-protocol/gitgalaxy/issues/2012 . Two distinct sub-patterns visible in the sample: (1) zero-undercounting for out-of-class method definitions with real parameters (VBufStorage_buffer_t::replaceSubtrees, Translator::BuildBuffer, Translator::BuildVhloCompositeV1Op, and every `operator()` call-operator overload in godot/node.h) where ctags and tree-sitter both correctly count real, non-zero parameter lists and GitGalaxy reads 0; (2) an off-by-one OVERcount for a constructor with a member-initializer-list but zero real parameters (VBufStorage_buffer_t's default constructor -- ctags/tree-sitter correctly read 0 params, GitGalaxy reads 1). Not the same shape as the func_start recall gaps in #2009/#2010 -- these are all functions GitGalaxy already finds, just with the wrong parameter count. Needs its own dedicated investigation per the issue (may be one or two root causes)."
     },
@@ -2442,7 +2442,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2474,7 +2474,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2489,7 +2489,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "A single function (NVDA/storage.cpp's `outputEscapedAttribute`, `size_t outputEscapedAttribute(wostringstream& out, const wstring& text, size_t maxLength=0)`, 3 real parameters) where all three tools disagree for two already-independently-confirmed reasons, not a new one: ctags reads the correct count (3); GitGalaxy reads 0, matching the args-undercounting defect filed as https://github.com/squid-protocol/gitgalaxy/issues/2012 ; tree-sitter reads 2, matching the default-value-parameter undercount filed as https://github.com/squid-protocol/gitgalaxy/issues/2014 (this function's third parameter, `maxLength`, has a default value -- exactly the trigger condition for that bug). Both referenced issues cover the general pattern; no new finding here beyond confirming they can compound on the same function."
     },
@@ -2504,7 +2504,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -2590,7 +2590,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -2608,7 +2608,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2704,7 +2704,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real tree-sitter-cpp grammar limitation, not a GitGalaxy or ctags defect. Every sampled case (GDScriptFunction::call, Main::setup, Main::setup2, Main::start, Object::Connection::operator Variant) is a large, complex function -- GDScriptFunction::call in particular (godot/gdscript_vm.cpp:499) is a bytecode interpreter's main dispatch loop using GNU 'labels as values' computed-goto syntax (`&&OPCODE_LABEL`) via the same OPCODES_TABLE/OPCODE macro family documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- a non-standard GNU extension tree-sitter-cpp's grammar does not support, which plausibly causes a parse error cascade that loses the enclosing function_definition node entirely rather than just misreading the body. ctags and GitGalaxy both correctly find and name these functions regardless of body content, since neither one needs to fully parse the function body to recognize its signature. tree-sitter's non-detection is a confirmed limitation in tree-sitter itself -- but no credit_tools adjustment applies: ctags and GitGalaxy are already a 2-of-3 AGREEING PAIR on this shape (agreeing_tools has 2 members), which already satisfies reconcile_symbols' own `len(present) >= 2` precision-credit condition naturally with no ledger adjustment needed. credit_tools exists for a LONE, single-tool claim (agreeing_tools with exactly 1 member) the base algorithm can't otherwise corroborate -- applying it to an already-mutually-corroborating pair would double-count (confirmed: this exact mistake briefly pushed ctags' precision past 100% before being caught and reverted in this same session)."
     },
@@ -2722,7 +2722,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2737,7 +2737,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "The single sampled occurrence (mlir/flatbuffer_export.cc:654, the `Translator` class's constructor) is exactly the bug filed as https://github.com/squid-protocol/gitgalaxy/issues/2009 -- a member-initializer-list spanning 906 characters exceeds GitGalaxy's func_start regex's 500-character cap for that clause, so the whole constructor is invisible to GitGalaxy despite ctags and tree-sitter both finding it correctly. GitGalaxy's non-detection is a confirmed, filed limitation -- but no credit_tools adjustment applies: ctags and tree-sitter are already a 2-of-3 AGREEING PAIR on this shape, which already satisfies reconcile_symbols' own `len(present) >= 2` precision-credit condition naturally. See the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] entry for the full explanation of why credit_tools only applies to a LONE, single-tool claim, never an already-agreeing pair."
     },
@@ -2755,7 +2755,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2851,7 +2851,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed ctags-only limitation: ctags parses INSIDE C++ macro DEFINITION bodies as if they were real, already-expanded code. godot/object.h's GDCLASS/_FORCE_INLINE_-based macros (`#define GDCLASS(m_class, m_inherits) ... _FORCE_INLINE_ bool (Object::*_get_get() const)(...) {...} ...`) never run as written -- they only produce real code once expanded at a `GDCLASS(SomeClass, Base)` call site elsewhere -- but ctags tags `_get_get`/`_get_set`/`_get_bind_methods`/`_get_bind_compatibility_methods`/`_get_notification`/`_get_property_can_revert`/`_get_property_get_revert`/`_get_validate_property`/`_get_get_property_list` (all 9 sampled cases, all from this same macro) as if they were ordinary member functions. Neither GitGalaxy nor tree-sitter are fooled by this. Documented in ctags_reader.py's KIND MAPS section (cpp bullet) rather than fixed -- this is ctags' own parser behavior, nothing in this repo's tooling can distinguish a macro-definition body from real code without reimplementing preprocessing."
     },
@@ -2869,7 +2869,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2956,7 +2956,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "UPDATED after a real production fix. The OPCODE-family shared mistake documented in this shape's prior verdict (~96 of the original 105 occurrences) is now FIXED: GitGalaxy's func_start (and by the same mechanism, C's) now scans each file for `#define NAME(...)` function-like macro definitions and excludes any match whose captured name is a known macro -- the exact same fact universal-ctags itself already used (confirmed via a direct `ctags -f -` run: ctags tags `OPCODE` only once, at its own #define line, kind `d`, and produces zero tags at any invocation site -- it isn't smarter about the invocation's shape, it just already knows the name is a macro and never re-tags it). This also fixed the already-documented C `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL`/`DICT___REVERSED___METHODDEF` false positives as a bonus (same mechanism, `lang_id in (\"c\", \"cpp\")`). Verified via 3 repeated full-corpus scans producing byte-identical function lists, the full extraction gauntlet, and both golden masters re-blessed. The remaining residual (9 occurrences, previously miscounted as more of the same shared mistake in the earlier verdict's blanket debit -- corrected here) is a DIFFERENT, unrelated finding: GitGalaxy and tree-sitter are CORRECT here, ctags is wrong. Two sub-patterns confirmed: (1) the already-documented macro-as-return-type-prefix pattern (`IFACEMETHODIMP_(void)` immediately before the real `FancyZones::Run() noexcept` -- ctags tags the macro invocation itself and loses the real name, powertoys/FancyZones.cpp, 4 occurrences); (2) a newly-confirmed, NOT yet root-caused ctags miss on an ordinary virtual method with no macro involvement at all (`virtual RID mesh_create_from_surfaces(const Vector<RenderingServerTypes::SurfaceData> &p_surfaces, int p_blend_shape_count = 0) override { ... }`, godot/rendering_server_default.h -- ctags produces zero tags anywhere near this real method, 5 occurrences). No credit_tools adjustment applies: GitGalaxy and tree-sitter are already a 2-of-3 agreeing pair here, which already satisfies reconcile_symbols' own natural precision-credit condition."
     },
@@ -2974,7 +2974,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3016,7 +3016,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Compound shape, three distinct causes confirmed via source, not one. (1) Most of the sample (OPCODE_WHILE x2, OPCODE_SWITCH, OPCODE) is the same GG+tree-sitter shared macro-misparse family documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry (godot/gdscript_vm.cpp's OPCODE/OPCODE_WHILE/OPCODE_SWITCH dispatch macros) -- here landing as 'GitGalaxy alone' because tree-sitter's own error recovery on this repeated macro pattern isn't fully deterministic across every occurrence, not because the underlying cause differs. GitGalaxy is WRONG for this portion (same debit as the sibling entry, not double-counted here since debit_tools is per-shape). (2) `attribute_buffer_applier_factories_`/`m_draggingState`/`std::thread` are a separate, real GitGalaxy FALSE POSITIVE: a lambda passed as a constructor argument or member-initializer-list entry (`m_draggingState([this]() {...}),`, `std::thread([...]() {...}).detach();`) is misread as a function definition. Filed as https://github.com/squid-protocol/gitgalaxy/issues/2013 . (3) `Variant::operator ::RID`/`Variant::operator ::AABB`/`Variant::operator Object *` are real functions GitGalaxy correctly finds (confirmed via godot/variant.cpp source) that didn't rank-match ctags/tree-sitter's own readings of the same functions by exact name string -- a residual, low-priority naming-comparison edge case (global-scope `::`-prefixed conversion-operator return types) not chased further in this pass. No credit/debit applied given the mixed, three-cause nature of this shape."
     },
@@ -3032,7 +3032,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -3118,7 +3118,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -3136,7 +3136,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -3232,7 +3232,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "UPDATED: count grew (98 -> 194) as a direct, correct consequence of the OPCODE-macro fix documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- tree-sitter's OWN OPCODE-family misparse (godot/gdscript_vm.cpp's bytecode-dispatch macro) was previously MASKED by GitGalaxy sharing the identical mistake (both wrong == they 'agreed', landing in the other shape instead of this one). Now that GitGalaxy correctly excludes known macro invocations, tree-sitter's own grammar limitation on this exact pattern is cleanly isolated here instead, confirmed via the shape's own examples (repeated `OPCODE` entries at godot/gdscript_vm.cpp, tree_sitter line set, ctags/gitgalaxy both None). The remaining, previously-documented causes (bare control-flow-keyword/`void` hallucination, conversion-operator naming-suffix convention) are unchanged and still contribute the bulk of the original 98. No credit/debit applies -- tree-sitter is the one that's wrong here, alone."
     },
@@ -3248,7 +3248,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-22T13:45:22Z",
+      "last_reconciled_at": "2026-08-22T14:08:37Z",
       "last_seen_count": 195,
       "last_seen_examples": [
         {
@@ -3334,7 +3334,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -3352,7 +3352,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3439,7 +3439,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Same root cause and file as the sibling function-existence shape (roslyn/LanguageParser.cs's tree-sitter parse-error cascade from line ~5198, Claim 3 in why_gitgalaxy_beats_ast_here.md, #1427/#1567) -- with the parse tree corrupted into a single ERROR node, tree-sitter can't resolve any class_declaration structure in the corrupted region either, including the outer LanguageParser class itself (whose body spans the entire cascade) and every enum/nested class declared inside it (VariableFlags, NameOptions, ScanTypeArgumentListKind, ScanTypeFlags, ParseTypeMode, etc.). ctags and GitGalaxy both correctly find these via text-based parsing, unaffected by tree-sitter's own AST failure. Not a GitGalaxy or ctags defect. CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct."
     },
@@ -3457,7 +3457,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3526,7 +3526,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3602,7 +3602,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3680,7 +3680,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": null
     },
@@ -3701,7 +3701,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3716,7 +3716,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed: both ctags and GitGalaxy are wrong here, tree-sitter alone is right. roslyn/CSharpCompilation.cs:2539's `Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` has 2 real parameters (both tuple-typed); tree_sitter correctly reports 2. GitGalaxy's args capture group truncates at the first unbalanced `)` inside the first tuple parameter's own type, reporting 1 (mechanism 2 of issue #2051, confirmed via direct regex testing). ctags independently also reports 1, for its own unrelated reason (the same tuple-parameter-splitting limitation documented elsewhere in this file for GetHashCode/Equals-with-bool-tuple-param) -- both tools land on the identical wrong number by coincidence, not real corroboration of each other."
     },
@@ -3734,7 +3734,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3803,7 +3803,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed GitGalaxy defect for 6 of 7 occurrences, root-caused to 3 distinct mechanisms in the csharp args regex, none of which func_start's own (already-hardened) regex shares: (1) Branch 1's return-type-loop character class has no parens, so any tuple-shaped or generic-wrapped-tuple return type fails to match at all (HasEntryPointSignature: real=2, GitGalaxy=0; SetCurrentSolutionEx: real=1, GitGalaxy=2; SetCurrentSolutionAsync both overloads: real=6/GitGalaxy=2, real=7/GitGalaxy=0); (2) the shared args capture group `(\\([^)]*\\))` truncates at the first unbalanced `)`, breaking on any parameter whose own type contains parens (ProcessEventHandlerWorkQueueAsync's ImmutableSegmentedList<(tuple)> param: real=2, GitGalaxy=1); (3) the name-capture has no generic-type-parameter stepper (func_start's already does), so a generic method's <T> before the real parens fails to match (OnAnyDocumentTextChanged<TArg>: real=7, GitGalaxy=2; ScheduleTask<T>: real=2, GitGalaxy=1). Filed as issue #2051 with full evidence per mechanism. The 7th occurrence (GetModifierExcludingScoped) is NOT a real defect on either side: both of its overloads (1 param and 2 params) are correctly counted by GitGalaxy; the apparent ctags=2/gitgalaxy=1 mismatch is the reconciler's rank-based (not name/overload-based) pairing comparing two DIFFERENT real overloads against each other, not a genuine disagreement about the same declaration -- confirmed by reading both real declarations directly. No credit/debit: GitGalaxy is genuinely wrong on 6/7, and the reconciler-pairing noise on the 7th isn't a tool defect at all."
     },
@@ -3824,7 +3824,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -3866,7 +3866,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed shape. 1 of 4 is a confirmed genuine ctags defect: GetHashCode's tuple-parameter overload (`GetHashCode((ImmutableArray<byte> ContentHash, int Position) obj)`, 1 real param) -- ctags reports 2, mis-splitting the tuple-typed parameter's own internal comma as a second top-level parameter, the same family as the already-documented tuple-related ctags limitations in tests/tools/ctags_reader.py's csharp bullet. The other 3 (GetModifierExcludingScoped and two SetCurrentSolution rows) are NOT real tool disagreements at all -- SetCurrentSolution has 4 real overloads (1/6/4/5 real params respectively) in roslyn/Workspace.cs; every individual reading from every tool across both rows (ctags=6, gitgalaxy=1, tree_sitter=1, ctags=4, gitgalaxy=6, tree_sitter=6) independently matches SOME real overload's true count exactly when checked against the source -- the ledger shape only exists because the reconciler's rank-based pairing compared different tools' readings of DIFFERENT overloads against each other, not because any tool actually miscounted anything. Confirmed via direct line-by-line source reading of all 4 overloads. Credit gitgalaxy+tree_sitter for the 1 real ctags defect only; the shape as a whole is left without a clean credit/debit since 3 of 4 occurrences aren't a real disagreement to adjudicate."
     },
@@ -3883,7 +3883,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3898,7 +3898,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Tangled: partly the same reconciler rank-pairing artifact as the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] shape (SetCurrentSolution's 4 real overloads, 1/6/4/5 params), partly a genuine GitGalaxy defect underneath. ctags=5 and tree_sitter=4 each correctly match a DIFFERENT real overload's true count (line 444's 5 params, line 230's 4 params respectively) -- not wrong, just paired against each other by rank rather than by which declaration they actually read. GitGalaxy=0 traces to the SAME occurrence tree_sitter's 4 reading corresponds to (line 230, a bare tuple return type `(bool updated, Solution newSolution)` before the method name) -- a confirmed instance of issue #2051's mechanism 1 (GitGalaxy's args regex fails to match tuple return types at all). No credit/debit: too tangled between real defect and pairing noise to cleanly adjudicate at the shape level."
     },
@@ -3913,7 +3913,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -3999,7 +3999,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -4017,7 +4017,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -4113,7 +4113,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed: this shape is entirely tree-sitter-c-sharp's own known parse-error cascade in roslyn/LanguageParser.cs, already root-caused and evidence-backed as Claim 3 in docs/why_gitgalaxy_beats_ast_here.md (issues #1427/#1567). A syntax construct at line ~5198 triggers a parse error whose recovery fails to resynchronize for the rest of the (14,680-line) file -- tree.root_node.type itself becomes ERROR, so tree-sitter's own recall for this file collapses to near-zero past that point. GitGalaxy's regex and ctags' text-based parser are both unaffected and correctly find these functions (all sampled: ParseVariableDeclarator, GetPrecedence, ParsePrimaryExpression, ScanType x3 -- real, ordinary private methods, exact line-number agreement between ctags and gitgalaxy on every one). This is the tri-comparison ledger's own version of a phenomenon already fully diagnosed for the 2-way tree_sitter_accuracy_audit.py tool via its cascade_promotable logic -- that logic was never ported to tri_comparison_gatherer.py/tri_comparison_reconcile.py, which is why this shows as an unvalidated ledger shape despite being a known, closed question. Not a GitGalaxy or ctags defect. CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct."
     },
@@ -4131,7 +4131,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -4191,7 +4191,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4206,7 +4206,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed genuine ctags false positive, not a GitGalaxy or tree-sitter gap. roslyn/CSharpCompilation.cs:2539's real declaration is `public bool Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` -- an Equals overload with tuple-typed parameters. ctags' lightweight C# parser misreads the return-type/tuple-parameter boundary and tags the match under the name `bool` instead of `Equals`. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet alongside this shape's sibling ctags limitations (local-function blindness, complex-signature misses, overload-name collision -- see the agree[gitgalaxy,tree_sitter]_vs[ctags] shape). Not crediting/debiting: a single-tool false positive from an otherwise-unaffected precision baseline, no shared-mistake mechanism applies."
     },
@@ -4224,7 +4224,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -4320,7 +4320,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real ctags parser limitations, not a GitGalaxy or tree-sitter defect, via direct source reading and raw `ctags -x` runs against the flagged files. Two distinct mechanisms: (1) Local/nested functions -- roslyn/CSharpCompilation.cs's `validateSignature` (nested inside a larger method) and `isSupportedType` (a `static bool isSupportedType(...)` local function) are both structurally invisible to ctags, whose csharp kind map is only 'm' (top-level methods; \"C# has no free functions\" per ctags_reader.py's own comment) with no local-function concept at all -- this generalizes to every local function in the corpus, not just the sampled two. (2) Complex-signature misses and overload collisions on ordinary top-level private methods -- `FindEntryPoint` (nullable return/param types plus a generic `out` parameter) and `GetSourceDeclarationDiagnostics` (5 params, two with default values, one a `Func<...>` generic delegate) get no ctags tag at all, confirmed via `ctags -x` showing tags immediately before/after but not at their own lines -- isolated misses, not a wider blind region (unlike the tree-sitter cascade in the sibling ledger shape). `ReportUnusedImports` has two overloads at different lines; ctags tags only the first, silently dropping the second. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet. Credited on the strength of mechanism (1) generalizing structurally to the whole shape (ctags cannot see ANY local function, by construction) even though only ~5 of 107 occurrences were individually read -- mechanism (2)'s complex-signature misses are a smaller, less certain-to-generalize contributor to the same shape but point the same direction (ctags-side, not GitGalaxy/tree-sitter). CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct."
     },
@@ -4340,7 +4340,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -4436,7 +4436,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed shape, confirmed via a full name-diff against gather_language('csharp') rather than the capped sample alone: 44 of 48 are genuine local (nested) functions inside roslyn/LanguageParser.cs's tree-sitter parse-error cascade region (line >= ~5198, same mechanism as the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] shape / Claim 3) -- tree-sitter is fully blind there, and ctags additionally has no concept of a local/nested function at all (only top-level 'm' method tags), so GitGalaxy is the only tool that can see these. The remaining 2 are genuine GitGalaxy false positives with a confirmed, unrelated root cause: roslyn/CSharpCompilation.cs:2282's GetWellKnownType( (a call, no declaration exists anywhere in the file) and roslyn/LanguageParser.cs:2338's this.EatToken( (a call inside a switch-expression arm) are both mis-captured because func_start's return-type-loop character class allows unbalanced parens/commas in a single 'token', letting it swallow a real call-expression fragment as if it were part of a return type and land on the wrong identifier as the 'function name'. Filed as GitHub issue #2035 with root cause and fix direction; fix in progress in an isolated worktree as of this writing. Not crediting/debiting any tool on this shape since it's genuinely mixed (44 real local-function finds, 2 real false positives) -- re-visit once #2035 merges and re-run to confirm the shape drops to 44 (or fewer, if further false positives of the same class surface once #2035's fix generalizes across the full corpus). FOLLOW-UP (2026-08-21, post-#2035/#2036 re-verification): re-checked this shape with a full, uncapped corpus diff rather than the capped example sample. The 2 originally-confirmed false positives (GetWellKnownType, this.EatToken) are gone as expected. However 2 MORE confirmed false positives remain, distinct mechanisms from #2035's fix: CSharpCompilation.cs's `ref mdName, ..., CreateReflectionTypeNotFoundError(` (a real call site mistaken for a declaration because `ref` is a legitimate Branch A modifier keyword when used in a real declaration, but here it's a call-argument prefix) and LanguageParser.cs:2336's `_syntaxFactory.TypeConstraint(this.ParseType())` (a ternary `?` operator consumed by the return-type loop's nullable-type-marker allowance, same general shape as this.EatToken but not covered by #2035's specific fix). Filed as issue #2054. This shape remains genuinely mixed (the overwhelming majority are real cascade-region local functions, but a small residual of false positives keeps surfacing) -- still correctly left uncredited pending #2054. CLOSED (2026-08-21): this shape is now fully clean. Both remaining false-positive mechanisms (issue #2054: bare-comma call-argument absorption, ternary-? consumption, and the nested-generic-return-type regression its own fix introduced and #2061 corrected) are fixed and merged. A full uncapped re-diff confirms all 44 remaining occurrences are genuine local functions inside LanguageParser.cs's tree-sitter parse-error cascade region (Claim 3), zero non-cascade residue. credit_tools is now correctly applicable -- gitgalaxy is alone on this shape (no tool to share the credit-double-counting error this session already found and fixed on the sibling agree[ctags,gitgalaxy]/agree[gitgalaxy,tree_sitter] shapes with), and every one of its 44 claims here is confirmed real with the reason ctags (no local-function concept) and tree-sitter (parse cascade) don't corroborate it being a confirmed limitation in THEM, not an open question about GitGalaxy."
     },
@@ -4452,7 +4452,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 317,
       "last_seen_examples": [
         {
@@ -4538,7 +4538,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -4556,7 +4556,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-22T13:45:28Z",
+      "last_reconciled_at": "2026-08-22T14:08:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4589,7 +4589,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-22T13:45:30Z",
+      "last_reconciled_at": "2026-08-22T14:08:45Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -4622,7 +4622,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed ctags-side structural limitation, not a GitGalaxy defect. GitGalaxy's own func_start regex (language_standards.py) deliberately matches CSS at-rule keywords (@media/@supports/@container/@layer/@keyframes/@-webkit-keyframes) as the closest function-shaped construct CSS has, since CSS has no true function-definition/call syntax. tree-sitter's CSS grammar independently corroborates this: media_statement/supports_statement/keyframes_statement are real, distinct node types, already mapped 1:1 onto GitGalaxy's own at-rule set per issue #1313 (see tree_sitter_accuracy_audit.py's css NODE_MAPS entry and its media_statement/supports_statement name-extraction branches). Re-ran gather_language('css') directly against the full 4-file corpus (not just the ledger's capped 3-example sample): GitGalaxy and tree-sitter agree exactly on function count in every file (3/3 total, zero diff files) -- the agreement generalizes completely, it is not a partial/mixed sample. ctags' own FUNCTION_KIND_MAP already documents 'css': set()  # no function-equivalent (ctags_reader.py) -- confirmed empty (ctags_funcs: []) across all 4 corpus files too. ctags structurally cannot tag CSS at-rules as anything function-like; it isn't wrong about a claim, it has no claim to make here at all. No new doc note needed -- both the GitGalaxy/tree-sitter convention (#1313) and the ctags limitation are already documented in code. GitGalaxy+tree-sitter's agreement is real corroboration, not a shared mistake, so no credit/debit adjustment applies; ctags' lack of a comparable slot here is already handled correctly by the reconciler's own total_slots mechanics."
     },
@@ -4638,7 +4638,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T13:45:34Z",
+      "last_reconciled_at": "2026-08-22T14:08:49Z",
       "last_seen_count": 218,
       "last_seen_examples": [
         {
@@ -4741,7 +4741,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T13:45:34Z",
+      "last_reconciled_at": "2026-08-22T14:08:49Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -4836,7 +4836,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-22T13:45:34Z",
+      "last_reconciled_at": "2026-08-22T14:08:49Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -4940,7 +4940,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -5035,7 +5035,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5067,7 +5067,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5082,7 +5082,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real GitGalaxy engine defect (filed, not fixed -- needs real design work). wrf/module_physics_init.F's phy_init is a genuine 677-parameter subroutine (confirmed via `ctags --fields=+S`, which correctly reports all 677 comma-separated dummy args). GitGalaxy (40) and tree-sitter (39) both wrong, for different, independently confirmed reasons: GitGalaxy's args regex first alternative `\\([^)]*\\)` has no paren-depth awareness and stops at the FIRST literal ')' anywhere in the window -- which, in this signature, is the ')' closing an embedded `#if ( EM_CORE == 1 )` guard ~12 lines into the parameter list, not the real closing paren ~245 lines later (directly traced: the window-bounding fix from #1973 correctly extends to the real closing paren at line 276, but the args regex itself still truncates early). Tree-sitter's undercount is the same already-documented #1709 ERROR/preproc_* cascade applied to its own parse of this signature. ctags alone gets this right because its signature accumulation isn't a single bounded regex. This is a genuine 3-way split (no two tools agree with each other at all), so no credit/debit pair applies. Filed as https://github.com/squid-protocol/gitgalaxy/issues/2077 -- fixing it needs a real depth-aware paren scanner (mirroring dart's _count_top_level_args / cpp's _cpp_class_has_body pattern) over the already-correctly-bounded args_search_text, not a one-line regex tweak, so left for its own follow-up PR rather than shipped inline."
     },
@@ -5097,7 +5097,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5111,7 +5111,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -5129,7 +5129,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -5225,7 +5225,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed already-documented tree-sitter-fortran limitation (#1709/Claim 7 in docs/why_gitgalaxy_beats_ast_here.md), re-verified directly against this exact shape's 14 occurrences (11 in wrf/module_physics_init.F: bl_init, ra_init, landuse_init, mp_init, cu_init, shcu_init, CAM_INIT, z2sigma, fdob_init, fg_init, ALLOCATE_CAM_ARRAYS; 3 in wrf/wrf_timeseries.F: calc_p8w, calc_ts, write_ts). Directly ran tree_sitter_accuracy_audit.py's own _find_blind_spot_ranges() against both files' real parse trees: every one of the 14 occurrences' start lines falls inside a tree-sitter ERROR/preproc_* blind-spot range (e.g. bl_init/mp_init/cu_init/shcu_init all sit inside one continuous (2203,4393) span; all 3 wrf_timeseries.F occurrences fall inside a (1,1200) span). ctags and GitGalaxy are both correct; tree-sitter-fortran's own grammar cascades into ERROR nodes on the CPP #if/#endif guards surrounding these subroutines. Added as new evidence to the existing Claim 7 in docs/why_gitgalaxy_beats_ast_here.md (this ledger shape is independently sourced from the original accuracy-audit finding -- a raw per-file name diff via tri_comparison_gatherer.py, not the audit tool's promotion logic)."
     },
@@ -5243,7 +5243,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5287,7 +5287,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5302,7 +5302,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed GitGalaxy correct on both. 'vint' (module_initialize_real.F:5375, inside #ifdef VERT_UNIT) and 'foo' (module_initialize_real.F:7519, inside #if 0) are both real, syntactically valid `PROGRAM name` declarations. tree-sitter misses both via the already-documented #1709 ERROR/preproc_* blind-spot mechanism (both sit inside #if/#ifdef-guarded regions). ctags misses 'foo' only because CTAGS_FUNC_KINDS['fortran'] was {'f','s'} (functions/subroutines only) -- ctags itself DOES correctly tag `foo` as a 'p' (program) kind (confirmed via `ctags -x --kinds-Fortran=p`), just invisible to this comparison. Fixed in tests/tools/ctags_reader.py: CTAGS_FUNC_KINDS['fortran'] now {'f','s','p','e'} (added program, entry -- matching GitGalaxy's own func_start scope of FUNCTION|SUBROUTINE|PROGRAM|ENTRY). ctags separately, genuinely fails to tag 'vint' at all under any kind in this specific file (confirmed it tags an isolated test file with identical #ifdef-wrapped `program vint` syntax fine, so it's a real, unexplained ctags-fortran-parser corruption specific to this file's content, not a preprocessor-conditional-skip decision) -- a genuine, narrow ctags limitation, not chased further for a single occurrence."
     },
@@ -5318,7 +5318,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-22T13:45:41Z",
+      "last_reconciled_at": "2026-08-22T14:08:56Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5404,7 +5404,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -5422,7 +5422,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-22T13:45:43Z",
+      "last_reconciled_at": "2026-08-22T14:08:58Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5518,7 +5518,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -5533,7 +5533,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-22T13:45:43Z",
+      "last_reconciled_at": "2026-08-22T14:08:58Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5619,7 +5619,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -5637,7 +5637,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5733,7 +5733,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Not a real discrepancy -- structural tooling gap, already documented in the codebase. tests/tools/ctags_reader.py:39-40,228 sets CTAGS_CLASS_KINDS['haskell'] = set() on purpose: \"ctags' Haskell parser has no class-shaped kind at all (constructor/function/module/type only)\". Every example in this shape (data/newtype/class declarations -- ReaderOptions, CiteMethod, HasSyntaxExtensions, etc.) is real; ctags structurally cannot report any of them for this language, not a sample-specific miss. No action needed beyond this note."
     },
@@ -5749,13 +5749,14 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
-      "last_seen_count": 10,
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
+      "last_seen_count": 9,
       "last_seen_examples": [
         {
           "file_path": "pandoc/App.hs",
           "name": "getMetadataFromFiles",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 2
           }
@@ -5764,6 +5765,7 @@
           "file_path": "pandoc/App.hs",
           "name": "writerFn",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 2
           }
@@ -5772,6 +5774,7 @@
           "file_path": "pandoc/App.hs",
           "name": "writeFnBinary",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 1
           }
@@ -5780,6 +5783,7 @@
           "file_path": "pandoc/Shared.hs",
           "name": "textToIdentifier",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 1
           }
@@ -5788,6 +5792,7 @@
           "file_path": "pandoc/Shared.hs",
           "name": "tabFilter",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 1
           }
@@ -5796,6 +5801,7 @@
           "file_path": "pandoc/Shared.hs",
           "name": "inlineListToIdentifier",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 1
           }
@@ -5804,6 +5810,7 @@
           "file_path": "pandoc/Shared.hs",
           "name": "formatCode",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 1
           }
@@ -5812,6 +5819,7 @@
           "file_path": "pandoc/Shared.hs",
           "name": "splitTextByIndices",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 1
           }
@@ -5820,15 +5828,8 @@
           "file_path": "pandoc/Shared.hs",
           "name": "blocksToInlinesWithSep",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "pandoc/Shared.hs",
-          "name": "unEmoji",
-          "readings": {
-            "gitgalaxy": 0,
             "tree_sitter": 1
           }
         }
@@ -5853,7 +5854,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -5967,7 +5968,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -6063,7 +6064,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "All 10 sampled cases are ctags-side artifacts, not real GitGalaxy/tree-sitter misses -- confirmed via direct `ctags -x` output against the corpus. Three distinct ctags Haskell-parser weaknesses cover the sample: (1) multi-clause double/triple-tagging -- ctags tags every pattern-matched equation line as its own occurrence of the name (writerFn/writeFnBinary/expandFilterPath: confirmed 2-3 raw ctags tags per function, one per clause; a file-wide count found 45 such extra same-name tags across the 7-file corpus, e.g. blockToInlines alone has 14). GitGalaxy/tree-sitter both correctly anchor to the FIRST clause only, leaving ctags' later-clause tags as the ones unpaired. (2) keyword-as-identifier misparsing -- `class`/`where`/`pattern` (from PatternSynonyms) get tagged as function names when ctags fails to parse past the keyword; confirmed at Options.hs:62 (`class HasSyntaxExtensions`), Parsing.hs:184 (module-header `where`), and 3 PatternSynonyms declarations in Options.hs. (3) CAF/value-vs-function kind collapse -- defaultAbbrevs/defaultKaTeXURL/defaultMathJaxURL/defaultWebTeXURL are zero-arg top-level VALUES (non-arrow type signatures), not functions; ctags has no value/variable kind at all (`ctags --list-kinds-full=Haskell` shows only constructor/function/module/type) so it lumps every `name = expr` binding into \"function\". GitGalaxy (language_standards.py haskell rules, #1312) and tree-sitter's own audit tooling (_find_haskell_signature_for_bind, #1566) both independently make the same value-vs-function distinction correctly -- real cross-tool corroboration, not coincidence. (4) TH-splice call sites misread as definitions -- deriveJSON at Options.hs:454/458 is a Template Haskell splice INVOKING an imported function, not defining one; ctags misparses the call as a definition. No GitGalaxy/tree-sitter defect anywhere in this shape; purely a ctags parser limitation, same category as the already-documented empty CTAGS_CLASS_KINDS['haskell']."
     },
@@ -6081,7 +6082,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -6177,7 +6178,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed: all 10 sampled misses (and, by cross-check against additional non-sampled instances in Options.hs/Shared.hs, plausibly all 69) are locally-scoped function definitions -- `instance ... where` methods, `where`-clause helpers, or `let`-bound names inside `do` blocks -- never top-level module definitions. ctags' Haskell parser has no layout-rule/scope awareness and only tags equations anchored at column 1; it correctly handles multi-clause TOP-LEVEL definitions (verified via expandFilterPath, writeFnBinary, writerFn -- all tag fine, clauses and all), so this is a pure scope blind spot, not a clause-counting bug (distinct from the tree-sitter clause-splitting bug fixed earlier in this same effort, which shares 2 of the 10 sample names by coincidence of subject matter, not root cause). GitGalaxy and tree-sitter are both correct; ctags is not wrong so much as structurally incapable of seeing these. Known, expected limitation of ctags' Haskell parser, now documented alongside its existing Haskell notes in tests/tools/ctags_reader.py -- not a GitHub issue, nothing in this repo to fix."
     },
@@ -6197,7 +6198,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6212,7 +6213,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Mixed shape as originally investigated (2 occurrences): (1) Options.hs:438 getExtensions -- real function, `instance HasSyntaxExtensions WriterOptions where getExtensions opts = writerExtensions opts`. A sibling instance for ReaderOptions at Options.hs:80 has the identical shape. Tree-sitter's Haskell grammar doesn't expose typeclass-instance-method clause bodies the way it does top-level bindings, and ctags' Haskell parser has no instance-method kind either -- GitGalaxy is correct, both other tools have a real recall gap on typeclass instance methods. (2) Shared.hs:475 extensionEnabled -- was NOT a real function (imported from Text.Pandoc.Extensions, only ever appears as a guard-clause call inside a multi-line `||` condition) -- a genuine GitGalaxy false positive, filed as #2082 and fixed in PR #2083 (2026-08-22): `_slice_by_indentation` now skips an equation-form func_start match whose immediately preceding line ends in `||`/`&&`. Reconciled post-fix: only the getExtensions occurrence remains, so this shape is now a clean, unambiguous GitGalaxy win -- credited accordingly."
     },
@@ -6229,7 +6230,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6243,7 +6244,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -6261,7 +6262,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-22T13:45:47Z",
+      "last_reconciled_at": "2026-08-22T14:09:01Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -6375,7 +6376,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -6489,7 +6490,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -6603,7 +6604,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -6716,7 +6717,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6749,7 +6750,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6800,7 +6801,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -6914,7 +6915,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-22T13:45:50Z",
+      "last_reconciled_at": "2026-08-22T14:09:04Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6965,7 +6966,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -7061,7 +7062,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner tags its 'class' kind on ANY bare object-literal assignment (`var X = {...}`) or function-expression assignment (`var X = function(){}`, `obj.prop = function(){}`), a blanket heuristic for 'might be used as a pre-ES6 constructor' that fires regardless of whether `new` is ever used on it. Confirmed via a minimal isolated repro (plainObj/ctorLike/obj.Thing all tagged 'class' alongside a real ES6 class) and directly against the corpus: jqXHR (jquery/ajax.js, a plain config object), cssHooks/cssNormalTransform/cssShow (jquery/css.js), promise (jquery/deferred.js), Event/event/special (jquery/event.js, one of which -- Event -- IS a pre-ES6 constructor-style function, correctly ambiguous under ctags' heuristic but still not a real ES6 class), and the ALPHA_MODES/WEBGL_CONSTANTS/etc. config objects in threejs/GLTFLoader.js. GitGalaxy's class_start regex and tree-sitter's class_declaration node both correctly require the literal `class` keyword. Doc note added to ctags_reader.py's javascript CTAGS_CLASS_KINDS entry."
     },
@@ -7079,7 +7080,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7148,7 +7149,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed tree-sitter-alone argument-count corruption, a third facet of the same Flow-parsing family. Even where tree-sitter DOES still produce a real function_declaration node (outside any ERROR-swallowed region), a Flow parameter type with a union (`current: Fiber | null`) corrupts that node's own formal_parameters child list. Confirmed directly via react/ReactFiberBeginWork.js:405 `updateForwardRef(current: Fiber | null, workInProgress: Fiber, Component: any, nextProps: any, renderLanes: Lanes)` -- 5 real parameters (GitGalaxy=5, ctags=5, both correct) but tree-sitter's own formal_parameters node contains a single ERROR child swallowing 'current: Fiber | null,\\n  workInProgress:' whole (merging two real parameters into one unstructured blob), followed by a bare identifier node reading 'Fiber' -- the type name of the swallowed second parameter, left behind by the same ERROR recovery and miscounted as if it were itself a parameter. Net effect: 4 instead of 5, an off-by-one undercount rather than total loss. Documented in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension as the 'third facet.'"
     },
@@ -7166,7 +7167,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7190,7 +7191,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed comparison-methodology artifact (name-based reconciliation colliding on a reused property name), not a real defect in any of the three tools. jquery/event.js defines TWO separate object-literal properties both named 'setup' (line 441, taking 1 param `function(data)`) and 'trigger' (line 458, 1 param) inside one plugin-hook object, and a SECOND, unrelated pair of 'setup'/'trigger' properties (lines 759/774, taking 0 params) inside a different object later in the same file. This module's/the ledger's reconciliation pairs occurrences by NAME across the whole file, with no scope/position disambiguation, so a same-name collision between two genuinely different functions can produce a spurious per-name args mismatch depending on which occurrence each tool's internal ordering happens to surface first. Both readings (1 param and 0 params) are independently real and correct for their respective definition sites -- there is no actual counting defect here, just a reconciliation limitation inherent to comparing by name only. No credit/debit; no code fix warranted for 2 occurrences arising from a rare same-name collision."
     },
@@ -7205,7 +7206,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -7291,7 +7292,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -7309,7 +7310,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -7405,7 +7406,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed tree-sitter-alone recall gap, same Flow-cascade family as agree[gitgalaxy]_vs[ctags,tree_sitter] above but from the other side: for these specific names (updateContextProvider, reconcileChildren, updateScopeComponent, markWorkInProgressReceivedUpdate, shouldForceFlushFallbacksInDEV, patchConsole, abortIterable, abortStream, error, throwTaintViolation), ctags' own Flow-return-type cascade trigger point happens to sit AFTER these functions (or never fires in that file), so ctags finds them correctly and agrees with GitGalaxy at the exact same line number, while tree-sitter's independent (earlier-triggering, different-construct) ERROR cascade has already swallowed them. Because the two tools' cascades trigger on different Flow constructs starting at different lines, they lose different, non-identical sets of functions -- this is why the ledger shows several distinct 3-way shapes instead of one clean 'both non-GitGalaxy tools agree on what they missed' shape. Documented alongside the fuller write-up in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension."
     },
@@ -7423,7 +7424,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -7501,7 +7502,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed ctags-side synthetic-placeholder artifact, not a real discrepancy -- ctags' JavaScript scanner emits a synthetic 'AnonymousFunction<hex><seq>' tag for every genuinely anonymous function expression (a bare inline callback with no attributable name, e.g. `jQuery.ajaxPrefilter(function(s) {...})`), and GitGalaxy/tree-sitter both correctly agree these aren't named functions worth counting. Fixed by extending `tri_comparison_gatherer.py`'s existing `_is_ctags_synthetic_anon_name` (previously only matched the C-parser's `__anon<hex>` scheme) with a second regex for JavaScript's differently-shaped 'AnonymousFunction'/'AnonymousClass' scheme -- verified this removes every 'Anonymous*' entry across the full 18-file corpus with zero regressions (ruff/mypy audits clean)."
     },
@@ -7519,7 +7520,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -7615,7 +7616,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner loses the real property-key name for a function-valued object-literal property specifically when that literal is a CALL ARGUMENT rather than a direct assignment -- confirmed via jquery/ajax.js's `jQuery.extend(jQuery, {ajaxSetup: function(target, settings){...}, ajax: function(url, options){...}})`: ctags emits a synthetic 'AnonymousFunction<hex>' tag for both instead of using the real 'ajaxSetup'/'ajax' key text, while GitGalaxy and tree-sitter both correctly attribute the property key as the name. Generalizes across the whole corpus, not a one-file fluke -- the identical shape recurs in jquery/css.js (css/get/set/style), jquery/deferred.js (Deferred/catch/pipe/promise/then/when), jquery/event.js (Event/handler/off/one/postDispatch/set), jquery/core.js (20+ utility methods, reducing ctags' whole-file function count from 26 to 1), and threejs's Editor.js/GLTFLoader.js/WebGLRenderer.js/WebGLProgram.js. Doc note added to ctags_reader.py's javascript CTAGS_FUNC_KINDS entry."
     },
@@ -7633,7 +7634,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -7729,7 +7730,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed GitGalaxy correct; both ctags and tree-sitter structurally can't, for two INDEPENDENT reasons. All four affected react/*.js corpus files carry the `@flow` pragma. tree-sitter-javascript's grammar can't parse Flow's parenthesized type-cast syntax (`(expr: Type)`, e.g. `(workInProgress.child: any)`), producing an ERROR node that swallows a large trailing region of the file -- confirmed directly: ReactFiberBeginWork.js's ERROR spans lines 3221-4448 (1227 of 4448 lines), and ReactFiberWorkLoop.js/ReactFlightServer.js each produce ONE error node spanning the ENTIRE file (line 1 to EOF). Real, ordinary functions inside these regions (beginWork, attemptEarlyBailoutIfNoScheduledUpdate, mountLazyComponent, and 18 others sampled) have no tree-sitter node at all. Separately, ctags' own hand-written JS scanner hits an independent cascade triggered by a Flow RETURN-type annotation (`): Fiber | null {`) -- confirmed via a minimal isolated repro (a 4-function test file where the function with a Flow return-type annotation and everything textually after it produce zero ctags output), and confirmed against the real corpus (beginWork itself, which has exactly this return-type shape, produces zero ctags tags). GitGalaxy's regex has no dependency on either tool's parse state and finds every one of these correctly. Documented in docs/why_gitgalaxy_beats_ast_here.md (Claim 3, new subsection completing/extending the existing 'Second instance: javascript' write-up with the recall-loss half plus the newly-confirmed ctags cascade)."
     },
@@ -7745,7 +7746,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -7831,7 +7832,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -7849,7 +7850,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-22T13:45:53Z",
+      "last_reconciled_at": "2026-08-22T14:09:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7882,7 +7883,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T13:45:56Z",
+      "last_reconciled_at": "2026-08-22T14:09:10Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -7935,7 +7936,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T13:45:56Z",
+      "last_reconciled_at": "2026-08-22T14:09:10Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -8031,7 +8032,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed ctags-side over-detection, not a GitGalaxy/tree-sitter recall gap. Direct `ctags -x --languages=Kotlin` on okhttp/Dispatcher.kt shows all 15 occurrences split into two false-positive shapes ctags' Kotlin parser tags with the same 'method' kind as real functions: (1) 10 trailing-lambda blocks passed as call arguments -- `require(x >= 1) { \"...\" }` (lines 48/68), `synchronized(this) { ... }` (49/69/178), `check(...) { ... }` (180/185), `.also { readyAsyncCalls.clear() }` (210), and `.map { it.call }` (279/283) -- each tagged as a synthetic `<lambda>` symbol; (2) 5 `for (x in collection)` loop iteration variables tagged as methods literally named after the variable (`call` at 143/146/149 in cancelAll(), `existingCall` at 128/131 in findExistingCallWithHost()). GitGalaxy's own func_start regex and tree-sitter-kotlin's grammar both correctly require a real `fun`/constructor declaration, so their agreement (neither claims these 15) is real corroboration, not a shared miss. Not fixable via ctags_reader.py's FUNCTION_KINDS map -- ctags gives Kotlin no separate kind for 'anonymous lambda literal' or 'for-loop binding' vs. a real named function in the first place (confirmed: both false-positive shapes tag plain 'method', identical to genuine functions). Documented in ctags_reader.py's kotlin FUNCTION_KINDS comment. ctags' own claim on this shape is confirmed wrong, so it's debited."
     },
@@ -8049,7 +8050,7 @@
       "investigated_at": "2026-08-22T11:45:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T13:45:56Z",
+      "last_reconciled_at": "2026-08-22T14:09:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8064,7 +8065,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Direct continuation of the already-investigated constructor shape (see the now-still_reproduces=False agree[gitgalaxy]_vs[ctags,tree_sitter] entry's verdict for the full investigation): fixing tree_sitter_accuracy_audit.py's kotlin func_node_types to include `secondary_constructor` made tree-sitter agree with GitGalaxy on okhttp/Dispatcher.kt line 119's `constructor(executorService: ExecutorService?) : this() { ... }`, which regrouped this exact occurrence into a NEW 2-vs-1 shape. ctags' own Kotlin parser was independently confirmed (via `ctags -x --languages=Kotlin`) to emit no entry at all for line 119, under any kind -- a genuine ctags parser limitation (it doesn't recognize secondary-constructor syntax as a symbol in the first place), not a ctags_reader.py kind-mapping gap (there is nothing to remap; ctags never sees this construct as a taggable symbol). No credit/debit: ctags never claimed this occurrence at all (a miss, not a wrong claim), so there is nothing in its matched_consensus to debit, and gitgalaxy/tree_sitter's own claims were already correctly counted independent of this adjustment mechanism."
     },
@@ -8082,7 +8083,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-22T13:45:56Z",
+      "last_reconciled_at": "2026-08-22T14:09:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8114,7 +8115,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T13:46:03Z",
+      "last_reconciled_at": "2026-08-22T14:09:16Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8152,7 +8153,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Confirmed real GitGalaxy false positive, not yet fixed (tracked separately). m4's own class_start rule is explicitly None (m4 has no class/OOP concept) -- but detector.py's class extraction branch only checks _CLASS_START_NAMED_EXTRACTION_LANGS allowlist membership, not whether the language's own class_start is None, so m4 (and 18 other class_start=None languages) falls through to the generic 'class|struct|interface|trait|enum NAME' fallback regex regardless. That fallback has no awareness of m4 document structure, so it matches raw C struct declarations embedded as literal text inside autoconf feature-test macro arguments (e.g. curl/configure.ac:1358's 'struct SocketIFace *ISocket = NULL;' inside an AC_LANG_PROGRAM([[ ... ]]) block) as if they were real m4 classes. Verified directly against the live gatherer: gg_classes for curl/configure.ac returns ['SocketIFace', 'Library', 'sockaddr_in6'], none of which are real m4 constructs; ctags correctly reports none (no class-shaped kind for m4 at all). Filed as GitHub issue #1925 (broader architectural gap, confirmed for m4, 18 other class_start=None languages not yet checked) -- not fixed in this sweep."
     },
@@ -8169,7 +8170,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T13:46:03Z",
+      "last_reconciled_at": "2026-08-22T14:09:16Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -8255,7 +8256,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Clean, single-cause shape (all 10 sampled cases), not a GitGalaxy defect. Every sampled occurrence (curl/configure.ac lines 967-4994) is a real AC_DEFINE or AC_DEFINE_UNQUOTED call (e.g. line 2112: AC_DEFINE_UNQUOTED([CURL_DEFAULT_SSL_BACKEND], [...], [...])) -- an autoconf helper that emits a C preprocessor #define into the generated config.h at build time, NOT a new callable M4 macro definition. GitGalaxy's own func_start regex for m4 deliberately excludes AC_DEFINE/AC_DEFINE_UNQUOTED from its keyword set (m4_define|define|AC_DEFUN|AC_DEFUN_ONCE|AU_DEFUN|m4_defun only), so its silence here is correct. ctags' M4 parser heuristically tags any AC_DEFINE*-family call with a bracketed/plain first argument as a macro definition -- same macro-invocation-vs-definition confusion already documented for C's RICHCMP_WRAPPER pattern, now also documented in tests/tools/ctags_reader.py's m4 note. No GitHub issue against GitGalaxy -- this is a real, confirmed ctags-side limitation. (Separately, unrelated to this shape: a deeper live-pipeline recall gap causing GitGalaxy to extract only 1 m4 function total across the whole corpus, despite its func_start regex matching dozens of genuine AC_DEFUN/m4_define calls when run standalone, was found and fixed in part -- see PR #1927 for the func_start capture-group fix; the remaining pipeline-level gap is tracked separately, not part of this shape's verdict.) Investigated via gemini-3.1-pro-high (agy), all 10 sampled file:line citations independently verified."
     },
@@ -8272,7 +8273,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-22T13:46:03Z",
+      "last_reconciled_at": "2026-08-22T14:09:16Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -8358,7 +8359,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real GitGalaxy false positive, now fixed. The old func_start regex had no capture group over the macro-name argument, so it matched the AC_DEFUN keyword itself as the 'function name' -- structurally identical to matching 'def' as a Python function's name instead of what follows it. gnucobol/configure.ac:658 'AC_DEFUN([AC_PROG_F77], [])' was reported as a function literally named 'AC_DEFUN'; ctags correctly reports nothing here since this call defines an empty macro body (a no-op placeholder, common autoconf idiom for stubbing out a check). Fixed in PR #1927: func_start now captures the real macro-name argument (AC_PROG_F77), handling m4's three real quoting conventions (backtick/apostrophe, bracket, double-bracket). Verified directly: the pipeline now reports 'AC_PROG_F77' at line 658, not 'AC_DEFUN'."
     },
@@ -8376,7 +8377,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-22T13:46:04Z",
+      "last_reconciled_at": "2026-08-22T14:09:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8391,7 +8392,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8407,13 +8408,14 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-22T13:46:06Z",
+      "last_reconciled_at": "2026-08-22T14:09:19Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
           "file_path": "eeglab/eeglab.m",
           "name": "ismatlab",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 1,
             "tree_sitter": 0
           }
@@ -8439,7 +8441,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T13:46:08Z",
+      "last_reconciled_at": "2026-08-22T14:09:21Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -8535,7 +8537,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8553,7 +8555,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T13:46:08Z",
+      "last_reconciled_at": "2026-08-22T14:09:21Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -8649,7 +8651,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8667,7 +8669,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T13:46:08Z",
+      "last_reconciled_at": "2026-08-22T14:09:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8682,7 +8684,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8698,7 +8700,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T13:46:08Z",
+      "last_reconciled_at": "2026-08-22T14:09:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8712,7 +8714,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8730,7 +8732,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T13:46:08Z",
+      "last_reconciled_at": "2026-08-22T14:09:21Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8754,7 +8756,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8770,7 +8772,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-22T13:46:08Z",
+      "last_reconciled_at": "2026-08-22T14:09:21Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8792,7 +8794,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -8810,7 +8812,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8825,7 +8827,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -8843,7 +8845,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8874,7 +8876,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8888,7 +8890,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": null
     },
@@ -8904,13 +8906,14 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
           "file_path": "bugzilla/Bug.pm",
           "name": "_multi_select_accessor",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 2
           }
@@ -8919,6 +8922,7 @@
           "file_path": "bugzilla/Bug.pm",
           "name": "_cf_accessor",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 2
           }
@@ -8927,6 +8931,7 @@
           "file_path": "bugzilla/CGI.pm",
           "name": "multipart_start",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 1,
             "tree_sitter": 2
           }
@@ -8935,6 +8940,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "ParseArguments",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 0
           }
@@ -8943,6 +8949,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "ReadValue",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 6,
             "tree_sitter": 0
           }
@@ -8951,6 +8958,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "WindowsLongPath",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 0
           }
@@ -8959,6 +8967,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "Open",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 4,
             "tree_sitter": 0
           }
@@ -8967,6 +8976,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "EncodeFileName",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 0
           }
@@ -8975,6 +8985,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "DecodeBits",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 0
           }
@@ -8983,6 +8994,7 @@
           "file_path": "exiftool/ExifTool.pm",
           "name": "Filter",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 0
           }
@@ -9008,7 +9020,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9077,7 +9089,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9095,7 +9107,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9164,7 +9176,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9182,7 +9194,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9197,7 +9209,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9213,7 +9225,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9227,7 +9239,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9245,7 +9257,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -9341,7 +9353,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9357,7 +9369,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-22T13:46:14Z",
+      "last_reconciled_at": "2026-08-22T14:09:27Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -9443,7 +9455,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9461,7 +9473,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T13:46:19Z",
+      "last_reconciled_at": "2026-08-22T14:09:32Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9476,7 +9488,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -9494,7 +9506,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T13:46:19Z",
+      "last_reconciled_at": "2026-08-22T14:09:32Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9509,7 +9521,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9527,7 +9539,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T13:46:19Z",
+      "last_reconciled_at": "2026-08-22T14:09:32Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -9639,7 +9651,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-22T13:46:19Z",
+      "last_reconciled_at": "2026-08-22T14:09:32Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9653,7 +9665,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9671,7 +9683,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T13:46:21Z",
+      "last_reconciled_at": "2026-08-22T14:09:35Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9740,7 +9752,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -9756,13 +9768,14 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T13:46:21Z",
+      "last_reconciled_at": "2026-08-22T14:09:35Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
           "file_path": "core/packaging.psm1",
           "name": "Start-PSPackage",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 0,
             "tree_sitter": 12
           }
@@ -9771,6 +9784,7 @@
           "file_path": "core/packaging.psm1",
           "name": "New-MSIPackage",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 11,
             "tree_sitter": 10
           }
@@ -9779,6 +9793,7 @@
           "file_path": "core/packaging.psm1",
           "name": "Invoke-AzDevOpsLinuxPackageBuild",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 0,
             "tree_sitter": 2
           }
@@ -9787,6 +9802,7 @@
           "file_path": "core/packaging.psm1",
           "name": "Invoke-AzDevOpsLinuxPackageCreation",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 0,
             "tree_sitter": 3
           }
@@ -9795,6 +9811,7 @@
           "file_path": "core/packaging.psm1",
           "name": "Get-LinuxPackageSemanticVersion",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 0,
             "tree_sitter": 1
           }
@@ -9820,7 +9837,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T13:46:21Z",
+      "last_reconciled_at": "2026-08-22T14:09:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9835,7 +9852,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9853,7 +9870,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T13:46:21Z",
+      "last_reconciled_at": "2026-08-22T14:09:35Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9949,7 +9966,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9965,7 +9982,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-22T13:46:21Z",
+      "last_reconciled_at": "2026-08-22T14:09:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9979,7 +9996,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -9997,7 +10014,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T13:46:29Z",
+      "last_reconciled_at": "2026-08-22T14:09:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10039,7 +10056,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Extends Claim 2 (docs/why_gitgalaxy_beats_ast_here.md) one syntactic level up: tree-sitter-python doesn't just lose track of scope inside a cdef class block, it fails to recognize the 'cdef class' declaration itself as a class at all -- 0 class nodes reported for cython/MemoryView.pyx, missing all 4 real classes (array, Enum, memoryview, _memoryviewslice). GitGalaxy's class_start regex and ctags both correctly identify all 4 by name, confirmed via direct gather_language() check. Note: GitGalaxy's own class_data schema has no start_line column (documented in tri_comparison_gatherer.py's own module docstring), so the ledger's stored example shows a None 'reading' for GitGalaxy on this shape -- that's the (structurally absent) line number field, not an indication GitGalaxy missed the class; by NAME it matches ctags exactly. No GitGalaxy fix needed -- tree-sitter-python grammar limitation. docs/why_gitgalaxy_beats_ast_here.md's Claim 2 updated with this class-level evidence in the same PR."
     },
@@ -10055,7 +10072,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-22T13:46:29Z",
+      "last_reconciled_at": "2026-08-22T14:09:45Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10093,7 +10110,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": null
     },
@@ -10111,7 +10128,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T13:46:29Z",
+      "last_reconciled_at": "2026-08-22T14:09:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10144,7 +10161,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T13:46:29Z",
+      "last_reconciled_at": "2026-08-22T14:09:45Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -10240,7 +10257,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Already documented as Claim 2 in docs/why_gitgalaxy_beats_ast_here.md: tree-sitter-python has no concept of Cython's cdef class/cdef/cpdef syntax at all and loses track of scope at each cdef class boundary, so it finds 0 functions in cython/MemoryView.pyx and cython/MemoryView.pxd (0/0 vs GitGalaxy+ctags' 72/16, full agreement as of the 2026-08-21 get_slice_from_memview follow-up fix -- see the sibling agree[ctags]_vs[gitgalaxy,tree_sitter] shape's verdict for that fix's details). This shape's count grew from 32 to 99 to 100 across this PR's two fixes: it originally covered only the 32 'def'-based methods inside cdef class blocks; each cdef/cpdef func_start fix moved newly-recognized occurrences into THIS shape too, since they still disagree with tree-sitter for the identical underlying reason. GitGalaxy now has zero recall gaps on this corpus for Cython functions -- the only remaining disagreement with tree-sitter is tree-sitter's own structural blindness to the Cython dialect, not a GitGalaxy defect. No GitGalaxy fix needed for tree-sitter's own recall here -- grammar limitation, not an engine defect."
     },
@@ -10260,7 +10277,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-22T13:46:29Z",
+      "last_reconciled_at": "2026-08-22T14:09:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10291,7 +10308,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-22T13:46:29Z",
+      "last_reconciled_at": "2026-08-22T14:09:45Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -10377,7 +10394,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10395,7 +10412,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T13:46:31Z",
+      "last_reconciled_at": "2026-08-22T14:09:46Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10419,7 +10436,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -10437,7 +10454,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T13:46:31Z",
+      "last_reconciled_at": "2026-08-22T14:09:46Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10497,7 +10514,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -10515,7 +10532,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T13:46:31Z",
+      "last_reconciled_at": "2026-08-22T14:09:46Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -10548,7 +10565,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10566,7 +10583,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T13:46:31Z",
+      "last_reconciled_at": "2026-08-22T14:09:46Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10626,7 +10643,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10641,7 +10658,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-22T13:46:31Z",
+      "last_reconciled_at": "2026-08-22T14:09:46Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10719,7 +10736,7 @@
       ],
       "metric": "args",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -10736,7 +10753,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -10850,7 +10867,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -10883,7 +10900,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Confirmed structural ctags limitation, not a bug -- resolved directly (no dispatch needed). All 3 sampled names (XRegUnion, FRegUnion, VRegUnion) are real Rust `union { }` declarations (confirmed at wasmtime/wasmtime_pulley_interp.rs:404,529,604), distinct from `struct` -- Rust's less-common C-style unsafe union construct. Ran `ctags --list-kinds-full=Rust` directly: its Rust parser's kind list is macro/method/implementation/enumerator/function/enum/interface/field/module/struct/typedef/variable -- there is NO union kind at all. Confirmed via direct ctags run against this exact file: it correctly finds the wrapping `struct FRegVal(FRegUnion)`-shaped types right next to each missed union, so this isn't a general miss, specifically a missing Rust-union kind. Same category as the already-documented ctags Haskell class-kind gap (tests/tools/ctags_reader.py) -- worth a similar doc note there, not a GitHub issue (nothing to fix, ctags upstream has no union support for this language)."
     },
@@ -10903,7 +10920,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -10999,7 +11016,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": "Same mechanism as the already-resolved rust/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter] shape (Claim 6, docs/why_gitgalaxy_beats_ast_here.md) -- extended from `fn` definitions inside `quote!{}` invocation bodies to `struct` definitions inside `macro_rules!` DEFINITION bodies. All 6 sampled names confirmed, independently re-verified against source (not just the dispatched agent's own read): NonZeroVisitor (line 90), SaturatingVisitor (112), PrimitiveVisitor (136) inside serde/serde_core_de_impls.rs's `impl_deserialize_num!` macro (def starts line 81); SeqVisitor (998), SeqInPlaceVisitor (1036) inside `seq_impl!` (def starts 978); TupleVisitor (1403) inside `tuple_impl_body!` (nested in `tuple_impls!`, def starts 1396). All 6 are real, complete `struct` declarations, each immediately followed by a genuine `impl<'de,...> Visitor<'de> for <Name>` block -- generated once per macro invocation, not fragments or hallucinated matches. tree-sitter and ctags both treat a macro_rules! arm's body as an opaque, unexpanded token tree and structurally cannot emit struct nodes from inside one, for the identical reason they can't see function definitions inside quote!{} bodies. GitGalaxy is correct in all 6 sampled cases; judged (not independently re-confirmed beyond the sample) to generalize to the full 25, all same-shaped serde-crate occurrences. No new tool defect -- Claim 6's doc text already covered this generically (`struct_item` was already named) but had no concrete cited example for this specific shape; added one (docs/why_gitgalaxy_beats_ast_here.md) rather than filing an issue."
     },
@@ -11015,7 +11032,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -11101,7 +11118,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": null
     },
@@ -11118,7 +11135,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -11169,7 +11186,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -11265,7 +11282,7 @@
       ],
       "metric": "args",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together."
     },
@@ -11281,37 +11298,14 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
-      "last_seen_count": 42,
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
+      "last_seen_count": 21,
       "last_seen_examples": [
-        {
-          "file_path": "bevy/bevy_ecs_table.rs",
-          "name": "initialize",
-          "readings": {
-            "gitgalaxy": 3,
-            "tree_sitter": 5
-          }
-        },
-        {
-          "file_path": "bevy/bevy_ecs_table.rs",
-          "name": "replace",
-          "readings": {
-            "gitgalaxy": 3,
-            "tree_sitter": 5
-          }
-        },
-        {
-          "file_path": "bevy/bevy_ecs_world.rs",
-          "name": "insert_resource_by_id",
-          "readings": {
-            "gitgalaxy": 3,
-            "tree_sitter": 4
-          }
-        },
         {
           "file_path": "bevy/bevy_ecs_world.rs",
           "name": "spawn_at_unchecked",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 4
           }
@@ -11320,14 +11314,7 @@
           "file_path": "bevy/bevy_ecs_world.rs",
           "name": "spawn_at_with_caller",
           "readings": {
-            "gitgalaxy": 3,
-            "tree_sitter": 4
-          }
-        },
-        {
-          "file_path": "bevy/bevy_ecs_world.rs",
-          "name": "insert_non_send_by_id",
-          "readings": {
+            "ctags": null,
             "gitgalaxy": 3,
             "tree_sitter": 4
           }
@@ -11336,32 +11323,72 @@
           "file_path": "bevy/bevy_ecs_world.rs",
           "name": "spawn_with_caller",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 3
-          }
-        },
-        {
-          "file_path": "bevy/bevy_reflect_path.rs",
-          "name": "new",
-          "readings": {
-            "gitgalaxy": 3,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "serde/serde_core_de_impls.rs",
-          "name": "new",
-          "readings": {
-            "gitgalaxy": 3,
-            "tree_sitter": 1
           }
         },
         {
           "file_path": "serde/serde_core_de_mod.rs",
           "name": "deserialize_unit_struct",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 3
+          }
+        },
+        {
+          "file_path": "serde/serde_core_de_mod.rs",
+          "name": "deserialize_newtype_struct",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 3
+          }
+        },
+        {
+          "file_path": "serde/serde_core_de_mod.rs",
+          "name": "deserialize_tuple_struct",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 4
+          }
+        },
+        {
+          "file_path": "serde/serde_core_de_mod.rs",
+          "name": "deserialize_struct",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 4
+          }
+        },
+        {
+          "file_path": "serde/serde_core_de_mod.rs",
+          "name": "deserialize_enum",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 4
+          }
+        },
+        {
+          "file_path": "serde/serde_internals_ast.rs",
+          "name": "enum_from_ast",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 4
+          }
+        },
+        {
+          "file_path": "serde/serde_internals_ast.rs",
+          "name": "fields_from_ast",
+          "readings": {
+            "ctags": null,
+            "gitgalaxy": 2,
+            "tree_sitter": 5
           }
         }
       ],
@@ -11384,7 +11411,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -11497,7 +11524,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11530,7 +11557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11545,7 +11572,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed via direct ctags run and sibling comparison, resolved directly (no dispatch needed). `done_decode` (wasmtime/wasmtime_pulley_interp.rs:964) has a destructuring-pattern parameter -- `Done { _priv }: Done`, not a simple `name: Type` binding. Ran ctags directly against the file: its IMMEDIATE SIBLING in the same impl block, `debug_assert_done_reason_none` (line 960, same visibility/receiver shape, ordinary `&mut self`-only signature), IS correctly found as a ctags 'method'. done_decode alone is missing from ctags' output. Isolates the cause precisely to the destructuring-pattern parameter -- ctags' regex-based Rust parser appears to fail/skip the whole function when a parameter is a struct pattern rather than a plain identifier binding. GitGalaxy and tree-sitter both handle this fine (both agree on line 964). N=1 in this corpus, plausibly a real, narrow ctags parser gap (not GitGalaxy's) -- not chasing further given the tiny sample, noting rather than filing an issue since there's nothing in this repo to fix."
     },
@@ -11565,7 +11592,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -11661,7 +11688,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Not a new question -- already-documented, evidence-backed rust behavior (Claim 6, docs/why_gitgalaxy_beats_ast_here.md: 'structure recall inside opaque macro bodies'). Confirmed directly: all 5 sampled names (get_param, init_access, get_components, from_components, apply) are in bevy/bevy_ecs_macros.rs, inside a `quote! { ... }` proc-macro body (confirmed at source lines 444-460 -- `#path`/`#fields_alias` interpolation syntax is the classic quote! token-generation pattern). These are real Rust function definitions being code-generated by a proc macro; GitGalaxy's regex correctly parses real function syntax wherever it textually appears, including inside macro bodies. tree-sitter-rust and ctags' Rust parser both treat macro_rules!/macro-invocation bodies as opaque token trees and structurally cannot emit function nodes for anything inside one -- not a bug in either, a real grammar limitation. This is exactly why rust is one of the 3 languages (with csharp/fortran) already promoted into ground truth via blind-spot-region detection in the OLD bi-comparison tool (tree_sitter_accuracy_audit.py's _find_blind_spot_ranges) -- this tri-comparison ledger entry is that same, already-understood gap surfacing again under the new 3-tool reconciliation. GitGalaxy is correct; no engine defect, no issue needed. Resolved directly from existing documentation, no fresh dispatch required (tri-comparison-ledger-sweep skill step 1.3)."
     },
@@ -11677,7 +11704,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-22T13:46:35Z",
+      "last_reconciled_at": "2026-08-22T14:09:50Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -11763,7 +11790,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -11779,7 +11806,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-22T13:46:37Z",
+      "last_reconciled_at": "2026-08-22T14:09:53Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -11882,7 +11909,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T13:46:42Z",
+      "last_reconciled_at": "2026-08-22T14:09:57Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -11968,7 +11995,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": "Confirmed real, catastrophic GitGalaxy engine defect, generalizes to the full 92 occurrences (and beyond -- this was a 100% recall drop for the whole language, not specific to the sampled cases). Root cause isolated to detector.py's StructuralExtractor._slice_by_braces (Integration Mode B): its scope-delimiter selection checked `lang_id == \"lisp\"` to choose parenthesis delimiters over the curly-brace default -- but \"lisp\" has never been a real key in LANGUAGE_DEFINITIONS (only \"scheme\" is), so that branch was unreachable dead code in production. Every real scheme file fell through to the curly-brace default; since scheme is entirely parenthesis-delimited, the downstream scope-body search never found an opener and silently discarded every func_start match. GitGalaxy's own func_start regex was never the problem -- confirmed matching correctly standalone (31/31 hits on one file) and prism.py's comment stripping confirmed clean (raw (define count unchanged pre/post-prism). Fixed: delimiter choice now keys off lexical_family (\"recursive_block_lisp\") instead of the dead lang_id string, verified directly against the gatherer (0 -> 58 real functions found; ctags finds 92, so a smaller residual recall gap remains for a future pass, tracked as a follow-on, not blocking this fix). Filed as GitHub issue #1928. A pre-existing unit test (test_detector_mode_b_lisp_family) had been passing for the wrong reason (its mock language was literally named \"lisp\", matching the dead string check by construction) -- corrected to use scheme's real lexical_family value so it now validates the actual production mechanism. Investigated via gemini-3.1-pro-high (agy): live-pipeline isolation with a monkey-patch before/after proof (0 -> 14 functions when lang_id coerced to match the old check), independently re-verified by Claude against the exact cited source lines before applying."
     },
@@ -11984,7 +12011,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-22T13:46:42Z",
+      "last_reconciled_at": "2026-08-22T14:09:57Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -12070,7 +12097,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12088,7 +12115,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-22T13:46:43Z",
+      "last_reconciled_at": "2026-08-22T14:09:59Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12103,7 +12130,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12120,7 +12147,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-22T13:46:45Z",
+      "last_reconciled_at": "2026-08-22T14:10:00Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -12190,7 +12217,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T13:46:47Z",
+      "last_reconciled_at": "2026-08-22T14:10:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12221,7 +12248,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T13:46:47Z",
+      "last_reconciled_at": "2026-08-22T14:10:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12252,7 +12279,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-22T13:46:47Z",
+      "last_reconciled_at": "2026-08-22T14:10:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12284,7 +12311,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12299,7 +12326,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12317,7 +12344,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12341,7 +12368,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12359,7 +12386,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -12401,7 +12428,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12419,7 +12446,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12434,7 +12461,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12450,7 +12477,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12472,7 +12499,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12489,7 +12516,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12529,7 +12556,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-22T13:46:48Z",
+      "last_reconciled_at": "2026-08-22T14:10:03Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12551,7 +12578,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12569,7 +12596,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12593,7 +12620,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -12611,7 +12638,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -12707,7 +12734,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "class",
       "verdict": null
     },
@@ -12723,77 +12750,32 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
-      "last_seen_count": 17,
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
+      "last_seen_count": 4,
       "last_seen_examples": [
         {
-          "file_path": "playwright/frames.ts",
-          "name": "predicate",
-          "readings": {
-            "gitgalaxy": 0,
-            "tree_sitter": 1
-          }
-        },
-        {
           "file_path": "vscode/async.ts",
           "name": "constructor",
           "readings": {
+            "ctags": null,
             "gitgalaxy": 2,
             "tree_sitter": 0
           }
         },
         {
-          "file_path": "vscode/async.ts",
+          "file_path": "vscode/vscode.d.ts",
           "name": "constructor",
           "readings": {
-            "gitgalaxy": 1,
+            "ctags": null,
+            "gitgalaxy": 5,
             "tree_sitter": 2
           }
         },
         {
-          "file_path": "vscode/async.ts",
+          "file_path": "vscode/vscode.d.ts",
           "name": "constructor",
           "readings": {
-            "gitgalaxy": 0,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "gitgalaxy": 1,
-            "tree_sitter": 2
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "gitgalaxy": 1,
-            "tree_sitter": 0
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "gitgalaxy": 2,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
-            "gitgalaxy": 2,
-            "tree_sitter": 1
-          }
-        },
-        {
-          "file_path": "vscode/async.ts",
-          "name": "constructor",
-          "readings": {
+            "ctags": null,
             "gitgalaxy": 1,
             "tree_sitter": 2
           }
@@ -12802,8 +12784,9 @@
           "file_path": "vscode/vscode.d.ts",
           "name": "constructor",
           "readings": {
-            "gitgalaxy": 5,
-            "tree_sitter": 2
+            "ctags": null,
+            "gitgalaxy": 1,
+            "tree_sitter": 4
           }
         }
       ],
@@ -12826,7 +12809,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12859,7 +12842,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -12946,7 +12929,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -12964,7 +12947,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -13060,7 +13043,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -13078,7 +13061,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -13174,7 +13157,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -13192,7 +13175,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13216,7 +13199,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -13232,7 +13215,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13254,7 +13237,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -13272,7 +13255,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -13368,7 +13351,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": false,
+      "still_reproduces": true,
       "symbol_type": "function",
       "verdict": null
     },
@@ -13384,7 +13367,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-22T13:47:09Z",
+      "last_reconciled_at": "2026-08-22T14:10:24Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -13470,7 +13453,7 @@
       ],
       "metric": "existence",
       "status": "unvalidated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "function",
       "verdict": null
     },
@@ -13487,7 +13470,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T13:47:19Z",
+      "last_reconciled_at": "2026-08-22T14:10:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13518,7 +13501,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T13:47:19Z",
+      "last_reconciled_at": "2026-08-22T14:10:34Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -13621,7 +13604,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "zig",
-      "last_reconciled_at": "2026-08-22T13:47:19Z",
+      "last_reconciled_at": "2026-08-22T14:10:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_points_of_interest.md
+++ b/docs/self_scan/tri_comparison_points_of_interest.md
@@ -8,7 +8,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `agc_assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 215 occurrences as of 2026-08-22T11:40:58Z*
+*2-vs-1 -- 215 occurrences as of 2026-08-22T14:08:18Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed-cause shape, fully accounted for via a corpus-wide cross-reference of ctags' actual output against GitGalaxy's raw func_start regex matches and its real pipeline/DB output (215 + 50 = 265, no unexplained residual). (1) 215/265 (81%): ctags' Asm "l" kind tags EVERY line-start label unconditionally, including pure data/constant-definition labels (e.g. ERASCON1 OCTAL 00061, S10BITS, LSTBNKCH -- AGC_BLOCK_TWO_SELF-CHECK.agc:133 and nearby) that are never followed by an executable instruction. GitGalaxy's func_start regex deliberately requires the label be followed by a real instruction mnemonic from a fixed whitelist, so it does not count these as functions -- a genuine, intentional precision distinction (code label vs. data label), not a GitGalaxy defect; ctags' generic Asm parser has no way to make this distinction at all. (2) 50/265 (19%): a real, confirmed GitGalaxy engine defect in detector.py's _slice_by_labels (Mode A), independently root-caused to two separate bugs: (a) `RELINT` is incorrectly included in `self.assembly_returns`'s early-termination keyword list (detector.py:572-575) -- in real AGC assembly RELINT means "release interrupt inhibit" and commonly opens a long interrupt-handler routine rather than closing one, so it truncates the real body to one line (confirmed: ELOOPFIN, AGC_BLOCK_TWO_SELF-CHECK.agc:303, a 20+-line real routine collapsed to just its own label line); (b) the `len(block.splitlines()) < 2` guard (detector.py:1973) unconditionally discards legitimate single-instruction assembly subroutines when the next func_start match sits on the very next line (confirmed: SOPTION1-SOPTION5+, AGC_BLOCK_TWO_SELF-CHECK.agc:210-214, each a real one-instruction label). Filed as #1949 -- a follow-up read-only Gemini/agy dispatch confirmed both root causes generalize beyond agc_assembly to the shared Mode A mechanism (assembly, cobol, fortran, abap all independently exhibit bug 1; assembly and cobol also exhibit bug 2), plus two further bug-1 variants not visible from agc_assembly alone: the terminator regex also false-matches inside comments (assembly) and inside hyphenated identifier names (cobol), not just legitimate-but-misclassified instructions. See #1949 for the full cross-language evidence and fix scope. No credit/debit -- the 215 portion is an honest scope difference (not two tools independently wrong about the same fact), and the 50 portion is GitGalaxy's own unresolved bug, not something ctags corroborates or contradicts.
@@ -28,7 +28,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `agc_assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 37 occurrences as of 2026-08-22T11:40:58Z*
+*2-vs-1 -- 37 occurrences as of 2026-08-22T14:08:18Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Confirmed: all 35 occurrences are real AGC labels that GitGalaxy correctly extracts and Universal Ctags' generic Asm parser structurally cannot tag, due to AGC assembly's non-standard label-naming conventions. Two sub-patterns, both confirmed corpus-wide (14/35 + 21/35 = 35/35, not just the sample): (1) labels with an embedded hyphen -- AGC's own convention of naming a point relative to an event, e.g. TIG-35/TIG-30/CALLT-35 in BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc:250/292/222 ("35/30 seconds before Time of Ignition"); (2) labels starting with a digit or a leading minus sign, e.g. 1CHK/2EBANK/-1CHK in AGC_BLOCK_TWO_SELF-CHECK.agc:184 (real label text is "-1CHK"). Directly verified via `ctags --language-force=Asm --kinds-Asm=l` against the real corpus files: ctags emits zero tags for any of these names (confirmed by grepping its actual output for the exact names and their surrounding CHK-suffixed siblings, which ARE tagged when they don't start with a hyphen/digit) -- ctags' Asm parser requires a tag name to start with a letter and contain no hyphen, neither of which is a real constraint in AGC assembly's own label syntax. GitGalaxy's func_start regex ([A-Z0-9_-]+ at line start) has no such restriction. This is a confirmed, structural ctags/Asm-parser limitation, not corroboration of anything wrong on GitGalaxy's side -- logged to docs/why_gitgalaxy_beats_ast_here.md.
@@ -50,7 +50,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `assembly` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 26 occurrences as of 2026-08-22T11:41:01Z*
+*2-vs-1 -- 26 occurrences as of 2026-08-22T14:08:22Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed shape, no clean credit/debit call. (1) A real, confirmed GitGalaxy defect: the same detector.py `_slice_by_labels` bug filed for agc_assembly as #1949 (RELINT-style early truncation and single-line/blank-collapsed body discard) independently confirmed live for generic assembly too -- `del_command:` (bootos/os.asm:269) sits immediately before the next label `os22:` with nothing between, collapsing to a one-line block and getting discarded; `C:`/`prtstr:` (hellosilicon/matrixmultneon.s:90,92) are each followed only by a data directive (`.fill`, `.asciz`) then a blank line before the next label, same one-line-after-strip() collapse. All three are real regex matches (confirmed via direct func_start.finditer against the raw text) that never reach the final function list -- tracked under #1949, not a new issue. (2) A correct-by-design GitGalaxy exclusion: `.Lenv0:`/`.Largv0:` (cosmopolitan/ape.S:1784-1785) start with the `.L` prefix func_start's own negative lookahead deliberately excludes (GCC's own convention for compiler-generated local/temporary labels) -- both are genuinely data labels (`.asciz` string constants) here, not real subroutines; ctags' generic Asm parser has no such convention-awareness and tags them anyway. (3) ctags itself over-tags some non-callable constructs GitGalaxy correctly excludes -- C-preprocessor `#define` macro constants (`GRUB_MAGIC`/`GRUB_EAX`/`GRUB_AOUT`/`GRUB_CHECKSUM`/`USE_SYMBOL_HACK`, cosmopolitan/ape.S:49,1679-1682) are not real assembly labels at all (no trailing `:`), but ctags' Asm parser tags them regardless. No credit/debit -- the shape mixes a real unresolved GitGalaxy recall gap (#1949) with cases where ctags is the one over-tagging, not a clean corroboration story either direction.
@@ -70,7 +70,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `assembly` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:01Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:08:22Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-20T00:00:00Z):
 > Mixed shape, three distinct confirmed mechanisms, no clean credit/debit call (real wins and real gaps in both directions within the same shape). (1) A dot-prefix naming-convention split -- NASM/GAS local labels scoped to the preceding global label are written with a leading `.` (e.g. `.load_vec:`, `.loop:` in bootos/os.asm:197,306), which GitGalaxy's func_start regex captures verbatim but ctags' Asm parser strips before emitting the tag (confirmed: ctags reports the SAME real label as `load_vec`/`loop`, no dot -- both tools genuinely found the same real construct, they just serialize the name differently). This is a name-string artifact of exact-string ledger grouping, not a detection difference on either side. (2) A genuine ctags gap: purely numeric local labels (`.1:`, `.2:` in bootos/counter.asm:52,67) are not tagged by ctags' Asm parser under ANY name (confirmed: neither `1`/`2` nor `.1`/`.2` appear in its output at all) -- GitGalaxy correctly finds these. (3) A genuine GitGalaxy precision gap, the mirror image of agc_assembly's own win: unlike agc_assembly's func_start (which requires a label be followed by a real instruction opcode), generic assembly's func_start has no such requirement -- ANY `identifier:` at line start matches, so it also matches pure data/constant declaration labels ctags' comparatively more conservative reading skips: `max_entries: equ sector_size/entry_size` (bootos/os.asm:166, a compile-time constant, not a subroutine), and several string/metadata labels in cosmopolitan/ape.S followed only by `.asciz`/data directives (`ape.ident`, `freebsd.ident`, `netbsd.ident`, `openbsd.ident`, `str.error`, `str.crlf`, `str.e820`, `str.oldcpu`). Not filed as a bug -- generic assembly's func_start is intentionally permissive because it has to span wildly different, informally-specified dialects (x86/ARM/legacy real-mode) where a fixed per-opcode whitelist like agc_assembly's isn't practical; worth a future harden-language-extraction look at whether a narrower heuristic (e.g. excluding labels followed only by known data-directive pseudo-ops like .asciz/.long/.byte/equ) could recover some of this precision without losing real dialect coverage, but that's a design tradeoff, not a clear regression to fix urgently.
@@ -89,7 +89,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 74 occurrences as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 74 occurrences as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed, independently verified all 6 sampled names against real source -- GitGalaxy and ctags both correct, tree-sitter over-recalling from two related but distinct preprocessor-driven mechanisms, both already covered by existing infrastructure: (1) keyword/macro misparse -- 'if' (dictobject.c:522-527, an `#if SIZEOF_VOID_P > 4` / `else if` sequence desyncs the parse) and 'DICT___REVERSED___METHODDEF' (dictobject.c:5102, a PyMethodDef array-initializer macro, not a definition) are both ALREADY in tree_sitter_accuracy_audit.py's `_C_KNOWN_MACRO_HALLUCINATIONS` exclusion set (confirmed by reading it directly) -- this tri-comparison tool's raw walk deliberately doesn't apply that list (it's a curated, ground-truth-shaped judgment call, appropriately left to reconciliation per this module's own stated design, not baked into the walk). (2) dead #if 0 code -- '_PyObject_ManagedDictValidityCheck' (dictobject.c:7396) and 'tos_char'/'print_stack'/'print_stacks' (frameobject.c:1264-1313) are genuinely well-formed function definitions sitting entirely inside `#if 0 ... #endif` guards; tree-sitter has no preprocessor model and parses the dead branch as live code. Both mechanisms are already the exact shape docs/why_gitgalaxy_beats_ast_here.md's Claim 8 names generically ('a dead #if 0 block... macro definitions... that merely look structural') -- added these 4 new concrete citations to Claim 8's evidence section rather than treating this as a new finding. No GitHub issue -- both tools already behave as intended; this is expected, already-documented tree-sitter preprocessor-blindness surfacing under the new tri-comparison reconciliation, not a fresh defect.
@@ -109,7 +109,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 14 occurrences as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 14 occurrences as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a new finding -- both sampled names are ALREADY in tree_sitter_accuracy_audit.py's _C_KNOWN_MACRO_HALLUCINATIONS exclusion set (confirmed by grep: 'EXPORT_FUN' and 'MICROPY_WRAP_MP_EXECUTE_BYTECODE' both present). This shape is the same already-documented macro-hallucination mechanism (Claim 8) as the earlier tree-sitter-alone shape, just with ctags ALSO independently hallucinating the same 2 names the same way (both tools' regex/grammar parsers get fooled by the same macro-definition text). GitGalaxy correctly excludes both. Resolved directly, no dispatch needed.
@@ -129,7 +129,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > 3 distinct causes, all genuine tree-sitter-c grammar limitations (GitGalaxy and ctags both correct in all 10 sampled cases) -- confirmed via dispatched investigation (which ran tree-sitter's C grammar directly and found ERROR nodes in every case) plus independent source-level spot-checks of all 3 trigger shapes. This is a C-scale instance of Claim 7 (CPP-directive-driven recall loss) -- added to that claim's evidence section. (1) 4 samples: an #if/#else pair splitting a single `if` condition inside a function body (ceval.c:33, _Py_ReachedRecursionLimitWithMargin). (2) 5 samples: bare, un-semicoloned macro invocations the grammar can't cleanly recover from, losing the next real function (object.c:1269-1271's _Py_COMP_DIAG_PUSH/IGNORE_DEPR_DECLS/POP before _PyObject_SetAttributeErrorContext; similar shape for the typeobject.c slot-getattr cluster). (3) 1 sample: #if/#endif wrapping only the `static` storage-class specifier, separated from the rest of the signature (micropython/compile.c:3473-3476, mp_compile_to_raw_code). Unlike Fortran's existing Claim 7 evidence (entire trailing sections lost), C's version is local -- one function lost per trigger, not a cascading region. No GitHub issue -- documented as new Claim 7 evidence, not a fixable tooling bug (this repo doesn't control tree-sitter-c's grammar).
@@ -149,7 +149,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed real ctags limitation, not a GitGalaxy or tree-sitter defect -- resolved directly (no dispatch needed), source read confirms all 7 sampled names. RICHCMP_WRAPPER/SLOT0/SLOT1/SLOT1BINFULL are all-caps macro names; every occurrence is a MACRO INVOCATION (a call to a previously-#define'd boilerplate-generating macro), not a function definition -- confirmed at cpython/typeobject.c:10099 (`RICHCMP_WRAPPER(lt, Py_LT)`) and :10544 (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`), same shape as the multiple SLOT0/SLOT1 hits at different lines (each is a separate invocation of the same macro generating a different wrapper function). ctags' regex-based C parser tags the macro-invocation site itself as a function; GitGalaxy and tree-sitter both correctly don't. Deliberately NOT fixed with a curated name-exclusion list in the gatherer (unlike the sibling __anon* class shape, this would require hand-curating specific macro names -- the same ground-truth-judgment category tri_comparison_gatherer.py's own docstring reasons belongs in reconciliation, not the raw reader) -- documented in ctags_reader.py instead, alongside its existing per-language notes.
@@ -166,7 +166,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy correct, real finding -- a new, narrower instance of Claim 3 (parse-error cascade), added to docs/why_gitgalaxy_beats_ast_here.md. All 4 sampled names (slot_mp_ass_subscript:10544, slot_nb_inplace_power:10697, slot_tp_repr:10714, slot_tp_hash:10730, all cpython/typeobject.c) are ordinary, unremarkable function definitions -- nothing unusual individually -- but each sits directly after a bare SLOT0/SLOT1 macro-invocation LINE (`SLOT1(slot_mp_subscript, __getitem__, PyObject *)`, `SLOT0(slot_tp_str, __str__)`, etc.) that isn't valid freestanding C without macro expansion. GitGalaxy's regex has no adjacency sensitivity and finds all 4 correctly; both ctags and tree-sitter locally lose the SINGLE function immediately following each such line (recovers after just one function, not a full cascade to EOF -- confirmed by resolving all 4 as isolated single-function misses, not a growing region). Resolved directly, no dispatch needed -- same pattern verified at all 4 sample points before writing up.
@@ -180,7 +180,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > UPDATED after a real production fix (the same fix documented in cpp's agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- c and cpp share the mechanism, `lang_id in ("c", "cpp")` in detector.py's `_slice_by_braces`). GitGalaxy now scans each file for `#define NAME(...)` function-like macro definitions and excludes any func_start match whose captured name is a known macro -- confirmed to eliminate the already-documented `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL`/`DICT___REVERSED___METHODDEF` cpython/typeobject.c false positives entirely (a direct `SELECT func_name ... WHERE func_name IN (...)` query against a fresh scan returned zero rows). The small residual (3 occurrences: `slot_nb_power`, `slot_nb_bool`, `wrap_next`, all cpython/typeobject.c) is a DIFFERENT, unrelated finding, not yet individually root-caused -- GitGalaxy and tree-sitter both correctly find these real functions and ctags doesn't; plausibly the same category of ctags miss documented in cpp's sibling entry (an ordinary function ctags' C++ parser fails to tag for reasons unrelated to macros) but not directly confirmed for these three specific names. No credit_tools adjustment applies -- already a naturally-corroborated 2-of-3 agreeing pair.
@@ -193,7 +193,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `c` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:07Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:08:27Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved + fixed directly, no dispatch needed), 2026-08-19T00:00:00Z):
 > Not a GitGalaxy or ctags defect -- a bug in this tool's OWN _count_ctags_signature_params (tri_comparison_gatherer.py), now fixed. Confirmed directly: ran ctags against cpython/ceval.c, PyEval_GetLocals(void)'s raw signature field is literally the text '(void)'. GitGalaxy and tree-sitter both already special-case C's explicit empty-parameter-list idiom (0 real args, matching detector.py's own _count_top_level_args docstring) -- _count_ctags_signature_params did not, splitting '(void)' into one non-empty segment and counting it as 1 real parameter (the same class of bug its own docstring already describes fixing twice for Python's trailing-comma and bare * / marker cases). Added 'void' to the segment-exclusion set alongside the existing '*'/'/'/'**' -- verified fix: _count_ctags_signature_params('(void)') now returns 0. This corpus (cpython) uses the (void) idiom extremely heavily, plausibly explaining most/all of the 104 occurrences; not independently re-verified beyond the sample, but the mechanism is unconditional (any '(void)' signature was miscounted the same way, corpus-wide) so high confidence it generalizes. No GitHub issue needed -- fixed directly in this same commit, not a repo-code defect.
@@ -206,10 +206,10 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cobol` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 136 occurrences as of 2026-08-22T11:41:12Z*
+*2-vs-1 -- 119 occurrences as of 2026-08-22T14:08:32Z*
 
-**Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-19):
-> Mixed-cause shape, majority ctags-side false positives plus a smaller hidden GitGalaxy defect. (1) Majority (all 10 capped examples, all named END-IF): Universal Ctags' COBOL parser tags ANY period-terminated word as a 'paragraph' (kind p), including scope terminators like END-IF./END-PERFORM. that are not paragraph definitions -- confirmed by a live ctags run on cics-banking-sample-application-cbsa/BANKDATA.cbl showing dozens of plain 'END-IF.' lines (e.g. lines 455, 600) tagged as paragraphs. GitGalaxy correctly excludes these via its END-[A-Za-z0-9_-]+ reserved-word shield. This is a permanent, structural ctags limitation (documented in tests/tools/ctags_reader.py), not a GitGalaxy defect. (2) A smaller (~20 of 133), genuine GitGalaxy false-negative hiding underneath: cics-genapp/lgdpol01.cbl:139 'DELETE-POLICY-DB2-INFO.' and lgapol01.cbl:137 'WRITE-ERROR-MESSAGE.' are real, called (PERFORM'd) paragraph definitions that GitGalaxy's own func_start regex wrongly excludes -- its reserved-word negative lookahead ends in a bare \b, and since '-' is a non-word character in Python re, any real paragraph name that happens to start with a banned keyword followed by a hyphen (a common COBOL verb-prefixed naming convention: WRITE-*, READ-*, SET-*, DELETE-*, ...) is wrongly rejected. Verified directly against the compiled regex (both return no match) and confirmed ~20 such real paragraphs exist corpus-wide via grep. Filed as GitHub issue #1892. Investigated via gemini-3.1-pro-high (agy), file:line citations and regex behavior independently re-verified by Claude before applying.
+**Verdict** (by Agent, 2026-08-22T00:00:00Z):
+> Confirmed GitGalaxy engine defect (issue #1892). Fixed in the same pass by replacing the bare  boundary with (?=[ \t\n.]) in the func_start reserved word shield, preventing hyphenated verbs like DELETE-POLICY from being incorrectly shielded.
 
 | file | name | GitGalaxy | tree-sitter | ctags |
 |---|---|---|---|---|
@@ -226,7 +226,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cobol` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 43 occurrences as of 2026-08-22T11:41:12Z*
+*2-vs-1 -- 46 occurrences as of 2026-08-22T14:08:32Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-19):
 > Mixed-cause shape, two independent confirmed defects, neither in GitGalaxy's core function detection being right or wrong as a whole. (1) MAINLINE/TIMESTAMP and most of the 18 cases: these are real COBOL SECTION headers in the PROCEDURE DIVISION (e.g. cics-genapp/lgacdb01.cbl:128 "MAINLINE SECTION.", cics-banking-sample-application-cbsa/BANKDATA.cbl:1441 "TIMESTAMP SECTION." followed by executable CALL statements) that GitGalaxy correctly captures per its own documented func_start scope ("Paragraphs and Sections") -- and ctags ALSO correctly tags them, as kind 'section' (verified via live ), not as the 'paragraph' kind. The disagreement is manufactured by tests/tools/ctags_reader.py's CTAGS_FUNC_KINDS["cobol"] = {"p"}, which drops section-kind tags before comparison -- a test-harness bug, not a real ctags-vs-GitGalaxy disagreement. Filed as GitHub issue #1891. (2) LOCAL-STORAGE (cics-banking-sample-application-cbsa/XFRFUN.cbl:107 "LOCAL-STORAGE SECTION." immediately followed by 01-level data item declarations, no executable logic): this is a genuine GitGalaxy false positive -- the func_start regex's reserved-word negative lookahead bans WORKING-STORAGE and LINKAGE as Data Division section names but omits LOCAL-STORAGE, so it slips through and gets miscounted as a paragraph. ctags correctly reports nothing here. Filed as GitHub issue #1890. Investigated via gemini-3.1-pro-high (agy), file:line citations independently re-verified by Claude against language_standards.py and a live ctags run before applying.
@@ -240,15 +240,15 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | cics-banking-sample-application-cbsa/BANKDATA.cbl | `POPULATE-ACC` | 712 | *(n/a)* | *(n/a)* |
 | cics-banking-sample-application-cbsa/BANKDATA.cbl | `GENERATE-OPENED-DATE` | 876 | *(n/a)* | *(n/a)* |
 | cics-banking-sample-application-cbsa/BANKDATA.cbl | `INITIALISE-ARRAYS` | 925 | *(n/a)* | *(n/a)* |
+| cics-banking-sample-application-cbsa/BANKDATA.cbl | `DELETE-DB2-ROWS` | 1179 | *(n/a)* | *(n/a)* |
 | cics-banking-sample-application-cbsa/BANKDATA.cbl | `GET-TODAYS-DATE` | 1382 | *(n/a)* | *(n/a)* |
 | cics-banking-sample-application-cbsa/BANKDATA.cbl | `CALC-DAY-OF-WEEK` | 1405 | *(n/a)* | *(n/a)* |
-| cics-banking-sample-application-cbsa/BNKMENU.cbl | `PREMIERE` | 108 | *(n/a)* | *(n/a)* |
 
 ## cpp
 
 ### ✅ `cpp` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 194 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 194 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > UPDATED: count grew (98 -> 194) as a direct, correct consequence of the OPCODE-macro fix documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- tree-sitter's OWN OPCODE-family misparse (godot/gdscript_vm.cpp's bytecode-dispatch macro) was previously MASKED by GitGalaxy sharing the identical mistake (both wrong == they 'agreed', landing in the other shape instead of this one). Now that GitGalaxy correctly excludes known macro invocations, tree-sitter's own grammar limitation on this exact pattern is cleanly isolated here instead, confirmed via the shape's own examples (repeated `OPCODE` entries at godot/gdscript_vm.cpp, tree_sitter line set, ctags/gitgalaxy both None). The remaining, previously-documented causes (bare control-flow-keyword/`void` hallucination, conversion-operator naming-suffix convention) are unchanged and still contribute the bulk of the original 98. No credit/debit applies -- tree-sitter is the one that's wrong here, alone.
@@ -268,7 +268,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 60 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 60 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy args-counting defect, filed as https://github.com/squid-protocol/gitgalaxy/issues/2012 . Two distinct sub-patterns visible in the sample: (1) zero-undercounting for out-of-class method definitions with real parameters (VBufStorage_buffer_t::replaceSubtrees, Translator::BuildBuffer, Translator::BuildVhloCompositeV1Op, and every `operator()` call-operator overload in godot/node.h) where ctags and tree-sitter both correctly count real, non-zero parameter lists and GitGalaxy reads 0; (2) an off-by-one OVERcount for a constructor with a member-initializer-list but zero real parameters (VBufStorage_buffer_t's default constructor -- ctags/tree-sitter correctly read 0 params, GitGalaxy reads 1). Not the same shape as the func_start recall gaps in #2009/#2010 -- these are all functions GitGalaxy already finds, just with the wrong parameter count. Needs its own dedicated investigation per the issue (may be one or two root causes).
@@ -288,7 +288,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 60 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 60 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real tree-sitter-cpp grammar limitation, not a GitGalaxy or ctags defect. Every sampled case (GDScriptFunction::call, Main::setup, Main::setup2, Main::start, Object::Connection::operator Variant) is a large, complex function -- GDScriptFunction::call in particular (godot/gdscript_vm.cpp:499) is a bytecode interpreter's main dispatch loop using GNU 'labels as values' computed-goto syntax (`&&OPCODE_LABEL`) via the same OPCODES_TABLE/OPCODE macro family documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry -- a non-standard GNU extension tree-sitter-cpp's grammar does not support, which plausibly causes a parse error cascade that loses the enclosing function_definition node entirely rather than just misreading the body. ctags and GitGalaxy both correctly find and name these functions regardless of body content, since neither one needs to fully parse the function body to recognize its signature. tree-sitter's non-detection is a confirmed limitation in tree-sitter itself -- but no credit_tools adjustment applies: ctags and GitGalaxy are already a 2-of-3 AGREEING PAIR on this shape (agreeing_tools has 2 members), which already satisfies reconcile_symbols' own `len(present) >= 2` precision-credit condition naturally with no ledger adjustment needed. credit_tools exists for a LONE, single-tool claim (agreeing_tools with exactly 1 member) the base algorithm can't otherwise corroborate -- applying it to an already-mutually-corroborating pair would double-count (confirmed: this exact mistake briefly pushed ctags' precision past 100% before being caught and reverted in this same session).
@@ -308,7 +308,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 30 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 30 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed ctags-only limitation: ctags parses INSIDE C++ macro DEFINITION bodies as if they were real, already-expanded code. godot/object.h's GDCLASS/_FORCE_INLINE_-based macros (`#define GDCLASS(m_class, m_inherits) ... _FORCE_INLINE_ bool (Object::*_get_get() const)(...) {...} ...`) never run as written -- they only produce real code once expanded at a `GDCLASS(SomeClass, Base)` call site elsewhere -- but ctags tags `_get_get`/`_get_set`/`_get_bind_methods`/`_get_bind_compatibility_methods`/`_get_notification`/`_get_property_can_revert`/`_get_property_get_revert`/`_get_validate_property`/`_get_get_property_list` (all 9 sampled cases, all from this same macro) as if they were ordinary member functions. Neither GitGalaxy nor tree-sitter are fooled by this. Documented in ctags_reader.py's KIND MAPS section (cpp bullet) rather than fixed -- this is ctags' own parser behavior, nothing in this repo's tooling can distinguish a macro-definition body from real code without reimplementing preprocessing.
@@ -328,7 +328,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 13 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 13 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real tree-sitter accuracy-tool limitation, filed separately (see the sibling agree[none]_vs[ctags,gitgalaxy,tree_sitter] args entry and its referenced issue for the full writeup). tree-sitter's own parameter count (via the shared `_get_param_count` helper in tree_sitter_accuracy_audit.py, reused by tri_comparison_gatherer.py) undercounts by exactly 1 whenever a function has a parameter with a default value -- confirmed 6/6 sampled cases (save_scene_to_path, step, get_index, atr_n, atr, ObjectSignalLock), all off by exactly 1, all involving a `= default_value` parameter, ctags and GitGalaxy both correctly counting the real total. No credit_tools/debit_tools adjustment applies -- this is an args-metric shape, and apply_verified_adjustments only ever touches existence-metric precision (args scores have no equivalent verified-adjustment mechanism in this ledger's own code, see tri_comparison_ledger.py's apply_verified_adjustments docstring), so these fields would be a pure no-op here regardless of value -- left empty rather than set-but-inert, for an accurate record.
@@ -348,7 +348,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > UPDATED after a real production fix. The OPCODE-family shared mistake documented in this shape's prior verdict (~96 of the original 105 occurrences) is now FIXED: GitGalaxy's func_start (and by the same mechanism, C's) now scans each file for `#define NAME(...)` function-like macro definitions and excludes any match whose captured name is a known macro -- the exact same fact universal-ctags itself already used (confirmed via a direct `ctags -f -` run: ctags tags `OPCODE` only once, at its own #define line, kind `d`, and produces zero tags at any invocation site -- it isn't smarter about the invocation's shape, it just already knows the name is a macro and never re-tags it). This also fixed the already-documented C `RICHCMP_WRAPPER`/`SLOT0`/`SLOT1`/`SLOT1BINFULL`/`DICT___REVERSED___METHODDEF` false positives as a bonus (same mechanism, `lang_id in ("c", "cpp")`). Verified via 3 repeated full-corpus scans producing byte-identical function lists, the full extraction gauntlet, and both golden masters re-blessed. The remaining residual (9 occurrences, previously miscounted as more of the same shared mistake in the earlier verdict's blanket debit -- corrected here) is a DIFFERENT, unrelated finding: GitGalaxy and tree-sitter are CORRECT here, ctags is wrong. Two sub-patterns confirmed: (1) the already-documented macro-as-return-type-prefix pattern (`IFACEMETHODIMP_(void)` immediately before the real `FancyZones::Run() noexcept` -- ctags tags the macro invocation itself and loses the real name, powertoys/FancyZones.cpp, 4 occurrences); (2) a newly-confirmed, NOT yet root-caused ctags miss on an ordinary virtual method with no macro involvement at all (`virtual RID mesh_create_from_surfaces(const Vector<RenderingServerTypes::SurfaceData> &p_surfaces, int p_blend_shape_count = 0) override { ... }`, godot/rendering_server_default.h -- ctags produces zero tags anywhere near this real method, 5 occurrences). No credit_tools adjustment applies: GitGalaxy and tree-sitter are already a 2-of-3 agreeing pair here, which already satisfies reconcile_symbols' own natural precision-credit condition.
@@ -367,7 +367,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Compound shape, three distinct causes confirmed via source, not one. (1) Most of the sample (OPCODE_WHILE x2, OPCODE_SWITCH, OPCODE) is the same GG+tree-sitter shared macro-misparse family documented in the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry (godot/gdscript_vm.cpp's OPCODE/OPCODE_WHILE/OPCODE_SWITCH dispatch macros) -- here landing as 'GitGalaxy alone' because tree-sitter's own error recovery on this repeated macro pattern isn't fully deterministic across every occurrence, not because the underlying cause differs. GitGalaxy is WRONG for this portion (same debit as the sibling entry, not double-counted here since debit_tools is per-shape). (2) `attribute_buffer_applier_factories_`/`m_draggingState`/`std::thread` are a separate, real GitGalaxy FALSE POSITIVE: a lambda passed as a constructor argument or member-initializer-list entry (`m_draggingState([this]() {...}),`, `std::thread([...]() {...}).detach();`) is misread as a function definition. Filed as https://github.com/squid-protocol/gitgalaxy/issues/2013 . (3) `Variant::operator ::RID`/`Variant::operator ::AABB`/`Variant::operator Object *` are real functions GitGalaxy correctly finds (confirmed via godot/variant.cpp source) that didn't rank-match ctags/tree-sitter's own readings of the same functions by exact name string -- a residual, low-priority naming-comparison edge case (global-scope `::`-prefixed conversion-operator return types) not chased further in this pass. No credit/debit applied given the mixed, three-cause nature of this shape.
@@ -381,7 +381,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Not a real existence disagreement -- a template-argument name-formatting difference in the comparison tooling. `godot/variant.h`'s `HashMapComparatorDefault<Variant>` and `is_zero_constructible<Variant>` are template CLASS specializations; GitGalaxy and tree-sitter both read the name WITH its template argument baked in (matching the instantiation as written in source), while ctags strips the `<...>` template-argument suffix from its own class tag name. All three tools found the exact same class definition at the exact same line -- confirmed via the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] entry, which is the same pair of classes from the opposite direction. Low magnitude (2 occurrences) -- not chased to a code fix in this pass, but a plausible future micro-fix would strip a trailing `<...>` from gg/tree-sitter's class name before matching, mirroring how ctags_reader.py's operator-name normalization already handles a similar formatting mismatch.
@@ -393,7 +393,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Same template-argument name-formatting difference as the sibling agree[ctags]_vs[gitgalaxy,tree_sitter] class entry, viewed from the opposite direction -- `HashMapComparatorDefault`/`is_zero_constructible` (ctags' bare names) vs. `HashMapComparatorDefault<Variant>`/`is_zero_constructible<Variant>` (GitGalaxy/tree-sitter's names, template argument included). Not a real disagreement about whether these classes exist -- see the sibling entry for the full explanation.
@@ -405,7 +405,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:17Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > The single sampled occurrence (mlir/flatbuffer_export.cc:654, the `Translator` class's constructor) is exactly the bug filed as https://github.com/squid-protocol/gitgalaxy/issues/2009 -- a member-initializer-list spanning 906 characters exceeds GitGalaxy's func_start regex's 500-character cap for that clause, so the whole constructor is invisible to GitGalaxy despite ctags and tree-sitter both finding it correctly. GitGalaxy's non-detection is a confirmed, filed limitation -- but no credit_tools adjustment applies: ctags and tree-sitter are already a 2-of-3 AGREEING PAIR on this shape, which already satisfies reconcile_symbols' own `len(present) >= 2` precision-credit condition naturally. See the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] entry for the full explanation of why credit_tools only applies to a LONE, single-tool claim, never an already-agreeing pair.
@@ -416,7 +416,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `cpp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T11:41:17Z*
+*3-way split -- 1 occurrence as of 2026-08-22T14:08:37Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > A single function (NVDA/storage.cpp's `outputEscapedAttribute`, `size_t outputEscapedAttribute(wostringstream& out, const wstring& text, size_t maxLength=0)`, 3 real parameters) where all three tools disagree for two already-independently-confirmed reasons, not a new one: ctags reads the correct count (3); GitGalaxy reads 0, matching the args-undercounting defect filed as https://github.com/squid-protocol/gitgalaxy/issues/2012 ; tree-sitter reads 2, matching the default-value-parameter undercount filed as https://github.com/squid-protocol/gitgalaxy/issues/2014 (this function's third parameter, `maxLength`, has a default value -- exactly the trigger condition for that bug). Both referenced issues cover the general pattern; no new finding here beyond confirming they can compound on the same function.
@@ -429,7 +429,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 271 occurrences as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 271 occurrences as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:27Z):
 > Confirmed: this shape is entirely tree-sitter-c-sharp's own known parse-error cascade in roslyn/LanguageParser.cs, already root-caused and evidence-backed as Claim 3 in docs/why_gitgalaxy_beats_ast_here.md (issues #1427/#1567). A syntax construct at line ~5198 triggers a parse error whose recovery fails to resynchronize for the rest of the (14,680-line) file -- tree.root_node.type itself becomes ERROR, so tree-sitter's own recall for this file collapses to near-zero past that point. GitGalaxy's regex and ctags' text-based parser are both unaffected and correctly find these functions (all sampled: ParseVariableDeclarator, GetPrecedence, ParsePrimaryExpression, ScanType x3 -- real, ordinary private methods, exact line-number agreement between ctags and gitgalaxy on every one). This is the tri-comparison ledger's own version of a phenomenon already fully diagnosed for the 2-way tree_sitter_accuracy_audit.py tool via its cascade_promotable logic -- that logic was never ported to tri_comparison_gatherer.py/tri_comparison_reconcile.py, which is why this shows as an unvalidated ledger shape despite being a known, closed question. Not a GitGalaxy or ctags defect. CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct.
@@ -449,7 +449,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 108 occurrences as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 108 occurrences as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:44Z):
 > Confirmed real ctags parser limitations, not a GitGalaxy or tree-sitter defect, via direct source reading and raw `ctags -x` runs against the flagged files. Two distinct mechanisms: (1) Local/nested functions -- roslyn/CSharpCompilation.cs's `validateSignature` (nested inside a larger method) and `isSupportedType` (a `static bool isSupportedType(...)` local function) are both structurally invisible to ctags, whose csharp kind map is only 'm' (top-level methods; "C# has no free functions" per ctags_reader.py's own comment) with no local-function concept at all -- this generalizes to every local function in the corpus, not just the sampled two. (2) Complex-signature misses and overload collisions on ordinary top-level private methods -- `FindEntryPoint` (nullable return/param types plus a generic `out` parameter) and `GetSourceDeclarationDiagnostics` (5 params, two with default values, one a `Func<...>` generic delegate) get no ctags tag at all, confirmed via `ctags -x` showing tags immediately before/after but not at their own lines -- isolated misses, not a wider blind region (unlike the tree-sitter cascade in the sibling ledger shape). `ReportUnusedImports` has two overloads at different lines; ctags tags only the first, silently dropping the second. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet. Credited on the strength of mechanism (1) generalizing structurally to the whole shape (ctags cannot see ANY local function, by construction) even though only ~5 of 107 occurrences were individually read -- mechanism (2)'s complex-signature misses are a smaller, less certain-to-generalize contributor to the same shape but point the same direction (ctags-side, not GitGalaxy/tree-sitter). CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct.
@@ -469,7 +469,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 46 occurrences as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 46 occurrences as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T21:45:53Z):
 > Mixed shape, confirmed via a full name-diff against gather_language('csharp') rather than the capped sample alone: 44 of 48 are genuine local (nested) functions inside roslyn/LanguageParser.cs's tree-sitter parse-error cascade region (line >= ~5198, same mechanism as the sibling agree[ctags,gitgalaxy]_vs[tree_sitter] shape / Claim 3) -- tree-sitter is fully blind there, and ctags additionally has no concept of a local/nested function at all (only top-level 'm' method tags), so GitGalaxy is the only tool that can see these. The remaining 2 are genuine GitGalaxy false positives with a confirmed, unrelated root cause: roslyn/CSharpCompilation.cs:2282's GetWellKnownType( (a call, no declaration exists anywhere in the file) and roslyn/LanguageParser.cs:2338's this.EatToken( (a call inside a switch-expression arm) are both mis-captured because func_start's return-type-loop character class allows unbalanced parens/commas in a single 'token', letting it swallow a real call-expression fragment as if it were part of a return type and land on the wrong identifier as the 'function name'. Filed as GitHub issue #2035 with root cause and fix direction; fix in progress in an isolated worktree as of this writing. Not crediting/debiting any tool on this shape since it's genuinely mixed (44 real local-function finds, 2 real false positives) -- re-visit once #2035 merges and re-run to confirm the shape drops to 44 (or fewer, if further false positives of the same class surface once #2035's fix generalizes across the full corpus). FOLLOW-UP (2026-08-21, post-#2035/#2036 re-verification): re-checked this shape with a full, uncapped corpus diff rather than the capped example sample. The 2 originally-confirmed false positives (GetWellKnownType, this.EatToken) are gone as expected. However 2 MORE confirmed false positives remain, distinct mechanisms from #2035's fix: CSharpCompilation.cs's `ref mdName, ..., CreateReflectionTypeNotFoundError(` (a real call site mistaken for a declaration because `ref` is a legitimate Branch A modifier keyword when used in a real declaration, but here it's a call-argument prefix) and LanguageParser.cs:2336's `_syntaxFactory.TypeConstraint(this.ParseType())` (a ternary `?` operator consumed by the return-type loop's nullable-type-marker allowance, same general shape as this.EatToken but not covered by #2035's specific fix). Filed as issue #2054. This shape remains genuinely mixed (the overwhelming majority are real cascade-region local functions, but a small residual of false positives keeps surfacing) -- still correctly left uncredited pending #2054. CLOSED (2026-08-21): this shape is now fully clean. Both remaining false-positive mechanisms (issue #2054: bare-comma call-argument absorption, ternary-? consumption, and the nested-generic-return-type regression its own fix introduced and #2061 corrected) are fixed and merged. A full uncapped re-diff confirms all 44 remaining occurrences are genuine local functions inside LanguageParser.cs's tree-sitter parse-error cascade region (Claim 3), zero non-cascade residue. credit_tools is now correctly applicable -- gitgalaxy is alone on this shape (no tool to share the credit-double-counting error this session already found and fixed on the sibling agree[ctags,gitgalaxy]/agree[gitgalaxy,tree_sitter] shapes with), and every one of its 44 claims here is confirmed real with the reason ctags (no local-function concept) and tree-sitter (parse cascade) don't corroborate it being a confirmed limitation in THEM, not an open question about GitGalaxy.
@@ -489,7 +489,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:27Z):
 > Same root cause and file as the sibling function-existence shape (roslyn/LanguageParser.cs's tree-sitter parse-error cascade from line ~5198, Claim 3 in why_gitgalaxy_beats_ast_here.md, #1427/#1567) -- with the parse tree corrupted into a single ERROR node, tree-sitter can't resolve any class_declaration structure in the corrupted region either, including the outer LanguageParser class itself (whose body spans the entire cascade) and every enum/nested class declared inside it (VariableFlags, NameOptions, ScanTypeArgumentListKind, ScanTypeFlags, ParseTypeMode, etc.). ctags and GitGalaxy both correctly find these via text-based parsing, unaffected by tree-sitter's own AST failure. Not a GitGalaxy or ctags defect. CORRECTION (2026-08-21): credit_tools was originally set here, but this is wrong -- these tools already mutually corroborate each other (2-of-3 agreement), so their occurrences were already counted in base precision before any credit was applied. Adding credit on top double-counted them, pushing gitgalaxy's func_precision matched_consensus past its own total_slots (1297/965, >100%, a real, visible chart-rendering bug). credit_tools is only valid for a shape where a tool is completely ALONE and otherwise uncorroborated (e.g. this language's agree[gitgalaxy]_vs[ctags,tree_sitter] shape), never for an already-mutually-agreeing pair. Reset to empty; the validation itself (which tool is factually correct here) is unaffected and remains correct.
@@ -508,7 +508,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Confirmed GitGalaxy defect for 6 of 7 occurrences, root-caused to 3 distinct mechanisms in the csharp args regex, none of which func_start's own (already-hardened) regex shares: (1) Branch 1's return-type-loop character class has no parens, so any tuple-shaped or generic-wrapped-tuple return type fails to match at all (HasEntryPointSignature: real=2, GitGalaxy=0; SetCurrentSolutionEx: real=1, GitGalaxy=2; SetCurrentSolutionAsync both overloads: real=6/GitGalaxy=2, real=7/GitGalaxy=0); (2) the shared args capture group `(\([^)]*\))` truncates at the first unbalanced `)`, breaking on any parameter whose own type contains parens (ProcessEventHandlerWorkQueueAsync's ImmutableSegmentedList<(tuple)> param: real=2, GitGalaxy=1); (3) the name-capture has no generic-type-parameter stepper (func_start's already does), so a generic method's <T> before the real parens fails to match (OnAnyDocumentTextChanged<TArg>: real=7, GitGalaxy=2; ScheduleTask<T>: real=2, GitGalaxy=1). Filed as issue #2051 with full evidence per mechanism. The 7th occurrence (GetModifierExcludingScoped) is NOT a real defect on either side: both of its overloads (1 param and 2 params) are correctly counted by GitGalaxy; the apparent ctags=2/gitgalaxy=1 mismatch is the reconciler's rank-based (not name/overload-based) pairing comparing two DIFFERENT real overloads against each other, not a genuine disagreement about the same declaration -- confirmed by reading both real declarations directly. No credit/debit: GitGalaxy is genuinely wrong on 6/7, and the reconciler-pairing noise on the 7th isn't a tool defect at all.
@@ -525,7 +525,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Mixed shape. 1 of 4 is a confirmed genuine ctags defect: GetHashCode's tuple-parameter overload (`GetHashCode((ImmutableArray<byte> ContentHash, int Position) obj)`, 1 real param) -- ctags reports 2, mis-splitting the tuple-typed parameter's own internal comma as a second top-level parameter, the same family as the already-documented tuple-related ctags limitations in tests/tools/ctags_reader.py's csharp bullet. The other 3 (GetModifierExcludingScoped and two SetCurrentSolution rows) are NOT real tool disagreements at all -- SetCurrentSolution has 4 real overloads (1/6/4/5 real params respectively) in roslyn/Workspace.cs; every individual reading from every tool across both rows (ctags=6, gitgalaxy=1, tree_sitter=1, ctags=4, gitgalaxy=6, tree_sitter=6) independently matches SOME real overload's true count exactly when checked against the source -- the ledger shape only exists because the reconciler's rank-based pairing compared different tools' readings of DIFFERENT overloads against each other, not because any tool actually miscounted anything. Confirmed via direct line-by-line source reading of all 4 overloads. Credit gitgalaxy+tree_sitter for the 1 real ctags defect only; the shape as a whole is left without a clean credit/debit since 3 of 4 occurrences aren't a real disagreement to adjudicate.
@@ -539,7 +539,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Confirmed: both ctags and GitGalaxy are wrong here, tree-sitter alone is right. roslyn/CSharpCompilation.cs:2539's `Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` has 2 real parameters (both tuple-typed); tree_sitter correctly reports 2. GitGalaxy's args capture group truncates at the first unbalanced `)` inside the first tuple parameter's own type, reporting 1 (mechanism 2 of issue #2051, confirmed via direct regex testing). ctags independently also reports 1, for its own unrelated reason (the same tuple-parameter-splitting limitation documented elsewhere in this file for GetHashCode/Equals-with-bool-tuple-param) -- both tools land on the identical wrong number by coincidence, not real corroboration of each other.
@@ -550,7 +550,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:23Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T18:13:27Z):
 > Confirmed genuine ctags false positive, not a GitGalaxy or tree-sitter gap. roslyn/CSharpCompilation.cs:2539's real declaration is `public bool Equals((ImmutableArray<byte> ContentHash, int Position) x, (ImmutableArray<byte> ContentHash, int Position) y)` -- an Equals overload with tuple-typed parameters. ctags' lightweight C# parser misreads the return-type/tuple-parameter boundary and tags the match under the name `bool` instead of `Equals`. Documented in tests/tools/ctags_reader.py's csharp KIND MAPS bullet alongside this shape's sibling ctags limitations (local-function blindness, complex-signature misses, overload-name collision -- see the agree[gitgalaxy,tree_sitter]_vs[ctags] shape). Not crediting/debiting: a single-tool false positive from an otherwise-unaffected precision baseline, no shared-mistake mechanism applies.
@@ -561,7 +561,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `csharp` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T11:41:23Z*
+*3-way split -- 1 occurrence as of 2026-08-22T14:08:43Z*
 
 **Verdict** (by Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T20:06:45Z):
 > Tangled: partly the same reconciler rank-pairing artifact as the sibling agree[gitgalaxy,tree_sitter]_vs[ctags] shape (SetCurrentSolution's 4 real overloads, 1/6/4/5 params), partly a genuine GitGalaxy defect underneath. ctags=5 and tree_sitter=4 each correctly match a DIFFERENT real overload's true count (line 444's 5 params, line 230's 4 params respectively) -- not wrong, just paired against each other by rank rather than by which declaration they actually read. GitGalaxy=0 traces to the SAME occurrence tree_sitter's 4 reading corresponds to (line 230, a bare tuple return type `(bool updated, Solution newSolution)` before the method name) -- a confirmed instance of issue #2051's mechanism 1 (GitGalaxy's args regex fails to match tuple return types at all). No credit/debit: too tangled between real defect and pairing noise to cleanly adjudicate at the shape level.
@@ -574,7 +574,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `css` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T11:41:24Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T14:08:45Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed ctags-side structural limitation, not a GitGalaxy defect. GitGalaxy's own func_start regex (language_standards.py) deliberately matches CSS at-rule keywords (@media/@supports/@container/@layer/@keyframes/@-webkit-keyframes) as the closest function-shaped construct CSS has, since CSS has no true function-definition/call syntax. tree-sitter's CSS grammar independently corroborates this: media_statement/supports_statement/keyframes_statement are real, distinct node types, already mapped 1:1 onto GitGalaxy's own at-rule set per issue #1313 (see tree_sitter_accuracy_audit.py's css NODE_MAPS entry and its media_statement/supports_statement name-extraction branches). Re-ran gather_language('css') directly against the full 4-file corpus (not just the ledger's capped 3-example sample): GitGalaxy and tree-sitter agree exactly on function count in every file (3/3 total, zero diff files) -- the agreement generalizes completely, it is not a partial/mixed sample. ctags' own FUNCTION_KIND_MAP already documents 'css': set()  # no function-equivalent (ctags_reader.py) -- confirmed empty (ctags_funcs: []) across all 4 corpus files too. ctags structurally cannot tag CSS at-rules as anything function-like; it isn't wrong about a claim, it has no claim to make here at all. No new doc note needed -- both the GitGalaxy/tree-sitter convention (#1313) and the ctags limitation are already documented in code. GitGalaxy+tree-sitter's agreement is real corroboration, not a shared mistake, so no credit/debit adjustment applies; ctags' lack of a comparable slot here is already handled correctly by the reconciler's own total_slots mechanics.
@@ -589,7 +589,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `dart` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-22T11:41:29Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-22T14:08:49Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy recall gaps (tree-sitter is correct), several distinct causes found via direct source investigation against language-crucible/data/dart. Some entries in this shape's original capped example list were incidentally resolved as a side effect of the func_start fix in gitgalaxy#2071 (e.g. EditableText's own multi-line constructor, generic-return-type getters like `Iterable<Element> get children =>`, and dotted-name getters like `T? get currentState => switch (...) {...}` all now regex-match correctly and reach the final pipeline output). A post-fix full-corpus name-diff still shows 12 residual missing_from_gg cases across 5 distinct confirmed root causes, none yet fixed: (1) EditableText's constructor and a private named constructor (_DiscreteKeyFrameSimulation._(...)) regex-match (confirmed via direct probe) but don't reach the final pipeline output -- a detector.py-level extraction bug downstream of the regex, not yet traced; (2) static getters with a dotted/prefixed-import return type (`static ui.BoxHeightStyle get defaultSelectionHeightStyle {`) never regex-match at all, because the return-type-prefix character class excludes `.`; (3) bodyless default constructors (`_EditableTextTapOutsideAction();`) don't regex-match; (4-5) several more names (recorder, ChildSemanticsConfigurationsResultBuilder, OrdinalSortKey, SemanticsData, SemanticsProperties, extension) not yet individually root-caused. All tracked as a consolidated follow-up in gitgalaxy#2072 -- deliberately not rushed, since the sibling existence shape's investigation already found one naive fix (broadening the return-type charclass or the keyword-exclusion list) can silently break a much more common legitimate pattern elsewhere, so each of these needs its own regression check before shipping.
@@ -609,7 +609,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `dart` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T11:41:29Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T14:08:49Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy engine defect, not a tree-sitter limitation. Root-caused two distinct false-positive bugs in dart's func_start regex's zero-prefix branch, both in gitgalaxy/standards/language_standards.py: (1) Dart 3 switch-expression arms (`Pattern => result,` including bare `_ => result,`) matched as getter definitions, because the branch's bare-`=>` lookahead alternative was unconditional (no `get` keyword required) even though Dart's real grammar has no parameterless `=> expr` construct without `get`. (2) Call statements with a lambda argument (`obj.method((x) => ...)`, `setState(() {...})`, bare self-calls like `visitChildren((Element child) {...})`) matched as function definitions, because the paren-lookahead used a naive non-balanced-paren check (`\([^)]*\)`) that stopped at the lambda's own closing paren instead of the outer call's. A full corpus-wide before/after diff (language-crucible/data/dart, 7 Flutter framework files) confirmed 126 false-positive matches removed and only 1 new match gained (a genuine recall fix for EditableText's own multi-line constructor) -- every one of the 126 manually spot-checked as a real false positive (dotted call receiver, or a statement ending `);`, or a switch-expression arm), none a lost real definition. Fixed in gitgalaxy#2071 (merged via this ledger-sweep PR) by gating the bare-arrow alternative behind the existing `get`-group conditional and switching to the same balanced-paren pattern already used elsewhere in this regex. A smaller, related false positive (multi-line class headers with with/implements clauses absorbed as a phantom function's return-type prefix, e.g. `implements AutofillClient {` matching as a function named AutofillClient) was found in the same investigation but is NOT fixed -- the straightforward fix (excluding implements/with/extends from the return-type-prefix vocabulary) was tested and confirmed to break a much more common legitimate pattern, generic method type-parameter bounds (`static Future<T?> pushNamed<T extends Object?>(...)`), which also uses `extends`. Tracked in gitgalaxy#2072 along with several other confirmed-but-deferred recall gaps found in the same pass.
@@ -628,7 +628,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `dart` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 218 occurrences as of 2026-08-22T11:41:29Z*
+*3-way split -- 218 occurrences as of 2026-08-22T14:08:49Z*
 
 **Verdict** (by Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep, 2026-08-21T00:00:00Z):
 > Confirmed real GitGalaxy defect on args counts for class/constructor names, root cause distinct from (but likely overlapping with) the func_start existence bugs fixed in gitgalaxy#2071. Spot-checked via language-crucible/data/dart, e.g. flutter/editable_text.dart's `_DeleteTextAction` class (`class _DeleteTextAction<T extends DirectionalTextEditingIntent> extends ContextAction<T> {` at line 6352, real constructor `_DeleteTextAction(this.state, this.getTextBoundary, this._applyTextBoundary);` at line 6353 taking 3 args) -- tree-sitter correctly reports args=3 for the constructor, GitGalaxy reports args=0, most likely because GitGalaxy's func_start is matching the class declaration header itself under the same name (no explicit `(...)` immediately after the class name, since it's followed by `<T extends ...>` then `extends ContextAction<T> {`) rather than the real constructor line. This looks like the same underlying class-header-vs-function-signature ambiguity as gitgalaxy#2072 item 1 (multi-line class headers with generic type-parameter bounds), not yet isolated or fixed -- a full re-diff after this ledger sweep's existence fix still shows 302 name-matched args disagreements, most following this same class/constructor-name shape. Deliberately not fixed in this pass: root-causing exactly which of the func_start branches is misattributing these needs its own investigation with the same regression discipline the existence fix required (a naive class-header exclusion already proved unsafe once in this same investigation). Tracked as a named follow-up under gitgalaxy#2072's scope.
@@ -650,7 +650,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `fortran` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-22T11:41:35Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-22T14:08:56Z*
 
 **Verdict** (by Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T23:35:49Z):
 > Confirmed already-documented tree-sitter-fortran limitation (#1709/Claim 7 in docs/why_gitgalaxy_beats_ast_here.md), re-verified directly against this exact shape's 14 occurrences (11 in wrf/module_physics_init.F: bl_init, ra_init, landuse_init, mp_init, cu_init, shcu_init, CAM_INIT, z2sigma, fdob_init, fg_init, ALLOCATE_CAM_ARRAYS; 3 in wrf/wrf_timeseries.F: calc_p8w, calc_ts, write_ts). Directly ran tree_sitter_accuracy_audit.py's own _find_blind_spot_ranges() against both files' real parse trees: every one of the 14 occurrences' start lines falls inside a tree-sitter ERROR/preproc_* blind-spot range (e.g. bl_init/mp_init/cu_init/shcu_init all sit inside one continuous (2203,4393) span; all 3 wrf_timeseries.F occurrences fall inside a (1,1200) span). ctags and GitGalaxy are both correct; tree-sitter-fortran's own grammar cascades into ERROR nodes on the CPP #if/#endif guards surrounding these subroutines. Added as new evidence to the existing Claim 7 in docs/why_gitgalaxy_beats_ast_here.md (this ledger shape is independently sourced from the original accuracy-audit finding -- a raw per-file name diff via tri_comparison_gatherer.py, not the audit tool's promotion logic).
@@ -668,20 +668,9 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 | wrf/module_physics_init.F | `z2sigma` | 4965 | *(n/a)* | 4965 |
 | wrf/module_physics_init.F | `fg_init` | 4700 | *(n/a)* | 4700 |
 
-### ✅ `fortran` function args: tree-sitter, ctags agree, GitGalaxy differ
-
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:35Z*
-
-**Verdict** (by Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985), 2026-08-21T00:00:00Z):
-> Confirmed GitGalaxy engine defect, ctags and tree-sitter both correct. init_domain (module_initialize_real.F:41, `SUBROUTINE init_domain ( grid )`) genuinely takes 1 parameter. GitGalaxy's own args regex correctly matches '( grid )' when tested in isolation against the real declaration line -- the bug is upstream of the args regex entirely: fortran's func_start regex's optional return-TYPE-prefix group (`(?:INTEGER|REAL|...)[A-Za-z0-9_ \t\n&*,()=:]{0,40}?`) allows up to 40 characters including newlines between the TYPE keyword and the following FUNCTION/SUBROUTINE/etc keyword, with no requirement that they belong to the same statement. In this file, an unrelated, already-terminated `INTEGER :: internal_time_loop` declaration sits ~30 characters (4 blank lines) before `SUBROUTINE init_domain`, so the regex's own match.start() lands on that earlier, unrelated line instead of the real declaration -- corrupting every downstream computation anchored to it (start_line, body span, and -- since #1973's fix correctly bounds the args search to the label's OWN statement span -- the args search window too, which can no longer reach the real '( grid )' text several lines later). Filed as #1982 (not yet fixed). No credit/debit -- ctags and tree-sitter aren't corroborating each other by coincidence here, they're both just correctly parsing real Fortran grammar that GitGalaxy's func_start regex currently mis-anchors.
-
-| file | name | GitGalaxy | tree-sitter | ctags |
-|---|---|---|---|---|
-| wrf/module_initialize_real.F | `init_domain` | 0 | 1 | 1 |
-
 ### ✅ `fortran` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:35Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:08:56Z*
 
 **Verdict** (by Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T23:35:49Z):
 > Confirmed GitGalaxy correct on both. 'vint' (module_initialize_real.F:5375, inside #ifdef VERT_UNIT) and 'foo' (module_initialize_real.F:7519, inside #if 0) are both real, syntactically valid `PROGRAM name` declarations. tree-sitter misses both via the already-documented #1709 ERROR/preproc_* blind-spot mechanism (both sit inside #if/#ifdef-guarded regions). ctags misses 'foo' only because CTAGS_FUNC_KINDS['fortran'] was {'f','s'} (functions/subroutines only) -- ctags itself DOES correctly tag `foo` as a 'p' (program) kind (confirmed via `ctags -x --kinds-Fortran=p`), just invisible to this comparison. Fixed in tests/tools/ctags_reader.py: CTAGS_FUNC_KINDS['fortran'] now {'f','s','p','e'} (added program, entry -- matching GitGalaxy's own func_start scope of FUNCTION|SUBROUTINE|PROGRAM|ENTRY). ctags separately, genuinely fails to tag 'vint' at all under any kind in this specific file (confirmed it tags an isolated test file with identical #ifdef-wrapped `program vint` syntax fine, so it's a real, unexplained ctags-fortran-parser corruption specific to this file's content, not a preprocessor-conditional-skip decision) -- a genuine, narrow ctags limitation, not chased further for a single occurrence.
@@ -692,7 +681,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `fortran` function args: none agree, GitGalaxy, tree-sitter, ctags differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T11:41:35Z*
+*3-way split -- 1 occurrence as of 2026-08-22T14:08:56Z*
 
 **Verdict** (by Sonnet 5, dispatched via tri-comparison-ledger-sweep, 2026-08-21T23:35:49Z):
 > Confirmed real GitGalaxy engine defect (filed, not fixed -- needs real design work). wrf/module_physics_init.F's phy_init is a genuine 677-parameter subroutine (confirmed via `ctags --fields=+S`, which correctly reports all 677 comma-separated dummy args). GitGalaxy (40) and tree-sitter (39) both wrong, for different, independently confirmed reasons: GitGalaxy's args regex first alternative `\([^)]*\)` has no paren-depth awareness and stops at the FIRST literal ')' anywhere in the window -- which, in this signature, is the ')' closing an embedded `#if ( EM_CORE == 1 )` guard ~12 lines into the parameter list, not the real closing paren ~245 lines later (directly traced: the window-bounding fix from #1973 correctly extends to the real closing paren at line 276, but the args regex itself still truncates early). Tree-sitter's undercount is the same already-documented #1709 ERROR/preproc_* cascade applied to its own parse of this signature. ctags alone gets this right because its signature accumulation isn't a single bounded regex. This is a genuine 3-way split (no two tools agree with each other at all), so no credit/debit pair applies. Filed as https://github.com/squid-protocol/gitgalaxy/issues/2077 -- fixing it needs a real depth-aware paren scanner (mirroring dart's _count_top_level_args / cpp's _cpp_class_has_body pattern) over the already-correctly-bounded args_search_text, not a one-line regex tweak, so left for its own follow-up PR rather than shipped inline.
@@ -705,7 +694,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `go` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 75 occurrences as of 2026-08-22T11:41:37Z*
+*2-vs-1 -- 75 occurrences as of 2026-08-22T14:08:58Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`go/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -726,7 +715,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 103 occurrences as of 2026-08-22T11:41:40Z*
+*2-vs-1 -- 103 occurrences as of 2026-08-22T14:09:01Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > All 10 sampled cases are ctags-side artifacts, not real GitGalaxy/tree-sitter misses -- confirmed via direct `ctags -x` output against the corpus. Three distinct ctags Haskell-parser weaknesses cover the sample: (1) multi-clause double/triple-tagging -- ctags tags every pattern-matched equation line as its own occurrence of the name (writerFn/writeFnBinary/expandFilterPath: confirmed 2-3 raw ctags tags per function, one per clause; a file-wide count found 45 such extra same-name tags across the 7-file corpus, e.g. blockToInlines alone has 14). GitGalaxy/tree-sitter both correctly anchor to the FIRST clause only, leaving ctags' later-clause tags as the ones unpaired. (2) keyword-as-identifier misparsing -- `class`/`where`/`pattern` (from PatternSynonyms) get tagged as function names when ctags fails to parse past the keyword; confirmed at Options.hs:62 (`class HasSyntaxExtensions`), Parsing.hs:184 (module-header `where`), and 3 PatternSynonyms declarations in Options.hs. (3) CAF/value-vs-function kind collapse -- defaultAbbrevs/defaultKaTeXURL/defaultMathJaxURL/defaultWebTeXURL are zero-arg top-level VALUES (non-arrow type signatures), not functions; ctags has no value/variable kind at all (`ctags --list-kinds-full=Haskell` shows only constructor/function/module/type) so it lumps every `name = expr` binding into "function". GitGalaxy (language_standards.py haskell rules, #1312) and tree-sitter's own audit tooling (_find_haskell_signature_for_bind, #1566) both independently make the same value-vs-function distinction correctly -- real cross-tool corroboration, not coincidence. (4) TH-splice call sites misread as definitions -- deriveJSON at Options.hs:454/458 is a Template Haskell splice INVOKING an imported function, not defining one; ctags misparses the call as a definition. No GitGalaxy/tree-sitter defect anywhere in this shape; purely a ctags parser limitation, same category as the already-documented empty CTAGS_CLASS_KINDS['haskell'].
@@ -746,7 +735,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 69 occurrences as of 2026-08-22T11:41:40Z*
+*2-vs-1 -- 69 occurrences as of 2026-08-22T14:09:01Z*
 
 **Verdict** (by Claude Sonnet 5 (dispatched agent investigation), 2026-08-19T00:00:00Z):
 > Confirmed: all 10 sampled misses (and, by cross-check against additional non-sampled instances in Options.hs/Shared.hs, plausibly all 69) are locally-scoped function definitions -- `instance ... where` methods, `where`-clause helpers, or `let`-bound names inside `do` blocks -- never top-level module definitions. ctags' Haskell parser has no layout-rule/scope awareness and only tags equations anchored at column 1; it correctly handles multi-clause TOP-LEVEL definitions (verified via expandFilterPath, writeFnBinary, writerFn -- all tag fine, clauses and all), so this is a pure scope blind spot, not a clause-counting bug (distinct from the tree-sitter clause-splitting bug fixed earlier in this same effort, which shares 2 of the 10 sample names by coincidence of subject matter, not root cause). GitGalaxy and tree-sitter are both correct; ctags is not wrong so much as structurally incapable of seeing these. Known, expected limitation of ctags' Haskell parser, now documented alongside its existing Haskell notes in tests/tools/ctags_reader.py -- not a GitHub issue, nothing in this repo to fix.
@@ -766,7 +755,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-22T11:41:40Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-22T14:09:01Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Not a real discrepancy -- structural tooling gap, already documented in the codebase. tests/tools/ctags_reader.py:39-40,228 sets CTAGS_CLASS_KINDS['haskell'] = set() on purpose: "ctags' Haskell parser has no class-shaped kind at all (constructor/function/module/type only)". Every example in this shape (data/newtype/class declarations -- ReaderOptions, CiteMethod, HasSyntaxExtensions, etc.) is real; ctags structurally cannot report any of them for this language, not a sample-specific miss. No action needed beyond this note.
@@ -786,7 +775,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:40Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:01Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > Mixed shape as originally investigated (2 occurrences): (1) Options.hs:438 getExtensions -- real function, `instance HasSyntaxExtensions WriterOptions where getExtensions opts = writerExtensions opts`. A sibling instance for ReaderOptions at Options.hs:80 has the identical shape. Tree-sitter's Haskell grammar doesn't expose typeclass-instance-method clause bodies the way it does top-level bindings, and ctags' Haskell parser has no instance-method kind either -- GitGalaxy is correct, both other tools have a real recall gap on typeclass instance methods. (2) Shared.hs:475 extensionEnabled -- was NOT a real function (imported from Text.Pandoc.Extensions, only ever appears as a guard-clause call inside a multi-line `||` condition) -- a genuine GitGalaxy false positive, filed as #2082 and fixed in PR #2083 (2026-08-22): `_slice_by_indentation` now skips an equation-form func_start match whose immediately preceding line ends in `||`/`&&`. Reconciled post-fix: only the getExtensions occurrence remains, so this shape is now a clean, unambiguous GitGalaxy win -- credited accordingly.
@@ -797,7 +786,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `haskell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 9 occurrences as of 2026-08-22T11:41:40Z*
+*3-way split -- 9 occurrences as of 2026-08-22T14:09:01Z*
 
 **Verdict** (by Claude Sonnet 5 (session investigation), 2026-08-19T00:00:00Z):
 > One systematic cause, confirmed by reading source for 3 of the 9 (getMetadataFromFiles App.hs:395-397, splitTextByIndices Shared.hs:142-143, tabFilter Shared.hs:256-259) and consistent with the shape of the remaining 6. Every case is a point-free/eta-reduced Haskell equation: the type signature declares N params, but the specific clause GitGalaxy and tree-sitter both align to only explicitly binds N-1 of them, handling the trailing argument via composition (`.`) or `\case`. GitGalaxy counts arity from the full type signature (the true logical arity); tree-sitter's declaration-only reading counts only the clause's explicitly-bound patterns (correct for that one equation, but undercounts true arity). Neither reader is wrong about what it's measuring -- same shape as Claim 1 in docs/why_gitgalaxy_beats_ast_here.md. GitGalaxy's answer is arguably the more useful coupling signal; recommend documenting as a candidate Claim rather than treating as an engine defect to fix toward matching tree-sitter.
@@ -818,7 +807,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 265 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 265 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner loses the real property-key name for a function-valued object-literal property specifically when that literal is a CALL ARGUMENT rather than a direct assignment -- confirmed via jquery/ajax.js's `jQuery.extend(jQuery, {ajaxSetup: function(target, settings){...}, ajax: function(url, options){...}})`: ctags emits a synthetic 'AnonymousFunction<hex>' tag for both instead of using the real 'ajaxSetup'/'ajax' key text, while GitGalaxy and tree-sitter both correctly attribute the property key as the name. Generalizes across the whole corpus, not a one-file fluke -- the identical shape recurs in jquery/css.js (css/get/set/style), jquery/deferred.js (Deferred/catch/pipe/promise/then/when), jquery/event.js (Event/handler/off/one/postDispatch/set), jquery/core.js (20+ utility methods, reducing ctags' whole-file function count from 26 to 1), and threejs's Editor.js/GLTFLoader.js/WebGLRenderer.js/WebGLProgram.js. Doc note added to ctags_reader.py's javascript CTAGS_FUNC_KINDS entry.
@@ -838,7 +827,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 183 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 183 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed GitGalaxy correct; both ctags and tree-sitter structurally can't, for two INDEPENDENT reasons. All four affected react/*.js corpus files carry the `@flow` pragma. tree-sitter-javascript's grammar can't parse Flow's parenthesized type-cast syntax (`(expr: Type)`, e.g. `(workInProgress.child: any)`), producing an ERROR node that swallows a large trailing region of the file -- confirmed directly: ReactFiberBeginWork.js's ERROR spans lines 3221-4448 (1227 of 4448 lines), and ReactFiberWorkLoop.js/ReactFlightServer.js each produce ONE error node spanning the ENTIRE file (line 1 to EOF). Real, ordinary functions inside these regions (beginWork, attemptEarlyBailoutIfNoScheduledUpdate, mountLazyComponent, and 18 others sampled) have no tree-sitter node at all. Separately, ctags' own hand-written JS scanner hits an independent cascade triggered by a Flow RETURN-type annotation (`): Fiber | null {`) -- confirmed via a minimal isolated repro (a 4-function test file where the function with a Flow return-type annotation and everything textually after it produce zero ctags output), and confirmed against the real corpus (beginWork itself, which has exactly this return-type shape, produces zero ctags tags). GitGalaxy's regex has no dependency on either tool's parse state and finds every one of these correctly. Documented in docs/why_gitgalaxy_beats_ast_here.md (Claim 3, new subsection completing/extending the existing 'Second instance: javascript' write-up with the recall-loss half plus the newly-confirmed ctags cascade).
@@ -858,7 +847,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 93 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 93 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed ctags-side parser limitation, not a GitGalaxy or tree-sitter defect. ctags' JavaScript scanner tags its 'class' kind on ANY bare object-literal assignment (`var X = {...}`) or function-expression assignment (`var X = function(){}`, `obj.prop = function(){}`), a blanket heuristic for 'might be used as a pre-ES6 constructor' that fires regardless of whether `new` is ever used on it. Confirmed via a minimal isolated repro (plainObj/ctorLike/obj.Thing all tagged 'class' alongside a real ES6 class) and directly against the corpus: jqXHR (jquery/ajax.js, a plain config object), cssHooks/cssNormalTransform/cssShow (jquery/css.js), promise (jquery/deferred.js), Event/event/special (jquery/event.js, one of which -- Event -- IS a pre-ES6 constructor-style function, correctly ambiguous under ctags' heuristic but still not a real ES6 class), and the ALPHA_MODES/WEBGL_CONSTANTS/etc. config objects in threejs/GLTFLoader.js. GitGalaxy's class_start regex and tree-sitter's class_declaration node both correctly require the literal `class` keyword. Doc note added to ctags_reader.py's javascript CTAGS_CLASS_KINDS entry.
@@ -878,7 +867,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 11 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 11 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed tree-sitter-alone recall gap, same Flow-cascade family as agree[gitgalaxy]_vs[ctags,tree_sitter] above but from the other side: for these specific names (updateContextProvider, reconcileChildren, updateScopeComponent, markWorkInProgressReceivedUpdate, shouldForceFlushFallbacksInDEV, patchConsole, abortIterable, abortStream, error, throwTaintViolation), ctags' own Flow-return-type cascade trigger point happens to sit AFTER these functions (or never fires in that file), so ctags finds them correctly and agrees with GitGalaxy at the exact same line number, while tree-sitter's independent (earlier-triggering, different-construct) ERROR cascade has already swallowed them. Because the two tools' cascades trigger on different Flow constructs starting at different lines, they lose different, non-identical sets of functions -- this is why the ledger shows several distinct 3-way shapes instead of one clean 'both non-GitGalaxy tools agree on what they missed' shape. Documented alongside the fuller write-up in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension.
@@ -898,7 +887,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 8 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 8 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed ctags-side synthetic-placeholder artifact, not a real discrepancy -- ctags' JavaScript scanner emits a synthetic 'AnonymousFunction<hex><seq>' tag for every genuinely anonymous function expression (a bare inline callback with no attributable name, e.g. `jQuery.ajaxPrefilter(function(s) {...})`), and GitGalaxy/tree-sitter both correctly agree these aren't named functions worth counting. Fixed by extending `tri_comparison_gatherer.py`'s existing `_is_ctags_synthetic_anon_name` (previously only matched the C-parser's `__anon<hex>` scheme) with a second regex for JavaScript's differently-shaped 'AnonymousFunction'/'AnonymousClass' scheme -- verified this removes every 'Anonymous*' entry across the full 18-file corpus with zero regressions (ruff/mypy audits clean).
@@ -916,7 +905,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed tree-sitter-alone argument-count corruption, a third facet of the same Flow-parsing family. Even where tree-sitter DOES still produce a real function_declaration node (outside any ERROR-swallowed region), a Flow parameter type with a union (`current: Fiber | null`) corrupts that node's own formal_parameters child list. Confirmed directly via react/ReactFiberBeginWork.js:405 `updateForwardRef(current: Fiber | null, workInProgress: Fiber, Component: any, nextProps: any, renderLanes: Lanes)` -- 5 real parameters (GitGalaxy=5, ctags=5, both correct) but tree-sitter's own formal_parameters node contains a single ERROR child swallowing 'current: Fiber | null,\n  workInProgress:' whole (merging two real parameters into one unstructured blob), followed by a bare identifier node reading 'Fiber' -- the type name of the swallowed second parameter, left behind by the same ERROR recovery and miscounted as if it were itself a parameter. Net effect: 4 instead of 5, an off-by-one undercount rather than total loss. Documented in docs/why_gitgalaxy_beats_ast_here.md's Claim 3 extension as the 'third facet.'
@@ -933,7 +922,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `javascript` function args: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:41:46Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:09:07Z*
 
 **Verdict** (by Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep, 2026-08-21):
 > Confirmed comparison-methodology artifact (name-based reconciliation colliding on a reused property name), not a real defect in any of the three tools. jquery/event.js defines TWO separate object-literal properties both named 'setup' (line 441, taking 1 param `function(data)`) and 'trigger' (line 458, 1 param) inside one plugin-hook object, and a SECOND, unrelated pair of 'setup'/'trigger' properties (lines 759/774, taking 0 params) inside a different object later in the same file. This module's/the ledger's reconciliation pairs occurrences by NAME across the whole file, with no scope/position disambiguation, so a same-name collision between two genuinely different functions can produce a spurious per-name args mismatch depending on which occurrence each tool's internal ordering happens to surface first. Both readings (1 param and 0 params) are independently real and correct for their respective definition sites -- there is no actual counting defect here, just a reconciliation limitation inherent to comparing by name only. No credit/debit; no code fix warranted for 2 occurrences arising from a rare same-name collision.
@@ -947,7 +936,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `kotlin` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 15 occurrences as of 2026-08-22T11:41:49Z*
+*2-vs-1 -- 15 occurrences as of 2026-08-22T14:09:10Z*
 
 **Verdict** (by claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable), 2026-08-22T11:40:48Z):
 > Confirmed ctags-side over-detection, not a GitGalaxy/tree-sitter recall gap. Direct `ctags -x --languages=Kotlin` on okhttp/Dispatcher.kt shows all 15 occurrences split into two false-positive shapes ctags' Kotlin parser tags with the same 'method' kind as real functions: (1) 10 trailing-lambda blocks passed as call arguments -- `require(x >= 1) { "..." }` (lines 48/68), `synchronized(this) { ... }` (49/69/178), `check(...) { ... }` (180/185), `.also { readyAsyncCalls.clear() }` (210), and `.map { it.call }` (279/283) -- each tagged as a synthetic `<lambda>` symbol; (2) 5 `for (x in collection)` loop iteration variables tagged as methods literally named after the variable (`call` at 143/146/149 in cancelAll(), `existingCall` at 128/131 in findExistingCallWithHost()). GitGalaxy's own func_start regex and tree-sitter-kotlin's grammar both correctly require a real `fun`/constructor declaration, so their agreement (neither claims these 15) is real corroboration, not a shared miss. Not fixable via ctags_reader.py's FUNCTION_KINDS map -- ctags gives Kotlin no separate kind for 'anonymous lambda literal' or 'for-loop binding' vs. a real named function in the first place (confirmed: both false-positive shapes tag plain 'method', identical to genuine functions). Documented in ctags_reader.py's kotlin FUNCTION_KINDS comment. ctags' own claim on this shape is confirmed wrong, so it's debited.
@@ -967,7 +956,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `kotlin` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:49Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:10Z*
 
 **Verdict** (by claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch), 2026-08-22T11:45:48Z):
 > Direct continuation of the already-investigated constructor shape (see the now-still_reproduces=False agree[gitgalaxy]_vs[ctags,tree_sitter] entry's verdict for the full investigation): fixing tree_sitter_accuracy_audit.py's kotlin func_node_types to include `secondary_constructor` made tree-sitter agree with GitGalaxy on okhttp/Dispatcher.kt line 119's `constructor(executorService: ExecutorService?) : this() { ... }`, which regrouped this exact occurrence into a NEW 2-vs-1 shape. ctags' own Kotlin parser was independently confirmed (via `ctags -x --languages=Kotlin`) to emit no entry at all for line 119, under any kind -- a genuine ctags parser limitation (it doesn't recognize secondary-constructor syntax as a symbol in the first place), not a ctags_reader.py kind-mapping gap (there is nothing to remap; ctags never sees this construct as a taggable symbol). No credit/debit: ctags never claimed this occurrence at all (a miss, not a wrong claim), so there is nothing in its matched_consensus to debit, and gitgalaxy/tree_sitter's own claims were already correctly counted independent of this adjustment mechanism.
@@ -980,7 +969,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 76 occurrences as of 2026-08-22T11:41:55Z*
+*2-vs-1 -- 76 occurrences as of 2026-08-22T14:09:16Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5, 2026-08-20):
 > Clean, single-cause shape (all 10 sampled cases), not a GitGalaxy defect. Every sampled occurrence (curl/configure.ac lines 967-4994) is a real AC_DEFINE or AC_DEFINE_UNQUOTED call (e.g. line 2112: AC_DEFINE_UNQUOTED([CURL_DEFAULT_SSL_BACKEND], [...], [...])) -- an autoconf helper that emits a C preprocessor #define into the generated config.h at build time, NOT a new callable M4 macro definition. GitGalaxy's own func_start regex for m4 deliberately excludes AC_DEFINE/AC_DEFINE_UNQUOTED from its keyword set (m4_define|define|AC_DEFUN|AC_DEFUN_ONCE|AU_DEFUN|m4_defun only), so its silence here is correct. ctags' M4 parser heuristically tags any AC_DEFINE*-family call with a bracketed/plain first argument as a macro definition -- same macro-invocation-vs-definition confusion already documented for C's RICHCMP_WRAPPER pattern, now also documented in tests/tools/ctags_reader.py's m4 note. No GitHub issue against GitGalaxy -- this is a real, confirmed ctags-side limitation. (Separately, unrelated to this shape: a deeper live-pipeline recall gap causing GitGalaxy to extract only 1 m4 function total across the whole corpus, despite its func_start regex matching dozens of genuine AC_DEFUN/m4_define calls when run standalone, was found and fixed in part -- see PR #1927 for the func_start capture-group fix; the remaining pipeline-level gap is tracked separately, not part of this shape's verdict.) Investigated via gemini-3.1-pro-high (agy), all 10 sampled file:line citations independently verified.
@@ -1000,7 +989,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 36 occurrences as of 2026-08-22T11:41:55Z*
+*2-vs-1 -- 36 occurrences as of 2026-08-22T14:09:16Z*
 
 **Verdict** (by claude-sonnet-5 (direct source read, no dispatch needed), 2026-08-20):
 > Confirmed real GitGalaxy false positive, now fixed. The old func_start regex had no capture group over the macro-name argument, so it matched the AC_DEFUN keyword itself as the 'function name' -- structurally identical to matching 'def' as a Python function's name instead of what follows it. gnucobol/configure.ac:658 'AC_DEFUN([AC_PROG_F77], [])' was reported as a function literally named 'AC_DEFUN'; ctags correctly reports nothing here since this call defines an empty macro body (a no-op placeholder, common autoconf idiom for stubbing out a check). Fixed in PR #1927: func_start now captures the real macro-name argument (AC_PROG_F77), handling m4's three real quoting conventions (backtick/apostrophe, bracket, double-bracket). Verified directly: the pipeline now reports 'AC_PROG_F77' at line 658, not 'AC_DEFUN'.
@@ -1020,7 +1009,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `m4` class existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T11:41:55Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T14:09:16Z*
 
 **Verdict** (by claude-sonnet-5 (direct source read, no dispatch needed), 2026-08-20):
 > Confirmed real GitGalaxy false positive, not yet fixed (tracked separately). m4's own class_start rule is explicitly None (m4 has no class/OOP concept) -- but detector.py's class extraction branch only checks _CLASS_START_NAMED_EXTRACTION_LANGS allowlist membership, not whether the language's own class_start is None, so m4 (and 18 other class_start=None languages) falls through to the generic 'class|struct|interface|trait|enum NAME' fallback regex regardless. That fallback has no awareness of m4 document structure, so it matches raw C struct declarations embedded as literal text inside autoconf feature-test macro arguments (e.g. curl/configure.ac:1358's 'struct SocketIFace *ISocket = NULL;' inside an AC_LANG_PROGRAM([[ ... ]]) block) as if they were real m4 classes. Verified directly against the live gatherer: gg_classes for curl/configure.ac returns ['SocketIFace', 'Library', 'sockaddr_in6'], none of which are real m4 constructs; ctags correctly reports none (no class-shaped kind for m4 at all). Filed as GitHub issue #1925 (broader architectural gap, confirmed for m4, 18 other class_start=None languages not yet checked) -- not fixed in this sweep.
@@ -1036,7 +1025,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `makefile` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:41:56Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:18Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`makefile/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1048,7 +1037,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `matlab` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T11:41:58Z*
+*3-way split -- 1 occurrence as of 2026-08-22T14:09:19Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`matlab/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1060,7 +1049,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 104 occurrences as of 2026-08-22T11:42:00Z*
+*2-vs-1 -- 104 occurrences as of 2026-08-22T14:09:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1079,7 +1068,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 91 occurrences as of 2026-08-22T11:42:00Z*
+*2-vs-1 -- 91 occurrences as of 2026-08-22T14:09:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1098,7 +1087,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:42:00Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:09:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1109,7 +1098,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `objective-c` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:00Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:21Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`objective-c/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1121,7 +1110,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 122 occurrences as of 2026-08-22T11:42:06Z*
+*2-vs-1 -- 122 occurrences as of 2026-08-22T14:09:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1140,7 +1129,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:42:06Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:09:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1156,7 +1145,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:42:06Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:09:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1172,7 +1161,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:06Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/class/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1182,7 +1171,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:06Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1192,7 +1181,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `perl` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 64 occurrences as of 2026-08-22T11:42:06Z*
+*3-way split -- 64 occurrences as of 2026-08-22T14:09:27Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`perl/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1213,7 +1202,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:11Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:32Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1223,7 +1212,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `php` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:11Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:32Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`php/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1235,7 +1224,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 16 occurrences as of 2026-08-22T11:42:13Z*
+*2-vs-1 -- 16 occurrences as of 2026-08-22T14:09:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1254,7 +1243,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 7 occurrences as of 2026-08-22T11:42:13Z*
+*2-vs-1 -- 7 occurrences as of 2026-08-22T14:09:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1270,7 +1259,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:13Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1280,7 +1269,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `powershell` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 5 occurrences as of 2026-08-22T11:42:13Z*
+*3-way split -- 5 occurrences as of 2026-08-22T14:09:35Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`powershell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1296,7 +1285,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `python` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 100 occurrences as of 2026-08-22T11:42:23Z*
+*2-vs-1 -- 100 occurrences as of 2026-08-22T14:09:45Z*
 
 **Verdict** (by claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed), 2026-08-21T12:03:03Z):
 > Already documented as Claim 2 in docs/why_gitgalaxy_beats_ast_here.md: tree-sitter-python has no concept of Cython's cdef class/cdef/cpdef syntax at all and loses track of scope at each cdef class boundary, so it finds 0 functions in cython/MemoryView.pyx and cython/MemoryView.pxd (0/0 vs GitGalaxy+ctags' 72/16, full agreement as of the 2026-08-21 get_slice_from_memview follow-up fix -- see the sibling agree[ctags]_vs[gitgalaxy,tree_sitter] shape's verdict for that fix's details). This shape's count grew from 32 to 99 to 100 across this PR's two fixes: it originally covered only the 32 'def'-based methods inside cdef class blocks; each cdef/cpdef func_start fix moved newly-recognized occurrences into THIS shape too, since they still disagree with tree-sitter for the identical underlying reason. GitGalaxy now has zero recall gaps on this corpus for Cython functions -- the only remaining disagreement with tree-sitter is tree-sitter's own structural blindness to the Cython dialect, not a GitGalaxy defect. No GitGalaxy fix needed for tree-sitter's own recall here -- grammar limitation, not an engine defect.
@@ -1316,7 +1305,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `python` class existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T11:42:23Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T14:09:45Z*
 
 **Verdict** (by claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed), 2026-08-21T03:23:52Z):
 > Extends Claim 2 (docs/why_gitgalaxy_beats_ast_here.md) one syntactic level up: tree-sitter-python doesn't just lose track of scope inside a cdef class block, it fails to recognize the 'cdef class' declaration itself as a class at all -- 0 class nodes reported for cython/MemoryView.pyx, missing all 4 real classes (array, Enum, memoryview, _memoryviewslice). GitGalaxy's class_start regex and ctags both correctly identify all 4 by name, confirmed via direct gather_language() check. Note: GitGalaxy's own class_data schema has no start_line column (documented in tri_comparison_gatherer.py's own module docstring), so the ledger's stored example shows a None 'reading' for GitGalaxy on this shape -- that's the (structurally absent) line number field, not an indication GitGalaxy missed the class; by NAME it matches ctags exactly. No GitGalaxy fix needed -- tree-sitter-python grammar limitation. docs/why_gitgalaxy_beats_ast_here.md's Claim 2 updated with this class-level evidence in the same PR.
@@ -1332,7 +1321,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-22T11:42:24Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-22T14:09:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1347,7 +1336,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-22T11:42:24Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-22T14:09:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1362,7 +1351,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` function args: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T11:42:24Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T14:09:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/function/args/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1374,7 +1363,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `ruby` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:42:24Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:09:46Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`ruby/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1387,7 +1376,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 152 occurrences as of 2026-08-22T11:42:28Z*
+*2-vs-1 -- 152 occurrences as of 2026-08-22T14:09:50Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch), 2026-08-19T00:00:00Z):
 > Not a new question -- already-documented, evidence-backed rust behavior (Claim 6, docs/why_gitgalaxy_beats_ast_here.md: 'structure recall inside opaque macro bodies'). Confirmed directly: all 5 sampled names (get_param, init_access, get_components, from_components, apply) are in bevy/bevy_ecs_macros.rs, inside a `quote! { ... }` proc-macro body (confirmed at source lines 444-460 -- `#path`/`#fields_alias` interpolation syntax is the classic quote! token-generation pattern). These are real Rust function definitions being code-generated by a proc macro; GitGalaxy's regex correctly parses real function syntax wherever it textually appears, including inside macro bodies. tree-sitter-rust and ctags' Rust parser both treat macro_rules!/macro-invocation bodies as opaque token trees and structurally cannot emit function nodes for anything inside one -- not a bug in either, a real grammar limitation. This is exactly why rust is one of the 3 languages (with csharp/fortran) already promoted into ground truth via blind-spot-region detection in the OLD bi-comparison tool (tree_sitter_accuracy_audit.py's _find_blind_spot_ranges) -- this tri-comparison ledger entry is that same, already-understood gap surfacing again under the new 3-tool reconciliation. GitGalaxy is correct; no engine defect, no issue needed. Resolved directly from existing documentation, no fresh dispatch required (tri-comparison-ledger-sweep skill step 1.3).
@@ -1407,7 +1396,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 25 occurrences as of 2026-08-22T11:42:28Z*
+*2-vs-1 -- 25 occurrences as of 2026-08-22T14:09:50Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Same mechanism as the already-resolved rust/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter] shape (Claim 6, docs/why_gitgalaxy_beats_ast_here.md) -- extended from `fn` definitions inside `quote!{}` invocation bodies to `struct` definitions inside `macro_rules!` DEFINITION bodies. All 6 sampled names confirmed, independently re-verified against source (not just the dispatched agent's own read): NonZeroVisitor (line 90), SaturatingVisitor (112), PrimitiveVisitor (136) inside serde/serde_core_de_impls.rs's `impl_deserialize_num!` macro (def starts line 81); SeqVisitor (998), SeqInPlaceVisitor (1036) inside `seq_impl!` (def starts 978); TupleVisitor (1403) inside `tuple_impl_body!` (nested in `tuple_impls!`, def starts 1396). All 6 are real, complete `struct` declarations, each immediately followed by a genuine `impl<'de,...> Visitor<'de> for <Name>` block -- generated once per macro invocation, not fragments or hallucinated matches. tree-sitter and ctags both treat a macro_rules! arm's body as an opaque, unexpanded token tree and structurally cannot emit struct nodes from inside one, for the identical reason they can't see function definitions inside quote!{} bodies. GitGalaxy is correct in all 6 sampled cases; judged (not independently re-confirmed beyond the sample) to generalize to the full 25, all same-shaped serde-crate occurrences. No new tool defect -- Claim 6's doc text already covered this generically (`struct_item` was already named) but had no concrete cited example for this specific shape; added one (docs/why_gitgalaxy_beats_ast_here.md) rather than filing an issue.
@@ -1427,7 +1416,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 21 occurrences as of 2026-08-22T11:42:28Z*
+*2-vs-1 -- 21 occurrences as of 2026-08-22T14:09:50Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, same root cause as the sibling shape rust/function/args/agree[none]_vs[gitgalaxy,tree_sitter] (#1872): a Rust lifetime tick (`'_`, `'a`, `'static`) never gets recognized as non-string during bracket/quote scanning. This shape surfaces the SECOND manifestation, in a different function than the first: `_matching_paren_end` (gitgalaxy/core/detector.py:3675-3703) has NO lifetime guard at all (unlike _count_top_level_args's broken-but-present one). A lifetime tick makes its self-containment check falsely fail, falling through to the comma/whitespace-split fallback meant for Lisp/Scheme/Shell (~line 4296) -- for single-parameter signatures with a lifetime and no comma this OVER-counts (opposite direction from the sibling shape's under-count), for multi-param signatures it under-counts via the same swallowed-closing-paren mechanism. Extends the how_to_investigate_a_discrepancy.md worked example (bevy_ecs_table.rs::initialize, 5 real params, GitGalaxy reports 3) across the full 8-item sample, independently hand-traced and confirmed exact-match against real source for all 8: bevy_ecs_table.rs:171,194, bevy_ecs_world.rs:2969,3005, serde_internals_ast.rs:62 (under-count, multi-param); bevy_reflect_path.rs:43, serde_core_de_impls.rs:3147, serde_internals_ast.rs:119 (over-count, single-param via the whitespace-split fallback). Dispatched investigation initially produced a fabricated mechanism on its first pass; caught by the dispatching agent's own manual code trace, corrected on a second pass, then independently re-verified byte-for-byte against all 8 real signatures before being accepted here -- treat this as a genuinely double-checked finding, not a single-pass claim. ctags and tree-sitter are both correct in every case. Judged to plausibly explain most/all of the remaining 21 (any rust signature with a lifetime annotation is susceptible) and possibly under-reported beyond this specific ledger shape too, since lifetimes are extremely common idiomatic rust. Added as a follow-up comment on #1872 rather than a duplicate issue, since both bugs should be fixed together.
@@ -1447,7 +1436,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 3 occurrences as of 2026-08-22T11:42:28Z*
+*2-vs-1 -- 3 occurrences as of 2026-08-22T14:09:50Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed structural ctags limitation, not a bug -- resolved directly (no dispatch needed). All 3 sampled names (XRegUnion, FRegUnion, VRegUnion) are real Rust `union { }` declarations (confirmed at wasmtime/wasmtime_pulley_interp.rs:404,529,604), distinct from `struct` -- Rust's less-common C-style unsafe union construct. Ran `ctags --list-kinds-full=Rust` directly: its Rust parser's kind list is macro/method/implementation/enumerator/function/enum/interface/field/module/struct/typedef/variable -- there is NO union kind at all. Confirmed via direct ctags run against this exact file: it correctly finds the wrapping `struct FRegVal(FRegUnion)`-shaped types right next to each missed union, so this isn't a general miss, specifically a missing Rust-union kind. Same category as the already-documented ctags Haskell class-kind gap (tests/tools/ctags_reader.py) -- worth a similar doc note there, not a GitHub issue (nothing to fix, ctags upstream has no union support for this language).
@@ -1460,7 +1449,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:28Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:50Z*
 
 **Verdict** (by Claude Sonnet 5 (resolved directly via live ctags run, no dispatch), 2026-08-19T00:00:00Z):
 > Confirmed via direct ctags run and sibling comparison, resolved directly (no dispatch needed). `done_decode` (wasmtime/wasmtime_pulley_interp.rs:964) has a destructuring-pattern parameter -- `Done { _priv }: Done`, not a simple `name: Type` binding. Ran ctags directly against the file: its IMMEDIATE SIBLING in the same impl block, `debug_assert_done_reason_none` (line 960, same visibility/receiver shape, ordinary `&mut self`-only signature), IS correctly found as a ctags 'method'. done_decode alone is missing from ctags' output. Isolates the cause precisely to the destructuring-pattern parameter -- ctags' regex-based Rust parser appears to fail/skip the whole function when a parameter is a struct pattern rather than a plain identifier binding. GitGalaxy and tree-sitter both handle this fine (both agree on line 964). N=1 in this corpus, plausibly a real, narrow ctags parser gap (not GitGalaxy's) -- not chasing further given the tiny sample, noting rather than filing an issue since there's nothing in this repo to fix.
@@ -1471,7 +1460,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `rust` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 21 occurrences as of 2026-08-22T11:42:28Z*
+*3-way split -- 21 occurrences as of 2026-08-22T14:09:50Z*
 
 **Verdict** (by Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5, 2026-08-19T00:00:00Z):
 > Confirmed GitGalaxy engine defect, not a modeling disagreement -- tree-sitter is correct in all 8 sampled cases (and this generalizes to the full 21: every sampled name is a deserialize_*/spawn_*_caller-shaped signature carrying a rust lifetime annotation, the exact trigger). Root cause, independently confirmed via two methods (dispatched agent read the code path; a second grep pass confirmed the attribute is dead): `gitgalaxy/core/detector.py::StructuralExtractor._count_top_level_args` has a guard meant to exempt rust/scala lifetime marks (`'_`, `'static`) from its string-literal scanner -- `getattr(self, 'language', '') in ('rust', 'scala')` around line 3766 -- but the class stores the language as `self.primary_lang_id` (set at line 497), never `self.language`. `self.language` is referenced NOWHERE ELSE in the file, confirmed by grep. The getattr always silently falls back to `''`, so the exemption guard never fires for any language, ever -- every lifetime `'` gets treated as an unterminated string-literal opener, swallowing all subsequent top-level commas until a real closing quote or end-of-string, fusing 2+ parameters into 1. A signature with 3 lifetime marks (odd count) never exits string mode at all and undercounts every remaining parameter. Real signatures confirmed at source: bevy/bevy_ecs_world.rs:1106,1121,1270 (`MovingPtr<'_, B>` swallows the next comma, 3 vs real 4, or 2 vs real 3); serde/serde_core_de_mod.rs:1105,1115 (`&'static str` swallows the next comma, 2 vs real 3); serde_core_de_mod.rs:1136 (two lifetimes, both trailing commas swallowed, 2 vs real 4); serde_core_de_mod.rs:1152,1163 (three lifetime marks, odd count means string mode never exits, 2 vs real 4). ctags has null coverage for these specific occurrences because they're bodyless trait-method declarations (ending in `;` inside a `trait` block) -- unrelated to the args bug, ctags appears to skip signature-only declarations generally. Filed as its own GitHub issue (attribute-name mismatch, one-line fix: `self.language` -> `self.primary_lang_id`, or equivalent), separate from this ledger record.
@@ -1493,7 +1482,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scala` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 16 occurrences as of 2026-08-22T11:42:31Z*
+*3-way split -- 16 occurrences as of 2026-08-22T14:09:53Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scala/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1514,7 +1503,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `scheme` function existence: GitGalaxy agree, ctags differ
 
-*2-vs-1 -- 50 occurrences as of 2026-08-22T11:42:35Z*
+*2-vs-1 -- 50 occurrences as of 2026-08-22T14:09:57Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`scheme/function/existence/agree[gitgalaxy]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1533,7 +1522,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ✅ `scheme` function existence: ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 84 occurrences as of 2026-08-22T11:42:35Z*
+*2-vs-1 -- 84 occurrences as of 2026-08-22T14:09:57Z*
 
 **Verdict** (by gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5, 2026-08-20):
 > Confirmed real, catastrophic GitGalaxy engine defect, generalizes to the full 92 occurrences (and beyond -- this was a 100% recall drop for the whole language, not specific to the sampled cases). Root cause isolated to detector.py's StructuralExtractor._slice_by_braces (Integration Mode B): its scope-delimiter selection checked `lang_id == "lisp"` to choose parenthesis delimiters over the curly-brace default -- but "lisp" has never been a real key in LANGUAGE_DEFINITIONS (only "scheme" is), so that branch was unreachable dead code in production. Every real scheme file fell through to the curly-brace default; since scheme is entirely parenthesis-delimited, the downstream scope-body search never found an opener and silently discarded every func_start match. GitGalaxy's own func_start regex was never the problem -- confirmed matching correctly standalone (31/31 hits on one file) and prism.py's comment stripping confirmed clean (raw (define count unchanged pre/post-prism). Fixed: delimiter choice now keys off lexical_family ("recursive_block_lisp") instead of the dead lang_id string, verified directly against the gatherer (0 -> 58 real functions found; ctags finds 92, so a smaller residual recall gap remains for a future pass, tracked as a follow-on, not blocking this fix). Filed as GitHub issue #1928. A pre-existing unit test (test_detector_mode_b_lisp_family) had been passing for the wrong reason (its mock language was literally named "lisp", matching the dead string check by construction) -- corrected to use scheme's real lexical_family value so it now validates the actual production mechanism. Investigated via gemini-3.1-pro-high (agy): live-pipeline isolation with a monkey-patch before/after proof (0 -> 14 functions when lang_id coerced to match the old check), independently re-verified by Claude against the exact cited source lines before applying.
@@ -1555,7 +1544,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `shell` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:36Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:09:59Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`shell/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1567,7 +1556,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `solidity` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 6 occurrences as of 2026-08-22T11:42:38Z*
+*2-vs-1 -- 6 occurrences as of 2026-08-22T14:10:00Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`solidity/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1584,7 +1573,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:39Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:10:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1594,7 +1583,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:39Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:10:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1604,7 +1593,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `swift` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 1 occurrence as of 2026-08-22T11:42:39Z*
+*3-way split -- 1 occurrence as of 2026-08-22T14:10:02Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`swift/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1616,7 +1605,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 4 occurrences as of 2026-08-22T11:42:41Z*
+*2-vs-1 -- 4 occurrences as of 2026-08-22T14:10:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1629,7 +1618,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:42:41Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:10:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1640,7 +1629,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy, ctags agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:41Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:10:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[ctags,gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1650,7 +1639,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `tcl` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:42:41Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:10:03Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`tcl/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1662,7 +1651,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 1907 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 1907 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1681,7 +1670,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: GitGalaxy, tree-sitter agree, ctags differ
 
-*2-vs-1 -- 501 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 501 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[gitgalaxy,tree_sitter]_vs[ctags]`) in `tri_comparison_ledger.json`.
 
@@ -1700,7 +1689,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter agree, GitGalaxy, ctags differ
 
-*2-vs-1 -- 174 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 174 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1719,7 +1708,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 61 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 61 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1738,7 +1727,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: tree-sitter, ctags agree, GitGalaxy differ
 
-*2-vs-1 -- 9 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 9 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[ctags,tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1756,7 +1745,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` class existence: ctags agree, GitGalaxy, tree-sitter differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/class/existence/agree[ctags]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1767,7 +1756,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function existence: GitGalaxy agree, tree-sitter, ctags differ
 
-*2-vs-1 -- 2 occurrences as of 2026-08-22T11:43:02Z*
+*2-vs-1 -- 2 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/existence/agree[gitgalaxy]_vs[ctags,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1778,7 +1767,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `typescript` function args: none agree, GitGalaxy, tree-sitter differ
 
-*3-way split -- 4 occurrences as of 2026-08-22T11:43:02Z*
+*3-way split -- 4 occurrences as of 2026-08-22T14:10:24Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`typescript/function/args/agree[none]_vs[gitgalaxy,tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1793,7 +1782,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 10 occurrences as of 2026-08-22T11:43:10Z*
+*2-vs-1 -- 10 occurrences as of 2026-08-22T14:10:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 
@@ -1812,7 +1801,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` class existence: GitGalaxy agree, tree-sitter differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:43:10Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:10:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/class/existence/agree[gitgalaxy]_vs[tree_sitter]`) in `tri_comparison_ledger.json`.
 
@@ -1822,7 +1811,7 @@ Sorted 2-vs-1 splits before 3-way splits, unvalidated before validated, biggest 
 
 ### ❓ `zig` function existence: tree-sitter agree, GitGalaxy differ
 
-*2-vs-1 -- 1 occurrence as of 2026-08-22T11:43:10Z*
+*2-vs-1 -- 1 occurrence as of 2026-08-22T14:10:34Z*
 
 **Not yet investigated.** See `docs/self_scan/how_to_investigate_a_discrepancy.md` for the process -- read the source at a few examples below, then hand-edit this entry (`zig/function/existence/agree[tree_sitter]_vs[gitgalaxy]`) in `tri_comparison_ledger.json`.
 


### PR DESCRIPTION
## Summary
- PR #2111's chart/ledger regen ran with no real `universal-ctags` on PATH (Ubuntu's `arduino-ctags` package shadows the `ctags` binary name), so every language silently degraded to a 2-tool comparison instead of erroring — cobol lost its "G" full-precision badge (showed a nonsensical `0/168` precision), fortran lost its ctags bar, and ctags data vanished from every ctags-covered language in the chart.
- Regenerated for real with `ctags --version` confirmed as "Universal Ctags" on PATH, via `tests/tools/tri_comparison_chart.py --all --write` and `tests/tools/tri_comparison_report.py --write`. cobol now correctly shows `168` (up from `148`, reflecting the real #1892 recall improvement) against ctags' `241`, badge restored; fortran back to `138/138` ctags-matched. No validated `status`/`verdict` was touched — only `last_seen_count`/`still_reproduces` were recomputed from a live gather, which also self-corrected a second slip: the #1892 fix commit had hand-set `still_reproduces: false` on a cobol shape whose majority cause (ctags mistagging `END-IF.` as a paragraph) is permanent and still reproduces.
- Adds a full "Tri-Comparison Chart & Ledger" section to `ANTIGRAVITY.md` (Gemini/Antigravity had zero guidance on this system, which is how the regen shipped unnoticed) and a pointer from `CLAUDE.md`'s existing tri-comparison section — both now cite `docs/self_scan/tri_comparison_README.md` as the single canonical regen doc instead of duplicating the procedure.

## Test plan
- [x] Verified `ctags --version` printed "Universal Ctags" (not arduino-ctags) before regenerating
- [x] Confirmed cobol/fortran rows visually match their pre-#2111 validated state, with the #1892 recall improvement correctly reflected
- [x] Diffed the ledger programmatically: 0 `status` changes, 0 `verdict` text changes vs. the committed HEAD, only `last_seen_count`/`still_reproduces` recomputed
- [x] Confirmed no other tracked files changed besides the three tri-comparison docs and the two agent-instruction files

🤖 Generated with [Claude Code](https://claude.com/claude-code)