### PR TITLE
docs: auto-update LLM architectural brief

### DIFF
--- a/docs/gitgalaxy_architecture_brief.md
+++ b/docs/gitgalaxy_architecture_brief.md
@@ -6,10 +6,10 @@
 |---|---|
 | **Engine** | `GitGalaxy Scope vlatest (Delta Mode)` |
 | **Target Path** | `/home/runner/work/gitgalaxy/gitgalaxy` |
-| **Timestamp** | `2026-08-27T08:50:55.055719+00:00` |
-| **Scan Duration** | `10.13s` |
+| **Timestamp** | `2026-08-27T08:53:18.577773+00:00` |
+| **Scan Duration** | `7.63s` |
 | **Git Branch** | `main` |
-| **Git Commit** | `735812523a7d01cfb31879fc53cce2e0ad451a7e` |
+| **Git Commit** | `49bd49a962495472843f772b28d5c442b61c220c` |
 | **Git Remote** | `https://github.com/squid-protocol/gitgalaxy` |
 | **Zero-Dependency Mode** | `Inactive (Full Precision)` |
 


### PR DESCRIPTION
Automated update from the latest GalaxyScope scan on `main`.