### PR TITLE
chore: bump Muninn action to v0.3.11

### DIFF
--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run Muninn
         # zizmor: ignore[github_action_from_unverified_creator_used]
-        uses: skaldlab/muninn@9be5658042b937aae8fa4e7b27458558541f9c32 # v0.3.10
+        uses: skaldlab/muninn@46fc8f39905c160070071a4e2312c3e7c139b62b # v0.3.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail-on: info


### PR DESCRIPTION
## Summary
- Pin `.github/workflows/muninn.yml` to Muninn **v0.3.11** (`46fc8f39905c160070071a4e2312c3e7c139b62b`).
- Previous pin was v0.3.10.

## Test plan
- [ ] Workflow YAML still SHA-pins the action (zizmor-friendly)
- [ ] After merge, Muninn scan job pulls v0.3.11