### PR TITLE
fix(core-engine): Rosetta sweep batch 2 — nine slicer/regex/DAG fixes (Gemini-implemented)

### DIFF
--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -13,7 +13,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-09-02T02:27:35Z",
+      "last_reconciled_at": "2026-09-02T12:18:44Z",
       "last_seen_count": 215,
       "last_seen_examples": [
         {
@@ -118,7 +118,7 @@
       "investigated_at": "2026-08-20T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "agc_assembly",
-      "last_reconciled_at": "2026-09-02T02:27:35Z",
+      "last_reconciled_at": "2026-09-02T12:18:44Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -221,7 +221,7 @@
       "investigated_at": "2026-08-20T22:17:39Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch needed -- root cause was immediately clear from source)",
       "language": "apex",
-      "last_reconciled_at": "2026-09-02T02:27:36Z",
+      "last_reconciled_at": "2026-09-02T12:18:46Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -260,7 +260,7 @@
       "investigated_at": "2026-08-31",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-09-02T02:27:40Z",
+      "last_reconciled_at": "2026-09-02T12:18:50Z",
       "last_seen_count": 1791,
       "last_seen_examples": [
         {
@@ -365,7 +365,7 @@
       "investigated_at": "2026-08-31",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "assembly",
-      "last_reconciled_at": "2026-09-02T02:27:40Z",
+      "last_reconciled_at": "2026-09-02T12:18:50Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -469,7 +469,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 23,
       "last_seen_examples": [
         {
@@ -583,7 +583,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -688,7 +688,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 525,
       "last_seen_examples": [
         {
@@ -802,7 +802,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed) -- corrected after cross-referencing #1837",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -835,7 +835,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -868,7 +868,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -985,7 +985,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1036,7 +1036,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved + fixed directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -1123,7 +1123,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -1176,7 +1176,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly, no dispatch needed)",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -1235,7 +1235,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 17,
       "last_seen_examples": [
         {
@@ -1339,7 +1339,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 74,
       "last_seen_examples": [
         {
@@ -1452,7 +1452,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "c",
-      "last_reconciled_at": "2026-09-02T02:27:47Z",
+      "last_reconciled_at": "2026-09-02T12:18:56Z",
       "last_seen_count": 88,
       "last_seen_examples": [
         {
@@ -1557,7 +1557,7 @@
       "investigated_at": "2026-08-19",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, self-corrected and reviewed by claude-sonnet-5",
       "language": "cobol",
-      "last_reconciled_at": "2026-09-02T02:28:15Z",
+      "last_reconciled_at": "2026-09-02T12:19:14Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -1630,7 +1630,7 @@
       "investigated_at": "2026-08-28",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "cobol",
-      "last_reconciled_at": "2026-09-02T02:28:15Z",
+      "last_reconciled_at": "2026-09-02T12:19:14Z",
       "last_seen_count": 164,
       "last_seen_examples": [
         {
@@ -1733,7 +1733,7 @@
       "investigated_at": "2026-08-28",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "cobol",
-      "last_reconciled_at": "2026-09-02T02:28:15Z",
+      "last_reconciled_at": "2026-09-02T12:19:14Z",
       "last_seen_count": 3040,
       "last_seen_examples": [
         {
@@ -1838,7 +1838,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude (Sonnet 5), direct investigation + fix (gitgalaxy#2480 follow-up)",
       "language": "cobol",
-      "last_reconciled_at": "2026-09-02T02:28:15Z",
+      "last_reconciled_at": "2026-09-02T12:19:14Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -1934,7 +1934,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -1976,7 +1976,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -2018,7 +2018,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -2132,7 +2132,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2246,7 +2246,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -2288,7 +2288,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 61,
       "last_seen_examples": [
         {
@@ -2402,7 +2402,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2434,7 +2434,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2465,7 +2465,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -2569,7 +2569,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -2683,7 +2683,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -2716,7 +2716,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 30,
       "last_seen_examples": [
         {
@@ -2830,7 +2830,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -2944,7 +2944,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -3057,7 +3057,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 64,
       "last_seen_examples": [
         {
@@ -3161,7 +3161,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 135,
       "last_seen_examples": [
         {
@@ -3274,7 +3274,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "cpp",
-      "last_reconciled_at": "2026-09-02T02:28:21Z",
+      "last_reconciled_at": "2026-09-02T12:19:20Z",
       "last_seen_count": 195,
       "last_seen_examples": [
         {
@@ -3378,7 +3378,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3483,7 +3483,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -3552,7 +3552,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -3629,7 +3629,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -3728,7 +3728,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3761,7 +3761,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -3851,7 +3851,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -3892,7 +3892,7 @@
       "investigated_at": "2026-08-21T20:06:45Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -3925,7 +3925,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 26,
       "last_seen_examples": [
         {
@@ -4029,7 +4029,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 271,
       "last_seen_examples": [
         {
@@ -4143,7 +4143,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -4203,7 +4203,7 @@
       "investigated_at": "2026-08-21T18:13:27Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4236,7 +4236,7 @@
       "investigated_at": "2026-08-21T18:13:44Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 108,
       "last_seen_examples": [
         {
@@ -4352,7 +4352,7 @@
       "investigated_at": "2026-08-21T21:45:53Z",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 46,
       "last_seen_examples": [
         {
@@ -4465,7 +4465,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 317,
       "last_seen_examples": [
         {
@@ -4569,7 +4569,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "csharp",
-      "last_reconciled_at": "2026-09-02T02:28:28Z",
+      "last_reconciled_at": "2026-09-02T12:19:25Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -4602,7 +4602,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-09-02T02:28:29Z",
+      "last_reconciled_at": "2026-09-02T12:19:27Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -4716,7 +4716,7 @@
       "investigated_at": "2026-08-30T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-09-02T02:28:29Z",
+      "last_reconciled_at": "2026-09-02T12:19:27Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -4785,7 +4785,7 @@
       "investigated_at": "2026-08-30T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "css",
-      "last_reconciled_at": "2026-09-02T02:28:29Z",
+      "last_reconciled_at": "2026-09-02T12:19:27Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -4843,7 +4843,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-09-02T02:28:34Z",
+      "last_reconciled_at": "2026-09-02T12:19:31Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -4914,7 +4914,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-09-02T02:28:34Z",
+      "last_reconciled_at": "2026-09-02T12:19:31Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -5009,7 +5009,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "dart",
-      "last_reconciled_at": "2026-09-02T02:28:34Z",
+      "last_reconciled_at": "2026-09-02T12:19:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5039,7 +5039,7 @@
       "investigated_at": "2026-08-31T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "embedded_python",
-      "last_reconciled_at": "2026-09-02T02:28:36Z",
+      "last_reconciled_at": "2026-09-02T12:19:34Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5070,7 +5070,7 @@
       "investigated_at": "2026-08-31T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "embedded_python",
-      "last_reconciled_at": "2026-09-02T02:28:36Z",
+      "last_reconciled_at": "2026-09-02T12:19:34Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -5174,7 +5174,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 8,
       "last_seen_examples": [
         {
@@ -5275,7 +5275,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5307,7 +5307,7 @@
       "investigated_at": "2026-08-21T00:00:00Z",
       "investigated_by": "Claude Sonnet 5, direct investigation (surfaced while re-blessing the tri-comparison chart after #1973/#1985)",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5339,7 +5339,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5370,7 +5370,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5402,7 +5402,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -5516,7 +5516,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -5560,7 +5560,7 @@
       "investigated_at": "2026-08-21T23:35:49Z",
       "investigated_by": "Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -5592,7 +5592,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "fortran",
-      "last_reconciled_at": "2026-09-02T02:28:42Z",
+      "last_reconciled_at": "2026-09-02T12:19:39Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -5701,7 +5701,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "go",
-      "last_reconciled_at": "2026-09-02T02:28:44Z",
+      "last_reconciled_at": "2026-09-02T12:19:41Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5813,7 +5813,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "go",
-      "last_reconciled_at": "2026-09-02T02:28:44Z",
+      "last_reconciled_at": "2026-09-02T12:19:41Z",
       "last_seen_count": 75,
       "last_seen_examples": [
         {
@@ -5917,7 +5917,7 @@
       "investigated_at": "2026-08-31T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "groovy",
-      "last_reconciled_at": "2026-09-02T02:28:47Z",
+      "last_reconciled_at": "2026-09-02T12:19:44Z",
       "last_seen_count": 721,
       "last_seen_examples": [
         {
@@ -6021,7 +6021,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -6133,7 +6133,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -6238,7 +6238,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6271,7 +6271,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6304,7 +6304,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 102,
       "last_seen_examples": [
         {
@@ -6418,7 +6418,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (dispatched agent investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 69,
       "last_seen_examples": [
         {
@@ -6534,7 +6534,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (session investigation)",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6566,7 +6566,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6598,7 +6598,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "haskell",
-      "last_reconciled_at": "2026-09-02T02:28:48Z",
+      "last_reconciled_at": "2026-09-02T12:19:45Z",
       "last_seen_count": 91,
       "last_seen_examples": [
         {
@@ -6712,7 +6712,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "html",
-      "last_reconciled_at": "2026-09-02T02:28:50Z",
+      "last_reconciled_at": "2026-09-02T12:19:47Z",
       "last_seen_count": 37,
       "last_seen_examples": [
         {
@@ -6826,7 +6826,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "html",
-      "last_reconciled_at": "2026-09-02T02:28:50Z",
+      "last_reconciled_at": "2026-09-02T12:19:47Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -6859,7 +6859,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "html",
-      "last_reconciled_at": "2026-09-02T02:28:50Z",
+      "last_reconciled_at": "2026-09-02T12:19:47Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -6901,7 +6901,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -7015,7 +7015,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -7129,7 +7129,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 28,
       "last_seen_examples": [
         {
@@ -7242,7 +7242,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -7275,7 +7275,7 @@
       "investigated_at": "2026-08-22T01:15:53Z",
       "investigated_by": "Sonnet 5, direct investigation via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -7326,7 +7326,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 315,
       "last_seen_examples": [
         {
@@ -7440,7 +7440,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "java",
-      "last_reconciled_at": "2026-09-02T02:28:51Z",
+      "last_reconciled_at": "2026-09-02T12:19:49Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -7491,7 +7491,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -7605,7 +7605,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7692,7 +7692,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7732,7 +7732,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -7836,7 +7836,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8028,7 +8028,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -8144,7 +8144,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 189,
       "last_seen_examples": [
         {
@@ -8257,7 +8257,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -8361,7 +8361,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-02T02:28:54Z",
+      "last_reconciled_at": "2026-09-02T12:19:52Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8394,7 +8394,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-09-02T02:28:56Z",
+      "last_reconciled_at": "2026-09-02T12:19:55Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -8447,7 +8447,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-09-02T02:28:56Z",
+      "last_reconciled_at": "2026-09-02T12:19:55Z",
       "last_seen_count": 15,
       "last_seen_examples": [
         {
@@ -8561,7 +8561,7 @@
       "investigated_at": "2026-08-22T11:45:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-09-02T02:28:56Z",
+      "last_reconciled_at": "2026-09-02T12:19:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8594,7 +8594,7 @@
       "investigated_at": "2026-08-22T11:40:48Z",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep (direct investigation, no Gemini dispatch -- small occurrence counts, answer was directly checkable)",
       "language": "kotlin",
-      "last_reconciled_at": "2026-09-02T02:28:56Z",
+      "last_reconciled_at": "2026-09-02T12:19:55Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8627,7 +8627,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8658,7 +8658,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 42,
       "last_seen_examples": [
         {
@@ -8772,7 +8772,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8850,7 +8850,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -8883,7 +8883,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 487,
       "last_seen_examples": [
         {
@@ -8997,7 +8997,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 22,
       "last_seen_examples": [
         {
@@ -9111,7 +9111,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9144,7 +9144,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "lua",
-      "last_reconciled_at": "2026-09-02T02:29:02Z",
+      "last_reconciled_at": "2026-09-02T12:20:01Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -9259,7 +9259,7 @@
       "investigated_at": "2026-08-24T03:52:19Z",
       "investigated_by": "Antigravity (direct source read)",
       "language": "m4",
-      "last_reconciled_at": "2026-09-02T02:29:03Z",
+      "last_reconciled_at": "2026-09-02T12:20:03Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -9316,7 +9316,7 @@
       "investigated_at": "2026-08-24T03:52:19Z",
       "investigated_by": "Antigravity (direct source read)",
       "language": "m4",
-      "last_reconciled_at": "2026-09-02T02:29:03Z",
+      "last_reconciled_at": "2026-09-02T12:20:03Z",
       "last_seen_count": 76,
       "last_seen_examples": [
         {
@@ -9421,7 +9421,7 @@
       "investigated_at": "2026-08-24T03:52:19Z",
       "investigated_by": "Antigravity (direct source read)",
       "language": "m4",
-      "last_reconciled_at": "2026-09-02T02:29:03Z",
+      "last_reconciled_at": "2026-09-02T12:20:03Z",
       "last_seen_count": 36,
       "last_seen_examples": [
         {
@@ -9525,7 +9525,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "makefile",
-      "last_reconciled_at": "2026-09-02T02:29:04Z",
+      "last_reconciled_at": "2026-09-02T12:20:04Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9560,7 +9560,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "matlab",
-      "last_reconciled_at": "2026-09-02T02:29:06Z",
+      "last_reconciled_at": "2026-09-02T12:20:06Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9592,7 +9592,7 @@
       "investigated_at": null,
       "investigated_by": null,
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9634,7 +9634,7 @@
       "investigated_at": "2026-08-25T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -9678,7 +9678,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 89,
       "last_seen_examples": [
         {
@@ -9792,7 +9792,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 104,
       "last_seen_examples": [
         {
@@ -9908,7 +9908,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9940,7 +9940,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -9974,7 +9974,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10015,7 +10015,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "objective-c",
-      "last_reconciled_at": "2026-09-02T02:29:07Z",
+      "last_reconciled_at": "2026-09-02T12:20:07Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -10055,7 +10055,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10088,7 +10088,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10120,7 +10120,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10150,7 +10150,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 12,
       "last_seen_examples": [
         {
@@ -10264,7 +10264,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -10351,7 +10351,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -10440,7 +10440,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10474,7 +10474,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10506,7 +10506,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation correcting a prior misdiagnosis",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -10619,7 +10619,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "perl",
-      "last_reconciled_at": "2026-09-02T02:29:14Z",
+      "last_reconciled_at": "2026-09-02T12:20:13Z",
       "last_seen_count": 122,
       "last_seen_examples": [
         {
@@ -10723,12 +10723,12 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "php",
-      "last_reconciled_at": "2026-09-02T02:29:20Z",
+      "last_reconciled_at": "2026-09-02T12:20:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
           "file_path": "laravel_core/BladeCompiler.php",
-          "name": "AnonymousClassa08aab890100",
+          "name": "AnonymousClassea70ff800100",
           "readings": {
             "ctags": 342,
             "gitgalaxy": null,
@@ -10756,7 +10756,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "php",
-      "last_reconciled_at": "2026-09-02T02:29:20Z",
+      "last_reconciled_at": "2026-09-02T12:20:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10789,7 +10789,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "php",
-      "last_reconciled_at": "2026-09-02T02:29:20Z",
+      "last_reconciled_at": "2026-09-02T12:20:18Z",
       "last_seen_count": 68,
       "last_seen_examples": [
         {
@@ -10902,7 +10902,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "php",
-      "last_reconciled_at": "2026-09-02T02:29:20Z",
+      "last_reconciled_at": "2026-09-02T12:20:18Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -10934,7 +10934,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-09-02T02:29:24Z",
+      "last_reconciled_at": "2026-09-02T12:20:22Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -11039,7 +11039,7 @@
       "investigated_at": "2026-08-29",
       "investigated_by": "Claude Sonnet 5, dispatched via tri-comparison-ledger-sweep",
       "language": "powershell",
-      "last_reconciled_at": "2026-09-02T02:29:24Z",
+      "last_reconciled_at": "2026-09-02T12:20:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11070,7 +11070,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-09-02T02:29:24Z",
+      "last_reconciled_at": "2026-09-02T12:20:22Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -11139,7 +11139,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-09-02T02:29:24Z",
+      "last_reconciled_at": "2026-09-02T12:20:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11172,7 +11172,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "powershell",
-      "last_reconciled_at": "2026-09-02T02:29:24Z",
+      "last_reconciled_at": "2026-09-02T12:20:22Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -11285,7 +11285,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "powershell",
-      "last_reconciled_at": "2026-09-02T02:29:24Z",
+      "last_reconciled_at": "2026-09-02T12:20:22Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11317,7 +11317,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -11376,7 +11376,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -11432,7 +11432,7 @@
       "investigated_at": "2026-08-21T03:23:52Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -11465,7 +11465,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -11581,7 +11581,7 @@
       "investigated_at": "2026-08-21T12:03:03Z",
       "investigated_by": "claude sonnet 5, tri-comparison-ledger-sweep (direct investigation, no dispatch needed)",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -11650,7 +11650,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 5,
       "last_seen_examples": [
         {
@@ -11718,7 +11718,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "python",
-      "last_reconciled_at": "2026-09-02T02:29:37Z",
+      "last_reconciled_at": "2026-09-02T12:20:31Z",
       "last_seen_count": 100,
       "last_seen_examples": [
         {
@@ -11824,7 +11824,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-09-02T02:29:38Z",
+      "last_reconciled_at": "2026-09-02T12:20:33Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -11866,7 +11866,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-09-02T02:29:38Z",
+      "last_reconciled_at": "2026-09-02T12:20:33Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -11944,7 +11944,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-09-02T02:29:38Z",
+      "last_reconciled_at": "2026-09-02T12:20:33Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -11995,7 +11995,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "ruby",
-      "last_reconciled_at": "2026-09-02T02:29:38Z",
+      "last_reconciled_at": "2026-09-02T12:20:33Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -12073,7 +12073,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "ruby",
-      "last_reconciled_at": "2026-09-02T02:29:38Z",
+      "last_reconciled_at": "2026-09-02T12:20:33Z",
       "last_seen_count": 9,
       "last_seen_examples": [
         {
@@ -12169,7 +12169,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -12283,7 +12283,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -12336,7 +12336,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -12449,7 +12449,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 25,
       "last_seen_examples": [
         {
@@ -12555,7 +12555,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 3,
       "last_seen_examples": [
         {
@@ -12606,7 +12606,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep, 2 rounds with self-correction), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -12718,7 +12718,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Gemini (dispatched via tri-comparison-ledger-sweep), confirmed by Claude Sonnet 5",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 21,
       "last_seen_examples": [
         {
@@ -12832,7 +12832,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 83,
       "last_seen_examples": [
         {
@@ -12946,7 +12946,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -12979,7 +12979,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved directly via live ctags run, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13014,7 +13014,7 @@
       "investigated_at": "2026-08-19T00:00:00Z",
       "investigated_by": "Claude Sonnet 5 (resolved from existing Claim 6 documentation, no dispatch)",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -13127,7 +13127,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "rust",
-      "last_reconciled_at": "2026-09-02T02:29:42Z",
+      "last_reconciled_at": "2026-09-02T12:20:37Z",
       "last_seen_count": 152,
       "last_seen_examples": [
         {
@@ -13233,7 +13233,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "scala",
-      "last_reconciled_at": "2026-09-02T02:29:44Z",
+      "last_reconciled_at": "2026-09-02T12:20:39Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -13336,7 +13336,7 @@
       "investigated_at": "2026-08-20",
       "investigated_by": "gemini-3.1-pro-high (agy), dispatched via tri-comparison-ledger-sweep, reviewed and fixed by claude-sonnet-5",
       "language": "scheme",
-      "last_reconciled_at": "2026-09-02T02:29:48Z",
+      "last_reconciled_at": "2026-09-02T12:20:44Z",
       "last_seen_count": 84,
       "last_seen_examples": [
         {
@@ -13443,7 +13443,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "scheme",
-      "last_reconciled_at": "2026-09-02T02:29:48Z",
+      "last_reconciled_at": "2026-09-02T12:20:44Z",
       "last_seen_count": 50,
       "last_seen_examples": [
         {
@@ -13545,7 +13545,7 @@
       "investigated_at": "2026-08-28T23:59:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "shell",
-      "last_reconciled_at": "2026-09-02T02:29:53Z",
+      "last_reconciled_at": "2026-09-02T12:20:48Z",
       "last_seen_count": 11,
       "last_seen_examples": [
         {
@@ -13659,7 +13659,7 @@
       "investigated_at": "2026-08-28T23:59:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "shell",
-      "last_reconciled_at": "2026-09-02T02:29:53Z",
+      "last_reconciled_at": "2026-09-02T12:20:48Z",
       "last_seen_count": 14,
       "last_seen_examples": [
         {
@@ -13773,7 +13773,7 @@
       "investigated_at": "2026-08-28T23:59:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "shell",
-      "last_reconciled_at": "2026-09-02T02:29:53Z",
+      "last_reconciled_at": "2026-09-02T12:20:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13806,7 +13806,7 @@
       "investigated_at": "2026-08-28T23:59:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "shell",
-      "last_reconciled_at": "2026-09-02T02:29:53Z",
+      "last_reconciled_at": "2026-09-02T12:20:48Z",
       "last_seen_count": 41,
       "last_seen_examples": [
         {
@@ -13920,7 +13920,7 @@
       "investigated_at": "2026-08-28T23:59:00Z",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "shell",
-      "last_reconciled_at": "2026-09-02T02:29:53Z",
+      "last_reconciled_at": "2026-09-02T12:20:48Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -13956,7 +13956,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "solidity",
-      "last_reconciled_at": "2026-09-02T02:29:54Z",
+      "last_reconciled_at": "2026-09-02T12:20:49Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -14026,7 +14026,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "sqlite",
-      "last_reconciled_at": "2026-09-02T02:29:55Z",
+      "last_reconciled_at": "2026-09-02T12:20:51Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14066,7 +14066,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "sqlite",
-      "last_reconciled_at": "2026-09-02T02:29:55Z",
+      "last_reconciled_at": "2026-09-02T12:20:51Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -14146,7 +14146,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "sqlite",
-      "last_reconciled_at": "2026-09-02T02:29:55Z",
+      "last_reconciled_at": "2026-09-02T12:20:51Z",
       "last_seen_count": 734,
       "last_seen_examples": [
         {
@@ -14248,7 +14248,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "swift",
-      "last_reconciled_at": "2026-09-02T02:29:56Z",
+      "last_reconciled_at": "2026-09-02T12:20:53Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14289,7 +14289,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "swift",
-      "last_reconciled_at": "2026-09-02T02:29:56Z",
+      "last_reconciled_at": "2026-09-02T12:20:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -14322,7 +14322,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "swift",
-      "last_reconciled_at": "2026-09-02T02:29:56Z",
+      "last_reconciled_at": "2026-09-02T12:20:53Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -14354,7 +14354,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -14473,7 +14473,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14515,7 +14515,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude (Sonnet 5), direct investigation via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -14629,7 +14629,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 16,
       "last_seen_examples": [
         {
@@ -14745,7 +14745,7 @@
       "investigated_at": "2026-08-30",
       "investigated_by": "Claude (Sonnet 5), enriched during docs/language_status/tcl.md write-up via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14786,7 +14786,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14830,7 +14830,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14875,7 +14875,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "tcl",
-      "last_reconciled_at": "2026-09-02T02:29:58Z",
+      "last_reconciled_at": "2026-09-02T12:20:55Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14915,7 +14915,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14957,7 +14957,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -15069,7 +15069,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -15129,7 +15129,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -15162,7 +15162,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -15249,7 +15249,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 204,
       "last_seen_examples": [
         {
@@ -15363,7 +15363,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 2226,
       "last_seen_examples": [
         {
@@ -15479,7 +15479,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15520,7 +15520,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15562,7 +15562,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15605,7 +15605,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:02Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -15708,7 +15708,7 @@
       "investigated_at": "2026-08-27",
       "investigated_by": "claude-sonnet-5, dispatched via tri-comparison-ledger-sweep",
       "language": "yacc",
-      "last_reconciled_at": "2026-09-02T02:30:08Z",
+      "last_reconciled_at": "2026-09-02T12:21:03Z",
       "last_seen_count": 18,
       "last_seen_examples": [
         {
@@ -15815,7 +15815,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-02T02:30:18Z",
+      "last_reconciled_at": "2026-09-02T12:21:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -15850,7 +15850,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-02T02:30:18Z",
+      "last_reconciled_at": "2026-09-02T12:21:11Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15893,7 +15893,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-02T02:30:18Z",
+      "last_reconciled_at": "2026-09-02T12:21:11Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -2390,6 +2390,24 @@ class StructuralExtractor:
                         # the trailing `%%`), exactly like COBOL's label-only
                         # paragraphs. `.l`/`.ll` (lex/flex) share this rule set.
                         "yacc",
+                        # #2648: makefile has no ScopeParsingRegistry entry and no
+                        # brace-delimited bodies at all (target recipes are
+                        # tab-indented, no braces at all), so it was silently
+                        # falling through to Mode_B_Braces below -- which only
+                        # "succeeds" when a `{` happens to appear by coincidence.
+                        # This dropped 100% of real matches (0 of 14 raw matches
+                        # reached the named list). Mode A's "greedy to the next
+                        # func_start match" body heuristic is a correct, direct fit.
+                        "makefile",
+                        # #2648: ada has no ScopeParsingRegistry entry and no
+                        # brace-delimited bodies at all (procedures use `is ...
+                        # begin ... end;`, never `{`/`}`), so it was silently
+                        # falling through to Mode_B_Braces below -- which only
+                        # "succeeds" when a `{` happens to appear by coincidence.
+                        # This dropped 100% of real matches (0 of 13 raw matches
+                        # reached the named list). Mode A's "greedy to the next
+                        # func_start match" body heuristic is a correct, direct fit.
+                        "ada",
                     ) or family in ("column_sensitive"):
                         mode_name = "Mode_A_Labels"
                         sats, impact = self._slice_by_labels(code, rules, offset, spatial_map)

--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -4751,9 +4751,11 @@ class StructuralExtractor:
 
             # Extract the raw payload using the ORIGINAL code to retain the exact executable payload
             block = code[start_idx:end_idx].strip()
+            # #2649: YAML GitHub Actions steps (e.g., `- run: pytest`) are overwhelmingly single-line
+            # entities; they must bypass the multi-line floor or they are completely dropped.
             if not block or (
                 len(block.splitlines()) < 2
-                and lang_id not in ("haskell", "python", "embedded_python", "typescript", "javascript")
+                and lang_id not in ("haskell", "python", "embedded_python", "typescript", "javascript", "yaml")
             ):
                 continue
 

--- a/gitgalaxy/standards/language_standards/languages/abap.py
+++ b/gitgalaxy/standards/language_standards/languages/abap.py
@@ -125,13 +125,16 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # 13. doc: Structured Documentation. ABAP Doc annotations and metadata headers.
+        # BUG FIX (#2650): The doc rule matched AUTHOR: which is owned by the ownership
+        # rule, causing double counting. AUTHOR removed from doc's bare alternative;
+        # DESCRIPTION/PURPOSE/REMARKS remain as they do not collide.
         # BUG FIX: the trailing `\b` sat right after a literal `:` (Rule 9,
         # mirror case). Real headers are written as "AUTHOR: Jane Doe" --
         # the space after `:` means both sides of that position are
         # non-word, so `\b` never fired and the realistic form never
         # matched. `:` is already self-delimiting; `\b` dropped.
         "doc": re.compile(
-            r'^"!\s*@(?:parameter|raising|return)|\b(?:AUTHOR|DESCRIPTION|PURPOSE|REMARKS):',
+            r'^"!\s*@(?:parameter|raising|return)|\b(?:DESCRIPTION|PURPOSE|REMARKS):',
             re.I | re.M,
         ),
         # 14. test: Testing & Assertions. ABAP Unit markers and test-injection.

--- a/gitgalaxy/standards/language_standards/languages/agc_assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/agc_assembly.py
@@ -131,7 +131,7 @@ DEFINITION: dict[str, Any] = {
         "dead_code": re.compile(r"(?i)#[ \t]*(?:TCF|CCS|INDEX|BZF|BZN|CA|CS)\b"),
         # 13. doc (Structured Documentation)
         "doc": re.compile(
-            r"^#\s*(?:Page|MOD\s+(?:BY|NO)|FUNCTIONAL\s+DESCRIPTION|SUBROUTINE|PURPOSE|CALLING\s+SEQUENCE|AUTHOR|PROGRAM|REVISION)",
+            r"^#\s*(?:Page|MOD\s+(?:BY|NO)|FUNCTIONAL\s+DESCRIPTION|SUBROUTINE|PURPOSE|CALLING\s+SEQUENCE|PROGRAM|REVISION)",
             re.M | re.I,
         ),
         # 14. test (Testing & Assertions)

--- a/gitgalaxy/standards/language_standards/languages/dart.py
+++ b/gitgalaxy/standards/language_standards/languages/dart.py
@@ -295,8 +295,10 @@ DEFINITION: dict[str, Any] = {
         # elsewhere in this sweep.
         "closures": re.compile(r"=>|\(\s*[^)]{0,300}\)\s*(?:async\*?|sync\*?)?[ \t]*\{"),
         # 18. globals: Global / Shared State. Static class fields and environmental bindings.
+        # BUG FIX (#2651): Anchored to true column-0 (no indentation) to prevent
+        # function-local var/const declarations from being incorrectly counted as globals.
         "globals": re.compile(
-            r"\b(static\s+final|static\s+const|Platform\.environment|window\.|Zone\.current)\b|^[ \t]*(?:final|const|var)\s+[A-Za-z_$][\w$]*[ \t]*=",
+            r"\b(static\s+final|static\s+const|Platform\.environment|window\.|Zone\.current)\b|^(?![ \t])(?:final|const|var)\s+[A-Za-z_$][\w$]*[ \t]*=",
             re.I | re.M,
         ),
         # 19. decorators: Decorators / Annotations. Annotations applied to methods/classes.

--- a/gitgalaxy/standards/language_standards/languages/embedded_python.py
+++ b/gitgalaxy/standards/language_standards/languages/embedded_python.py
@@ -115,7 +115,9 @@ DEFINITION: dict[str, Any] = {
         # 13. doc (Structured Documentation)
         # BUG FIX #2658: Match full docstring span as a single bounded body so
         # """ counts as doc=1, not 2. Unterminated delimiters fail safely.
-        "doc": re.compile(r'"""[\s\S]{0,15000}?"""|\'\'\'[\s\S]{0,15000}?\'\'\'|:param|:return|:raises|:type|#\s*Pin[ \t]*=|#\s*GPIO'),
+        "doc": re.compile(
+            r'"""[\s\S]{0,15000}?"""|\'\'\'[\s\S]{0,15000}?\'\'\'|:param|:return|:raises|:type|#\s*Pin[ \t]*=|#\s*GPIO'
+        ),
         # 14. test (Testing & Assertions)
         # BUG FIX: `test_` was wrapped inside the shared `\b(...)\b` group.
         # `_` is a word character, so the trailing `\b` after `test_` demands

--- a/gitgalaxy/standards/language_standards/languages/embedded_python.py
+++ b/gitgalaxy/standards/language_standards/languages/embedded_python.py
@@ -113,7 +113,9 @@ DEFINITION: dict[str, Any] = {
         # 12. dead_code (Commented Logic / Deprecated Trails)
         "dead_code": re.compile(r"#[ \t]*(?:def|class|import|if|for|while|try|print|machine\.Pin)\b"),
         # 13. doc (Structured Documentation)
-        "doc": re.compile(r'"""|\'\'\'|:param|:return|:raises|:type|#\s*Pin[ \t]*=|#\s*GPIO'),
+        # BUG FIX #2658: Match full docstring span as a single bounded body so
+        # """ counts as doc=1, not 2. Unterminated delimiters fail safely.
+        "doc": re.compile(r'"""[\s\S]{0,15000}?"""|\'\'\'[\s\S]{0,15000}?\'\'\'|:param|:return|:raises|:type|#\s*Pin[ \t]*=|#\s*GPIO'),
         # 14. test (Testing & Assertions)
         # BUG FIX: `test_` was wrapped inside the shared `\b(...)\b` group.
         # `_` is a word character, so the trailing `\b` after `test_` demands

--- a/gitgalaxy/standards/language_standards/languages/fortran.py
+++ b/gitgalaxy/standards/language_standards/languages/fortran.py
@@ -257,7 +257,7 @@ DEFINITION: dict[str, Any] = {
         # 13. doc (Structured Documentation)
         # Documentation meant to be parsed by generators (Doxygen style `!>`, `!<`, or `! @`).
         "doc": re.compile(
-            r"^[Cc*!dD][ \t]*[@><\\]|^[ \t]*![ \t]*(?:Author|Description|Param|Return):",
+            r"^[Cc*!dD][ \t]*[@><\\]|^[ \t]*![ \t]*(?:Description|Param|Return):",
             re.I | re.M,
         ),
         # 14. test (Testing & Assertions)

--- a/gitgalaxy/standards/language_standards/languages/html.py
+++ b/gitgalaxy/standards/language_standards/languages/html.py
@@ -157,7 +157,7 @@ DEFINITION: dict[str, Any] = {
         # 13. doc (Structured Documentation)
         # Structured intent for crawlers and accessibility.
         "doc": re.compile(
-            r"<title>[^<]*</title>|<meta\s+name=(?:\"(?:description|keywords|author)\"|'(?:description|keywords|author)')\s+content=(?:\"[^\"]*\"|'[^']*')|\baria-(?:description|label|labelledby|describedby|details)=(?:\"[^\"]*\"|'[^']*')",
+            r"<title>[^<]*</title>|<meta\s+name=(?:\"(?:description|keywords)\"|'(?:description|keywords)')\s+content=(?:\"[^\"]*\"|'[^']*')|\baria-(?:description|label|labelledby|describedby|details)=(?:\"[^\"]*\"|'[^']*')",
             re.I,
         ),
         # 14. test (Testing & Assertions)

--- a/gitgalaxy/standards/language_standards/languages/livecode.py
+++ b/gitgalaxy/standards/language_standards/languages/livecode.py
@@ -202,8 +202,14 @@ DEFINITION: dict[str, Any] = {
         # non-word on both sides of that position, so the boundary never
         # fired and the tag never matched. `:` is already self-delimiting
         # (same principle as Rule 10), so the trailing `\b` is dropped.
+        #
+        # BUG FIX (#2659): `Author:` is already exclusively captured by the
+        # `ownership` rule. Including it in `doc`'s bare-tag alternation
+        # caused a double-count on every header author line. Removed here,
+        # following the established precedent in ada.py. Genuine structured
+        # `@author` tags remain in `doc`.
         "doc": re.compile(
-            r"^[ \t]*(?:--\||--@|/\*\*|//!).*(?:@param|@return|@author)|\b(?:Description|Purpose|Author|Summary):",
+            r"^[ \t]*(?:--\||--@|/\*\*|//!).*(?:@param|@return|@author)|\b(?:Description|Purpose|Summary):",
             re.I | re.M,
         ),
         # 14. test: Testing & Assertions. Unit testing framework markers.

--- a/gitgalaxy/standards/language_standards/languages/lua.py
+++ b/gitgalaxy/standards/language_standards/languages/lua.py
@@ -92,8 +92,10 @@ DEFINITION: dict[str, Any] = {
         # 9. io: I/O & Network Boundaries. Standard IO library and environment inquiries.
         "io": re.compile(r"\b(io\.open|io\.read|io\.lines|io\.close|io\.input|io\.output|io\.popen|os\.getenv)\b"),
         # 10. api: Public Surface Area. Functions NOT marked local or explicit module returns.
+        # BUG FIX #2657: The 'return M' module-export idiom is anchored to column 0 (^return)
+        # to avoid false positives on indented function-body returns, which spiked risk_api_exposure.
         "api": re.compile(
-            r"^[ \t]*function\s+[^_][\w.:]*|^[ \t]*return\s+[a-zA-Z_]\w*[ \t]*$|---@public|\bexport\b",
+            r"^[ \t]*function\s+[^_][\w.:]*|^return[ \t]+[a-zA-Z_]\w*[ \t]*$|---@public|\bexport\b",
             re.M,
         ),
         # 11. flux: State Mutation. State mutation (assignments and table mutators).

--- a/gitgalaxy/standards/language_standards/languages/powershell.py
+++ b/gitgalaxy/standards/language_standards/languages/powershell.py
@@ -166,8 +166,11 @@ DEFINITION: dict[str, Any] = {
             re.I,
         ),
         # api: Public Surface Area. Exposed surface area (Module exports and non-hidden functions).
+        # BUG FIX: Issue #2656. The bare-identifier alternative lacked the keyword-exclusion
+        # negative lookahead that func_start and args carry, causing 'param(', 'if (',
+        # and 'switch (' lines to miscount as API surface. Added the exclusion set.
         "api": re.compile(
-            r"\b(Export-ModuleMember|New-Alias|CmdletBinding)\b|^[ \t]*(?!hidden\s+)[a-zA-Z_]\w*\s*\(",
+            r"\b(Export-ModuleMember|New-Alias|CmdletBinding)\b|^[ \t]*(?!hidden\s+)(?!(?:if|elseif|switch|while|for|foreach|until|trap|catch|param)\b)[a-zA-Z_]\w*\s*\(",
             re.I | re.M,
         ),
         # 11. flux (State Mutation)

--- a/gitgalaxy/standards/language_standards/languages/python.py
+++ b/gitgalaxy/standards/language_standards/languages/python.py
@@ -203,7 +203,9 @@ DEFINITION: dict[str, Any] = {
         # 12. dead_code (Commented Logic / Deprecated Trails)
         "dead_code": re.compile(r"#[ \t]*(?:def|class|import|if|for|while|try|return)\b"),
         # 13. doc (Structured Documentation)
-        "doc": re.compile(r'"""|\'\'\'|:param|:return|:raises|:type|\b(?:Args|Returns|Yields|Raises|Attributes):\b'),
+        # BUG FIX #2658: Match full docstring span as a single bounded body so
+        # """ counts as doc=1, not 2. Unterminated delimiters fail safely.
+        "doc": re.compile(r'"""[\s\S]{0,15000}?"""|\'\'\'[\s\S]{0,15000}?\'\'\'|:param|:return|:raises|:type|\b(?:Args|Returns|Yields|Raises|Attributes):\b'),
         # 14. test (Testing & Assertions)
         # #2593: `assert` is a general-purpose validation keyword already owned by `safety`
         # (see that rule above) -- it isn't itself a testing signal, so a runtime invariant

--- a/gitgalaxy/standards/language_standards/languages/python.py
+++ b/gitgalaxy/standards/language_standards/languages/python.py
@@ -205,7 +205,9 @@ DEFINITION: dict[str, Any] = {
         # 13. doc (Structured Documentation)
         # BUG FIX #2658: Match full docstring span as a single bounded body so
         # """ counts as doc=1, not 2. Unterminated delimiters fail safely.
-        "doc": re.compile(r'"""[\s\S]{0,15000}?"""|\'\'\'[\s\S]{0,15000}?\'\'\'|:param|:return|:raises|:type|\b(?:Args|Returns|Yields|Raises|Attributes):\b'),
+        "doc": re.compile(
+            r'"""[\s\S]{0,15000}?"""|\'\'\'[\s\S]{0,15000}?\'\'\'|:param|:return|:raises|:type|\b(?:Args|Returns|Yields|Raises|Attributes):\b'
+        ),
         # 14. test (Testing & Assertions)
         # #2593: `assert` is a general-purpose validation keyword already owned by `safety`
         # (see that rule above) -- it isn't itself a testing signal, so a runtime invariant

--- a/gitgalaxy/standards/language_standards/languages/scheme.py
+++ b/gitgalaxy/standards/language_standards/languages/scheme.py
@@ -198,6 +198,18 @@ DEFINITION: dict[str, Any] = {
         # 24. import (Dependency Inclusions)
         # Scheme module resolution dependencies.
         "import": re.compile(r"^[ \t]*\([ \t]*(?:import|use-modules|require)(?![^ \t)\]\n\r])", re.M),
+        # BUG FIX (#2652): added _dependency_capture to support DAG edge creation.
+        # Handles both the rosetta corpus's bare `(import a)` form and real R7RS
+        # `(import (scheme base))` / Guile `(use-modules (ice-9 popen))` library-list
+        # forms; captures the last path component / module name as the DAG resolver
+        # expects. The optional leading `\(?` and bounded `{0,6}` component repeat
+        # keep this ReDoS-safe (no nested unbounded quantifiers).
+        "_dependency_capture": re.compile(
+            r"^[ \t]*\([ \t\n]*(?:import|use-modules|require)[ \t\n]+"
+            r"\(?[ \t\n]*(?:[a-zA-Z0-9_!?*+/<>=.~$%^&:-]+[ \t\n]+){0,6}"
+            r"([a-zA-Z0-9_!?*+/<>=.~$%^&:-]+)[ \t\n]*\)?[ \t\n]*\)",
+            re.M,
+        ),
         # 25. ownership (Authorship Metadata)
         "ownership": re.compile(
             r"^[ \t]*;+\s*(?:Author|Created by|Maintainer|Copyright):\s+(.*)",

--- a/gitgalaxy/standards/language_standards/languages/zig.py
+++ b/gitgalaxy/standards/language_standards/languages/zig.py
@@ -128,8 +128,10 @@ DEFINITION: dict[str, Any] = {
         # 17. closures: Closures / Anonymous Functions. (Zig lacks traditional anonymous closures).
         "closures": None,
         # 18. globals: Global / Shared State. Top-level file-scoped state.
+        # BUG FIX (#2651): Anchored to true column-0 (no indentation) to prevent
+        # function-local var/const declarations from being incorrectly counted as globals.
         "globals": re.compile(
-            r"^[ \t]*(?:pub[ \t]+)?(?:threadlocal[ \t]+)?(?:comptime[ \t]+)?(?:const|var)\s+[a-zA-Z_]\w*\s*(?::[^=]+)?=",
+            r"^(?![ \t])(?:pub[ \t]+)?(?:threadlocal[ \t]+)?(?:comptime[ \t]+)?(?:const|var)\s+[a-zA-Z_]\w*\s*(?::[^=]+)?=",
             re.M,
         ),
         # 19. decorators: Decorators / Annotations. (Zig uses @builtins instead).

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -3805,3 +3805,34 @@ def test_detector_early_returns_do_not_clobber_worker_raw_imports():
     py_detector = StructuralExtractor("python", MOCK_LANG_DEFS)
     empty_result = py_detector.splice("", "")
     assert "raw_imports" not in empty_result, "empty-code_stream splice() emitted a raw_imports placeholder"
+
+
+# ==============================================================================
+# TEST: MODE C 2-LINE FLOOR EXEMPTION FOR YAML (#2649)
+# ==============================================================================
+def test_detector_yaml_single_line_step_survives_two_line_floor():
+    """
+    Regression for #2649: _slice_by_indentation drops any sliced block under
+    2 lines unless the language is in a hardcoded exemption tuple. yaml was
+    missing from that tuple, so every single-line GitHub Actions step
+    (`- run: 'pytest'`) -- the dominant real-world form -- was silently
+    dropped from the function census. A multi-line block-scalar step must
+    keep working too.
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    yaml_detector = StructuralExtractor("yaml", LANGUAGE_DEFINITIONS)
+    code = (
+        "jobs:\n"
+        "  build:\n"
+        "    steps:\n"
+        "      - run: pytest\n"
+        "      - run: |\n"
+        "          echo one\n"
+        "          echo two\n"
+    )
+
+    result = yaml_detector.splice(code_stream=code, comment_stream="", confidence=1.0)
+    names = [f["name"] for f in result["functions"]]
+
+    assert len(names) == 2, f"expected both the single-line and multi-line run: steps, got {names}"

--- a/tests/extraction/languages/test_abap_strict.py
+++ b/tests/extraction/languages/test_abap_strict.py
@@ -100,7 +100,7 @@ _ABAP_SIMPLE_CASES = [
     ("api", "@OData.publish: true", "DATA lv_x TYPE i."),
     ("state_mutation", "MOVE lv_a TO lv_b.", "DATA lv_x TYPE i."),
     ("dead_code", "* DATA lv_old TYPE i.", "* just a note"),
-    ("doc", "* AUTHOR: Jane Doe", "* just a note"),
+    ("doc", "* DESCRIPTION: Jane Doe", "* just a note"),
     ("test", "METHOD foo FOR TESTING.", "DATA lv_x TYPE i."),
     ("concurrency", "CALL FUNCTION 'ENQUEUE_FOO'.", "DATA lv_x TYPE i."),
     ("ui_framework", "CALL SCREEN 100.", "DATA lv_x TYPE i."),
@@ -215,7 +215,7 @@ def test_abap_doc_trailing_colon_boundary_regression():
     `...\\b(?:AUTHOR|DESCRIPTION|PURPOSE|REMARKS):\\b`. A trailing `\\b`
     placed directly after a literal `:` can never fire when the colon is
     followed by whitespace (both sides of that position are non-word) --
-    and real ABAP headers are always written as "AUTHOR: Jane Doe" (space
+    and real ABAP headers are always written as "DESCRIPTION: Jane Doe" (space
     after the colon), so the realistic form never matched under the old
     pattern. `:` is already self-delimiting; the trailing `\\b` was dropped.
     """
@@ -223,11 +223,11 @@ def test_abap_doc_trailing_colon_boundary_regression():
         r'^"!\s*@(?:parameter|raising|return)|\b(?:AUTHOR|DESCRIPTION|PURPOSE|REMARKS):\b',
         re.I | re.M,
     )
-    realistic = "* AUTHOR: Jane Doe"
+    realistic = "* DESCRIPTION: Jane Doe"
     assert not old_pattern.search(realistic), "sanity check: bug must reproduce against the old pattern"
 
     doc = ABAP_RULES["doc"]
-    assert doc.search(realistic), "realistic space-after-colon AUTHOR header still didn't match"
+    assert doc.search(realistic), "realistic space-after-colon DESCRIPTION header still didn't match"
     assert doc.search('"! @parameter iv_x | The input'), "ABAPDoc form regressed"
 
 
@@ -282,18 +282,24 @@ def test_abap_dead_code_requires_column_anchor_not_just_token_presence():
     assert matches == ["* DATA"], f"only the real column-1 comment line should match, got {matches!r}"
 
 
-def test_abap_doc_vs_ownership_overlap_is_intentional():
+def test_abap_doc_vs_ownership_author_collision_fix():
     """
-    Ambiguity sweep finding: `doc` and `ownership` both fire on an
-    "AUTHOR: Jane Doe" header line. Confirmed intentional, not a bug --
-    both signatures are legitimately about traceability/metadata, and
-    `ownership` additionally captures the specific author name (group 1)
-    for downstream attribution, which `doc` does not attempt.
+    BUG FIX (#2650): The doc rule matching "AUTHOR:" double-counted the line
+    that rightfully belongs to ownership. AUTHOR has been removed from doc.
     """
+    doc = ABAP_RULES["doc"]
+    ownership = ABAP_RULES["ownership"]
+
     header = "* AUTHOR: Jane Doe"
-    assert ABAP_RULES["doc"].search(header)
-    m = ABAP_RULES["ownership"].search(header)
+    assert not doc.search(header), "AUTHOR: should NOT match doc"
+    m = ownership.search(header)
     assert m and m.group(1) == "Jane Doe"
+
+    # Genuine doc-idiom headers still match doc
+    assert doc.search('"! @parameter foo')
+    assert doc.search("* DESCRIPTION: Does something")
+    assert doc.search("* PURPOSE: To do something")
+    assert doc.search("* REMARKS: Important note")
 
 
 def test_abap_explicit_casts_vs_pointers_intentional_double_classification():

--- a/tests/extraction/languages/test_ada.py
+++ b/tests/extraction/languages/test_ada.py
@@ -250,3 +250,28 @@ def test_ada_import_excludes_aspect_specifications_regression():
         payload = f"   with {aspect} => True;"
         assert not import_rule.search(payload), f"import incorrectly matched aspect clause: {payload!r}"
     assert import_rule.search("   with Ada.Text_IO;"), "plain context clause must still match"
+
+def test_ada_mode_a_braceless_extraction_regression():
+    """
+    Pipeline-level regression for #2648: Ada procedures use `is ... begin ... end;`,
+    never `{`/`}`. They must be extracted via Mode A.
+    """
+    from gitgalaxy.core.detector import StructuralExtractor
+    extractor = StructuralExtractor("ada", LANGUAGE_DEFINITIONS)
+    
+    code = (
+        "procedure X is\n"
+        "begin\n"
+        "   Do_Something;\n"
+        "end X;\n"
+        "procedure Y is\n"
+        "begin\n"
+        "   Do_Something_Else;\n"
+        "end Y;\n"
+    )
+    segments = extractor._partition_segments(code, "ada")
+    functions, _ = extractor._function_slice(segments, [{} for _ in segments], {}, {}, None)
+    
+    names = [f["name"] for f in functions]
+    assert "X" in names, "Failed to extract X"
+    assert "Y" in names, "Failed to extract Y"

--- a/tests/extraction/languages/test_agc_assembly_strict.py
+++ b/tests/extraction/languages/test_agc_assembly_strict.py
@@ -237,3 +237,14 @@ def test_agc_assembly_redos_immunity_sweep():
     # sanity: all still match their real positive cases after the sweep
     assert AGC_RULES["func_start"].search("MYLABEL\tTC\tFOO")
     assert AGC_RULES["api"].search("MYLABEL\tEQUALS\t5")
+
+
+def test_agc_assembly_ambiguity_doc_vs_ownership_author_no_collision():
+    """
+    BUG FIX (#2659): `AUTHOR` is exclusively an `ownership` trait. Including it
+    in `doc` caused double-counting on standard authorship headers.
+    """
+    header = "# AUTHOR: Jane Doe"
+    assert not AGC_RULES["doc"].search(header)
+    m = AGC_RULES["ownership"].search(header)
+    assert m and m.group(1) == "Jane Doe"

--- a/tests/extraction/languages/test_dart.py
+++ b/tests/extraction/languages/test_dart.py
@@ -409,7 +409,43 @@ def test_dart_args_xfail_invalid(payload):
 
 
 # -------------------------------------------------------------------------
-# 4. DEPENDENCY CAPTURE RULES
+# 5. GLOBALS RULES
+# -------------------------------------------------------------------------
+GLOBALS_CASES = {
+    "valid": [
+        ("static final int x = 1;", "static final"),
+        ("static const String y = 'hi';", "static const"),
+        ("const MY_GLOBAL = 42;", None),
+        ("final globalStr = 'hi';", None),
+        ("var globalVar = true;", None),
+    ],
+    "invalid": [
+        "  const localVar = 1;",
+        "\tvar localVar = 2;",
+        "    final localVar = 'hi';",
+    ],
+    "xfail_invalid": [],
+}
+
+
+@pytest.mark.parametrize("payload,expected", GLOBALS_CASES["valid"])
+def test_dart_globals_valid(payload, expected):
+    assert_valid_match(DART_RULES["globals"], payload, expected, "dart.globals")
+
+
+@pytest.mark.parametrize("payload", GLOBALS_CASES["invalid"])
+def test_dart_globals_invalid(payload):
+    assert_invalid_no_match(DART_RULES["globals"], payload, "dart.globals")
+
+
+@pytest.mark.parametrize("payload", GLOBALS_CASES["xfail_invalid"])
+@pytest.mark.xfail(reason="String/comment lookalikes lack AST block shielding", strict=True)
+def test_dart_globals_xfail_invalid(payload):
+    assert_invalid_no_match(DART_RULES["globals"], payload, "dart.globals")
+
+
+# -------------------------------------------------------------------------
+# 6. DEPENDENCY CAPTURE RULES
 # -------------------------------------------------------------------------
 DEPENDENCY_CAPTURE_CASES = {
     "valid": [

--- a/tests/extraction/languages/test_dart_strict.py
+++ b/tests/extraction/languages/test_dart_strict.py
@@ -365,3 +365,16 @@ def test_dart_explicit_casts_and_pointers_no_false_collision():
 
 def test_dart_router_boundary_regression():
     assert LANGUAGE_DEFINITIONS["dart"]["rules"]["ssr_boundaries"].search("final app = Router();")
+
+
+def test_dart_globals_anchor_bug_regression():
+    """#2651: `globals` rule anchored to column-0 to prevent function-local
+    declarations from being counted as globals."""
+    globals_rule = DART_RULES["globals"]
+
+    assert globals_rule.search("const MY_GLOBAL = 42;"), "true top-level const must count as global"
+    assert globals_rule.search("var global_state = false;"), "true top-level var must count as global"
+
+    assert not globals_rule.search("    const local_var = 1;"), "indented const must NOT count as global"
+    assert not globals_rule.search("\tvar local_var = false;"), "tab-indented var must NOT count as global"
+

--- a/tests/extraction/languages/test_embedded_python_strict.py
+++ b/tests/extraction/languages/test_embedded_python_strict.py
@@ -498,3 +498,18 @@ def test_embedded_python_comprehensions_one_level_nesting():
     pattern = EP_RULES["comprehensions"]
     assert pattern.search("[x for x in [y for y in range(10)]]")
     assert pattern.search("{k: v for k, v in {a: b for a, b in pairs}.items()}")
+
+
+def test_embedded_python_doc_docstring_counts_once_regression():
+    """
+    #2658: same fix as python's doc rule -- one docstring must count once,
+    not twice from unpaired open/close delimiter matches.
+    """
+    doc = LANGUAGE_DEFINITIONS["embedded_python"]["rules"]["doc"]
+
+    assert len(doc.findall('"""one docstring"""')) == 1, "a single docstring must count once, not twice"
+
+    two = '"""first"""\ndef f():\n    """second"""\n'
+    assert len(doc.findall(two)) == 2, "two separate docstrings must count as 2"
+
+    assert_redos_immune(doc, '"""' + "x" * 200000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_fortran_strict.py
+++ b/tests/extraction/languages/test_fortran_strict.py
@@ -386,16 +386,13 @@ def test_fortran_dead_code_column_anchor_vs_free_form_inline_comment():
     assert dead_code.search("C IF (x) THEN"), "column-1 legacy comment must still match"
 
 
-def test_fortran_doc_vs_ownership_overlap_is_intentional():
+def test_fortran_doc_vs_ownership_author_no_collision():
     """
-    Ambiguity sweep finding (mirrors the abap case): `doc` and `ownership`
-    both fire on an "! Author: Jane Doe" header line -- both signatures
-    are legitimately about traceability/metadata, and `ownership`
-    additionally captures the specific author name (group 1) for
-    downstream attribution, which `doc` does not attempt.
+    BUG FIX (#2659): `Author:` is exclusively an `ownership` trait. Including it
+    in `doc` caused double-counting on standard authorship headers.
     """
     header = "! Author: Jane Doe"
-    assert FORTRAN_RULES["doc"].search(header)
+    assert not FORTRAN_RULES["doc"].search(header)
     m = FORTRAN_RULES["ownership"].search(header)
     assert m and m.group(1) == "Jane Doe"
 
@@ -411,9 +408,9 @@ def test_fortran_ownership_column_anchor_stricter_than_doc():
     not a bug: `ownership`'s docstring targets legacy fixed-form headers,
     which are always unindented at file/routine scope.
     """
-    indented = "   ! Author: Jane Doe"
+    indented = "   ! Description: A thing"
     assert FORTRAN_RULES["doc"].search(indented), "doc should tolerate leading whitespace before '!'"
-    assert not FORTRAN_RULES["ownership"].search(indented), (
+    assert not FORTRAN_RULES["ownership"].search("   ! Author: Jane Doe"), (
         "ownership requires column-1 anchoring -- indented form must not match"
     )
 

--- a/tests/extraction/languages/test_html_strict.py
+++ b/tests/extraction/languages/test_html_strict.py
@@ -642,3 +642,14 @@ def test_html_signature_deep(signature, positive, negative):
     assert pattern.search(positive), f"html {signature!r} failed to match deep positive case: {positive!r}"
     if negative is not None:
         assert not pattern.search(negative), f"html {signature!r} incorrectly matched deep negative case: {negative!r}"
+
+
+def test_html_ambiguity_doc_vs_ownership_author_no_collision():
+    """
+    BUG FIX (#2659): `meta name="author"` is exclusively an `ownership` trait. Including it
+    in `doc` caused double-counting on standard authorship headers.
+    """
+    header = '<meta name="author" content="Jane Doe">'
+    assert not HTML_RULES["doc"].search(header)
+    m = HTML_RULES["ownership"].search(header)
+    assert m and m.group(1) == "Jane Doe"

--- a/tests/extraction/languages/test_livecode_strict.py
+++ b/tests/extraction/languages/test_livecode_strict.py
@@ -78,7 +78,7 @@ _LIVECODE_SIMPLE_CASES = [
     ("api", 'on mouseUp\n  answer "hi"\nend mouseUp', "private command foo"),
     ("state_mutation", "put the effective filename of this stack into tPath", "answer 1"),
     ("dead_code", "-- put 1 into x", "put 1 into x"),
-    ("doc", "-- Author: Jane Doe", "put 1 into x"),
+    ("doc", "-- Purpose: To do something", "put 1 into x"),
     ("test", "command testLogin", "put 1 into x"),
     ("concurrency", 'send "myHandler" to me in 2 seconds', "put 1 into x"),
     ("ui_framework", 'put the label of button "OK" into tLabel', "put 1 into x"),
@@ -267,16 +267,15 @@ def test_livecode_args_multiline_anchor_regression():
 def test_livecode_doc_author_colon_trailing_boundary_regression():
     """
     Regression test (Rule 9/10-class trailing-boundary bug): the
-    `Description|Purpose|Author|Summary` alternation had a trailing `\\b`
+    `Description|Purpose|Summary` alternation had a trailing `\b`
     placed immediately after the literal `:` it requires. `:` is a
-    non-word character, so that `\\b` only fires if the very next character
+    non-word character, so that `\b` only fires if the very next character
     is a word character -- but the near-universal real form is
-    "Author: John Doe" (colon then a space), which is non-word on both
+    "Description: John Doe" (colon then a space), which is non-word on both
     sides of that exact position, so the tag never matched. Fixed by
-    dropping the trailing `\\b` (`:` is already self-delimiting).
+    dropping the trailing `\b` (`:` is already self-delimiting).
     """
     pattern = LIVECODE_RULES["doc"]
-    assert pattern.search("-- Author: John Doe"), "'Author: ' (colon-space) form still didn't match"
     assert pattern.search("-- Description: Handles login"), "'Description: ' form still didn't match"
     assert pattern.search("-- Purpose: Validates input"), "'Purpose: ' form still didn't match"
     assert pattern.search("-- Summary: Entry point"), "'Summary: ' form still didn't match"
@@ -465,7 +464,7 @@ def test_livecode_doc_comment_style_completeness():
     assert pattern.search("--@ @author Jane Doe"), "'--@' doc-block style regressed"
     assert pattern.search("/** @param pName the user name\n@return true */"), "'/**' doc-block style regressed"
     assert pattern.search("//! @author Jane Doe"), "'//!' doc-block style regressed"
-    assert pattern.search("-- Author: Jane Doe"), "'--' plain Author: tag regressed"
+    assert pattern.search("-- Purpose: Something"), "'--' plain Purpose: tag regressed"
 
 
 def test_livecode_ownership_comment_style_completeness():
@@ -532,18 +531,16 @@ def test_livecode_ambiguity_listeners_func_start_events_full_overlap():
     assert func_start.search(text) and listeners.search(text) and events.search(text)
 
 
-def test_livecode_ambiguity_doc_vs_ownership_author_dual_classification():
+def test_livecode_ambiguity_doc_vs_ownership_author_no_collision():
     """
-    Confirmed intentional dual-classification, not a bug: an "Author:"
-    tag is simultaneously structured documentation (`doc`) and authorship
-    metadata (`ownership`) -- the same real-world convention JSDoc's
-    `@author` tag represents in other languages, where both signatures
-    are expected to co-fire on the same line.
+    BUG FIX (#2659): `Author:` is exclusively an `ownership` trait. Including it
+    in `doc` caused double-counting on standard authorship headers.
     """
     doc = LIVECODE_RULES["doc"]
     ownership = LIVECODE_RULES["ownership"]
     text = "-- Author: Jane Doe"
-    assert doc.search(text) and ownership.search(text)
+    assert not doc.search(text)
+    assert ownership.search(text)
 
 
 def test_livecode_ambiguity_io_vs_ipc_rpc_bridges_url_dual_classification():

--- a/tests/extraction/languages/test_lua_strict.py
+++ b/tests/extraction/languages/test_lua_strict.py
@@ -221,3 +221,19 @@ def test_lua_redos_immunity_sweep():
     ratios) before writing this as a permanent regression pin.
     """
     assert_redos_immune(LUA_RULES["args"], "function foo(" + "(" * 100000, timeout_sec=3.0)
+
+
+def test_lua_api_module_return_column_anchored_regression():
+    """
+    #2657: the api rule's `return M`-at-EOF module-export idiom used a
+    `^[ \t]*` (any-indentation) anchor, so an ordinary indented `return x`
+    inside a function body false-positived as a module export (rosetta
+    corpus: risk_api_exposure +110%). Anchored to true column 0.
+    """
+    api = LUA_RULES["api"]
+
+    assert not api.search("    return x"), "indented function-body return must NOT count as api"
+    assert not api.search("\treturn value"), "tab-indented function-body return must NOT count as api"
+
+    assert api.search("return M"), "column-0 module-final return must still count as api"
+    assert api.search("return MyModule"), "column-0 module-final return (named module) must still count as api"

--- a/tests/extraction/languages/test_makefile.py
+++ b/tests/extraction/languages/test_makefile.py
@@ -328,3 +328,25 @@ def test_makefile_dependency_capture_redos_immunity():
     dep = MAKEFILE_RULES["_dependency_capture"]
     assert_redos_immune(dep, " " * 200000 + "include x.mk", timeout_sec=3.0)
     assert dep.search("include x.mk")
+
+def test_makefile_mode_a_braceless_extraction_regression():
+    """
+    Pipeline-level regression for #2648: Makefile targets are tab-indented,
+    not brace-delimited. They must be extracted via Mode A, finding the full
+    recipe block.
+    """
+    from gitgalaxy.core.detector import StructuralExtractor
+    extractor = StructuralExtractor("makefile", LANGUAGE_DEFINITIONS)
+    
+    code = (
+        "target1: dep1\n"
+        "\techo 'recipe 1'\n"
+        "target2: dep2\n"
+        "\techo 'recipe 2'\n"
+    )
+    segments = extractor._partition_segments(code, "makefile")
+    functions, _ = extractor._function_slice(segments, [{} for _ in segments], {}, {}, None)
+    
+    names = [f["name"] for f in functions]
+    assert "target1" in names, "Failed to extract target1"
+    assert "target2" in names, "Failed to extract target2"

--- a/tests/extraction/languages/test_powershell_strict.py
+++ b/tests/extraction/languages/test_powershell_strict.py
@@ -483,3 +483,23 @@ def test_powershell_return_not_counted_as_branch_regression():
     assert branch.search("if ($x) { return 1 }"), "the real if must still count as branch"
     assert len(branch.findall("if ($x) { return 1 }")) == 1, "only the if should match, not the return"
     assert structural.search("return $x"), "return must still be tracked via structural_boundaries"
+
+def test_powershell_api_no_control_flow_false_positives():
+    """#2656: the api rule's bare-identifier alternative lacked keyword exclusions,
+    causing control-flow lines ('param(', 'if (', 'switch (') to miscount as API
+    surface. It must not match control-flow; a real exported function or 
+    Export-ModuleMember must still match."""
+    api = POWERSHELL_RULES["api"]
+
+    # Must NOT count as API
+    assert not api.search("param("), "param( must not count as API"
+    assert not api.search("if ($x) {"), "if ( must not count as API"
+    assert not api.search("switch ($x) {"), "switch ( must not count as API"
+    assert not api.search("while ($true) {"), "while ( must not count as API"
+
+    # Must STILL count as API
+    assert api.search("Export-ModuleMember -Function 'Get-Foo'"), "Export-ModuleMember must count as API"
+    # NB: the bare-identifier alternative's [a-zA-Z_]\w* never matched hyphenated
+    # Verb-Noun cmdlet names (pre-existing, unrelated to #2656) -- use a plain
+    # identifier here to test the exclusion fix in isolation.
+    assert api.search("GetFoo ("), "Real bare-identifier function call should count as API"

--- a/tests/extraction/languages/test_python_strict.py
+++ b/tests/extraction/languages/test_python_strict.py
@@ -338,3 +338,23 @@ def test_python_globals_builtin_call_boundary_regression():
     r = LANGUAGE_DEFINITIONS["python"]["rules"]
     assert r["globals"].search("x = globals()")
     assert r["globals"].search("y = locals()")
+
+
+def test_python_doc_docstring_counts_once_regression():
+    """
+    #2658: the doc rule matched opening and closing docstring delimiters
+    independently with no pairing, so one docstring counted doc=2. Match
+    the full delimited span as a single bounded non-greedy hit instead.
+    """
+    doc = PY_RULES["doc"]
+
+    assert len(doc.findall('"""one docstring"""')) == 1, "a single docstring must count once, not twice"
+    assert (
+        len(doc.findall("'''one docstring'''")) == 1
+    ), "a single '''-delimited docstring must count once, not twice"
+
+    two = '"""first"""\ndef f():\n    """second"""\n'
+    assert len(doc.findall(two)) == 2, "two separate docstrings must count as 2"
+
+    # An unterminated delimiter at EOF must not hang or falsely count.
+    assert_redos_immune(doc, '"""' + "x" * 200000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_scheme.py
+++ b/tests/extraction/languages/test_scheme.py
@@ -16,6 +16,7 @@ scheme_rules = LANGUAGE_DEFINITIONS["scheme"]["rules"]
 FUNC_START = scheme_rules.get("func_start")
 ARGS = scheme_rules.get("args")
 CLASS_START = scheme_rules.get("class_start")
+DEPENDENCY_CAPTURE = scheme_rules.get("_dependency_capture")
 
 FUNCTION_CASES = {
     "valid": [
@@ -77,6 +78,25 @@ CLASS_CASES = {
     ],
 }
 
+DEPENDENCY_CASES = {
+    "valid": [
+        ("(import (scheme base))", "base"),
+        ("(import (name))", "name"),
+        ("(use-modules (ice-9 match))", "match"),
+        # the rosetta corpus's actual shell convention -- bare, no inner parens
+        ("(import a)", "a"),
+        ("(use-modules b)", "b"),
+    ],
+    "invalid": [
+        "(define (foo x) x)",
+        "(import-not-real (foo))",
+        "; (import (scheme base))",
+    ],
+    "pathological": [
+        ("( \n import \n ( \n scheme \n base \n ) \n )", "base"),
+        ("(use-modules \t (ice-9\n  match))", "match"),
+    ],
+}
 
 class TestSchemeExtraction:
     @pytest.mark.parametrize("payload, expected_name", FUNCTION_CASES.get("valid", []))
@@ -132,3 +152,21 @@ class TestSchemeExtraction:
         if not CLASS_START:
             pytest.skip("No pattern")
         assert_pathological_match(CLASS_START, payload, expected_name, "scheme")
+
+    @pytest.mark.parametrize("payload, expected_name", DEPENDENCY_CASES.get("valid", []))
+    def test_positive_dependency_extraction(self, payload, expected_name):
+        if not DEPENDENCY_CAPTURE:
+            pytest.skip("No pattern")
+        assert_valid_match(DEPENDENCY_CAPTURE, payload, expected_name, "scheme")
+
+    @pytest.mark.parametrize("payload", DEPENDENCY_CASES.get("invalid", []))
+    def test_negative_dependency_extraction(self, payload):
+        if not DEPENDENCY_CAPTURE:
+            pytest.skip("No pattern")
+        assert_invalid_no_match(DEPENDENCY_CAPTURE, payload, "scheme")
+
+    @pytest.mark.parametrize("payload, expected_name", DEPENDENCY_CASES.get("pathological", []))
+    def test_pathological_dependency_extraction(self, payload, expected_name):
+        if not DEPENDENCY_CAPTURE:
+            pytest.skip("No pattern")
+        assert_pathological_match(DEPENDENCY_CAPTURE, payload, expected_name, "scheme")

--- a/tests/extraction/languages/test_scheme_strict.py
+++ b/tests/extraction/languages/test_scheme_strict.py
@@ -61,6 +61,7 @@ _SCHEME_SIMPLE_CASES = [
     ("scientific", "(sqrt 4)", "(+ x 1)"),
     ("reflection_metaprogramming", "(define-syntax my-macro (syntax-rules () ((_ x) x)))", "(+ x 1)"),
     ("import", "(import (scheme base))", "(+ x 1)"),
+    ("_dependency_capture", "(import (scheme base))", "(+ x 1)"),
     ("ownership", "; Author: Jane Doe", "; just a note"),
     ("planned_debt", "; TODO: fix this", "; done"),
     ("fragile_debt", "; HACK: workaround", "; clean"),
@@ -318,6 +319,7 @@ def test_scheme_redos_immunity_sweep():
     assert_redos_immune(SCHEME_RULES["dead_code"], ";" + " " * 100000, timeout_sec=3.0)
     assert_redos_immune(SCHEME_RULES["doc"], ";;;" + " " * 100000, timeout_sec=3.0)
     assert_redos_immune(SCHEME_RULES["ownership"], "; Author:" + " " * 100000, timeout_sec=3.0)
+    assert_redos_immune(SCHEME_RULES["_dependency_capture"], "(import (" + " " * 100000, timeout_sec=3.0)
 
     # sanity: all still match their real positive cases after the sweep
     assert SCHEME_RULES["func_start"].search("(define (list->vector x) x)")

--- a/tests/extraction/languages/test_zig.py
+++ b/tests/extraction/languages/test_zig.py
@@ -136,6 +136,34 @@ def test_zig_args_invalid(payload):
 
 
 # ==============================================================================
+# GLOBALS (globals)
+# ==============================================================================
+GLOBALS_VALID = [
+    ("const MY_GLOBAL = 42;", "const MY_GLOBAL"),
+    ("var global_state: i32 = 0;", "var global_state"),
+    ("pub const MAX_CONN = 100;", "pub const MAX_CONN"),
+    ("threadlocal var tls_var: bool = false;", "threadlocal var tls_var"),
+    ("comptime const TYPE = i32;", "comptime const TYPE"),
+]
+
+GLOBALS_INVALID = [
+    "    const local_var = 1;",
+    "\tvar x = 2;",
+    "  var y = 3;",
+]
+
+
+@pytest.mark.parametrize("payload,expected_name", GLOBALS_VALID)
+def test_zig_globals_valid(payload, expected_name):
+    assert_valid_match(ZIG_RULES["globals"], payload, expected_name, "zig.globals")
+
+
+@pytest.mark.parametrize("payload", GLOBALS_INVALID)
+def test_zig_globals_invalid(payload):
+    assert_invalid_no_match(ZIG_RULES["globals"], payload, "zig.globals")
+
+
+# ==============================================================================
 # DEPENDENCY CAPTURE (_dependency_capture)
 # ==============================================================================
 DEPENDENCY_VALID = [

--- a/tests/extraction/languages/test_zig_strict.py
+++ b/tests/extraction/languages/test_zig_strict.py
@@ -456,3 +456,16 @@ def test_zig_return_not_counted_as_branch_regression():
     assert branch.search("if (x) return 1;"), "the real if must still count as branch"
     assert len(branch.findall("if (x) return 1;")) == 1, "only the if should match, not the return"
     assert structural.search("return x;"), "return must still be tracked via structural_boundaries"
+
+
+def test_zig_globals_anchor_bug_regression():
+    """#2651: `globals` rule anchored to column-0 to prevent function-local
+    declarations from being counted as globals."""
+    globals_rule = ZIG_RULES["globals"]
+
+    assert globals_rule.search("const MY_GLOBAL = 42;"), "true top-level const must count as global"
+    assert globals_rule.search("var global_state: i32 = 0;"), "true top-level var must count as global"
+
+    assert not globals_rule.search("    const local_var = 1;"), "indented const must NOT count as global"
+    assert not globals_rule.search("\tvar local_var: i32 = 0;"), "tab-indented var must NOT count as global"
+


### PR DESCRIPTION
## Summary

Second Rosetta-corpus sweep batch, implemented via Gemini/agy dispatches (`gemini-analyzer`/`tree-sitter-accuracy-sweep` pattern) and independently verified/committed here. Fixes nine engine issues surfaced by the #2560 classification sweep that followed #2641.

### Function-census / slicer bugs

- **makefile + ada** (#2648): both had zero brace-delimited bodies but were missing from `detector.py`'s `Mode_A_Labels` tuple, silently falling through to `Mode_B_Braces` and dropping ~100% of real functions (rosetta corpus: 0/14 makefile, 0/13 ada). Added both to the tuple, matching the existing yacc/jcl/m4/dockerfile/abap precedent. On the real crucible corpus, `c/cpython/Makefile.pre.in` goes from 1 to 244 extracted functions — the clearest evidence of severity in this batch.
- **yaml** (#2649): `_slice_by_indentation`'s 2-line function-body floor lacked a yaml exemption, dropping every single-line GitHub Actions `- run:` step — the dominant real-world form (rosetta corpus: functions_found 3 vs 13 func_start matches). Added yaml to the exemption tuple.

### doc/ownership double-counting

- **abap** (#2650), **agc_assembly + fortran + livecode** (#2659): each language's `doc` rule included a bare `AUTHOR`/`Author:` alternative that the `ownership` rule already owns exclusively, so every header author line double-counted both signals. Removed `AUTHOR` from `doc` in all four; verified each language's `ownership` rule still captures every real corpus author line. **cobol shares the identical pattern but is deliberately excluded** — its rosetta shell has no other doc-idiom content, so the same fix would drop its doc signal to 0 (not dedupe it to 1); needs a corpus-side doc line planted first (filed as #2661).
- **html** (#2659): same collision via `<meta name="author">`, which html's own `ownership` rule already captures.
- **python + embedded_python** (#2658): `doc` matched opening and closing `"""`/`'''` delimiters independently with no pairing, so every docstring counted twice. Rewrote as a single bounded (0–15000 char) non-greedy span match; ReDoS-probed against a 200k-char unterminated delimiter (0.007s).

### api-exposure false positives

- **powershell** (#2656): `api`'s bare-identifier alternative lacked the keyword exclusions `func_start`/`args` already carry in the same file, so `param(`/`if (`/`switch (` miscounted as API surface (risk_api_exposure +82%). Added the same exclusion set.
- **lua** (#2657): the module-export idiom's `return <ident>` alternative allowed any indentation, so ordinary function-body returns miscounted as module exports (risk_api_exposure +110%, worst deviation in the sweep). Anchored to column 0. Regex fix only — the scoring/orphan-conversion half stays out of scope.

### Other

- **zig + dart** (#2651): `globals` anchored on `^[ \t]*` (any indentation), so function-local declarations counted as globals (zig: +150%). Anchored to true column 0 in both. Follow-up audit found 11 more languages sharing the same shape, filed separately (#2660).
- **scheme** (#2652): had no `_dependency_capture` at all — the whole dependency DAG was invisible, and popularity staying 0 blocked the orphan→api conversion (risk_tech_debt +100% as a downstream consequence). Added a capture handling both the rosetta corpus's bare `(import a)` form and real R7RS/Guile library-list forms — the first Gemini draft only handled the latter and silently matched nothing on the actual corpus files, caught by testing against them directly. On the real crucible corpus, `scheme/racket/cpnanopass.ss` gains 6 real dependency edges.

## Verification

Every fix independently verified beyond the implementing model's own report, per the dispatch pattern's stated distrust of self-reported "all green":
- Read every diff; confirmed each matches its diagnosed root cause and stays in scope.
- Re-ran the relevant test files myself for every fix (not just trusted the reported numbers).
- Fixed real problems found along the way: a bad test assertion in #2656 (asserted a hyphenated cmdlet name the regex never supported, pre- or post-fix), missing regression tests written from scratch for #2649/#2657/#2658 (each confirmed to fail on pre-fix code), source corrupted by a later edit pass in #2658 (recovered from Gemini's own `.orig` backup), a regex that didn't match the real corpus shape in #2652 (rewritten and empirically verified against the actual files), a duplicate abap.py change from #2659's cross-language audit (dropped — already landed via #2650), and cobol excluded from #2659 after its consequence (dropping doc to 0, not 1) was traced against the live corpus manifest.
- Full suite: **7277 passed** (up from #2641's 7238 baseline), 3 skipped, 2 deselected, 9 xfailed, 3 xpassed.
- `audit_check.py`: ruff/mypy/dead-key/ast-accuracy all clean (two files needed `ruff format` after merge — a ruff *version* mismatch first produced 67 spurious reformats; re-ran with the CI-pinned `ruff==0.16.0` and got the real 2).

## Golden masters

Re-blessed (`crucible_check.py --update --yes`, both modes). Verified **every** non-topological field-level diff (2831 per fixture) by cross-referencing file extension against the changed field — all trace cleanly to the nine languages above (doc/api/globals/dependency fields on exactly ps1/psm1/lua/py/pyx/pxd/F/agc/html/zig/dart/makefile/ss files). The remaining 1942/2831 diffs are topological X/Y/Z coordinates — `spatial_mapper`'s graph embedding recomputes every node's layout whenever any file's signal profile changes anywhere in the corpus, not evidence of unrelated drift. No unexpected language or extension appeared in any non-coordinate field. Tri-comparison chart also regenerated (`--all --write`); SVG is byte-identical, ledger diff is pure `last_reconciled_at` timestamps plus one unrelated PHP ctags anonymous-class-naming artifact.

## Notes for reviewers

- **cobol** (#2661), the 11-language **globals-anchor audit** (#2660), and the **`Author`-vs-doc scope decisions** left for each language are all filed as explicit follow-ups rather than silently expanded into this PR.
- This is engine-only; no rosetta corpus companion PR yet. Several manifests baked in the pre-fix behavior (doc=2, api inflated, etc.) and will need a re-baseline — same choreography as #2641/keyword-rosetta#24, to follow once this merges.
- The Azure DevOps check fails on every commit (org out of CI minutes) — known-broken, ignore.

Fixes #2648
Fixes #2649
Fixes #2650
Fixes #2651
Fixes #2652
Fixes #2656
Fixes #2657
Fixes #2658
Fixes #2659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
