### PR TITLE
fix(perl): correct misdiagnosed tri-comparison ledger entry crediting tree-sitter

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -685,12 +685,12 @@
 <rect class="bar-track" x="286" y="1399" width="88" height="34" rx="2"/>
 <rect x="286" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1407">941/941</text>
-<rect x="286" y="1411" width="88.0" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1419">1063/1063</text>
+<rect x="286" y="1411" width="77.9" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1419">941/1063</text>
 <rect x="286" y="1423" width="87.3" height="10" rx="2" fill="#1baf7a"/>
 <text class="bar-value-label" x="330.0" y="1431">934/941</text>
-<circle cx="390.0" cy="1416.0" r="8" fill="#eb6834"/>
-<text class="badge-label" x="390.0" y="1419.0">T</text>
+<circle cx="390.0" cy="1416.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1419.0">G</text>
 <rect class="bar-track" x="418" y="1399" width="88" height="34" rx="2"/>
 <rect x="418" y="1399" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1407">21</text>
@@ -1120,10 +1120,10 @@
 <text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 63 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 25 (40%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 26 (41%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
-<text class="legend-label" x="228.8" y="2188">tree-sitter best: 3 (5%)</text>
+<text class="legend-label" x="228.8" y="2188">tree-sitter best: 2 (3%)</text>
 <circle cx="408.6" cy="2184" r="7" fill="#1baf7a"/>
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-26T22:24:53Z",
+      "last_reconciled_at": "2026-08-26T23:56:34Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-08-26T22:24:53Z",
+      "last_reconciled_at": "2026-08-26T23:56:34Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-08-26T22:24:55Z",
+      "last_reconciled_at": "2026-08-26T23:56:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-26T22:24:56Z",
+      "last_reconciled_at": "2026-08-26T23:56:37Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -363,7 +363,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-08-26T22:24:56Z",
+      "last_reconciled_at": "2026-08-26T23:56:37Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -443,7 +443,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -557,7 +557,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -662,7 +662,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -776,7 +776,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -809,7 +809,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -842,7 +842,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -959,7 +959,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1010,7 +1010,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1097,7 +1097,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1150,7 +1150,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1209,7 +1209,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 17,
       "last_seen_examples": [
         {
@@ -1313,7 +1313,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1426,7 +1426,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-08-26T22:25:01Z",
+      "last_reconciled_at": "2026-08-26T23:56:42Z",
       "last_seen_count": 88,
       "last_seen_examples": [
         {
@@ -1531,7 +1531,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-26T22:25:06Z",
+      "last_reconciled_at": "2026-08-26T23:56:47Z",
       "last_seen_count": 19,
       "last_seen_examples": [
         {
@@ -1634,7 +1634,7 @@
       "investigated_at": "2026-08-22T00:00:00Z",
       "investigated_by": "Agent",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-26T22:25:06Z",
+      "last_reconciled_at": "2026-08-26T23:56:47Z",
       "last_seen_count": 181,
       "last_seen_examples": [
         {
@@ -1737,7 +1737,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-08-26T22:25:06Z",
+      "last_reconciled_at": "2026-08-26T23:56:47Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -1841,7 +1841,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1883,7 +1883,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1925,7 +1925,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -2039,7 +2039,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2153,7 +2153,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -2195,7 +2195,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -2309,7 +2309,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2341,7 +2341,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2372,7 +2372,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -2476,7 +2476,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 60,
       "last_seen_examples": [
         {
@@ -2590,7 +2590,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2623,7 +2623,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2737,7 +2737,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -2842,7 +2842,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -2955,7 +2955,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -3059,7 +3059,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -3172,7 +3172,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-08-26T22:25:11Z",
+      "last_reconciled_at": "2026-08-26T23:56:52Z",
       "last_seen_count": 195,
       "last_seen_examples": [
         {
@@ -3276,7 +3276,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3381,7 +3381,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3450,7 +3450,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3527,7 +3527,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3626,7 +3626,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3659,7 +3659,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3749,7 +3749,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3826,7 +3826,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3859,7 +3859,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -3963,7 +3963,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -4077,7 +4077,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -4137,7 +4137,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4170,7 +4170,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -4286,7 +4286,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -4399,7 +4399,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 317,
       "last_seen_examples": [
         {
@@ -4503,7 +4503,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-08-26T22:25:17Z",
+      "last_reconciled_at": "2026-08-26T23:56:58Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4536,7 +4536,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-08-26T22:25:18Z",
+      "last_reconciled_at": "2026-08-26T23:56:59Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -4585,7 +4585,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-26T22:25:22Z",
+      "last_reconciled_at": "2026-08-26T23:57:03Z",
       "last_seen_count": 221,
       "last_seen_examples": [
         {
@@ -4688,7 +4688,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-26T22:25:22Z",
+      "last_reconciled_at": "2026-08-26T23:57:03Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -4791,7 +4791,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-08-26T22:25:22Z",
+      "last_reconciled_at": "2026-08-26T23:57:03Z",
       "last_seen_count": 10,
       "last_seen_examples": [
         {
@@ -4895,7 +4895,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -4996,7 +4996,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5028,7 +5028,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5060,7 +5060,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5091,7 +5091,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5123,7 +5123,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -5237,7 +5237,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5281,7 +5281,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5313,7 +5313,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-08-26T22:25:28Z",
+      "last_reconciled_at": "2026-08-26T23:57:09Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5422,7 +5422,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "go",
-      "last_reconciled_at": "2026-08-26T22:25:30Z",
+      "last_reconciled_at": "2026-08-26T23:57:11Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5534,7 +5534,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "go",
-      "last_reconciled_at": "2026-08-26T22:25:30Z",
+      "last_reconciled_at": "2026-08-26T23:57:11Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5638,7 +5638,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5750,7 +5750,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -5855,7 +5855,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 38,
       "last_seen_examples": [
         {
@@ -5969,7 +5969,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 103,
       "last_seen_examples": [
         {
@@ -6083,7 +6083,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -6199,7 +6199,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6231,7 +6231,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6263,7 +6263,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-08-26T22:25:33Z",
+      "last_reconciled_at": "2026-08-26T23:57:14Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -6377,7 +6377,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -6491,7 +6491,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -6605,7 +6605,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -6718,7 +6718,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6751,7 +6751,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6802,7 +6802,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -6916,7 +6916,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-08-26T22:25:36Z",
+      "last_reconciled_at": "2026-08-26T23:57:17Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -6967,7 +6967,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -7081,7 +7081,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7168,7 +7168,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7208,7 +7208,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -7312,7 +7312,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -7426,7 +7426,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -7504,7 +7504,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -7620,7 +7620,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 189,
       "last_seen_examples": [
         {
@@ -7733,7 +7733,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -7837,7 +7837,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-08-26T22:25:39Z",
+      "last_reconciled_at": "2026-08-26T23:57:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7870,7 +7870,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-26T22:25:41Z",
+      "last_reconciled_at": "2026-08-26T23:57:22Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -7923,7 +7923,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-26T22:25:41Z",
+      "last_reconciled_at": "2026-08-26T23:57:22Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -8037,7 +8037,7 @@
       "investigated_at": "2026-08-22T11:45:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-26T22:25:41Z",
+      "last_reconciled_at": "2026-08-26T23:57:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8070,7 +8070,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-08-26T22:25:41Z",
+      "last_reconciled_at": "2026-08-26T23:57:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8104,7 +8104,7 @@
       "investigated_at": "2026-08-24T03:52:19Z",
       "investigated_by": "Antigravity (direct source read)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-26T22:25:47Z",
+      "last_reconciled_at": "2026-08-26T23:57:28Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -8161,7 +8161,7 @@
       "investigated_at": "2026-08-24T03:52:19Z",
       "investigated_by": "Antigravity (direct source read)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-26T22:25:47Z",
+      "last_reconciled_at": "2026-08-26T23:57:28Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -8266,7 +8266,7 @@
       "investigated_at": "2026-08-24T03:52:19Z",
       "investigated_by": "Antigravity (direct source read)",
       "language": "m4",
-      "last_reconciled_at": "2026-08-26T22:25:47Z",
+      "last_reconciled_at": "2026-08-26T23:57:28Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -8370,7 +8370,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "makefile",
-      "last_reconciled_at": "2026-08-26T22:25:48Z",
+      "last_reconciled_at": "2026-08-26T23:57:29Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8405,7 +8405,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "matlab",
-      "last_reconciled_at": "2026-08-26T22:25:50Z",
+      "last_reconciled_at": "2026-08-26T23:57:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8438,7 +8438,7 @@
       "investigated_at": "2026-08-25T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8482,7 +8482,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 89,
       "last_seen_examples": [
         {
@@ -8596,7 +8596,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -8712,7 +8712,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8744,7 +8744,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8778,7 +8778,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8819,7 +8819,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "objective-c",
-      "last_reconciled_at": "2026-08-26T22:25:51Z",
+      "last_reconciled_at": "2026-08-26T23:57:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -8859,7 +8859,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8892,7 +8892,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8924,7 +8924,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8954,7 +8954,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -9068,7 +9068,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9155,7 +9155,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9244,7 +9244,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9278,7 +9278,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9300,19 +9300,17 @@
       "agreeing_tools": [
         "tree_sitter"
       ],
-      "credit_tools": [
-        "tree_sitter"
-      ],
+      "credit_tools": [],
       "debit_tools": [],
       "dissenting_tools": [
         "ctags",
         "gitgalaxy"
       ],
       "first_seen_at": "2026-08-18T22:44:39Z",
-      "investigated_at": "2026-08-24T04:14:26Z",
-      "investigated_by": "Antigravity (direct sweep)",
+      "investigated_at": "2026-08-26T00:00:00Z",
+      "investigated_by": "Claude (Sonnet 5), direct investigation correcting a prior misdiagnosis",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -9410,7 +9408,7 @@
       "status": "validated",
       "still_reproduces": true,
       "symbol_type": "function",
-      "verdict": "GitGalaxy misses subroutines with prototypes or signatures."
+      "verdict": "Prior verdict (\"GitGalaxy misses subroutines with prototypes or signatures\", investigated_at 2026-08-24 by Antigravity) was a misdiagnosis, disproven by direct re-verification: ran both a raw galaxyscope scan of the real corpus file and the actual tri_comparison_gatherer.py pipeline against exiftool/ExifTool.pm. For all 10 sampled names (ParseArguments, ReadValue, WindowsLongPath, Open, EncodeFileName, DecodeBits, Filter, SplitFileName, Exists, IsDirectory), GitGalaxy and ctags EACH report exactly 1 occurrence, at the real body-bearing definition line, identical to each other in every case (e.g. Filter at ExifTool.pm:6483). GitGalaxy is not missing these subs at all. tree_sitter reports 2 occurrences for every one of them: the same real definition, PLUS a bodyless forward declaration a few hundred lines earlier (e.g. \"sub Filter($$$);\" at ExifTool.pm:97) -- the exact same tree-sitter grammar defect already root-caused and closed as #1608 (\"tree-sitter ground truth: perl bodyless forward declarations counted as real functions GitGalaxy correctly ignores\"), which the stale 2-tool sibling shape (perl/function/existence/agree[tree_sitter]_vs[gitgalaxy], still_reproduces: false) already documented correctly. This 3-tool shape exists only because tri_comparison_reconcile.py pairs same-named occurrences by RANK (1st-with-1st, 2nd-with-2nd): tree_sitter's phantom forward-declaration entry sorts first (lower line number) for every one of these names, so GitGalaxy/ctags' single real occurrence gets rank-paired against tree_sitter's phantom rank-1 entry instead of its real rank-2 one -- leaving tree_sitter's (correct, real) rank-2 occurrence looking unpaired and \"tree_sitter-only.\" No credit: tree_sitter's rank-2 reading is a real, correct claim, but crediting it here would incorrectly imply ctags/GitGalaxy have a confirmed limitation causing them to miss it -- they do not, they report the identical occurrence, just paired to a different (phantom) tree_sitter slot by the rank algorithm. No debit either: tree_sitter's claim at this rank is not itself wrong, only mis-paired by an artifact of its OWN separate, already-tracked #1608 bug elsewhere in the same file. Net: this shape should not move any tool's precision score in either direction."
     },
     "perl/function/existence/agree[tree_sitter]_vs[gitgalaxy]": {
       "agreeing_tools": [
@@ -9425,7 +9423,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-08-26T22:25:57Z",
+      "last_reconciled_at": "2026-08-26T23:57:38Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -9529,7 +9527,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "php",
-      "last_reconciled_at": "2026-08-26T22:26:02Z",
+      "last_reconciled_at": "2026-08-26T23:57:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9562,7 +9560,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "php",
-      "last_reconciled_at": "2026-08-26T22:26:02Z",
+      "last_reconciled_at": "2026-08-26T23:57:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9595,7 +9593,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "php",
-      "last_reconciled_at": "2026-08-26T22:26:02Z",
+      "last_reconciled_at": "2026-08-26T23:57:43Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -9708,7 +9706,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "php",
-      "last_reconciled_at": "2026-08-26T22:26:02Z",
+      "last_reconciled_at": "2026-08-26T23:57:43Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9740,7 +9738,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-08-26T22:26:04Z",
+      "last_reconciled_at": "2026-08-26T23:57:45Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -9825,7 +9823,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-08-26T22:26:04Z",
+      "last_reconciled_at": "2026-08-26T23:57:45Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -9894,7 +9892,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-08-26T22:26:04Z",
+      "last_reconciled_at": "2026-08-26T23:57:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9927,7 +9925,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-08-26T22:26:04Z",
+      "last_reconciled_at": "2026-08-26T23:57:45Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -10040,7 +10038,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "powershell",
-      "last_reconciled_at": "2026-08-26T22:26:04Z",
+      "last_reconciled_at": "2026-08-26T23:57:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10072,7 +10070,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10131,7 +10129,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -10187,7 +10185,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10220,7 +10218,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -10336,7 +10334,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -10405,7 +10403,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -10473,7 +10471,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "python",
-      "last_reconciled_at": "2026-08-26T22:26:13Z",
+      "last_reconciled_at": "2026-08-26T23:57:54Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -10579,7 +10577,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-08-26T22:26:15Z",
+      "last_reconciled_at": "2026-08-26T23:57:56Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10621,7 +10619,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-08-26T22:26:15Z",
+      "last_reconciled_at": "2026-08-26T23:57:56Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10699,7 +10697,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-08-26T22:26:15Z",
+      "last_reconciled_at": "2026-08-26T23:57:56Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -10750,7 +10748,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-08-26T22:26:15Z",
+      "last_reconciled_at": "2026-08-26T23:57:56Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -10828,7 +10826,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "ruby",
-      "last_reconciled_at": "2026-08-26T22:26:15Z",
+      "last_reconciled_at": "2026-08-26T23:57:56Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -10924,7 +10922,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -11038,7 +11036,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -11091,7 +11089,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -11204,7 +11202,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -11310,7 +11308,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -11361,7 +11359,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -11473,7 +11471,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -11587,7 +11585,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -11701,7 +11699,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11734,7 +11732,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11769,7 +11767,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -11882,7 +11880,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-08-26T22:26:19Z",
+      "last_reconciled_at": "2026-08-26T23:58:00Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -11988,7 +11986,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "scala",
-      "last_reconciled_at": "2026-08-26T22:26:21Z",
+      "last_reconciled_at": "2026-08-26T23:58:02Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -12091,7 +12089,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-26T22:26:25Z",
+      "last_reconciled_at": "2026-08-26T23:58:06Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -12198,7 +12196,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "scheme",
-      "last_reconciled_at": "2026-08-26T22:26:25Z",
+      "last_reconciled_at": "2026-08-26T23:58:06Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -12302,7 +12300,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "shell",
-      "last_reconciled_at": "2026-08-26T22:26:26Z",
+      "last_reconciled_at": "2026-08-26T23:58:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12338,7 +12336,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "solidity",
-      "last_reconciled_at": "2026-08-26T22:26:28Z",
+      "last_reconciled_at": "2026-08-26T23:58:09Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -12408,7 +12406,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "swift",
-      "last_reconciled_at": "2026-08-26T22:26:29Z",
+      "last_reconciled_at": "2026-08-26T23:58:10Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12449,7 +12447,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "swift",
-      "last_reconciled_at": "2026-08-26T22:26:29Z",
+      "last_reconciled_at": "2026-08-26T23:58:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12482,7 +12480,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "swift",
-      "last_reconciled_at": "2026-08-26T22:26:29Z",
+      "last_reconciled_at": "2026-08-26T23:58:10Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12514,7 +12512,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12552,7 +12550,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12594,7 +12592,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -12656,7 +12654,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12688,7 +12686,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12732,7 +12730,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12777,7 +12775,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-08-26T22:26:31Z",
+      "last_reconciled_at": "2026-08-26T23:58:12Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12817,7 +12815,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -12859,7 +12857,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -12971,7 +12969,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -13031,7 +13029,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13064,7 +13062,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -13151,7 +13149,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -13265,7 +13263,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 2080,
       "last_seen_examples": [
         {
@@ -13381,7 +13379,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13422,7 +13420,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13464,7 +13462,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -13516,7 +13514,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-08-26T22:26:37Z",
+      "last_reconciled_at": "2026-08-26T23:58:18Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -13623,7 +13621,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-08-26T22:26:45Z",
+      "last_reconciled_at": "2026-08-26T23:58:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13658,7 +13656,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-08-26T22:26:45Z",
+      "last_reconciled_at": "2026-08-26T23:58:26Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -13701,7 +13699,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-08-26T22:26:45Z",
+      "last_reconciled_at": "2026-08-26T23:58:26Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {


### PR DESCRIPTION
## Summary

`perl/function/existence/agree[tree_sitter]_vs[ctags,gitgalaxy]` (122 occurrences) was
credited to tree_sitter with the verdict "GitGalaxy misses subroutines with prototypes or
signatures" (Antigravity, 2026-08-24). That's a misdiagnosis -- it's what was dragging perl's
Func Precision badge onto tree-sitter and making perl look worse than GitGalaxy vs.
tree-sitter, when it isn't.

Direct re-verification (a raw `galaxyscope` scan of the real corpus file, plus running the
actual `tri_comparison_gatherer.py` pipeline against `exiftool/ExifTool.pm`) shows:
- **GitGalaxy and ctags** each report exactly 1 occurrence for every sampled name
  (`ParseArguments`, `ReadValue`, `Filter`, `DecodeBits`, etc.), at the real, body-bearing
  definition line, identical to each other in every case.
- **tree_sitter** reports 2 occurrences for each: the same real definition, plus a bodyless
  forward declaration a few hundred lines earlier (e.g. `sub Filter($$$);`) -- the same grammar
  defect already root-caused and closed as #1608.

The shape only exists because `tri_comparison_reconcile.py` pairs same-named occurrences by
rank (1st-with-1st, 2nd-with-2nd): tree_sitter's phantom forward-declaration entry sorts first
by line number, so GitGalaxy/ctags' single real occurrence gets rank-paired against
tree_sitter's *phantom* rank-1 entry instead of its real one -- stranding tree_sitter's real
occurrence as apparently "tree_sitter-only." GitGalaxy isn't missing anything here.

## Changes
- `docs/self_scan/tri_comparison_ledger.json` -- corrected the one entry (`credit_tools`
  cleared, verdict + investigation metadata replaced with the re-verified finding). Everything
  else in the diff is the routine `last_reconciled_at` timestamp refresh from a required
  `--all --write` regen (no other shape's status/verdict/credit changed).
- `docs/self_scan/tri_comparison_chart.svg` -- regenerated. Perl's Func Precision badge flips
  from tree-sitter to GitGalaxy: both are verified 100% correct, but tree-sitter's raw claim
  count included the phantom duplicates, so its confirmed precision is actually 941/1063, not
  1063/1063. Summary tally: GitGalaxy best 25->26, tree-sitter best 3->2.

## Verification
- `ctags --version` confirmed genuine Universal Ctags 5.9.0 (not the arduino-ctags shadow
  incident from #2111) before regenerating.
- Diffed the full ledger regen field-by-field -- confirmed only this one entry's
  `verdict`/`investigated_by`/`investigated_at`/`credit_tools` changed; all 182 entries got the
  expected `last_reconciled_at` bump and nothing else.
- Chart diff is scoped to exactly perl's Func Precision panel + the summary tally -- no other
  language or metric moved.

Note: unrelated to open PR #2306 (typescript baseline regen) -- branched fresh off `main`, no
overlap in scope or files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)