### PR TITLE
fix(cobol): func_start no longer mistakes LE service calls for paragraphs

### DIFF
--- a/gitgalaxy/standards/language_standards/languages/cobol.py
+++ b/gitgalaxy/standards/language_standards/languages/cobol.py
@@ -142,7 +142,27 @@ DEFINITION: dict[str, Any] = {
             # `CONTINUE.` is `<verb>.`, not a paragraph header. Confirmed FP against
             # language-crucible v1.2.0 (che-che4z_nist_ccvs85/IF4014.2.cbl:30 etc.,
             # cobol-sample_SAMPLE1.cbl). Same class as LOCAL-STORAGE (#1890).
-            r"DELETE|OPEN|CLOSE|CONTINUE|PROGRAM-ID|CLASS-ID|SECTION|DIVISION|END-[A-Za-z0-9_-]+)(?=[ \t\n.]))"
+            r"DELETE|OPEN|CLOSE|CONTINUE|"
+            # #2538: CEE3DMP/CEEMOUT/CEEDUMP are Language Environment (LE)
+            # runtime diagnostic service names -- already recognized elsewhere
+            # in this file as the `telemetry` class (see that rule below) -- not
+            # paragraph names. A bare `CEE3DMP.` statement call sitting on its
+            # own line, indented into Area B, was being swept up as a paragraph
+            # header: this shield had no entry for them, and the post-sequence-
+            # area slot (`[ \t]*`, item 1 above) tolerates any horizontal
+            # indent to support genuinely free-format source, so it doesn't
+            # distinguish Area A (paragraph names, columns 8-11) from Area B on
+            # its own. Confirmed FP: `data/cobol/b.cpy` (che-che4z #1096 control
+            # corpus) planted `CEE3DMP.`/`CEEMOUT.` in Area B and both were
+            # captured as extra paragraphs (func_start=5 for 3 real paragraphs).
+            # Scoped narrowly to these three known LE tokens, same fix class as
+            # CONTINUE/LOCAL-STORAGE above, rather than a general Area-A column
+            # anchor: the sequence-area consumer in item 1 can't reliably tell
+            # a genuine fixed-format sequence number from 6 free-format leading
+            # spaces, so a real structural fix needs file-level fixed/free-
+            # format detection -- out of scope for this narrow token exclusion.
+            r"CEE3DMP|CEEMOUT|CEEDUMP|"
+            r"PROGRAM-ID|CLASS-ID|SECTION|DIVISION|END-[A-Za-z0-9_-]+)(?=[ \t\n.]))"
             # 4. THE DIVISION/SECTION HEADER SHIELD
             # Bans any word followed immediately by DIVISION (e.g., "PROCEDURE DIVISION").
             # Upgraded to `[ \t\n]+` to prevent vertical ghosting.

--- a/tests/extraction/languages/test_cobol.py
+++ b/tests/extraction/languages/test_cobol.py
@@ -66,6 +66,9 @@ FUNCTION_CASES: dict[str, Any] = {
         "      * TargetFunc.",  # column-7 comment marker
         "123456* TargetFunc.",  # column-7 comment with real sequence numbers
         "      *> TargetFunc.",  # free-format inline comment marker
+        "000600            CEE3DMP.",  # #2538: LE diagnostic call, Area B, not a paragraph
+        "000700            CEEMOUT.",  # #2538: LE diagnostic call, Area B, not a paragraph
+        "               CEEDUMP.",  # #2538: same LE-service class, free-format indent
     ],
     "pathological": [
         ("TargetFunc \n           SECTION.", "TargetFunc"),  # carried-forward: margin-hugging + vertical split

--- a/tests/extraction/languages/test_cobol_strict.py
+++ b/tests/extraction/languages/test_cobol_strict.py
@@ -365,6 +365,11 @@ def test_cobol_func_start_excludes_reserved_verbs_and_headers():
     WRITE, EXIT, GOBACK, STOP, DISPLAY, DIVISION, SECTION headers) -- these
     are false alarms from the sweep picking up func_start's own exclusion
     list text, not a real double-match risk.
+
+    #2538 extends this same list: CEE3DMP/CEEMOUT/CEEDUMP (the `telemetry`
+    rule's LE runtime diagnostic service names) share the same "bare
+    token + period" shape as a paragraph header when indented into Area B,
+    with nothing in the old shield to exclude them.
     """
     func_start = COBOL_RULES["func_start"]
     for reserved in (
@@ -375,6 +380,9 @@ def test_cobol_func_start_excludes_reserved_verbs_and_headers():
         "       PROCEDURE DIVISION.",
         "       STOP RUN.",
         "       GOBACK.",
+        "            CEE3DMP.",
+        "            CEEMOUT.",
+        "            CEEDUMP.",
     ):
         assert not func_start.search(reserved), f"func_start incorrectly matched reserved line {reserved!r}"
 


### PR DESCRIPTION
Closes #2538.

## Root cause

`CEE3DMP.`/`CEEMOUT.` (Language Environment runtime diagnostic calls) sitting alone
on a line indented into COBOL's Area B were counted as paragraph headers by
`func_start` — the reserved-word negative-lookahead shield had no entry for them,
and the post-sequence-area whitespace slot (`[ \t]*`) tolerates any horizontal
indent to support genuinely free-format source, so it can't distinguish Area A
(paragraph names, columns 8-11) from Area B on its own.

## Was this deliberate?

No. #2489 (cited in the issue) is the previous `func_start` sequence-area
hardening, but it only narrowed the *vertical*-whitespace slot (`[ \t\n]*` →
`[ \t]*`) to fix a debug-line name-mangling bug — unrelated to column position.
Confirmed via `git log` that Area A/B has never been discussed or implemented in
this file's history before this issue.

## Fix

Added `CEE3DMP|CEEMOUT|CEEDUMP` to `func_start`'s existing reserved-word shield —
the same low-risk, precedent-backed fix pattern already used repeatedly in this
exact file (`CONTINUE` for #1890's sibling class, `LOCAL-STORAGE`,
`SOURCE-COMPUTER`/`OBJECT-COMPUTER`). These three tokens are already a recognized
class elsewhere in `cobol.py` (the `telemetry` rule), so this reuses an existing
categorization rather than inventing a new one.

**Considered and deferred:** a general Area-A column anchor (the issue's other
option). The existing optional 6-char sequence-area consumer is itself a loose
heuristic — `[0-9a-zA-Z \t]{6}` happily matches 6 leading spaces in a free-format
file too, so "did the sequence-area group engage" doesn't reliably distinguish a
genuine fixed-format line from a free-format one. A correct structural fix needs
file-level fixed/free-format detection, which is a materially bigger change than
this specific bug warrants — left as a follow-up if the general class (any bare
token in Area B, not just these three) needs closing later.

## Verification

- Reproduced the exact FP locally: 5 `func_start` matches for 3 real paragraphs
  (`CEE3DMP.`/`CEEMOUT.` both miscounted); confirmed the fix brings it back to 3.
- Added cases to `tests/extraction/languages/test_cobol.py` (invalid-match cases)
  and `test_cobol_strict.py` (reserved-verb exclusion sweep).
- `test_cobol.py` + `test_cobol_strict.py`: 148 passed.
- `tests/core_engine/test_language_standards_strict.py`: 21 passed.
- `tests/tools/audit_check.py`: clean (ruff/mypy/dead-key/ast-accuracy).
- `tests/tools/crucible_check.py` (both `full_precision` and `zero_dependency`
  modes, full corpus): **PASS**, zero diffs — these tokens aren't present in the
  existing golden-master/crucible corpus, so no other output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)