### PR TITLE
feat(recorder): drop per-scan-volatile fields from the committed LLM brief

### DIFF
--- a/docs/gitgalaxy_architecture_brief.md
+++ b/docs/gitgalaxy_architecture_brief.md
@@ -5,11 +5,6 @@
 | Metadata | Value |
 |---|---|
 | **Engine** | `GitGalaxy Scope vlatest (Delta Mode)` |
-| **Target Path** | `/home/runner/work/gitgalaxy/gitgalaxy` |
-| **Timestamp** | `2026-08-28T18:51:54.195945+00:00` |
-| **Scan Duration** | `7.55s` |
-| **Git Branch** | `main` |
-| **Git Commit** | `7a591bd6769ad6710fa45872208dc477801c7d62` |
 | **Git Remote** | `https://github.com/squid-protocol/gitgalaxy` |
 | **Zero-Dependency Mode** | `Inactive (Full Precision)` |
 

--- a/gitgalaxy/recorders/llm_recorder.py
+++ b/gitgalaxy/recorders/llm_recorder.py
@@ -169,12 +169,14 @@ class LLMRecorder:
         lines.append("## 0. FORENSIC TRACEABILITY")
         lines.append("| Metadata | Value |")
         lines.append("|---|---|")
+        # This brief is committed to docs/gitgalaxy_architecture_brief.md by a
+        # scheduled CI scan of main. Only fields that change when the repo's
+        # *architecture* changes belong here -- anything that varies between two
+        # scans of the same commit (Timestamp, Scan Duration, the absolute
+        # Target Path, the current Git Branch, the HEAD commit hash) made every
+        # scan produce a diff, and its PR auto-merges, so a per-scan field was a
+        # ~21-commits/day treadmill. Freshness lives in `git log` of the file.
         lines.append(f"| **Engine** | `{session_meta.get('engine', 'Unknown')}` |")
-        lines.append(f"| **Target Path** | `{session_meta.get('target_directory', 'Unknown')}` |")
-        lines.append(f"| **Timestamp** | `{session_meta.get('timestamp', 'Unknown')}` |")
-        lines.append(f"| **Scan Duration** | `{session_meta.get('duration_seconds', 0.0)}s` |")
-        lines.append(f"| **Git Branch** | `{git_audit.get('branch', 'N/A')}` |")
-        lines.append(f"| **Git Commit** | `{git_audit.get('commit_hash', 'N/A')}` |")
         lines.append(f"| **Git Remote** | `{git_audit.get('remote_url', 'N/A')}` |")
         lines.append(
             f"| **Zero-Dependency Mode** | `{'ACTIVE (Degraded Precision)' if session_meta.get('zero_dependency_mode') else 'Inactive (Full Precision)'}` |"

--- a/tests/ruff_audit_baseline.json
+++ b/tests/ruff_audit_baseline.json
@@ -22,7 +22,7 @@
   "gitgalaxy/recorders/audit_recorder.py:298: C414": "Unnecessary `list()` call within `sorted()`",
   "gitgalaxy/recorders/audit_recorder.py:358: PERF401": "Use `list.extend` to create a transformed list",
   "gitgalaxy/recorders/gpu_recorder.py:285: C414": "Unnecessary `list()` call within `sorted()`",
-  "gitgalaxy/recorders/llm_recorder.py:1016: SIM102": "Use a single `if` statement instead of nested `if` statements",
+  "gitgalaxy/recorders/llm_recorder.py:1018: SIM102": "Use a single `if` statement instead of nested `if` statements",
   "gitgalaxy/recorders/record_keeper.py:187: W291": "Trailing whitespace",
   "gitgalaxy/recorders/record_keeper.py:188: W291": "Trailing whitespace",
   "gitgalaxy/recorders/record_keeper.py:189: W291": "Trailing whitespace",

--- a/tests/tools_recorders/test_llm_recorder.py
+++ b/tests/tools_recorders/test_llm_recorder.py
@@ -159,6 +159,44 @@ def test_build_markdown_generates_context(recorder, mock_pipeline_state):
     assert "src/api/handler.py" in md_text  # Our mock file has I/O hits
 
 
+def test_build_markdown_omits_per_scan_volatile_fields(recorder):
+    """
+    The brief is committed to docs/gitgalaxy_architecture_brief.md by a
+    scheduled CI scan; any field that differs between two scans of the same
+    commit made every scan produce a diff whose PR auto-merges -- a
+    ~21-commits/day treadmill. The FORENSIC TRACEABILITY section must not
+    carry the scan timestamp, duration, HEAD commit hash, current branch, or
+    absolute target path.
+    """
+    session_meta = {
+        "engine": "GitGalaxy Scope vtest",
+        "target": "Repo",
+        "target_directory": "/home/runner/work/gitgalaxy/gitgalaxy",
+        "timestamp": "2026-06-18T12:00:00.123456+00:00",
+        "duration_seconds": 7.55,
+        "zero_dependency_mode": False,
+        "git_audit": {
+            "branch": "some-feature-branch",
+            "commit_hash": "7a591bd6769ad6710fa45872208dc477801c7d62",
+            "remote_url": "https://github.com/squid-protocol/gitgalaxy",
+        },
+    }
+    md_text = recorder._build_markdown([], [], {}, session_meta, {})
+
+    for volatile in (
+        "2026-06-18T12:00:00.123456+00:00",  # timestamp
+        "7.55",  # duration
+        "7a591bd6769ad6710fa45872208dc477801c7d62",  # HEAD commit
+        "some-feature-branch",  # current branch
+        "/home/runner/work/gitgalaxy/gitgalaxy",  # absolute target path
+    ):
+        assert volatile not in md_text, f"per-scan-volatile value leaked into the committed brief: {volatile!r}"
+
+    # The stable identity fields still render.
+    assert "GitGalaxy Scope vtest" in md_text
+    assert "https://github.com/squid-protocol/gitgalaxy" in md_text
+
+
 def test_house_of_cards_section_reads_fragile_dependency_chain(recorder, mock_pipeline_state):
     """
     Regression test for #370: the "House of Cards" section used to read


### PR DESCRIPTION
Follow-up to #2396 (the CI-throttle PR). Together they stop the
`docs: auto-update LLM architectural brief` treadmill (~21 commits/day).

## Problem

`docs/gitgalaxy_architecture_brief.md` is written by a CI scan of `main`.
Its **FORENSIC TRACEABILITY** table carried:

| Field | Why it churns |
|---|---|
| `Timestamp` | wall-clock, every scan |
| `Scan Duration` | timing jitter, every scan |
| `Target Path` | absolute path — runner-specific |
| `Git Branch` | whatever regenerated it |
| `Git Commit` | HEAD hash — every commit |

Any one guarantees a diff, `create-pull-request` opens a PR, it
auto-merges, and that merge is another push. Result: ~21 no-op brief
commits/day (a confirmed 13-in-13-minutes runaway on 2026-07-25).

## Fix

Keep only fields that change when the **architecture** does — `Engine`
(name + version), `Git Remote`, `Zero-Dependency Mode`. The brief is now
**byte-identical across repeated scans of the same commit** (verified
locally), so a scheduled scan opens no PR unless the structural content
actually moved.

- New `test_build_markdown_omits_per_scan_volatile_fields`.
- Committed brief hand-trimmed to the new shape here; the next scheduled
  scan (post-#2396) reconciles any real drift in one final update.
- No golden-master / crucible impact — the brief isn't in those fixtures.
  `test_llm_recorder.py` 7/7, audits clean (1 pure line-shift baseline
  bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)