### PR TITLE
docs: auto-update LLM architectural brief

### DIFF
--- a/docs/gitgalaxy_architecture_brief.md
+++ b/docs/gitgalaxy_architecture_brief.md
@@ -6,10 +6,10 @@
 |---|---|
 | **Engine** | `GitGalaxy Scope vlatest (Delta Mode)` |
 | **Target Path** | `/home/runner/work/gitgalaxy/gitgalaxy` |
-| **Timestamp** | `2026-08-28T12:59:51.239748+00:00` |
-| **Scan Duration** | `9.81s` |
+| **Timestamp** | `2026-08-28T13:01:48.035915+00:00` |
+| **Scan Duration** | `10.19s` |
 | **Git Branch** | `main` |
-| **Git Commit** | `4e45482174c1b9e9f3bfff0c8a26865c8e261d28` |
+| **Git Commit** | `d53f7b010a86d11f66fd65b59a349fa02800385d` |
 | **Git Remote** | `https://github.com/squid-protocol/gitgalaxy` |
 | **Zero-Dependency Mode** | `Inactive (Full Precision)` |
 


### PR DESCRIPTION
Automated update from the latest GalaxyScope scan on `main`.