### PR TITLE
fix(swift): capture single-letter imports

### DIFF
--- a/gitgalaxy/standards/language_standards/languages/swift.py
+++ b/gitgalaxy/standards/language_standards/languages/swift.py
@@ -196,7 +196,7 @@ DEFINITION: dict[str, Any] = {
         # 24. import (Dependency Inclusions)
         "import": re.compile(r"^[ \t]*(?:@_exported[ \t]+)?import\s+[a-zA-Z_]\w*", re.M),
         "_dependency_capture": re.compile(
-            r"^[ \t]*(?:@_exported[ \t]+)?import\s+(?:(?:typealias|struct|class|enum|protocol|let|var|func)\s+)?([a-zA-Z_][\w.]+)",
+            r"^[ \t]*(?:@_exported[ \t]+)?import\s+(?:(?:typealias|struct|class|enum|protocol|let|var|func)\s+)?([a-zA-Z_][\w.]*)",
             re.M,
         ),
         # 25. ownership (Authorship Metadata)

--- a/tests/extraction/languages/test_swift.py
+++ b/tests/extraction/languages/test_swift.py
@@ -235,10 +235,12 @@ def test_swift_class_start_pathological(payload, expected_name):
 # ==============================================================================
 DEPENDENCY_CASES: dict[str, Any] = {
     "valid": [
+        ("import a", "a"),  # issue #2543: single-letter module
         ("import Foundation", "Foundation"),
         ("@_exported import UIKit", "UIKit"),
     ],
     "invalid": [
+        "import",
         "var importData = true",
     ],
     "pathological": [
@@ -267,3 +269,7 @@ def test_swift_dependency_capture_pathological(payload, expected_path):
     assert_pathological_dependency_match(
         SWIFT_RULES["_dependency_capture"], payload, expected_path, "swift._dependency_capture"
     )
+
+
+def test_swift_dependency_capture_redos_immunity():
+    assert_redos_immune(SWIFT_RULES["_dependency_capture"], "import " + "a." * 50000, timeout_sec=3.0)


### PR DESCRIPTION
### Description

  Swift's `_dependency_capture` required an initial identifier character followed by one or more
  `[\w.]` characters. This made module names at least two characters long, so a valid single-letter
  import such as `import a` was silently omitted from the dependency DAG.

  This changes the tail quantifier from `+` to `*`, preserving existing imports while accepting
  single-letter module names.

  ### Changes

  - Accept single-letter Swift module names.
  - Add `import a` as a regression case.
  - Ensure bare `import` remains invalid.
  - Add adversarial ReDoS and scaling coverage.

  ### Validation

  - Swift extraction and strict suites: **130 passed**
  - Real compiled-regex candidates: **4/4 passed**
  - Scaling sweep: linear behavior
  - AST accuracy audit: passed
  - `git diff --check`: passed
  - Full-suite run: **7,146 passed**, 14 skipped, 2 deselected, 9 xfailed, 3 xpassed, and 15 failed
  - The dependency-related failures passed after installing their expected optional dependencies: **31
  relevant tests passed**
  - The two remaining failures are Windows-host constraints involving CP1252 console output and
  symlink privileges
  - No golden-master or baseline files changed

  ### Core Engine Modification Checklist

  - [ ] **Golden Master Verification:** Both Crucible engine scans completed across 2,817 files, but
  the Windows wrapper failed afterward while printing a Unicode timing glyph. Linux CI is
  authoritative.
  - [ ] **Tri-Comparison Audit:** Requires `ctags`, which was unavailable locally; handled
  automatically by CI.
  - [ ] **Tree-Sitter Accuracy:** Local execution was blocked by Windows corpus path handling; Linux
  CI is authoritative.

  ### Proof

  - [Regex fix](https://github.com/kanishk083/gitgalaxy/blob/fix/swift-import-regex/gitgalaxy/
  standards/language_standards/languages/swift.py#L198-L201)
  - [Regression and ReDoS tests](https://github.com/kanishk083/gitgalaxy/blob/fix/swift-import-regex/
  tests/extraction/languages/test_swift.py#L235-L275)
  - [Control corpus](https://github.com/squid-protocol/language-crucible), pinned at `v1.2.0`

  ### Cross-repo

  No companion code change is required. The control-corpus reproducer already exists. Rerun the Swift
  corpus ledger after this engine change lands.

  Fixes #2543