### PR TITLE
docs(language-status): correct #2535 references in cobol/python capstones

### DIFF
--- a/docs/language_status/cobol.md
+++ b/docs/language_status/cobol.md
@@ -452,14 +452,22 @@ ledgered or pinned to a named cross-cutting issue. The five-cause decomposition 
 5. **Median inflation / cross-cutting — COBOL is the honest one**: `state_mutation` 2 matches
    planted intent exactly; the median 6 is inflated by the ×3 flux weighting
    ([#2546](https://github.com/squid-protocol/gitgalaxy/issues/2546)).
-   `high_risk_execution`/`io` carry +1 each from a string-literal decoy COBOL doesn't shield
-   ([#2535](https://github.com/squid-protocol/gitgalaxy/issues/2535)'s selective-shielding
-   design question). No COBOL action; re-baselines when those land.
+   `high_risk_execution`/`io` carry +1 each because COBOL's `a.cpy` string decoy
+   (`'IF ALTER FAILS TRY OPEN AGAIN'`) contains `ALTER`/`OPEN` but not a token in COBOL's own
+   `safety` rule (`END-IF`/`END-PERFORM`/…/`VALIDATE`/`CHECK` — no `TRY`), so nothing dampens
+   them: this **is the raw, correct count**. [#2535](https://github.com/squid-protocol/gitgalaxy/issues/2535)
+   (closed, not-a-bug) traced the *median*'s pull the other way: languages whose safety rule
+   happens to include a `TRY`-shaped keyword get their same decoy's danger/io hit silenced by
+   the ordinary Silencer Region dampener — a real, working mechanism, just coincidentally
+   triggered by decoy prose. No COBOL action; the median re-baselines once
+   [keyword-rosetta#17](https://github.com/squid-protocol/keyword-rosetta/issues/17) redesigns
+   the decoy sentences corpus-wide to stop conflating that collision with literal counting.
 
 **Remaining out-of-band** (all accounted, none actionable at the COBOL level): `args` (bucket-4
-ledger), `state_mutation` (#2546), `globals`/`high_risk_execution`/`io` (bucket-4 ledger /
-#2535), and the §3 risk-score shadows (`risk_cognitive_load` −57%, `risk_safety_score` +42% —
-the epic forbids tuning risk formulas against biased inputs).
+ledger), `state_mutation` (#2546), `globals` (bucket-4 ledger), `high_risk_execution`/`io`
+(median inflation from other languages' decoy/safety-vocab collision — rosetta#17), and the §3
+risk-score shadows (`risk_cognitive_load` −57%, `risk_safety_score` +42% — the epic forbids
+tuning risk formulas against biased inputs).
 
 Reproduce: `GALAXYSCOPE_BIN=<venv>/bin/galaxyscope python tools/verify_language.py cobol` in the
 corpus repo (gate: 75 assertions), `python tools/language_deviations.py cobol` for the live

--- a/docs/language_status/python.md
+++ b/docs/language_status/python.md
@@ -418,18 +418,30 @@ skill's taxonomy; jcl.md and cobol.md §10 are the earlier capstones):
 5. **Median inflation / cross-cutting — python is the honest one**: `safety` 3 and
    `state_mutation` 2 match planted intent exactly (medians distorted by the ×3 flux weighting,
    [#2546](https://github.com/squid-protocol/gitgalaxy/issues/2546)); `doc` +100% is the
-   docstring open/close-delimiter double-count, adjacent to the literal-shielding question
-   ([#2535](https://github.com/squid-protocol/gitgalaxy/issues/2535)); and `comment_lines` +73%
-   surfaced a NEW engine-wide finding filed as
-   [#2625](https://github.com/squid-protocol/gitgalaxy/issues/2625) — `total_loc − coding_loc`
-   folds blank lines into "documentation" everywhere, loudest in python because its shells have
-   the highest blank-line ratio (jcl's and cobol's capstones hit the same proxy from the other
-   side).
+   docstring open/close-delimiter double-count — a genuinely separate mechanism, **not**
+   related to string-literal counting despite the earlier adjacency note here (see below).
 
-**Remaining out-of-band** (all accounted, none actionable in python's own rule file): `safety`/
-`state_mutation` (#2546), `doc` (#2535 — re-measure if that lands before assuming a residual
-bug), `comment_lines` (#2625), and the §3 risk shadows (`risk_api_exposure`,
-`risk_cognitive_load`). #2593 stays open pending those cross-cutting fixes — python re-baselines
+**UPDATE 2026-09-01 — two cross-cutting fixes landed since this section was written, and one
+earlier cross-reference here was wrong; corrected rather than left stale:**
+- **`comment_lines` is RESOLVED**: [#2625](https://github.com/squid-protocol/gitgalaxy/issues/2625)
+  (engine persists `doc_loc` instead of the blank-line-contaminated `total_loc − coding_loc`
+  proxy) took python 52 → 15, red → green.
+- **[#2535](https://github.com/squid-protocol/gitgalaxy/issues/2535) is closed, not-a-bug**:
+  there is no string-literal shielding mechanism in the engine at all — every "selective
+  shielding" reading traced to the ordinary Silencer Region dampener
+  ([#2546](https://github.com/squid-protocol/gitgalaxy/issues/2546)'s table) coincidentally
+  triggered by the shared decoy sentence's incidental overlap with a language's own `safety`
+  vocabulary. `doc`'s deviation is unaffected by this finding — it was never a literal-shielding
+  question, it's the docstring delimiter double-count, and stays an open residual on its own.
+- **A new residual surfaced live** (`io` 4 vs median 3, +33%) that predates a fresh sweep pass
+  and isn't triaged here — `tools/language_deviations.py python` currently reports **3🔴/3🟡**
+  (`doc`, `state_mutation`, `risk_cognitive_load` red; `io`, `safety`, `risk_api_exposure`
+  amber), down from this section's original 4🔴/3🟡. Re-run the sweep skill's Phase 0/1 before
+  trusting either count.
+
+**Remaining out-of-band** (all accounted, none actionable in python's own rule file without a
+fresh sweep): `safety`/`state_mutation` (#2546), `doc` (open residual, own cause), `io` (newly
+surfaced, unswept), and the §3 risk shadows. #2593 stays open pending #2546 and a fresh pass —
 into band on its own as they land.
 
 Reproduce: `GALAXYSCOPE_BIN=<venv>/bin/galaxyscope python tools/verify_language.py python` in


### PR DESCRIPTION
## Summary

#2535 (closed, not-a-bug — root cause: the ordinary Silencer Region dampener from #2546's
table, coincidentally triggered by the corpus decoy sentence's incidental overlap with a
language's own `safety`-rule vocabulary, not a literal-shielding design question) was cited as
an open design blocker in two published capstones. Corrected to the real explanation:

- **cobol.md §10**: `high_risk_execution`/`io`'s +1 each is the raw, correct count — cobol's
  `safety` rule has no `TRY`-shaped keyword, so nothing dampens its decoy's danger/io hit. The
  deviation is median inflation from *other* languages whose safety rule happens to collide
  with the shared decoy text, not anything cobol needs to fix.
- **python.md §11**: also picks up #2625's already-landed `comment_lines` resolution
  (52→15, red→green) which the capstone predated, and flags a fresh `io` deviation that
  surfaced live (needs its own sweep pass, not invented here).
- **jcl.md**: checked, carries no #2535 reference — nothing to correct.

Docs-only.

## Cross-repo

- Companions: gitgalaxy#2535 (closed), keyword-rosetta#18 (ledger correction), #17 (decoy
  redesign follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsVATdyMPhUoAUNBKbMUVi