### PR TITLE
docs: auto-update LLM architectural brief

### DIFF
--- a/docs/gitgalaxy_architecture_brief.md
+++ b/docs/gitgalaxy_architecture_brief.md
@@ -6,10 +6,10 @@
 |---|---|
 | **Engine** | `GitGalaxy Scope vlatest (Delta Mode)` |
 | **Target Path** | `/home/runner/work/gitgalaxy/gitgalaxy` |
-| **Timestamp** | `2026-08-27T17:47:26.686243+00:00` |
-| **Scan Duration** | `9.04s` |
+| **Timestamp** | `2026-08-27T17:50:36.280291+00:00` |
+| **Scan Duration** | `8.1s` |
 | **Git Branch** | `main` |
-| **Git Commit** | `b81adabe885b32fc48d3d15d51c8d615fda06182` |
+| **Git Commit** | `5347352970a473b4007ed78b206b966a16eeadfd` |
 | **Git Remote** | `https://github.com/squid-protocol/gitgalaxy` |
 | **Zero-Dependency Mode** | `Inactive (Full Precision)` |
 


### PR DESCRIPTION
Automated update from the latest GalaxyScope scan on `main`.