### PR TITLE
chore(deps): bump tornado from 6.5.7 to 6.5.8

### DIFF
--- a/gitgalaxy/requirements.txt
+++ b/gitgalaxy/requirements.txt
@@ -123,7 +123,7 @@ stripe==14.4.1
 threadpoolctl==3.6.0
 tiktoken==0.13.0
 tinycss2==1.4.0
-tornado==6.5.7
+tornado==6.5.8
 tqdm==4.69.0
 traitlets==5.16.1
 twine==7.0.0


### PR DESCRIPTION
## Why now

Two tornado advisories were published **2026-09-01 20:17 UTC** — seven minutes after main's last green `muninn` run (0244edbe, 20:10). `muninn` runs with `fail-on: info`, so it is now failing on **main and every open PR**, on a finding none of them introduced (e.g. #2634, where it is the only red check besides the expected `rosetta-audit` drift).

| advisory | severity | issue |
|---|---|---|
| [GHSA-8423-8fgw-73vq](https://github.com/tornadoweb/tornado/security/advisories/GHSA-8423-8fgw-73vq) | Moderate (CWE-770) | `parse_multipart_form_data` splits on the boundary *before* the `max_parts` check — a 600KB body with 100k parts materializes the full transient list first, then rejects. Pre-auth memory-amplification DoS. |
| [GHSA-wwv5-g3v4-889x](https://github.com/tornadoweb/tornado/security/advisories/GHSA-wwv5-g3v4-889x) | Low | Incomplete fix for CVE-2026-35536: the deprecated `**kwargs` path in `set_cookie` bypasses the validation loop, which only covers the hardcoded lowercase keys. |

## Scope

`tornado==6.5.7` → `6.5.8`, one line in `gitgalaxy/requirements.txt`. Both advisories are fixed in 6.5.8 and `osv.dev` reports no remaining advisories at that version. tornado is a transitive pin only — nothing under `gitgalaxy/` imports it, so no code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)