### PR TITLE
docs: auto-update LLM architectural brief

### DIFF
--- a/docs/gitgalaxy_architecture_brief.md
+++ b/docs/gitgalaxy_architecture_brief.md
@@ -6,10 +6,10 @@
 |---|---|
 | **Engine** | `GitGalaxy Scope vlatest (Delta Mode)` |
 | **Target Path** | `/home/runner/work/gitgalaxy/gitgalaxy` |
-| **Timestamp** | `2026-08-27T08:25:23.818194+00:00` |
-| **Scan Duration** | `10.03s` |
+| **Timestamp** | `2026-08-27T08:28:34.874249+00:00` |
+| **Scan Duration** | `9.74s` |
 | **Git Branch** | `main` |
-| **Git Commit** | `2064d02a2bf715f282001f459f4b267f01f4346e` |
+| **Git Commit** | `fe2825f8187eb5d72f2011e567749eeaae50d0c3` |
 | **Git Remote** | `https://github.com/squid-protocol/gitgalaxy` |
 | **Zero-Dependency Mode** | `Inactive (Full Precision)` |
 


### PR DESCRIPTION
Automated update from the latest GalaxyScope scan on `main`.