### PR TITLE
fix(ci): guard corpus-pin audits against an empty LANGUAGE_CRUCIBLE_REF

### DIFF
--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -51,7 +51,12 @@ jobs:
       - name: Fetch Golden Test Repo (Language Crucible)
         run: |
           echo "Cloning Language Crucible repository (pinned via LANGUAGE_CRUCIBLE_REF)..."
-          git clone --branch "${{ vars.LANGUAGE_CRUCIBLE_REF }}" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+          ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            exit 1
+          fi
+          git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
       - name: Run Golden Crucible Test (${{ matrix.mode }})
         run: |

--- a/.github/workflows/tree-sitter-accuracy-audit.yml
+++ b/.github/workflows/tree-sitter-accuracy-audit.yml
@@ -52,7 +52,13 @@ jobs:
       # Same pin golden-crucible.yml uses -- this tool reuses that corpus rather than
       # a fresh clone (see tests/tools/tree_sitter_accuracy_audit.py's own CORPUS section).
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
-        run: git clone --branch "${{ vars.LANGUAGE_CRUCIBLE_REF }}" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+        run: |
+          ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            exit 1
+          fi
+          git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
       - name: Run baseline-gated regression check across every baselined language
         run: |

--- a/.github/workflows/tree-sitter-accuracy-history.yml
+++ b/.github/workflows/tree-sitter-accuracy-history.yml
@@ -75,7 +75,13 @@ jobs:
           pip install tree-sitter-language-pack
 
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
-        run: git clone --branch "${{ vars.LANGUAGE_CRUCIBLE_REF }}" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+        run: |
+          ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            exit 1
+          fi
+          git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
       - name: Append accuracy history + regenerate summary table + chart
         run: |

--- a/.github/workflows/tri-comparison-audit.yml
+++ b/.github/workflows/tri-comparison-audit.yml
@@ -77,7 +77,13 @@ jobs:
       # Same pin golden-crucible.yml / tree-sitter-accuracy-audit.yml use -- this tool reuses
       # that corpus rather than a fresh clone.
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
-        run: git clone --branch "${{ vars.LANGUAGE_CRUCIBLE_REF }}" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+        run: |
+          ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            exit 1
+          fi
+          git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
       - name: Run baseline-gated precision regression check across every baselined language
         run: |

--- a/.github/workflows/tri-comparison-history.yml
+++ b/.github/workflows/tri-comparison-history.yml
@@ -86,7 +86,13 @@ jobs:
           fi
 
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
-        run: git clone --branch "${{ vars.LANGUAGE_CRUCIBLE_REF }}" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+        run: |
+          ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            exit 1
+          fi
+          git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
       - name: Regenerate chart + ledger + points-of-interest report
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,43 @@ When you modify GitGalaxy's core engine, several CI workflows will rigorously te
    - Run `python tests/tools/tree_sitter_accuracy_audit.py --ci --all`.
    - If your regex fix legitimately drops false positives causing ground truth drift, regenerate the baseline: `python tests/tools/tree_sitter_accuracy_audit.py --regenerate --lang <lang>`
 
