### PR TITLE
Re-verify jcl tri-comparison manual record against the v1.1.0 corpus

### DIFF
--- a/docs/language_status/jcl.md
+++ b/docs/language_status/jcl.md
@@ -146,4 +146,12 @@ staleness anchor — a PRECISION record):
   `**` — there is nothing to verify, so JCL carries no `args` entry in `manual_verification.json`
   (same as `dockerfile`, the other `none`-granularity gg-only language). The 2026-08-23 `1/1`
   args entry was removed. For the record, GitGalaxy's `args` regex matches 28 real `PARM=`
-  strings / PROC symbolic-parameter declarations across the full corpus, zero spurious.
+  strings / PROC symbolic-parameter declarations across the full corpus, zero spurious. Two
+  known, accepted proxy imprecisions, neither worth its own issue since the metric is `none`:
+  (1) the line-anchored `args` regex only sees `PARM=` when it sits on the `EXEC` line itself, so
+  ~16–18 `//` continuation-line `PARM=(...)` occurrences (`asmmap.jcl`, `BATCH.jcl`, `CICS.jcl`,
+  `CICSTS56.jcl:45`, `cobol.jcl:68`, `defdrep.jcl:39`, …) are not counted; (2) the per-step
+  `Occurrence.args` values feeding `gg_args_found` (`24‡`) are `0` for 352 steps, `1` for 17
+  (a `PARM=` is present), and `7` for one — `ZOSCSEC.jcl`'s `BPXIT` step, a mild over-count where
+  Mode A's unbounded args search (see [#1973](https://github.com/squid-protocol/gitgalaxy/issues/1973))
+  sweeps a multi-line `PARM='SH chmod …'` string.

--- a/docs/language_status/jcl.md
+++ b/docs/language_status/jcl.md
@@ -59,7 +59,12 @@
 
 ## 5. Known limitations (accepted, not fixed)
 
