### PR TITLE
chore: regenerate typescript tree-sitter accuracy baseline (post #2303)

### DIFF
--- a/gitgalaxy/standards/language_standards.py
+++ b/gitgalaxy/standards/language_standards.py
@@ -63,7 +63,7 @@ for the same metrics tracked over time across pushes to main.
 | Solidity | 100.0% | 94.3% | 100.0% | 100.0% |
 | Swift | 100.0% | 99.2% | 100.0% | 100.0% |
 | Tcl | 98.6% | 99.3% | N/A | N/A |
-| Typescript | 99.6% | 99.9% | 100.0% | 100.0% |
+| Typescript | 99.9% | 100.0% | 100.0% | 100.0% |
 | Zig | 100.0% | 100.0% | 100.0% | 100.0% |
 <!-- TREE_SITTER_ACCURACY_TABLE:END -->
 """

--- a/tests/tree_sitter_accuracy_baseline_typescript.json
+++ b/tests/tree_sitter_accuracy_baseline_typescript.json
@@ -1,12 +1,12 @@
 {
-  "args_comparable": 2902,
-  "args_exact_match": 2870,
+  "args_comparable": 2912,
+  "args_exact_match": 2879,
   "corpus_path": "language-crucible/data/typescript",
   "extra_classes": 0,
-  "extra_functions": 3,
+  "extra_functions": 1,
   "files_scanned": 23,
   "found_classes": 842,
-  "found_functions": 2902,
+  "found_functions": 2912,
   "real_classes": 842,
-  "real_functions": 2913
+  "real_functions": 2915
 }


### PR DESCRIPTION
## Summary
Follow-up to #2303, which merged before this baseline-regen commit landed (no required status checks on this repo means auto-merge doesn't wait for every check to finish, and `tree-sitter-accuracy-audit` isn't in the required list) -- main currently has the `abstract_method_signature` NODE_MAPS fix without its corresponding baseline update, which would fail `tree-sitter-accuracy-audit` on the next PR touching a related path. This closes that gap.

## Changes
- `tests/tree_sitter_accuracy_baseline_typescript.json` -- regenerated via `--regenerate`, which refuses to write if any metric regressed (it didn't; every changed metric improved): `extra_functions` 3->1 (the 2 false positives #2303 fixed; the remaining 1, `catch` in vscode/async.ts, is a separate, already-known, unrelated shape), `found_functions`/`args_exact_match` both up, `real_functions` 2913->2915 (tree-sitter now sees the 2 abstract method signatures it was blind to before).
- `gitgalaxy/standards/language_standards.py` -- summary table refreshed to match (auto-generated by the same `--regenerate` run, verified via `--summary-table`).

## Verification
- `python tests/tools/tree_sitter_accuracy_audit.py --lang typescript --ci` -- passes against current main.
- `python tests/tools/tree_sitter_accuracy_audit.py --summary-table` -- confirms no further diff.
- `tests/ruff_audit.py --ci` / `tests/mypy_audit.py --ci` -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)