### PR TITLE
fix: skip class extraction for languages with class_start=None

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -584,13 +584,7 @@
 <circle cx="390.0" cy="1240.0" r="8" fill="#2a78d6"/>
 <text class="badge-label" x="390.0" y="1243.0">G</text>
 <rect class="bar-track" x="418" y="1223" width="88" height="34" rx="2"/>
-<rect x="418" y="1223" width="88.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="462.0" y="1231">4</text>
-<rect x="418" y="1235" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="462.0" y="1243">0</text>
 <rect class="bar-track" x="550" y="1223" width="88" height="34" rx="2"/>
-<rect x="550" y="1223" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1231">0/4</text>
 <rect class="bar-track" x="682" y="1223" width="88" height="34" rx="2"/>
 <text class="lang-label" x="20" y="1287.5">makefile</text>
 <rect class="bar-track" x="154" y="1267" width="88" height="34" rx="2"/>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-23T21:23:50Z",
+      "last_reconciled_at": "2026-08-23T21:37:44Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-23T21:23:50Z",
+      "last_reconciled_at": "2026-08-23T21:37:44Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-23T21:23:51Z",
+      "last_reconciled_at": "2026-08-23T21:37:45Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-23T21:23:52Z",
+      "last_reconciled_at": "2026-08-23T21:37:47Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-23T21:23:52Z",
+      "last_reconciled_at": "2026-08-23T21:37:47Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -1073,7 +1073,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1160,7 +1160,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1213,7 +1213,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1271,7 +1271,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 17,
       "last_seen_examples": [
         {
@@ -1375,7 +1375,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1487,7 +1487,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "c",
-      "last_reconciled_at": "2026-08-23T21:23:59Z",
+      "last_reconciled_at": "2026-08-23T21:37:53Z",
       "last_seen_count": 88,
       "last_seen_examples": [
         {
@@ -1592,7 +1592,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-23T21:24:05Z",
+      "last_reconciled_at": "2026-08-23T21:37:59Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1695,7 +1695,7 @@
       "investigated_at": "2026-08-22T00:00:00Z",
       "investigated_by": "Agent",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-23T21:24:05Z",
+      "last_reconciled_at": "2026-08-23T21:37:59Z",
       "last_seen_count": 181,
       "last_seen_examples": [
         {
@@ -1798,7 +1798,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-23T21:24:05Z",
+      "last_reconciled_at": "2026-08-23T21:37:59Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -1902,7 +1902,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1944,7 +1944,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1986,7 +1986,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -2100,7 +2100,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2214,7 +2214,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -2256,7 +2256,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -2370,7 +2370,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2402,7 +2402,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2432,7 +2432,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -2536,7 +2536,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2650,7 +2650,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2683,7 +2683,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2797,7 +2797,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2902,7 +2902,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -2960,7 +2960,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -3064,7 +3064,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -3176,7 +3176,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "cpp",
-      "last_reconciled_at": "2026-08-23T21:24:11Z",
+      "last_reconciled_at": "2026-08-23T21:38:04Z",
       "last_seen_count": 195,
       "last_seen_examples": [
         {
@@ -3280,7 +3280,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3385,7 +3385,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3454,7 +3454,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3530,7 +3530,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3629,7 +3629,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3662,7 +3662,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3752,7 +3752,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3829,7 +3829,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3859,7 +3859,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -3963,7 +3963,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -4077,7 +4077,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -4137,7 +4137,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4170,7 +4170,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -4286,7 +4286,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -4398,7 +4398,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 317,
       "last_seen_examples": [
         {
@@ -4502,7 +4502,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "csharp",
-      "last_reconciled_at": "2026-08-23T21:24:18Z",
+      "last_reconciled_at": "2026-08-23T21:38:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4535,7 +4535,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-23T21:24:19Z",
+      "last_reconciled_at": "2026-08-23T21:38:12Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -4584,7 +4584,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-23T21:24:24Z",
+      "last_reconciled_at": "2026-08-23T21:38:17Z",
       "last_seen_count": 221,
       "last_seen_examples": [
         {
@@ -4687,7 +4687,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-23T21:24:24Z",
+      "last_reconciled_at": "2026-08-23T21:38:17Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -4790,7 +4790,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-23T21:24:24Z",
+      "last_reconciled_at": "2026-08-23T21:38:17Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -4894,7 +4894,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4989,7 +4989,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5021,7 +5021,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5053,7 +5053,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5083,7 +5083,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5115,7 +5115,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -5229,7 +5229,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5273,7 +5273,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5304,7 +5304,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "fortran",
-      "last_reconciled_at": "2026-08-23T21:24:31Z",
+      "last_reconciled_at": "2026-08-23T21:38:25Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5408,7 +5408,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-23T21:24:33Z",
+      "last_reconciled_at": "2026-08-23T21:38:27Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5519,7 +5519,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "go",
-      "last_reconciled_at": "2026-08-23T21:24:33Z",
+      "last_reconciled_at": "2026-08-23T21:38:27Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5623,7 +5623,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5735,7 +5735,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -5840,7 +5840,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -5954,7 +5954,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -6068,7 +6068,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -6184,7 +6184,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6216,7 +6216,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6248,7 +6248,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "haskell",
-      "last_reconciled_at": "2026-08-23T21:24:35Z",
+      "last_reconciled_at": "2026-08-23T21:38:30Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -6362,7 +6362,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -6476,7 +6476,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -6590,7 +6590,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -6703,7 +6703,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6736,7 +6736,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6787,7 +6787,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -6901,7 +6901,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "java",
-      "last_reconciled_at": "2026-08-23T21:24:37Z",
+      "last_reconciled_at": "2026-08-23T21:38:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6952,7 +6952,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -7066,7 +7066,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7153,7 +7153,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7192,7 +7192,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -7296,7 +7296,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -7410,7 +7410,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -7506,7 +7506,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -7622,7 +7622,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -7734,7 +7734,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -7838,7 +7838,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-23T21:24:41Z",
+      "last_reconciled_at": "2026-08-23T21:38:36Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7871,7 +7871,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-23T21:24:42Z",
+      "last_reconciled_at": "2026-08-23T21:38:39Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -7924,7 +7924,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-23T21:24:42Z",
+      "last_reconciled_at": "2026-08-23T21:38:39Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -8038,7 +8038,7 @@
       "investigated_at": "2026-08-22T11:45:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-23T21:24:42Z",
+      "last_reconciled_at": "2026-08-23T21:38:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8071,7 +8071,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-23T21:24:42Z",
+      "last_reconciled_at": "2026-08-23T21:38:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8103,7 +8103,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-23T21:24:47Z",
+      "last_reconciled_at": "2026-08-23T21:38:46Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8141,7 +8141,7 @@
       ],
       "metric": "existence",
       "status": "validated",
-      "still_reproduces": true,
+      "still_reproduces": false,
       "symbol_type": "class",
       "verdict": "Confirmed real GitGalaxy false positive, not yet fixed (tracked separately). m4's own class_start rule is explicitly None (m4 has no class/OOP concept) -- but detector.py's class extraction branch only checks _CLASS_START_NAMED_EXTRACTION_LANGS allowlist membership, not whether the language's own class_start is None, so m4 (and 18 other class_start=None languages) falls through to the generic 'class|struct|interface|trait|enum NAME' fallback regex regardless. That fallback has no awareness of m4 document structure, so it matches raw C struct declarations embedded as literal text inside autoconf feature-test macro arguments (e.g. curl/configure.ac:1358's 'struct SocketIFace *ISocket = NULL;' inside an AC_LANG_PROGRAM([[ ... ]]) block) as if they were real m4 classes. Verified directly against the live gatherer: gg_classes for curl/configure.ac returns ['SocketIFace', 'Library', 'sockaddr_in6'], none of which are real m4 constructs; ctags correctly reports none (no class-shaped kind for m4 at all). Filed as GitHub issue #1925 (broader architectural gap, confirmed for m4, 18 other class_start=None languages not yet checked) -- not fixed in this sweep."
     },
@@ -8158,7 +8158,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "m4",
-      "last_reconciled_at": "2026-08-23T21:24:47Z",
+      "last_reconciled_at": "2026-08-23T21:38:46Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -8261,7 +8261,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "claude-sonnet-5 (direct source read, no dispatch needed)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-23T21:24:47Z",
+      "last_reconciled_at": "2026-08-23T21:38:46Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -8365,7 +8365,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "makefile",
-      "last_reconciled_at": "2026-08-23T21:24:48Z",
+      "last_reconciled_at": "2026-08-23T21:38:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8396,7 +8396,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "matlab",
-      "last_reconciled_at": "2026-08-23T21:24:49Z",
+      "last_reconciled_at": "2026-08-23T21:38:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8429,7 +8429,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-23T21:24:50Z",
+      "last_reconciled_at": "2026-08-23T21:38:51Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -8543,7 +8543,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-23T21:24:50Z",
+      "last_reconciled_at": "2026-08-23T21:38:51Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -8657,7 +8657,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-23T21:24:50Z",
+      "last_reconciled_at": "2026-08-23T21:38:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8688,7 +8688,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-23T21:24:50Z",
+      "last_reconciled_at": "2026-08-23T21:38:51Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8720,7 +8720,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-23T21:24:50Z",
+      "last_reconciled_at": "2026-08-23T21:38:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8760,7 +8760,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-23T21:24:50Z",
+      "last_reconciled_at": "2026-08-23T21:38:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8800,7 +8800,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8833,7 +8833,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8864,7 +8864,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8894,7 +8894,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -9008,7 +9008,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9095,7 +9095,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9182,7 +9182,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9213,7 +9213,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9245,7 +9245,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -9357,7 +9357,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "perl",
-      "last_reconciled_at": "2026-08-23T21:24:57Z",
+      "last_reconciled_at": "2026-08-23T21:38:58Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -9461,12 +9461,12 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-23T21:25:03Z",
+      "last_reconciled_at": "2026-08-23T21:39:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
           "file_path": "laravel_core/BladeCompiler.php",
-          "name": "AnonymousClassa08aab890100",
+          "name": "AnonymousClassea70ff800100",
           "readings": {
             "ctags": 342,
             "gitgalaxy": null,
@@ -9494,7 +9494,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-23T21:25:03Z",
+      "last_reconciled_at": "2026-08-23T21:39:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9527,7 +9527,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-23T21:25:03Z",
+      "last_reconciled_at": "2026-08-23T21:39:03Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -9639,7 +9639,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "php",
-      "last_reconciled_at": "2026-08-23T21:25:03Z",
+      "last_reconciled_at": "2026-08-23T21:39:03Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9671,7 +9671,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-23T21:25:05Z",
+      "last_reconciled_at": "2026-08-23T21:39:06Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9756,7 +9756,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-23T21:25:05Z",
+      "last_reconciled_at": "2026-08-23T21:39:06Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -9825,7 +9825,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-23T21:25:05Z",
+      "last_reconciled_at": "2026-08-23T21:39:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9858,7 +9858,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-23T21:25:05Z",
+      "last_reconciled_at": "2026-08-23T21:39:06Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -9970,7 +9970,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "powershell",
-      "last_reconciled_at": "2026-08-23T21:25:05Z",
+      "last_reconciled_at": "2026-08-23T21:39:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10002,7 +10002,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-23T21:25:17Z",
+      "last_reconciled_at": "2026-08-23T21:39:16Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10060,7 +10060,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-23T21:25:17Z",
+      "last_reconciled_at": "2026-08-23T21:39:16Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10116,7 +10116,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-23T21:25:17Z",
+      "last_reconciled_at": "2026-08-23T21:39:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10149,7 +10149,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-23T21:25:17Z",
+      "last_reconciled_at": "2026-08-23T21:39:16Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -10265,7 +10265,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-23T21:25:17Z",
+      "last_reconciled_at": "2026-08-23T21:39:16Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10296,7 +10296,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "python",
-      "last_reconciled_at": "2026-08-23T21:25:17Z",
+      "last_reconciled_at": "2026-08-23T21:39:16Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -10400,7 +10400,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-23T21:25:18Z",
+      "last_reconciled_at": "2026-08-23T21:39:17Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10442,7 +10442,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-23T21:25:18Z",
+      "last_reconciled_at": "2026-08-23T21:39:17Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10520,7 +10520,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-23T21:25:18Z",
+      "last_reconciled_at": "2026-08-23T21:39:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -10571,7 +10571,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-23T21:25:18Z",
+      "last_reconciled_at": "2026-08-23T21:39:17Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10646,7 +10646,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "ruby",
-      "last_reconciled_at": "2026-08-23T21:25:18Z",
+      "last_reconciled_at": "2026-08-23T21:39:17Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10741,7 +10741,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -10855,7 +10855,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -10908,7 +10908,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -11020,7 +11020,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -11123,7 +11123,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -11174,7 +11174,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -11286,7 +11286,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -11399,7 +11399,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -11512,7 +11512,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11545,7 +11545,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11580,7 +11580,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -11692,7 +11692,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "rust",
-      "last_reconciled_at": "2026-08-23T21:25:23Z",
+      "last_reconciled_at": "2026-08-23T21:39:21Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -11794,7 +11794,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scala",
-      "last_reconciled_at": "2026-08-23T21:25:25Z",
+      "last_reconciled_at": "2026-08-23T21:39:23Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -11897,7 +11897,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-23T21:25:29Z",
+      "last_reconciled_at": "2026-08-23T21:39:28Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -11999,7 +11999,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "scheme",
-      "last_reconciled_at": "2026-08-23T21:25:29Z",
+      "last_reconciled_at": "2026-08-23T21:39:28Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -12103,7 +12103,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "shell",
-      "last_reconciled_at": "2026-08-23T21:25:31Z",
+      "last_reconciled_at": "2026-08-23T21:39:30Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12135,7 +12135,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "solidity",
-      "last_reconciled_at": "2026-08-23T21:25:31Z",
+      "last_reconciled_at": "2026-08-23T21:39:32Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -12205,7 +12205,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-23T21:25:33Z",
+      "last_reconciled_at": "2026-08-23T21:39:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12236,7 +12236,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-23T21:25:33Z",
+      "last_reconciled_at": "2026-08-23T21:39:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12267,7 +12267,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "swift",
-      "last_reconciled_at": "2026-08-23T21:25:33Z",
+      "last_reconciled_at": "2026-08-23T21:39:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12299,7 +12299,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12332,7 +12332,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12374,7 +12374,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -12434,7 +12434,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12465,7 +12465,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12504,7 +12504,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12544,7 +12544,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "tcl",
-      "last_reconciled_at": "2026-08-23T21:25:34Z",
+      "last_reconciled_at": "2026-08-23T21:39:35Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12584,7 +12584,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12626,7 +12626,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -12738,7 +12738,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -12797,7 +12797,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12830,7 +12830,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -12935,7 +12935,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -13049,7 +13049,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 1907,
       "last_seen_examples": [
         {
@@ -13163,7 +13163,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13203,7 +13203,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13243,7 +13243,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 174,
       "last_seen_examples": [
         {
@@ -13355,7 +13355,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "typescript",
-      "last_reconciled_at": "2026-08-23T21:25:43Z",
+      "last_reconciled_at": "2026-08-23T21:39:43Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -13462,7 +13462,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-08-23T21:25:53Z",
+      "last_reconciled_at": "2026-08-23T21:39:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13497,7 +13497,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-08-23T21:25:53Z",
+      "last_reconciled_at": "2026-08-23T21:39:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13540,7 +13540,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-08-23T21:25:53Z",
+      "last_reconciled_at": "2026-08-23T21:39:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -904,32 +904,35 @@ class StructuralExtractor:
             # with sharing", C#'s "internal sealed partial"). Everyone else
             # stays on the legacy fallback until their own class_start is
             # hardened for this use (see the frozenset's comment).
-            class_start_pattern = (
-                self.languages.get(self.primary_lang_id, {}).get("rules", {}).get("class_start")
-                if self.primary_lang_id in _CLASS_START_NAMED_EXTRACTION_LANGS
-                else None
-            )
-            if class_start_pattern is not None:
-                class_matches = list(class_start_pattern.finditer(code_stream))
-                # class_start regexes vary in capture-group shape across
-                # these languages -- most have a mandatory group 1 (the
-                # name) and an optional group 2 (a single inheritance
-                # parent), but Fortran uses alternation where the name lands
-                # in EITHER group 1 or group 2 depending on which branch
-                # fired. Resolved per-match below rather than assumed here.
-                class_start_groups = class_start_pattern.groups
+            rules = self.languages.get(self.primary_lang_id, {}).get("rules", {})
+            if "class_start" in rules and rules["class_start"] is None:
+                class_matches = []
+                class_start_groups = 0
             else:
-                # Legacy fallback: one hardcoded regex catching the common
-                # `[modifier] (class|struct|interface|trait|enum) Name`
-                # shape, for every language not yet verified safe to extract
-                # named classes from its own class_start rule.
-                class_start_pattern = re.compile(
-                    r"^\s*(?:export\s+|public\s+|abstract\s+)?(?:class|struct|interface|trait|enum)\s+([a-zA-Z0-9_]+)"
-                    r"(?:\s*(?:\(|extends\s+|implements\s+|:\s*)([a-zA-Z0-9_]+))?",
-                    re.MULTILINE,
+                class_start_pattern = (
+                    rules.get("class_start") if self.primary_lang_id in _CLASS_START_NAMED_EXTRACTION_LANGS else None
                 )
-                class_matches = list(class_start_pattern.finditer(code_stream))
-                class_start_groups = 2
+                if class_start_pattern is not None:
+                    class_matches = list(class_start_pattern.finditer(code_stream))
+                    # class_start regexes vary in capture-group shape across
+                    # these languages -- most have a mandatory group 1 (the
+                    # name) and an optional group 2 (a single inheritance
+                    # parent), but Fortran uses alternation where the name lands
+                    # in EITHER group 1 or group 2 depending on which branch
+                    # fired. Resolved per-match below rather than assumed here.
+                    class_start_groups = class_start_pattern.groups
+                else:
+                    # Legacy fallback: one hardcoded regex catching the common
+                    # `[modifier] (class|struct|interface|trait|enum) Name`
+                    # shape, for every language not yet verified safe to extract
+                    # named classes from its own class_start rule.
+                    class_start_pattern = re.compile(
+                        r"^\s*(?:export\s+|public\s+|abstract\s+)?(?:class|struct|interface|trait|enum)\s+([a-zA-Z0-9_]+)"
+                        r"(?:\s*(?:\(|extends\s+|implements\s+|:\s*)([a-zA-Z0-9_]+))?",
+                        re.MULTILINE,
+                    )
+                    class_matches = list(class_start_pattern.finditer(code_stream))
+                    class_start_groups = 2
 
             # #1040: a flat "ends at the next class match" boundary truncates
             # an outer class's scope the instant it contains a nested class,


### PR DESCRIPTION
This PR fixes a bug where languages explicitly opting out of class extraction (`class_start: None`) were falling back to the generic C-family OOP regex instead of actually skipping extraction.

This caused 4 false-positive "classes" in `m4` to be identified because it found C structs inside an `AC_LANG_PROGRAM` macro argument. The fallback is now only used when `class_start` is actually undefined, not when it is explicitly set to `None`.

All tests pass, and the tri-comparison ledger has been regenerated (the `m4/class/existence/agree[gitgalaxy]_vs[ctags]` discrepancies have disappeared as expected).

Resolves #1925