### PR TITLE
fix(tri-comparison): guard verified-adjustment geometry so precision can't go negative

### DIFF
--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -551,8 +551,8 @@
 <text class="bar-value-label" x="330.0" y="1099">28/28</text>
 <rect x="286" y="1103" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="330.0" y="1111">28/28</text>
-<rect x="286" y="1115" width="25.1" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1123">12/42</text>
+<rect x="286" y="1115" width="56.6" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1123">27/42</text>
 <rect class="bar-track" x="418" y="1091" width="88" height="34" rx="2"/>
 <rect x="418" y="1091" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1099">7</text>
@@ -587,8 +587,8 @@
 <rect class="bar-track" x="286" y="1223" width="88" height="34" rx="2"/>
 <rect x="286" y="1223" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1231">39/39</text>
-<rect x="286" y="1235" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1243">-73/79</text>
+<rect x="286" y="1235" width="3.3" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1243">3/79</text>
 <circle cx="390.0" cy="1240.0" r="8" fill="#2a78d6"/>
 <text class="badge-label" x="390.0" y="1243.0">G</text>
 <rect class="bar-track" x="418" y="1223" width="88" height="34" rx="2"/>
@@ -930,8 +930,8 @@
 <rect class="bar-track" x="286" y="1707" width="88" height="34" rx="2"/>
 <rect x="286" y="1707" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1715">58/58</text>
-<rect x="286" y="1719" width="2.0" height="10" rx="2" fill="#1baf7a"/>
-<text class="bar-value-label" x="330.0" y="1727">-42/92</text>
+<rect x="286" y="1719" width="7.7" height="10" rx="2" fill="#1baf7a"/>
+<text class="bar-value-label" x="330.0" y="1727">8/92</text>
 <circle cx="390.0" cy="1724.0" r="8" fill="#2a78d6"/>
 <text class="badge-label" x="390.0" y="1727.0">G</text>
 <rect class="bar-track" x="418" y="1707" width="88" height="34" rx="2"/>
@@ -969,8 +969,8 @@
 <rect class="bar-track" x="286" y="1795" width="88" height="34" rx="2"/>
 <rect x="286" y="1795" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="330.0" y="1803">105/105</text>
-<rect x="286" y="1807" width="82.7" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="330.0" y="1815">93/99</text>
+<rect x="286" y="1807" width="88.0" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="330.0" y="1815">99/99</text>
 <circle cx="390.0" cy="1812.0" r="8" fill="#2a78d6"/>
 <text class="badge-label" x="390.0" y="1815.0">G</text>
 <rect class="bar-track" x="418" y="1795" width="88" height="34" rx="2"/>
@@ -1115,10 +1115,10 @@
 <rect x="418" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="462.0" y="2123">730</text>
 <rect class="bar-track" x="550" y="2103" width="88" height="34" rx="2"/>
-<rect x="550" y="2103" width="88.2" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="2111">731/729</text>
-<rect x="550" y="2115" width="87.4" height="10" rx="2" fill="#eb6834"/>
-<text class="bar-value-label" x="594.0" y="2123">725/730</text>
+<rect x="550" y="2103" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="2111">729/729</text>
+<rect x="550" y="2115" width="87.8" height="10" rx="2" fill="#eb6834"/>
+<text class="bar-value-label" x="594.0" y="2123">728/730</text>
 <circle cx="654.0" cy="2120.0" r="8" fill="#2a78d6"/>
 <text class="badge-label" x="654.0" y="2123.0">G</text>
 <rect class="bar-track" x="682" y="2103" width="88" height="34" rx="2"/>

