### PR TITLE
fix(#1984): gate the GG SPLICE FUNCS trace behind --debug

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -435,7 +435,12 @@ def _process_file_worker(rel_path: str) -> dict[str, Any]:
                     logic_data["metadata"] = {}
                 logic_data["metadata"]["doc_umbrella"] = guidestar.documentation_coverage.get(dir_path, 0.0)
 
-                print("GG SPLICE FUNCS:", [f["name"] for f in logic_data.get("functions", [])])
+                # #1984: was a bare print() firing on every file of every real
+                # scan (and into CI logs). Kept as a trace, gated behind --debug
+                # like its neighbours.
+                if logger.isEnabledFor(logging.DEBUG):
+                    extracted_fn_names = [f["name"] for f in logic_data.get("functions", [])]
+                    logger.debug(f"[WORKER-TRACE] extracted functions for {rel_path}: {extracted_fn_names}")
 
                 logger.debug(f"[WORKER-TRACE] <<< EXITING EXTRACTOR: {rel_path}")
 


### PR DESCRIPTION
Closes #1984.

`galaxyscope.py`'s `_process_file_worker` had a bare
`print("GG SPLICE FUNCS:", [f["name"] for f in ...])` sitting next to the
`# --- INJECTED DEBUG TRACE ---` marker. It fired unconditionally on every
file of every real scan — straight to stdout, including CI logs (visible
flooding `crucible_check.py` output during this session).

Converted to a `logger.debug` `[WORKER-TRACE]` line matching the two
`logger.debug(f"[WORKER-TRACE] ...")` calls that already bracket it,
guarded by `logger.isEnabledFor(logging.DEBUG)` (the same pattern
`language_lens.py` uses) so the list comprehension is skipped entirely
when not tracing.

Cosmetic/noise only — no output-correctness change. `test_galaxyscope.py`
46/46 pass; ruff / mypy / dead-key / ast-accuracy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)