### PR TITLE
docs: Haskell arity args counting as Claim 14; tri-comparison args/line-start findings

### DIFF
--- a/docs/self_scan/tri_comparison_README.md
+++ b/docs/self_scan/tri_comparison_README.md
@@ -178,6 +178,51 @@ not accounted for (see `ctags_reader.py`'s `_QUALIFY_NAME_WITH_SCOPE` mechanism 
 case is handled: re-join name+scope from ctags' own tag data, gated on the qualified text actually
 appearing in the tag's own verbatim source line).
 
+## What the args data currently shows (2026-08-27)
+
+A whole-corpus probe of the args metric (of the parameter counts GitGalaxy reports on
+existence-agreed functions, how many at least one other tool corroborated) found **no open
+backlog on GitGalaxy's side**: args agreement is ~100% for essentially every language with a real
+second reader (c, cpp, csharp, rust, dart, php, typescript, java, javascript, kotlin, go,
+fortran, python, ruby, solidity, tcl, zig, objective-c), and every language that sits below 100%
+already has a *validated* ledger verdict, all of which land on "GitGalaxy's count is right":
+
+| language | gg args agreement | validated verdict |
+| --- | --- | --- |
+| haskell | ~88% | both readings valid — GitGalaxy counts true logical arity from the type signature, tree-sitter counts only the patterns the aligned equation binds. Logged as [Claim 14](../why_gitgalaxy_beats_ast_here.md). |
+| perl | ~93% | "GitGalaxy regex splits args appropriately" |
+| powershell | ~95% | "GitGalaxy extracts args accurately" |
+| matlab | ~96% | "GitGalaxy regex splits args more robustly than tree-sitter on MATLAB edge cases" |
+| scala | ~97% | "GitGalaxy counts args accurately" |
+| swift | ~99% | "GitGalaxy counts args accurately" |
+
+Every *reproducing* args discrepancy shape in the ledger resolves the same way — a tree-sitter
+limitation (Go grouped same-type parameters, Flow union-type parameter-list corruption, the
+shared `_get_param_count` helper undercounting a defaulted parameter by one, Fortran truncating a
+677-arg signature at 39), one ctags tuple-parameter mis-split in csharp, or a reconciliation
+artifact (name-only pairing comparing two different same-named overloads' readings against each
+other — see below) — **not** a GitGalaxy gap. The 2026-08-22 dart fix
+([#2341](https://github.com/squid-protocol/gitgalaxy/issues/2341)) closed dart's last args shape;
+it now reads 100%.
+
+Two known limits on how sharp this signal is, both worth fixing before args is worth ranking:
+
+- **Name-only rank pairing manufactures spurious args (and line) discrepancy shapes.** Where one
+  name has several unrelated definitions in a file (`build` across different Dart widgets,
+  `constructor` across TypeScript classes, C# method overloads), the reconciler pairs occurrences
+  by name and rank with no scope disambiguation, so it can compare tool A's reading of overload 1
+  against tool B's reading of overload 2 and record a "disagreement" where every individual
+  reading was correct for its own definition site. Both the csharp `SetCurrentSolution` and the
+  javascript jquery `setup`/`trigger` args verdicts document a concrete instance. Tracked in
+  [#2359](https://github.com/squid-protocol/gitgalaxy/issues/2359).
+- **Start-line agreement is not a usable correctness metric as-is.** The same probe measured
+  per-tool start-line agreement and found the disagreements are almost all naming-convention
+  offsets, not defects: ctags systematically reports the line one past GitGalaxy/tree-sitter in
+  c/php/java/typescript, and GitGalaxy anchors at the attribute/decorator/signature line where
+  tree-sitter starts at the keyword (Rust proc-macro attributes, decorated TS constructors,
+  Haskell type signatures). `line` stays a rank-ordering input only, not a scored metric — see
+  `tri_comparison_reconcile.py`'s `MATCHING METHODOLOGY` docstring.
+
 ## CI enforcement
 
 This system was skill/human-driven only until it wasn't: any PR touching `detector.py` /

--- a/docs/why_gitgalaxy_beats_ast_here.md
+++ b/docs/why_gitgalaxy_beats_ast_here.md
@@ -818,6 +818,54 @@ method in the first place. This is why `tree_sitter_accuracy_audit.py`'s walker 
 dissenting names as the misparsed leftover tokens `void`/`unsigned` rather than the real method
 names.
 
+## Claim 14: argument counting at true logical arity, when a grammar counts only the patterns one clause binds
+
+For a Haskell function whose type signature declares N parameters but whose defining equation is
+written point-free or eta-reduced — binding only the first N−1 explicitly and handling the last
+argument by composition (`.`), `\case`, or a returned partial application — GitGalaxy counts N
+(the true logical arity, read from the type signature), while tree-sitter's declaration-only
+reading counts only the patterns that one clause binds, undercounting by exactly the number of
+eta-reduced arguments. This is an *arity* claim, distinct from Claim 1 (a language with **no**
+formal parameter list anywhere — Haskell has one, in the signature) and from Claim 4 (which is
+about function *count* under per-clause node granularity, not how many arguments one function
+takes). Both readings are internally consistent — tree-sitter is correct about "patterns bound in
+this equation," GitGalaxy is correct about "arguments this function takes" — but for the coupling
+signal the arg count feeds (how many inputs a function actually depends on), the signature arity
+is the more useful answer, and the one a human reading the type would give.
+
+**The evidence:** `tri_comparison_ledger.json`'s
+`haskell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]` (9 occurrences, validated
+2026-08-19). Confirmed by reading source at 3 of the 9, all in
+`language-crucible/data/haskell/pandoc`:
+
+- `Shared.hs:256` — `tabFilter :: Int -> T.Text -> T.Text` (signature arity **2**); the second
+  clause `tabFilter tabStop = T.unlines . map go . T.lines` binds **1** pattern and produces the
+  remaining argument point-free via `.`. GitGalaxy 2, tree-sitter 1.
+- `Shared.hs:142` — `splitTextByIndices :: [Int] -> T.Text -> [T.Text]` (arity **2**);
+  `splitTextByIndices ns = splitTextByRelIndices (...) . T.unpack` binds **1**, second argument
+  point-free. GitGalaxy 2, tree-sitter 1.
+- `App.hs:395` — `getMetadataFromFiles :: PandocMonad m => Text -> ReaderOptions -> [FilePath] ->
+  m Meta` (arity **3**); `getMetadataFromFiles readerFormat readerOpts = \case ...` binds **2**
+  and consumes the third argument through `\case`. GitGalaxy 3 (ledger reading), tree-sitter 2.
+
+The remaining 6 are the same shape (a signature declaring more parameters than the aligned
+equation explicitly binds). No engine change: GitGalaxy's signature-derived arity was already the
+behavior worth keeping here — logged rather than "fixed" toward matching tree-sitter's
+clause-local count.
+
+## Where Claim 14 does NOT apply
+
+- Only where a real type signature is present to read the true arity from. A Haskell function
+  with no signature (GitGalaxy and tree-sitter both fall back to counting bound patterns) has no
+  such divergence, and a GitGalaxy/tree-sitter arg-count mismatch there is a normal bug to chase.
+- Not a licence to treat *any* GitGalaxy/tree-sitter arg-count gap on Haskell as this shape —
+  it's specifically signature-arity > clause-bound-patterns, in that direction, on an
+  existence-agreed function. The ledger entry records the direction and the mechanism; a gap that
+  doesn't match both is a separate question.
+- Says nothing about the other languages whose args agreement sits below 100% (perl, powershell,
+  matlab, scala, swift) — each of those has its own validated ledger verdict (all "GitGalaxy
+  counts args accurately"), none of them this eta-reduction mechanism.
+
 ## Where this doc is used
 
 - README.md's "One Graph, Not Five Separate Tools" section links here as the narrow exceptions to
@@ -861,3 +909,10 @@ names.
   "missing" them), so restating it as a tree-sitter-beats-tree-sitter claim would itself be an
   overstatement of exactly the kind this doc exists to avoid. Revisit only with a clean,
   independently-verified before/after.
+- Claim 14 (Haskell signature arity vs. clause-bound patterns) came out of a 2026-08-27
+  all-language probe of the tri-comparison's start-line and args agreement (summarised in
+  `docs/self_scan/tri_comparison_README.md`'s "What the args data currently shows" section). That
+  probe's headline was the *absence* of a backlog — GitGalaxy's args agreement is ~100% across the
+  corpus and every sub-100 language already has a validated "GitGalaxy is correct" verdict — so
+  Claim 14 is the one durable finding worth a claim of its own; it's cited from
+  `tests/tools/tri_comparison_reconcile.py`'s `EXISTENCE VS ARGS` docstring section.

--- a/tests/tools/tri_comparison_reconcile.py
+++ b/tests/tools/tri_comparison_reconcile.py
@@ -29,6 +29,19 @@ MATCHING METHODOLOGY (confirmed against real corpus data, not assumed)
     a "detect and subtract a per-file offset" mechanism was considered and rejected; it would
     correct for a problem that essentially doesn't occur here, while doing nothing for the
     problem that does.
+        A later all-language probe (2026-08-27) qualified the "offset is 0" claim: it holds for
+        Python and most languages, but NOT universally, and the exceptions are naming-convention
+        differences rather than the positional drift the rejected offset-correction mechanism
+        would have fixed. Two systematic ones, both on name-AGREED occurrences: (1) ctags reports
+        the line one PAST GitGalaxy/tree-sitter's agreed value in c/php/java/typescript (it
+        anchors on the opening brace / first body token, not the declarator line); (2) GitGalaxy
+        anchors at the attribute/decorator/signature line where tree-sitter starts at the keyword
+        -- rust `#[proc_macro_derive]`-decorated `pub fn`, decorated TypeScript `constructor`,
+        the Haskell type-signature line above the first equation. `line` is still not a match key
+        and not a scored metric: these offsets don't change WHICH occurrence pairs with which
+        (rank order within a name is identical), and "whose anchor convention is right" is not an
+        existence disagreement worth a ledger entry. The takeaway is only that the original "0 in
+        every single case" was a Python-specific measurement stated too broadly.
     Where one name occurs more than once in a file (property getter/setter pairs, same method
     name on different classes), each tool's occurrences of that name are sorted by line and
     paired by RANK (1st with 1st, 2nd with 2nd), the same instinct tree_sitter_accuracy_audit.py's
@@ -38,6 +51,15 @@ MATCHING METHODOLOGY (confirmed against real corpus data, not assumed)
     GitGalaxy is therefore by name multiset only, never rank-paired by position. This doesn't
     lose anything class-specific to compare positionally anyway: classes carry no `args` value in
     any of the three readers, so class matching only ever needs to answer an existence question.
+    KNOWN LIMITATION (#2359): rank pairing has no scope disambiguation, so a name with several
+    UNRELATED definitions in one file (method overloads, `build`/`constructor` across different
+    classes, a property name reused in two object literals) can pair tool A's reading of
+    definition #1 against tool B's reading of definition #2 -- manufacturing a spurious args (or
+    line) "disagreement" where every individual reading was correct for its own site. Confirmed
+    on csharp `SetCurrentSolution` and javascript jquery `setup`/`trigger` (both ledger verdicts
+    say "methodology artifact, not a real defect"). Existence reconciliation is largely immune (a
+    mis-pair there still agrees the symbol exists); it's the args/line sub-comparison that's
+    distorted, which is part of why args stays an unranked found-count for now.
 
 EXISTENCE VS. ARGS ARE SEPARATE QUESTIONS, SCOPED SEPARATELY
     A function's EXISTENCE (does a symbol named X exist at roughly this position) and its ARG
@@ -50,6 +72,14 @@ EXISTENCE VS. ARGS ARE SEPARATE QUESTIONS, SCOPED SEPARATELY
     exact occurrences, once the parsing bug was fixed, moved to 99.9%. Existence agreement for
     that same language/run never moved at all (97.3% throughout) -- proof the two questions are
     genuinely independent, not just conceptually separable.
+    Current picture (2026-08-27 all-language probe): GitGalaxy's args agreement is ~100% across
+    the corpus; every language below 100% (haskell, perl, powershell, matlab, scala, swift) has a
+    validated ledger verdict confirming GitGalaxy's count. The one arg-count divergence that
+    reflects a real, useful difference rather than a corpus quirk is haskell -- GitGalaxy counts
+    true logical arity from the type signature, tree-sitter counts only the patterns the aligned
+    equation binds (undercounts eta-reduced/point-free clauses). Logged as Claim 14 in
+    docs/why_gitgalaxy_beats_ast_here.md; ledger shape
+    haskell/function/args/agree[none]_vs[gitgalaxy,tree_sitter].
 
 DISCREPANCY SHAPE, NOT PER-INSTANCE LOGGING
     A language/metric pair can produce hundreds of individual disagreeing occurrences (rust


### PR DESCRIPTION
## What this is

Follow-up to a whole-corpus probe of the tri-comparison's **args** and **start-line** metrics
(2026-08-27), prompted by a question about whether GitGalaxy's argument-counting accuracy needs
more attention after the dart fix (#2341).

**Headline: it doesn't.** GitGalaxy's args agreement is ~100% for every language with a real
second reader, and every language below 100% (haskell, perl, powershell, matlab, scala, swift)
already has a *validated* ledger verdict, all landing on "GitGalaxy's count is right". Every
reproducing args discrepancy shape resolves to a tree-sitter limitation, one ctags tuple
mis-split, or a reconciliation artifact — not a GitGalaxy gap.

## Changes (docs + docstrings only — no engine or reconciliation logic change)

- **`docs/why_gitgalaxy_beats_ast_here.md` — Claim 14.** Haskell functions written point-free /
  eta-reduced: the type signature declares N params, the defining equation binds fewer and
  handles the rest by composition / `\case`. GitGalaxy counts N (true logical arity from the
  signature); tree-sitter counts only the bound patterns. Verified against 3 pandoc source sites
  (`tabFilter`, `splitTextByIndices`, `getMetadataFromFiles`); ledger shape
  `haskell/function/args/agree[none]_vs[gitgalaxy,tree_sitter]` (validated 2026-08-19). Distinct
  from Claim 1 (no formal param list at all) and Claim 4 (function *count*, not arity). No engine
  change — GitGalaxy's behavior here was already the one worth keeping.
- **`docs/self_scan/tri_comparison_README.md`** — new "What the args data currently shows"
  section with the per-language table and the two known sharpness limits.
- **`tests/tools/tri_comparison_reconcile.py` docstrings** —
  - Qualify the "line-number offset is 0 in every single case" claim: that was a Python-specific
    measurement. Corpus-wide, ctags systematically reports +1 in c/php/java/typescript, and
    GitGalaxy anchors at the attribute/decorator/signature line where tree-sitter starts at the
    keyword. These are naming-convention offsets, not positional drift; `line` stays a
    rank-ordering input only, never a scored metric.
  - Record the name-only rank-pairing limitation (#2359): a name with several unrelated
    definitions in one file can get tool A's reading of overload 1 paired against tool B's
    reading of overload 2, manufacturing spurious args/line "disagreements".

## Follow-up filed

- #2359 — `tri_comparison_reconcile.py` name-only rank pairing manufactures spurious args/line
  discrepancy shapes for repeated names.

## Testing

No logic changed. `ruff format --check` clean on the touched `.py`; `ast.parse` clean. The
`.md` changes are `paths-ignore`d by the audit workflows; the reconcile.py docstring edit trips
`tri-comparison-audit.yml`, which measures validated precision and is unaffected by a docstring
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
