### PR TITLE
fix(testing): include optional_parameter_declaration for cpp parameter counting

### DIFF
--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -1435,6 +1435,7 @@ def _get_param_count(node: Any, lang: str = "") -> int:
             "object_pattern",
             "rest_pattern",
             "parameter_declaration",
+            "optional_parameter_declaration",
             "parameter",
             "formal_parameter",
             "required_parameter",

--- a/tests/tree_sitter_accuracy_baseline_cpp.json
+++ b/tests/tree_sitter_accuracy_baseline_cpp.json
@@ -1,6 +1,6 @@
 {
   "args_comparable": 1296,
-  "args_exact_match": 1220,
+  "args_exact_match": 1233,
   "corpus_path": "language-crucible/data/cpp",
   "extra_classes": 0,
   "extra_functions": 60,


### PR DESCRIPTION
Fixes #2014. Adds `optional_parameter_declaration` to the `counted_types` whitelist in the audit tool to properly count C++ parameters that have default values.