-None identified in the current test suite.
+- **Perimeter filter drops JCL files whose name contains `gen`/`lib`/etc.**
+  ([#2415](https://github.com/squid-protocol/gitgalaxy/issues/2415)): `aperture.py`'s
+  `infra_path_pattern` has no left word boundary, so `MAPGEN.jcl` (matched as `gen`) and
+  `DBRMLIB.jcl` (matched as `lib`) are excluded before extraction when no manifest supplies
+  Intent. Not a JCL-specific bug; surfaced by the §9 manual-verification pass. Costs JCL 5 EXEC
+  steps and 1 JOB card against the v1.1.0 corpus.
 
 ## 6. Test depth
 
@@ -78,12 +83,67 @@ None identified in the current test suite.
 
 - [`jcl-assess`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/jcl-assess/jcl-assess_galaxy_llm.md) - A dedicated assessment project demonstrating pure JCL scanning.
 - [`cics-genapp`](https://github.com/squid-protocol/gitgalaxy-raw-output/blob/main/v2.4.7/cics-genapp/cics-genapp_galaxy_llm.md) - IBM's standard CICS General Insurance Application sample, showcasing JCL operating alongside COBOL in a larger mainframe system.
-## 9. Manual verification (No comparison tool)
+## 9. Manual verification (no comparison tool)
 
-JCL has no tree-sitter or ctags parser available for the tri-comparison tool, so its precision and recall are verified manually.
+JCL has no tree-sitter or ctags parser available for the tri-comparison tool, so its precision
+and recall are verified by hand and recorded in `docs/self_scan/manual_verification.json` (read
+directly by `tri_comparison_chart.py` to render the `**` marker and award GitGalaxy's badge). See
+`docs/self_scan/how_to_investigate_a_discrepancy.md` for the methodology and the
+`tri-comparison-ledger-sweep` skill's manual-verification fallback for the procedure.
 
-The initial manual verification run across the 3 JCL corpus files (`cics-genapp/base/cntl/wsavp01.jcl`, `cpsmde2.jcl`, and `itpentr.jcl`) revealed a bug where JCL was missing from `_CLASS_START_NAMED_EXTRACTION_LANGS`, which caused JCL classes (JOB cards) to fall back to a brace-sliced extraction that failed to parse. After adding JCL to the list, the pipeline perfectly matched the regex matches.
+### 2026-08-29: re-verified against the v1.1.0 corpus expansion
 
-- **Classes (JOB cards)**: 3/3 detected successfully across the 3 corpus files.
-- **Functions (EXEC steps)**: 3/3 detected successfully. JCL is appropriately routed to Mode A (greedy-to-next) slicing because it does not use brace-delimited blocks.
-- **Args**: 1/1 detected successfully. The one `args` matched is `PARM='NTWRK=GENAPP'` from `//RUNSIM EXEC PGM=ITPENTER,PARM='NTWRK=GENAPP'`. Note that `args` extraction is implemented as a proxy metric because JCL EXEC statements don't take a standard parenthesized parameter list.
+`language-crucible` v1.1.0 (pin bumped in [#2398](https://github.com/squid-protocol/gitgalaxy/pull/2398))
+grew JCL's corpus from **3 files** to **185 `.jcl` files / ~8.7k lines** across five IBM
+mainframe sample repos (`cash-account-cobol`, `cics-banking-sample-application-cbsa`,
+`cics-genapp`, `cobol-programming-course`, `zopeneditor-sample`). The 2026-08-23 3-file record
+(3/3/1) went stale, dropping JCL's precision panels to a bare `0/370` / `0/116` with no badge.
+This pass re-established the record against the full corpus.
+
+**Method.** Two independent readings per signature, sharing no implementation:
+
+1. GitGalaxy's own `func_start` / `class_start` regexes applied directly to raw source text
+   across all 185 files.
+2. An independent line scanner (skip any line starting `//*`; `^//([A-Za-z0-9#$@]{1,8})\s+JOB\b`
+   for JOB cards, `^//([A-Za-z0-9#$@]{0,8})\s+EXEC\s` for EXEC steps).
+
+Plus a step-2b pipeline cross-check: `file_data.struct_func_start` / `struct_class_start` from a
+real `galaxyscope --db-only` run, per file, against the raw regex count.
+
+| Signature | Raw-corpus truth | Independent scanner | False positives | Misses | Pipeline (`struct_*`) vs. raw, per scanned file |
+| :--- | :---: | :---: | :---: | :---: | :--- |
+| `func_start` (EXEC steps) | **375 / 375** | 375 | 0 | 0 | identical on all 182 scanned files |
+| `class_start` (JOB cards) | **117 / 117** | 117 | 0 | 0 | identical on all 182 scanned files |
+
+- **100% precision, 100% recall** for both signatures across the whole corpus. GitGalaxy
+  correctly rejects every `//*`-commented JOB/EXEC line, every keyword buried in inline SYSIN
+  card data, and the `//<CMASAPPL> JOB` angle-bracket template placeholder in `sampcma.jcl` /
+  `sampwui.jcl`. A naive `^//\S+\s+JOB` grep's 15 extra "hits" are all such noise.
+- **Extraction path is clean.** For every one of the 182 files the pipeline scans, the raw regex
+  count equals `struct_*` exactly — no `prism.py` comment-splitter corruption, no `detector.py`
+  body-slicing drop. Mode A (greedy-to-next-label) slicing is correct for JCL, which has no
+  brace-delimited bodies.
+
+**One engine defect found** ([#2415](https://github.com/squid-protocol/gitgalaxy/issues/2415)):
+`aperture.py`'s `infra_path_pattern` "Semantic Path Shield" has no left word boundary, so
+`MAPGEN.jcl` (matches `gen`) and `DBRMLIB.jcl` (matches `lib`) are blocked at the perimeter
+before extraction — costing 5 real EXEC steps and 1 real JOB card. `DFH$SIP1.jcl` is also not
+counted, correctly: it is a SYSIN parameter deck (`*`-prefixed lines, no `//` statements) with
+zero real signatures. Not a JCL-specific bug; the fix touches every language's file-filtering
+and ripples both golden masters, so it is filed for its own PR rather than fixed here.
+
+**Chart records** (`manual_verification.json`, keyed to GitGalaxy's live claim count as the
+staleness anchor — a PRECISION record):
+
+- **Functions (EXEC steps)**: `370 / 370` verified — every EXEC step the engine currently
+  extracts is a real one, and nothing real is missed within the files it scans. Raw-corpus truth
+  is `375 / 375`; the 5-step gap is entirely #2415.
+- **Classes (JOB cards)**: `116 / 116` verified — same standard. Raw-corpus truth is `117 / 117`;
+  the 1-card gap is entirely #2415.
+- **Args**: JCL `func_start` matches `EXEC` job steps, a document-structural marker with no
+  parameter-list concept at any granularity (`ARGS_GRANULARITY["jcl"] == "none"`). The chart
+  shows GitGalaxy's raw `PARM=` / PROC-symbolic signal count with the granularity marker and no
+  `**` — there is nothing to verify, so JCL carries no `args` entry in `manual_verification.json`
+  (same as `dockerfile`, the other `none`-granularity gg-only language). The 2026-08-23 `1/1`
+  args entry was removed. For the record, GitGalaxy's `args` regex matches 28 real `PARM=`
+  strings / PROC symbolic-parameter declarations across the full corpus, zero spurious.

--- a/docs/self_scan/manual_verification.json
+++ b/docs/self_scan/manual_verification.json
@@ -49,26 +49,19 @@
       }
     },
     "jcl": {
-      "args": {
-        "note": "args (PARM= or PROC definition args) verified manually across the 3 JCL corpus files. Found exactly 1 parameter string ('NTWRK=GENAPP') on the EXEC step in itpentr.jcl. The DB matches this extraction exactly.",
-        "total": 1,
-        "verified": 1,
-        "verified_at": "2026-08-23",
-        "verified_by": "Antigravity"
-      },
       "class": {
-        "note": "class_start (JOB cards) verified manually across the 3 JCL corpus files. Found exactly 3 JOB statements (one per file). Fixed issue where JCL was missing from _CLASS_START_NAMED_EXTRACTION_LANGS, causing fallback to brace-slicing. The DB now matches the raw regex count exactly (3).",
-        "total": 3,
-        "verified": 3,
-        "verified_at": "2026-08-23",
-        "verified_by": "Antigravity"
+        "note": "class_start (JCL JOB cards) re-verified against the language-crucible v1.1.0 corpus expansion (3 -> 185 .jcl files, 5 repos). Same two independent checks over all 182 pipeline-scanned files: (1) GitGalaxy's class_start regex vs. an independent JOB-card grep (^//[A-Za-z0-9@#$][A-Za-z0-9@#$]{0,7}[ \\t]+JOB([ \\t]|$), no shared implementation, independently rejects //*-commented job cards) -- exact agreement, 116 == 116, zero per-file mismatches. The 12 cics-banking-sample-application-cbsa/CREL0*.jcl + CREDB2L.jcl files whose entire JOB card is commented out (//*NAME JOB ...) and the 2 cics-genapp sampcma/sampwui.jcl files whose jobname is an angle-bracket placeholder (//<CMASAPPL> JOB) are correctly NOT counted -- confirmed by direct source read. (2) real pipeline DB output: struct_class_start == class_count == 116 on every file (JCL is in _CLASS_START_NAMED_EXTRACTION_LANGS since #2203, so no brace-slice fallback). All 185 corpus files carry at most one JOB card. Zero false positives. Total is the live pipeline class count over the 182 scanned files; 1 more valid JOB card exists in the aperture-excluded DBRMLIB.jcl (same infra_path_pattern issue as the function entry), tracked separately. See docs/language_status/jcl.md #9.",
+        "total": 116,
+        "verified": 116,
+        "verified_at": "2026-08-29",
+        "verified_by": "Claude Sonnet 5"
       },
       "function": {
-        "note": "func_start (EXEC steps) verified manually across the 3 JCL corpus files. Found exactly 3 EXEC statements (one per file). Mode A slicing handles the boundary correctly. The DB output matches the raw regex count exactly (3).",
-        "total": 3,
-        "verified": 3,
-        "verified_at": "2026-08-23",
-        "verified_by": "Antigravity"
+        "note": "func_start (JCL EXEC steps) re-verified against the language-crucible v1.1.0 corpus expansion (3 -> 185 .jcl files, 5 repos). Two independent checks over all 182 pipeline-scanned files: (1) GitGalaxy's func_start regex applied directly to raw source text, cross-checked line-for-line against an independent grep (^//[A-Za-z0-9@#$]{0,8}[ \\t]+EXEC([ \\t]|$), which shares no implementation with the primary regex and independently excludes //* comment lines) -- exact agreement, 370 == 370, zero per-file mismatches. (2) real pipeline DB output (galaxyscope --db-only): file_data.struct_func_start == function_count == 370 on every file, so neither prism.py's comment splitter nor detector.py's Mode A (_slice_by_labels) body slicing drops or corrupts any match before extraction. Spot-read against direct source for EXEC steps across itpll.jcl, CBL0001J.jcl, RUNASAM1.jcl including unnamed '// EXEC CICS,MEMBER=' statements (correctly matched with an empty step name). Zero false positives: every match is a real EXEC statement. Total is the live pipeline func count over the 182 scanned files; 3 more valid EXEC steps exist in MAPGEN.jcl / DBRMLIB.jcl but those files are silently excluded by aperture.py before scanning (issue: infra_path_pattern matches 'gen'/'lib' as filename substrings) -- a recall gap tracked separately, not folded into verified/total, which is defined against pipeline output. See docs/language_status/jcl.md #9.",
+        "total": 370,
+        "verified": 370,
+        "verified_at": "2026-08-29",
+        "verified_by": "Claude Sonnet 5"
       }
     },
     "livecode": {

--- a/docs/self_scan/tri_comparison_chart.svg
+++ b/docs/self_scan/tri_comparison_chart.svg
@@ -523,14 +523,18 @@
 <rect x="154" y="1047" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="198.0" y="1055">370</text>
 <rect class="bar-track" x="286" y="1047" width="88" height="34" rx="2"/>
-<rect x="286" y="1047" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="330.0" y="1055">0/370</text>
+<rect x="286" y="1047" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="330.0" y="1055">370/370**</text>
+<circle cx="390.0" cy="1064.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="390.0" y="1067.0">G</text>
 <rect class="bar-track" x="418" y="1047" width="88" height="34" rx="2"/>
 <rect x="418" y="1047" width="88.0" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="462.0" y="1055">116</text>
 <rect class="bar-track" x="550" y="1047" width="88" height="34" rx="2"/>
-<rect x="550" y="1047" width="2.0" height="10" rx="2" fill="#2a78d6"/>
-<text class="bar-value-label" x="594.0" y="1055">0/116</text>
+<rect x="550" y="1047" width="88.0" height="10" rx="2" fill="#2a78d6"/>
+<text class="bar-value-label" x="594.0" y="1055">116/116**</text>
+<circle cx="654.0" cy="1064.0" r="8" fill="#2a78d6"/>
+<text class="badge-label" x="654.0" y="1067.0">G</text>
 <rect class="bar-track" x="682" y="1047" width="88" height="34" rx="2"/>
 <rect x="682" y="1047" width="88" height="10" rx="2" fill="#2a78d6"/>
 <text class="bar-value-label" x="726.0" y="1055">24‡</text>
@@ -1167,10 +1171,10 @@
 <rect x="682" y="2115" width="88.0" height="10" rx="2" fill="#eb6834"/>
 <text class="bar-value-label" x="726.0" y="2123">2751</text>
 <line x1="16" y1="2152" x2="796" y2="2152" stroke="#dedcd6" stroke-width="1"/>
-<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 61 real comparisons (1-bar groups and empty panels don't count)</text>
+<text class="summary-title" x="16" y="2166">Summary -- best tool per (language, metric), ranked panels only (Func/Class Precision), 63 real comparisons (1-bar groups and empty panels don't count)</text>
 <circle cx="23" cy="2184" r="7" fill="#2a78d6"/>
 <text class="badge-label" x="23" y="2187">G</text>
-<text class="legend-label" x="36" y="2188">GitGalaxy best: 25 (41%)</text>
+<text class="legend-label" x="36" y="2188">GitGalaxy best: 27 (43%)</text>
 <circle cx="215.8" cy="2184" r="7" fill="#eb6834"/>
 <text class="badge-label" x="215.8" y="2187">T</text>
 <text class="legend-label" x="228.8" y="2188">tree-sitter best: 3 (5%)</text>
@@ -1178,6 +1182,6 @@
 <text class="badge-label" x="408.6" y="2187">C</text>
 <text class="legend-label" x="421.6" y="2188">ctags best: 0 (0%)</text>
 <circle cx="564.2" cy="2184" r="7" fill="#9a9a95"/>
-<text class="legend-label" x="577.2" y="2188">Ties: 33 (54%)</text>
+<text class="legend-label" x="577.2" y="2188">Ties: 33 (52%)</text>
 <text class="scope-note" x="16" y="2208">Ranked-panel labels are matched/total; found-count panels are a single raw count, no denominator. Regenerate: tri_comparison_chart.py --all --write</text>
 </svg>


### PR DESCRIPTION
## What

Re-verify JCL's tri-comparison manual-verification record against the `language-crucible` v1.1.0
corpus expansion (3 → 185 `.jcl` files, ~8.7k lines). Direct analogue of the cobol pass in #2404,
via the `tri-comparison-ledger-sweep` skill's manual-verification fallback (JCL is gg-only — no
tree-sitter, no ctags).

The 2026-08-23 3-file record went stale after #2398, so the chart currently shows JCL at a bare
`0/370` Func Precision / `0/116` Class Precision with no badge.

## Verification

Two independent readings per signature (gg's own regex vs. an independent line scanner sharing no
implementation), plus a per-file `struct_*` pipeline cross-check:

| Signature | Raw-corpus truth | Independent scanner | False pos | Misses | Pipeline vs. raw |
| :-- | :-: | :-: | :-: | :-: | :-- |
| `func_start` (EXEC steps) | **375 / 375** | 375 | 0 | 0 | identical on all 182 scanned files |
| `class_start` (JOB cards) | **117 / 117** | 117 | 0 | 0 | identical on all 182 scanned files |

100% precision + recall for both. GitGalaxy correctly rejects every `//*`-commented JOB/EXEC line,
SYSIN card-data keywords, and the `//<CMASAPPL> JOB` angle-bracket template placeholder. Extraction
path is clean — no `prism.py` / `detector.py` drift.

## Changes

- **`manual_verification.json`** — JCL `function` → `370/370`, `class` → `116/116` (PRECISION
  records keyed to gg's live claim count, the chart's staleness anchor). Removed the vestigial
  `1/1` `args` entry: JCL args granularity is `"none"` (EXEC is a document-structural marker, no
  parameter-list concept), same as `dockerfile`, which carries no `args` entry either.
- **`tri_comparison_chart.svg`** — regenerated `--all --write`. JCL now shows `370/370**` +
  `116/116**` + both GitGalaxy precision badges. Summary: 61 → 63 comparisons, GitGalaxy best
  25 → 27. Full-chart diff confirmed scoped to the JCL row + summary counters **only** — no other
  language moved (implicitly re-confirming abap / dockerfile / agc_assembly / livecode manual
  records are all still current against v1.1.0).
- **`docs/language_status/jcl.md`** — rewrote §9 with the v1.1.0 methodology + results; added a §5
  known-limitation note for #2415.

## Engine defect found (filed, not fixed here)

**#2415** — `aperture.py`'s `infra_path_pattern` "Semantic Path Shield" has no left word boundary,
so `MAPGEN.jcl` (matches `gen`) and `DBRMLIB.jcl` (matches `lib`) are dropped at the perimeter
before extraction — costing JCL 5 real EXEC steps and 1 real JOB card (hence `370` vs. `375`,
`116` vs. `117`). Not JCL-specific; the fix changes file-filtering for every language and ripples
both golden masters, so it belongs in its own PR.

## Audits

Docs + JSON only, zero `.py` changes → ruff / mypy / golden-master unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zm1uVBpVEZJ9SB7bWFR8S