--- a/tests/tools/test_tri_comparison_ledger.py
+++ b/tests/tools/test_tri_comparison_ledger.py
@@ -1,0 +1,154 @@
+"""Unit tests for tri_comparison_ledger.apply_verified_adjustments' geometry guard.
+
+Regression coverage for the chart bug where a `debit_tools` entry naming a tool that never
+earned cross-tool corroboration on a shape (a lone claimant, or a tool on the dissenting/absent
+side) drove GitGalaxy-vs-ctags precision numerators negative -- m4 rendered `-73/79`, scheme
+`-42/92` -- and the mirror-image bad `credit_tools` that gave zig an impossible 100.27% class
+precision.
+
+Per this repo's testing conventions (tests/ has no __init__.py anywhere): the sibling tool
+directory is put on sys.path and the modules are imported as bare top-level names, never as
+`tests.tools.x`.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import tri_comparison_ledger as ledger_mod  # noqa: E402
+from tri_comparison_reconcile import DiscrepancyGroup, MetricScore  # noqa: E402
+
+
+def _group(agreeing, dissenting, *, occ=10, metric="existence", symbol_type="function", lang="lang"):
+    return DiscrepancyGroup(
+        language=lang,
+        symbol_type=symbol_type,
+        metric=metric,
+        agreeing_tools=frozenset(agreeing),
+        dissenting_tools=frozenset(dissenting),
+        total_occurrences=occ,
+    )
+
+
+def _write_ledger(tmp_path, shape_key, *, credit=(), debit=(), status="validated"):
+    ledger = {
+        "entries": {
+            shape_key: {
+                "language": "lang",
+                "symbol_type": "function",
+                "metric": "existence",
+                "status": status,
+                "still_reproduces": True,
+                "credit_tools": list(credit),
+                "debit_tools": list(debit),
+            }
+        }
+    }
+    path = tmp_path / "ledger.json"
+    ledger_mod.save_ledger(ledger, path)
+    return path
+
+
+def _scores(**kw):
+    return {t: MetricScore(tool=t, matched_consensus=mc, total_slots=ts) for t, (mc, ts) in kw.items()}
+
+
+def test_valid_credit_on_lone_claimant_bumps_numerator(tmp_path):
+    g = _group(["gitgalaxy"], ["ctags", "tree_sitter"], occ=4)
+    path = _write_ledger(tmp_path, g.shape_key, credit=["gitgalaxy"])
+    scores = _scores(gitgalaxy=(1726, 1730))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["gitgalaxy"].matched_consensus == 1730  # 1726 + 4
+
+
+def test_valid_debit_on_two_tool_agreement_lowers_numerator(tmp_path):
+    g = _group(["ctags", "tree_sitter"], ["gitgalaxy"], occ=3)
+    path = _write_ledger(tmp_path, g.shape_key, debit=["ctags", "tree_sitter"])
+    scores = _scores(ctags=(100, 100), tree_sitter=(200, 200))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["ctags"].matched_consensus == 97
+    assert scores["tree_sitter"].matched_consensus == 197
+
+
+def test_debit_on_lone_claimant_is_skipped_not_applied(tmp_path, capsys):
+    # The m4 shape: ctags claims 76 functions gitgalaxy rejects; a human validates ctags wrong.
+    # ctags was never corroborated on those slots, so its numerator must not move (and must not
+    # go negative).
+    g = _group(["ctags"], ["gitgalaxy"], occ=76)
+    path = _write_ledger(tmp_path, g.shape_key, debit=["ctags"])
+    scores = _scores(ctags=(3, 79))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["ctags"].matched_consensus == 3
+    assert scores["ctags"].rate_pct == pytest.approx(3.797, abs=1e-3)
+    assert "ignoring malformed debit_tools=[ctags]" in capsys.readouterr().err
+
+
+def test_debit_on_dissenting_side_tool_is_skipped(tmp_path, capsys):
+    # The scheme shape: agree[gitgalaxy]_vs[ctags], someone put ctags in debit_tools even though
+    # ctags made no claim on this shape at all.
+    g = _group(["gitgalaxy"], ["ctags"], occ=50)
+    path = _write_ledger(tmp_path, g.shape_key, credit=["gitgalaxy"], debit=["ctags"])
+    scores = _scores(gitgalaxy=(8, 58), ctags=(8, 92))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["gitgalaxy"].matched_consensus == 58  # valid lone-claimant credit still applied
+    assert scores["ctags"].matched_consensus == 8  # bad debit skipped -- not -42
+    assert "ignoring malformed debit_tools=[ctags]" in capsys.readouterr().err
+
+
+def test_credit_on_two_tool_agreement_is_skipped(tmp_path, capsys):
+    # Crediting a tool that already shares a 2+-tool agreement would double-count -- reconcile
+    # already put those occurrences in its numerator.
+    g = _group(["ctags", "tree_sitter"], ["gitgalaxy"], occ=3)
+    path = _write_ledger(tmp_path, g.shape_key, credit=["ctags", "tree_sitter"])
+    scores = _scores(ctags=(100, 100), tree_sitter=(200, 200))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["ctags"].matched_consensus == 100
+    assert scores["tree_sitter"].matched_consensus == 200
+    assert "ignoring malformed credit_tools" in capsys.readouterr().err
+
+
+def test_credit_on_absent_tool_is_skipped(tmp_path, capsys):
+    # The zig class shape: agree[tree_sitter]_vs[gitgalaxy] with credit_tools=[gitgalaxy] gave
+    # gitgalaxy matched_consensus > total_slots (the impossible 100.27%).
+    g = _group(["tree_sitter"], ["gitgalaxy"], occ=2, symbol_type="class")
+    path = _write_ledger(tmp_path, g.shape_key, credit=["gitgalaxy"])
+    scores = _scores(gitgalaxy=(728, 729))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["gitgalaxy"].matched_consensus == 728
+    assert scores["gitgalaxy"].rate_pct <= 100.0
+    assert "ignoring malformed credit_tools=[gitgalaxy]" in capsys.readouterr().err
+
+
+def test_non_existence_group_is_ignored(tmp_path):
+    g = _group(["gitgalaxy"], ["ctags"], occ=5, metric="args")
+    path = _write_ledger(tmp_path, g.shape_key, credit=["gitgalaxy"])
+    scores = _scores(gitgalaxy=(10, 20))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["gitgalaxy"].matched_consensus == 10
+
+
+def test_unvalidated_entry_is_ignored(tmp_path):
+    g = _group(["gitgalaxy"], ["ctags"], occ=5)
+    path = _write_ledger(tmp_path, g.shape_key, credit=["gitgalaxy"], status="pending")
+    scores = _scores(gitgalaxy=(10, 20))
+
+    ledger_mod.apply_verified_adjustments(scores, [g], path=path)
+
+    assert scores["gitgalaxy"].matched_consensus == 10

--- a/tests/tools/tri_comparison_ledger.py
+++ b/tests/tools/tri_comparison_ledger.py
@@ -87,11 +87,20 @@ VERIFIED ADJUSTMENTS (credit_tools / debit_tools) -- LETTING A VERDICT MOVE THE 
     Scope discipline carries over from every other part of this module: set these two fields with
     the same rigor as `verdict` itself -- a rubber-stamped credit/debit is worse than leaving both
     empty, since it moves a number based on a conclusion nobody actually checked.
+      - GEOMETRY GUARD: a credit is only meaningful on a shape's SOLE agreeing tool (the one
+        reconcile_symbols left uncorroborated), and a debit is only meaningful on a tool that was
+        part of a 2+-tool agreement (the corroboration a debit revokes). `apply_verified_adjustments`
+        skips -- with a stderr warning, never a silent no-op -- any credit/debit whose named tool
+        doesn't fit that geometry (a debit on a lone claimant or a dissenting-side tool used to
+        drive the numerator negative: m4/scheme's `-73/79` and `-42/92` on the chart, and zig's
+        impossible 100.27% class precision from the mirror-image bad credit). The guard doesn't
+        rewrite the ledger; the warning is there so a human fixes the entry.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -201,6 +210,37 @@ def has_open_question(language: str, symbol_type: str, metric: str, path: Path =
     )
 
 
+def _credit_is_well_formed(tool: str, g: DiscrepancyGroup) -> bool:
+    """A credit only has a defined meaning when `tool` is the SOLE agreeing tool on this shape.
+    reconcile_symbols() adds an occurrence to a tool's precision `matched_consensus` iff at least
+    one OTHER tool corroborated it at that slot (`len(present) >= 2`); a lone claimant therefore
+    starts with those occurrences in `total_slots` but NOT `matched_consensus`, which is exactly
+    the gap a `credit` closes once a human confirms the uncorroborated claim was real. Crediting a
+    tool that already shares a 2+-tool agreement double-counts (it's already in `matched_consensus`);
+    crediting a tool that isn't in `agreeing_tools` at all invents a claim it never made."""
+    return tool in g.agreeing_tools and len(g.agreeing_tools) == 1
+
+
+def _debit_is_well_formed(tool: str, g: DiscrepancyGroup) -> bool:
+    """The mirror of `_credit_is_well_formed`: a debit only has a defined meaning when `tool` was
+    part of a 2+-tool agreement (so reconcile_symbols() already counted these occurrences as
+    corroborated in its `matched_consensus`) and the verdict now revokes that corroboration as a
+    shared mistake -- the C `agree[ctags,tree_sitter]_vs[gitgalaxy]` case in this module's own
+    docstring. Debiting a lone claimant, or a tool on the dissenting (absent) side, subtracts
+    occurrences that were never in `matched_consensus` to begin with and drives the numerator
+    negative (m4/scheme, real ledger entries that produced `-73/79` / `-42/92` on the chart)."""
+    return tool in g.agreeing_tools and len(g.agreeing_tools) >= 2
+
+
+def _warn_malformed(tool: str, g: DiscrepancyGroup, kind: str) -> None:
+    print(
+        f"tri_comparison_ledger: ignoring malformed {kind}_tools=[{tool}] on {g.shape_key} "
+        f"(agreeing_tools={sorted(g.agreeing_tools)}) -- a {kind} on this shape has no defined "
+        f"effect on precision; clean the ledger entry (see apply_verified_adjustments docstring).",
+        file=sys.stderr,
+    )
+
+
 def apply_verified_adjustments(
     precision_scores: dict[str, MetricScore], groups: list[DiscrepancyGroup], path: Path = LEDGER_PATH
 ) -> None:
@@ -215,7 +255,15 @@ def apply_verified_adjustments(
     tools are simply right/wrong" at all. Only ever touches precision -- `total_slots` (what a
     tool itself claimed) is untouched either direction, and recall/found-count panels don't call
     this at all since "found more" was never a ranked claim to begin with (see
-    tri_comparison_chart.py's own PANELS docstring)."""
+    tri_comparison_chart.py's own PANELS docstring).
+
+    A credit/debit that names a tool the shape's geometry can't support -- a credit on a tool
+    that already shares a 2+-tool agreement (or isn't in `agreeing_tools` at all), or a debit on
+    a lone claimant / a dissenting-side tool -- is malformed: it has no defined effect on
+    `matched_consensus` (and a bad debit drives the numerator negative, the m4/scheme `-73/79` /
+    `-42/92` bug). Those are skipped with a stderr warning rather than applied; see
+    `_credit_is_well_formed` / `_debit_is_well_formed`. The ledger JSON isn't rewritten here --
+    the warning is the signal to clean the offending entry by hand."""
     ledger = load_ledger(path)
     entries = ledger.get("entries", {})
     for g in groups:
@@ -229,8 +277,16 @@ def apply_verified_adjustments(
         if not entry or entry["status"] != "validated":
             continue
         for tool in entry.get("credit_tools", []):
-            if tool in precision_scores:
-                precision_scores[tool].matched_consensus += g.total_occurrences
+            if tool not in precision_scores:
+                continue
+            if not _credit_is_well_formed(tool, g):
+                _warn_malformed(tool, g, "credit")
+                continue
+            precision_scores[tool].matched_consensus += g.total_occurrences
         for tool in entry.get("debit_tools", []):
-            if tool in precision_scores:
-                precision_scores[tool].matched_consensus -= g.total_occurrences
+            if tool not in precision_scores:
+                continue
+            if not _debit_is_well_formed(tool, g):
+                _warn_malformed(tool, g, "debit")
+                continue
+            precision_scores[tool].matched_consensus -= g.total_occurrences

--- a/tests/tri_comparison_baseline_zig.json
+++ b/tests/tri_comparison_baseline_zig.json
@@ -1,4 +1,4 @@
 {
-  "class_precision": 100.27434842249657,
+  "class_precision": 100.0,
   "func_precision": 100.0
 }


### PR DESCRIPTION
## Problem

The tri-comparison chart rendered negative and impossible precision numerators:

| language / cell | rendered | should be |
|---|---|---|
| m4 — ctags func precision | `-73/79` | `3/79` |
| scheme — ctags func precision | `-42/92` | `8/92` |
| kotlin — ctags func precision | `12/42` (understated) | `27/42` |
| solidity — tree-sitter func precision | `93/99` (understated) | `99/99` |
| zig — class precision | `731/729` (**100.27%**, impossible) | `729/729` |

The zig 100.27% had also been baked into `tests/tri_comparison_baseline_zig.json`.

## Root cause

`tri_comparison_ledger.apply_verified_adjustments()` added / subtracted a validated shape's occurrence count to / from a tool's `matched_consensus` for **every** `credit_tools` / `debit_tools` entry, with no check that the adjustment was geometrically meaningful.

`reconcile_symbols()` only ever increments a tool's *precision* `matched_consensus` when **2+ tools agree** on a slot. So:

- **debiting a lone claimant** (`m4/function/existence/agree[ctags]_vs[gitgalaxy]`, kotlin) or a **dissenting-side / absent tool** (`scheme/function/existence/agree[gitgalaxy]_vs[ctags]`, solidity) subtracts occurrences that were never in the numerator → negative / understated.
- **crediting a tool already in a 2+-tool agreement, or an absent tool** (`zig/class/existence/agree[tree_sitter]_vs[gitgalaxy]` with `credit_tools:[gitgalaxy]`) double-counts / invents a claim → numerator exceeds denominator.

## Fix

`_credit_is_well_formed` / `_debit_is_well_formed`: a credit only applies to a shape's **sole** agreeing tool (the one `reconcile_symbols` left uncorroborated); a debit only to a tool that was **part of a 2+ agreement** (the corroboration a debit revokes — the C `agree[ctags,tree_sitter]_vs[gitgalaxy]` case the module docstring already describes).

Malformed credit/debit entries are **skipped with a stderr warning**, not applied. The ledger JSON is left untouched — per the repo rule against hand-setting ledger verdict fields, the warning is the signal for a human to clean the offending entry. Current warnings on a full run:

```
tri_comparison_ledger: ignoring malformed debit_tools=[ctags] on kotlin/function/existence/agree[ctags]_vs[gitgalaxy,tree_sitter] ...
tri_comparison_ledger: ignoring malformed debit_tools=[ctags] on m4/function/existence/agree[ctags]_vs[gitgalaxy] ...
```

(scheme/solidity/zig entries didn't reproduce as groups on this run, but the guard covers them.)

## Verification

- New `tests/tools/test_tri_comparison_ledger.py` — first unit tests for these modules (8 cases: valid credit/debit still apply, each malformed geometry is skipped + warns, non-existence / unvalidated entries ignored).
- Regenerated `docs/self_scan/tri_comparison_chart.svg` via `tri_comparison_chart.py --all --write` (real Universal Ctags 5.9.0 confirmed). Only the 6 value labels above changed; **no badge changes**.
- Regenerated `tests/tri_comparison_baseline_zig.json` (100.27 → 100.0, a correction). `tri_comparison_chart.py --all --ci` passes.
- `audit_check.py` (ruff / mypy / dead-key / ast-accuracy) all clear.
- Ledger `last_reconciled_at` / points-of-interest timestamp churn deliberately **not** committed — that's the post-merge history workflow's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)