+4. **Cross-Language Consistency (`rosetta-audit`, the [keyword-rosetta](https://github.com/squid-protocol/keyword-rosetta) corpus)**
+   This runs the control corpus's verifier across all 46 language folders against your engine build,
+   so a change that shifts corpus-observed counts fails **in the PR that caused it**. Unlike the three
+   baselines above, the expected values live in *another repository* — you cannot re-bless them here.
+   - Run one language locally: `GITGALAXY_PATH=<path-to-this-repo> python tools/verify_language.py <lang>` from a keyword-rosetta checkout.
+   - If the drift is an unintentional regression: fix the engine change. **Do not touch the pin.**
+   - If the drift is an intentional, corpus-visible improvement: it needs a companion re-baseline PR
+     in keyword-rosetta *before* this one can merge. Follow
+     [`docs/self_scan/BUMPING_THE_ROSETTA_PIN.md`](docs/self_scan/BUMPING_THE_ROSETTA_PIN.md) — in short,
+     set that repo's committed `ENGINE_REF` file to `pull/<your PR number>/head` so its gates run green
+     against your unmerged branch, then a maintainer restores it and bumps `KEYWORD_ROSETTA_REF` here.
+   - Bumping the pin needs repo admin, so **ask a maintainer** rather than trying to do it yourself.
+     Bumping a pin is never a way to make a red check go away.
+
 If your PR touches any baseline fixtures, **explain why in the PR description** (e.g. "improved the Rust parser, now correctly detects async trait bounds"). A CI check flags any PR that modifies these files so it's never invisible in a large diff.
+
+---
+
+## 🍴 Checks that cannot run on fork PRs
+
+If you opened your PR from a fork, expect these four checks to fail immediately, before your code
+is ever exercised:
+
+- `crucible-audit (full-precision)` and `crucible-audit (zero-dependency)`
+- `tree-sitter-accuracy-audit`
+- `tri-comparison-audit`
+
+**This is not a problem with your changes.** These audits clone the
+[language-crucible](https://github.com/squid-protocol/language-crucible) corpus at a ref pinned in
+the `LANGUAGE_CRUCIBLE_REF` Actions variable, and GitHub withholds repository variables — like
+secrets — from `pull_request` runs raised from a fork. The pin resolves to an empty string and the
+clone fails. A maintainer re-runs these audits from a branch in this repo before merging, so there
+is nothing for you to do.
+
+`rosetta-audit` is unaffected (it falls back to the corpus's `main`), and every other check —
+`full-suite`, the `smoke-test` matrix, `ruff-audit`, `mypy-audit`, `ast-accuracy-audit` — runs
+normally on a fork PR and is worth taking seriously.
 
 ---
 


### PR DESCRIPTION
### Description

Found via #2628, our first fork PR in a long while. It arrived with four red audits — both
`crucible-audit` modes, `tree-sitter-accuracy-audit`, `tri-comparison-audit` — all dying
identically at `fatal: Remote branch  not found in upstream origin`, before any engine code ran.

Root cause: GitHub withholds repository variables (like secrets) from `pull_request` runs raised
from a fork, so `vars.LANGUAGE_CRUCIBLE_REF` expands to an empty string and the workflows run
`git clone --branch ""`. The variable itself is fine (`v1.2.0`); it is simply not visible to the
run. `rosetta-audit` dodged this only because it happens to spell the lookup
`vars.KEYWORD_ROSETTA_REF || 'main'`.

### Changes

- Guard the clone in the five corpus-backed workflows: fail with an explicit `::error::` naming
  the fork limitation and pointing at CONTRIBUTING.md, instead of a bare git error.
- CONTRIBUTING.md: new **Checks that cannot run on fork PRs** section.
- CONTRIBUTING.md: add `rosetta-audit` as a fourth entry under **CI Pipeline & Baselines**.

### Why not `|| 'main'`

That is what `rosetta-audit` does, and it would turn these four checks green on fork PRs — but
these pins exist to make the audits deterministic. Falling back to the corpus's `main` would audit
against a snapshot nobody chose and hand back an authoritative-looking wrong answer, in either
direction. A legible failure is better than a silent substitution. Making these audits actually
*run* for fork contributors is a separate policy question (label-gated re-run, `workflow_run`,
or a committed default pin) worth deciding on its own merits.

### Note on `rosetta-audit`

Its `|| 'main'` fallback has the same determinism gap — on a fork PR it silently audits against
corpus `main` rather than `KEYWORD_ROSETTA_REF`. It produced a correct result on #2628, so this
PR leaves it alone, but it is worth a follow-up.

### Core Engine Modification Checklist

Not applicable — no engine code changes. CI configuration and contributor documentation only.

### Cross-repo

None required.

Refs #2628, #2557