### PR TITLE
test: fix zip(strict=) py3.9 breakage in tri-comparison reconcile test

### DIFF
--- a/tests/tools/test_tri_comparison_reconcile.py
+++ b/tests/tools/test_tri_comparison_reconcile.py
@@ -139,8 +139,10 @@ def test_single_occurrence_name_unchanged(monkeypatch):
     _force_rank_pairing(monkeypatch)
     rank_result = _reconcile(gg, ts)
 
-    for line_scores, rank_scores in zip(line_result[:3], rank_result[:3], strict=True):
-        assert _rates(line_scores) == _rates(rank_scores)
+    # _reconcile returns a fixed-shape tuple, so the first 3 elements always
+    # line up 1:1 -- compare them positionally without zip() (whose strict=
+    # kwarg is 3.10+ and this repo still supports 3.9).
+    assert [_rates(s) for s in line_result[:3]] == [_rates(s) for s in rank_result[:3]]
 
 
 def test_classes_never_use_line_pairing():


### PR DESCRIPTION
## Problem

`tests/tools/test_tri_comparison_reconcile.py::test_single_occurrence_name_unchanged`
uses `zip(line_result[:3], rank_result[:3], strict=True)`. The `strict=`
keyword on `zip()` is Python 3.10+; on 3.9 it raises
`TypeError: zip() takes no keyword arguments`.

The repo declares `requires-python = ">=3.9"` and the CI matrix includes
3.9, so this fails `full-suite-matrix (*, 3.9)` on **every open PR** (e.g.
#2371) and on `main` itself.

## Fix

`_reconcile` returns a fixed-shape tuple, so `line_result[:3]` and
`rank_result[:3]` are always equal length. Compare them positionally with
list comprehensions — no `zip`, and flake8-bugbear's `B905`
(zip-without-explicit-strict) stays satisfied.

Test-only change; no engine/parsing paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)