### PR TITLE
docs: auto-update LLM architectural brief

### DIFF
--- a/docs/gitgalaxy_architecture_brief.md
+++ b/docs/gitgalaxy_architecture_brief.md
@@ -6,10 +6,10 @@
 |---|---|
 | **Engine** | `GitGalaxy Scope vlatest (Delta Mode)` |
 | **Target Path** | `/home/runner/work/gitgalaxy/gitgalaxy` |
-| **Timestamp** | `2026-08-26T14:01:04.562676+00:00` |
-| **Scan Duration** | `10.07s` |
+| **Timestamp** | `2026-08-26T14:04:17.865473+00:00` |
+| **Scan Duration** | `9.58s` |
 | **Git Branch** | `main` |
-| **Git Commit** | `d914281e6e202de68cf8803b6f86add360b9fb63` |
+| **Git Commit** | `fcef65692934ba85812d31b3d29cecd747077625` |
 | **Git Remote** | `https://github.com/squid-protocol/gitgalaxy` |
 | **Zero-Dependency Mode** | `Inactive (Full Precision)` |
 


### PR DESCRIPTION
Automated update from the latest GalaxyScope scan on `main`.