### PR TITLE
fix(tri-comparison): pair repeated-name function occurrences by line proximity (#2359)

### DIFF
--- a/docs/self_scan/tri_comparison_README.md
+++ b/docs/self_scan/tri_comparison_README.md
@@ -205,16 +205,21 @@ other — see below) — **not** a GitGalaxy gap. The 2026-08-22 dart fix
 ([#2341](https://github.com/squid-protocol/gitgalaxy/issues/2341)) closed dart's last args shape;
 it now reads 100%.
 
-Two known limits on how sharp this signal is, both worth fixing before args is worth ranking:
+Two limits on how sharp this signal is:
 
-- **Name-only rank pairing manufactures spurious args (and line) discrepancy shapes.** Where one
-  name has several unrelated definitions in a file (`build` across different Dart widgets,
-  `constructor` across TypeScript classes, C# method overloads), the reconciler pairs occurrences
-  by name and rank with no scope disambiguation, so it can compare tool A's reading of overload 1
-  against tool B's reading of overload 2 and record a "disagreement" where every individual
-  reading was correct for its own definition site. Both the csharp `SetCurrentSolution` and the
-  javascript jquery `setup`/`trigger` args verdicts document a concrete instance. Tracked in
-  [#2359](https://github.com/squid-protocol/gitgalaxy/issues/2359).
+- **Repeated-name pairing (#2359, mitigated).** Where one name has several unrelated definitions
+  in a file (`build` across different Dart widgets, `constructor` across TypeScript classes, C#
+  method overloads), plain rank pairing (zip the two tools' line-sorted occurrence lists by
+  index) silently shifts every pairing after any occurrence one tool missed, comparing tool A's
+  overload #2 against tool B's overload #3. Functions now pair by **line proximity** instead
+  (`_pair_occurrences_by_line`): a genuinely-missed occurrence is left unpaired rather than
+  shifting the rest, and a residual line-spread guard skips the args comparison for any pair too
+  far apart to trust as the same function. Total slot count — and therefore existence
+  recall/precision — is unchanged by construction. This removed the csharp/javascript/cpp
+  spurious args shapes and recovered ~90 previously-mis-paired true args comparisons (all still
+  100% agreement). A narrow residual remains: if one tool reports a name several times far from
+  where the others place it (ctags mis-tagging a macro body, say), clustering can still split
+  what rank merged — rare, and it only moves that tool's own recall, never GitGalaxy's precision.
 - **Start-line agreement is not a usable correctness metric as-is.** The same probe measured
   per-tool start-line agreement and found the disagreements are almost all naming-convention
   offsets, not defects: ctags systematically reports the line one past GitGalaxy/tree-sitter in

--- a/tests/tools/test_tri_comparison_reconcile.py
+++ b/tests/tools/test_tri_comparison_reconcile.py
@@ -1,0 +1,159 @@
+"""Unit tests for tri_comparison_reconcile.reconcile_symbols -- in particular the #2359
+line-proximity function pairing that replaced rank pairing for repeated names.
+
+tri_comparison_reconcile only ever reads .name/.line/.args off occurrence objects and
+.gg_funcs/.ts_funcs/.ctags_funcs/.file_path off result objects (it duck-types on purpose so it
+imports without tree-sitter-language-pack -- see its own module docstring), so these tests build
+tiny stand-ins rather than importing tri_comparison_gatherer's real dataclasses.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import tri_comparison_reconcile as R  # noqa: E402 # type: ignore
+
+
+@dataclass
+class Occ:
+    name: str
+    line: int | None
+    args: int | None
+
+
+@dataclass
+class FR:
+    file_path: str = "f"
+    gg_funcs: list = field(default_factory=list)
+    gg_classes: list = field(default_factory=list)
+    ts_funcs: list = field(default_factory=list)
+    ts_classes: list = field(default_factory=list)
+    ctags_funcs: list = field(default_factory=list)
+    ctags_classes: list = field(default_factory=list)
+
+
+def _reconcile(gg, ts, ctags=None):
+    tools = ("gitgalaxy", "tree_sitter") if ctags is None else ("gitgalaxy", "tree_sitter", "ctags")
+    fr = FR(gg_funcs=gg, ts_funcs=ts, ctags_funcs=ctags or [])
+    recall, precision, args, groups = R.reconcile_symbols([fr], "function", tools, "csharp")
+    return recall, precision, args, groups
+
+
+def _rates(scores):
+    return {t: (m.matched_consensus, m.total_slots) for t, m in scores.items()}
+
+
+def _force_rank_pairing(monkeypatch):
+    monkeypatch.setattr(R, "_name_wants_line_pairing", lambda *a, **k: False)
+
+
+# --------------------------------------------------------------------------------------------
+# The #2359 regression: one tool missing an occurrence in the MIDDLE of a repeated name
+
+
+def test_missing_middle_occurrence_produces_no_spurious_args_discrepancy():
+    # gg finds foo x3 (1/2/3 args); ts misses the middle one, finds x2 (1/3 args).
+    gg = [Occ("foo", 10, 1), Occ("foo", 50, 2), Occ("foo", 90, 3)]
+    ts = [Occ("foo", 11, 1), Occ("foo", 91, 3)]
+    _, _, args, groups = _reconcile(gg, ts)
+
+    # existence: gg found one more than ts -- exactly one existence discrepancy, gg-only.
+    assert [g.metric for g in groups] == ["existence"]
+    assert groups[0].agreeing_tools == frozenset({"gitgalaxy"})
+    assert groups[0].total_occurrences == 1
+    # no args discrepancy at all -- the two real pairs (10<->11, 90<->91) agree.
+    assert not [g for g in groups if g.metric == "args"]
+    # both real pairs were actually compared and matched.
+    assert _rates(args) == {"gitgalaxy": (2, 2), "tree_sitter": (2, 2)}
+
+
+def test_missing_middle_leaves_existence_metrics_identical_to_rank_pairing(monkeypatch):
+    gg = [Occ("foo", 10, 1), Occ("foo", 50, 2), Occ("foo", 90, 3)]
+    ts = [Occ("foo", 11, 1), Occ("foo", 91, 3)]
+
+    recall_line, precision_line, _, groups_line = _reconcile(gg, ts)
+
+    _force_rank_pairing(monkeypatch)
+    recall_rank, precision_rank, _, groups_rank = _reconcile(gg, ts)
+
+    assert _rates(recall_line) == _rates(recall_rank)
+    assert _rates(precision_line) == _rates(precision_rank)
+    # same discrepancy SHAPE and count -- only the example line attribution differs.
+    assert [(g.metric, g.agreeing_tools, g.total_occurrences) for g in groups_line] == [
+        (g.metric, g.agreeing_tools, g.total_occurrences) for g in groups_rank
+    ]
+
+
+def test_overload_set_with_one_tool_missing_one_overload_pairs_cleanly():
+    # 4 overloads, args 1/6/4/5. ctags misses the 2nd; its remaining reads are +1 line (its
+    # usual anchor offset). Rank pairing would compare ctags overload#3 against gg overload#2.
+    gg = [Occ("F", 10, 1), Occ("F", 30, 6), Occ("F", 50, 4), Occ("F", 70, 5)]
+    ts = [Occ("F", 10, 1), Occ("F", 30, 6), Occ("F", 50, 4), Occ("F", 70, 5)]
+    ctags = [Occ("F", 11, 1), Occ("F", 51, 4), Occ("F", 71, 5)]
+    _, _, args, groups = _reconcile(gg, ts, ctags)
+
+    assert not [g for g in groups if g.metric == "args"]
+    assert [g.metric for g in groups] == ["existence"]
+    assert groups[0].dissenting_tools == frozenset({"ctags"})
+    assert _rates(args) == {"gitgalaxy": (3, 3), "tree_sitter": (3, 3), "ctags": (3, 3)}
+
+
+# --------------------------------------------------------------------------------------------
+# The belt-and-braces args line-spread guard
+
+
+def test_far_apart_same_name_single_occurrence_skips_args_comparison():
+    # one `g` each, 5000 lines apart, different arg counts. Both readers agree `g` exists
+    # (as today), but they're plainly not the same function -- args must not be compared.
+    gg = [Occ("g", 10, 1)]
+    ts = [Occ("g", 5000, 2)]
+    _, _, args, groups = _reconcile(gg, ts)
+
+    assert groups == []  # existence consensus, unchanged from rank pairing
+    assert _rates(args) == {"gitgalaxy": (0, 0), "tree_sitter": (0, 0)}
+
+
+def test_close_occurrences_within_spread_still_compare_args():
+    # a real +1 ctags-style offset must NOT trip the guard.
+    gg = [Occ("k", 100, 2)]
+    ts = [Occ("k", 101, 3)]
+    _, _, args, groups = _reconcile(gg, ts)
+
+    assert _rates(args) == {"gitgalaxy": (0, 1), "tree_sitter": (0, 1)}  # compared, disagreed
+    assert [g.metric for g in groups] == ["args"]
+
+
+# --------------------------------------------------------------------------------------------
+# The common case must be untouched
+
+
+def test_single_occurrence_name_unchanged(monkeypatch):
+    gg = [Occ("h", 10, 2)]
+    ts = [Occ("h", 10, 2)]
+    line_result = _reconcile(gg, ts)
+
+    _force_rank_pairing(monkeypatch)
+    rank_result = _reconcile(gg, ts)
+
+    for line_scores, rank_scores in zip(line_result[:3], rank_result[:3], strict=True):
+        assert _rates(line_scores) == _rates(rank_scores)
+
+
+def test_classes_never_use_line_pairing():
+    # gg classes carry no line; class reconciliation must stay name-multiset (rank) only.
+    occ_by_tool = {"gitgalaxy": [Occ("C", None, None), Occ("C", None, None)]}
+    assert R._name_wants_line_pairing(occ_by_tool, "class") is False
+
+
+def test_all_agree_no_discrepancies():
+    gg = [Occ("a", 1, 0), Occ("b", 10, 2), Occ("b", 40, 2)]
+    ts = [Occ("a", 1, 0), Occ("b", 10, 2), Occ("b", 41, 2)]
+    recall, _, args, groups = _reconcile(gg, ts)
+
+    assert groups == []
+    assert _rates(recall) == {"gitgalaxy": (3, 3), "tree_sitter": (3, 3)}
+    assert _rates(args) == {"gitgalaxy": (3, 3), "tree_sitter": (3, 3)}

--- a/tests/tools/tri_comparison_reconcile.py
+++ b/tests/tools/tri_comparison_reconcile.py
@@ -42,24 +42,30 @@ MATCHING METHODOLOGY (confirmed against real corpus data, not assumed)
         (rank order within a name is identical), and "whose anchor convention is right" is not an
         existence disagreement worth a ledger entry. The takeaway is only that the original "0 in
         every single case" was a Python-specific measurement stated too broadly.
-    Where one name occurs more than once in a file (property getter/setter pairs, same method
-    name on different classes), each tool's occurrences of that name are sorted by line and
-    paired by RANK (1st with 1st, 2nd with 2nd), the same instinct tree_sitter_accuracy_audit.py's
-    `_align_occurrences_by_line` already uses for two readers, generalized to however many of the
-    three tools are available for this language. GitGalaxy's own `class_data` rows carry no line
-    number at all (a pre-existing schema fact, not introduced here) -- class matching against
-    GitGalaxy is therefore by name multiset only, never rank-paired by position. This doesn't
-    lose anything class-specific to compare positionally anyway: classes carry no `args` value in
-    any of the three readers, so class matching only ever needs to answer an existence question.
-    KNOWN LIMITATION (#2359): rank pairing has no scope disambiguation, so a name with several
-    UNRELATED definitions in one file (method overloads, `build`/`constructor` across different
-    classes, a property name reused in two object literals) can pair tool A's reading of
-    definition #1 against tool B's reading of definition #2 -- manufacturing a spurious args (or
-    line) "disagreement" where every individual reading was correct for its own site. Confirmed
-    on csharp `SetCurrentSolution` and javascript jquery `setup`/`trigger` (both ledger verdicts
-    say "methodology artifact, not a real defect"). Existence reconciliation is largely immune (a
-    mis-pair there still agrees the symbol exists); it's the args/line sub-comparison that's
-    distorted, which is part of why args stays an unranked found-count for now.
+    Where one name occurs more than once in a file (property getter/setter pairs, method
+    overloads, `build`/`constructor` across different classes), each tool's occurrences of that
+    name are sorted by line, and then:
+      - CLASSES, or any name whose occurrences don't all carry a line: paired by RANK (1st with
+        1st, 2nd with 2nd), the same instinct tree_sitter_accuracy_audit.py's
+        `_align_occurrences_by_line` already uses for two readers, generalized to however many of
+        the three tools are available. GitGalaxy's own `class_data` rows carry no line number at
+        all (a pre-existing schema fact), so class matching is name-multiset only -- which loses
+        nothing, since classes carry no `args` value in any reader and only ever need an existence
+        answer.
+      - FUNCTIONS (every reader gives a real start line): paired by LINE PROXIMITY
+        (`_pair_occurrences_by_line`). Rank pairing silently breaks when one tool misses an
+        occurrence in the MIDDLE of a repeated name -- every pairing after the gap shifts by one,
+        so tool A's reading of overload #2 gets compared against tool B's reading of overload #3,
+        manufacturing a spurious args "disagreement" where each individual reading was correct for
+        its own site (confirmed #2359: csharp `SetCurrentSolution`, javascript jquery
+        `setup`/`trigger`). Line-proximity pairing single-linkage-clusters the occurrences in
+        line order instead, so a genuinely-missed occurrence is left unpaired rather than
+        shifting everything after it. The residual (occurrences that cluster alone) is still
+        rank-paired, so the total slot count -- and therefore existence recall/precision -- is
+        exactly what rank pairing gave; only which occurrence a discrepancy points at, and the
+        args sub-comparison, change. A final belt-and-braces guard skips the args comparison for
+        any slot whose paired occurrences span more than `_ARGS_LINE_SPREAD_MAX` lines (a
+        residual rank-pair, or a real anchor offset too wide to trust as the same function).
 
 EXISTENCE VS. ARGS ARE SEPARATE QUESTIONS, SCOPED SEPARATELY
     A function's EXISTENCE (does a symbol named X exist at roughly this position) and its ARG
@@ -154,6 +160,19 @@ class DiscrepancyGroup:
 
 _EXAMPLE_CAP = 10
 
+# #2359 line-proximity function pairing. _CLUSTER_GAP_LINES: two of the SAME tool's occurrences
+# of one name are always different functions, and two DIFFERENT tools' readings of the same
+# function land within a handful of lines of each other (0 for most languages; a documented +1
+# for ctags in c/php/java/typescript; a few more where GitGalaxy anchors at a decorator/attribute
+# line and tree-sitter at the keyword -- see MATCHING METHODOLOGY above). 8 lines comfortably
+# covers the real cross-tool offsets while staying below the typical gap between two adjacent
+# same-name overloads. _ARGS_LINE_SPREAD_MAX: the post-pairing guard -- only compare args when the
+# paired occurrences are confidently the same function; a wider spread means a residual rank-pair
+# or an anchor offset too large to trust, so existence is still counted but args is skipped
+# (a guessed args comparison is worse than none). Kept equal to the cluster gap on purpose.
+_CLUSTER_GAP_LINES = 8
+_ARGS_LINE_SPREAD_MAX = 8
+
 # Local-label leading-dot convention: NASM/GAS scope a local label to the preceding global
 # label by writing it with a leading '.' (`.loop:`, `.empty:`). Universal Ctags' Asm parser
 # strips that '.' before emitting the tag (`loop`, `empty`); GitGalaxy's func_start captures
@@ -186,6 +205,57 @@ def _pair_occurrences_by_rank(
     slots = []
     for i in range(max_n):
         slots.append({tool: (occs[i] if i < len(occs) else None) for tool, occs in occs_by_tool.items()})
+    return slots
+
+
+def _name_wants_line_pairing(occs_by_tool: dict[str, list[Occurrence]], symbol_type: str) -> bool:
+    """True only when line-proximity pairing can differ from rank pairing AND has the data to run:
+    functions (classes have no gg line), some tool saw the name 2+ times (with <=1 each, the two
+    strategies produce the identical single slot), and every occurrence carries a real line."""
+    if symbol_type != "function":
+        return False
+    if max((len(v) for v in occs_by_tool.values()), default=0) < 2:
+        return False
+    return all(o.line is not None for occs in occs_by_tool.values() for o in occs)
+
+
+def _pair_occurrences_by_line(
+    occs_by_tool: dict[str, list[Occurrence]],
+) -> list[dict[str, Occurrence | None]]:
+    """One function name's occurrences across tools, each list already line-sorted, every
+    occurrence carrying a real line (see `_name_wants_line_pairing`). Single-linkage-clusters
+    them in global line order -- a new cluster starts when the line gap exceeds
+    `_CLUSTER_GAP_LINES` or the current tool already occupies the open cluster (two of one tool's
+    occurrences of a name ARE two different functions). Clusters holding 2+ tools are confident
+    same-function slots; a tool alone in its cluster is "loose" and rank-paired against the other
+    tools' equally-loose occurrences, so the total slot count matches plain rank pairing and
+    existence recall/precision are unchanged -- see reconcile_symbols' caller comment and #2359.
+    """
+    flat = sorted(
+        (o.line, tool, o) for tool, occs in occs_by_tool.items() for o in occs
+    )  # (line, tool, occ), ascending by line
+    clusters: list[dict[str, Occurrence]] = []
+    cur: dict[str, Occurrence] = {}
+    cur_last_line = 0
+    for line, tool, occ in flat:
+        if cur and (tool in cur or line - cur_last_line > _CLUSTER_GAP_LINES):
+            clusters.append(cur)
+            cur = {}
+        cur[tool] = occ
+        cur_last_line = line
+    if cur:
+        clusters.append(cur)
+
+    slots: list[dict[str, Occurrence | None]] = []
+    loose: dict[str, list[Occurrence]] = {t: [] for t in occs_by_tool}
+    for c in clusters:
+        if len(c) >= 2:
+            slots.append({t: c.get(t) for t in occs_by_tool})
+        else:
+            (only_tool,) = c
+            loose[only_tool].append(c[only_tool])
+    slots.extend(_pair_occurrences_by_rank(loose))
+    slots.sort(key=lambda s: min((o.line for o in s.values() if o is not None), default=0))
     return slots
 
 
@@ -243,7 +313,12 @@ def reconcile_symbols(
             for tool in occs_by_tool:
                 occs_by_tool[tool].sort(key=lambda o: o.line if o.line is not None else -1)
 
-            for slot in _pair_occurrences_by_rank(occs_by_tool):
+            pair_fn = (
+                _pair_occurrences_by_line
+                if _name_wants_line_pairing(occs_by_tool, symbol_type)
+                else _pair_occurrences_by_rank
+            )
+            for slot in pair_fn(occs_by_tool):
                 present = frozenset(t for t, o in slot.items() if o is not None)
                 absent = frozenset(available_tools) - present
 
@@ -298,6 +373,16 @@ def reconcile_symbols(
                 # existence consensus reached for this slot -- compare args (functions only;
                 # classes never carry an args value in any reader)
                 if symbol_type != "function":
+                    continue
+                # #2359 belt-and-braces: only compare args when the paired occurrences are
+                # confidently the same function. Line-proximity pairing already avoids the gross
+                # mis-shifts, but a residual rank-paired slot (or an anchor offset wider than
+                # `_CLUSTER_GAP_LINES`) can still line up two different definitions of a repeated
+                # name. A wide line spread across the present tools is the tell -- skip args
+                # there (existence already counted above; a guessed args comparison is worse
+                # than none). Slots with <2 lined occurrences fall through unchanged.
+                slot_lines = [slot[t].line for t in present if slot[t].line is not None]
+                if len(slot_lines) >= 2 and max(slot_lines) - min(slot_lines) > _ARGS_LINE_SPREAD_MAX:
                     continue
                 args_vals = {t: slot[t].args for t in present}
                 # None means "this tool structurally can't report args here" (e.g. ctags on


### PR DESCRIPTION
Fixes #2359. **Stacked on #2360** (docs) — until that merges, the diff here also shows its
one docs commit; the reconcile change is the second commit (`a64cd259`).

## Problem

`tri_comparison_reconcile.py` pairs a repeated name's occurrences across tools by **rank** —
zip each tool's line-sorted occurrence list by index. If one tool misses an occurrence in the
*middle*, every pairing after it shifts by one, so tool A's overload #2 gets compared against
tool B's overload #3 — a spurious `args` "disagreement" where each reading was correct for its
own site (confirmed on csharp `SetCurrentSolution`, javascript jquery `setup`/`trigger`).

## Fix

Functions pair by **line proximity** (`_pair_occurrences_by_line`):

1. Single-linkage-cluster the occurrences in line order — new cluster when the gap exceeds
   `_CLUSTER_GAP_LINES` (8) or the current tool already occupies the open cluster (two of one
   tool's occurrences of a name *are* different functions). This absorbs the documented anchor
   offsets (ctags +1; GitGalaxy anchoring at the decorator/signature line).
2. Clusters with ≥2 tools → confident same-function slots. A tool alone in its cluster is
   **rank-paired against the other tools' equally-lonely occurrences**, so the total slot count —
   and therefore existence recall/precision — is *exactly* what rank pairing produced.
3. A residual line-spread guard (`_ARGS_LINE_SPREAD_MAX`) skips the args comparison for any slot
   whose paired occurrences are too far apart to trust as one function. Applies on the rank path
   too.

Classes are untouched (GitGalaxy's `class_data` has no line → name-multiset only), as is any
single-occurrence name.

## Measured effect (local `gather_language` on the corpus)

| language | before | after |
|---|---|---|
| cpp | 1 spurious args shape | **0** |
| javascript | jquery `setup`/`trigger` artifact shape present | **gone** (only the real ts Flow-union shape remains) |
| csharp | `SetCurrentSolution` shape (rank mis-pairs) | shrunk |
| typescript / csharp / cpp / dart | — | +~90 previously-mis-paired **true** args comparisons recovered, all still 100% agreement |

GitGalaxy args agreement unchanged or up everywhere, never down.

## Verification

- `python tests/tools/tri_comparison_chart.py --all --ci` — javascript / typescript / zig
  baselines all OK, no regressions (existence precision is computed before the args block and
  from a provably-unchanged slot count).
- New `tests/tools/test_tri_comparison_reconcile.py` (8 tests): missing-middle case, overload set
  with a tool missing one overload, the spread guard (both trips and doesn't-trip), the
  existence-metrics-identical-to-rank invariant, single-occurrence unchanged, classes never
  line-paired.

## Known residual

If one tool reports a name several times *far* from where the others place it (ctags mis-tagging
a macro body), clustering can still split what rank merged — rare, and it only moves that tool's
own recall, never GitGalaxy's precision (the CI-gated metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
