### PR TITLE
ci: run corpus-backed audits on fork PRs via in-repo pin fallback

### DIFF
--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -51,9 +51,22 @@ jobs:
       - name: Fetch Golden Test Repo (Language Crucible)
         run: |
           echo "Cloning Language Crucible repository (pinned via LANGUAGE_CRUCIBLE_REF)..."
+          # GitHub withholds repository variables (like secrets) from pull_request runs
+          # raised from a fork, so `vars.LANGUAGE_CRUCIBLE_REF` is empty there. That used to
+          # fail this job before any code ran. But the corpus repo is PUBLIC and clones with
+          # no credentials -- the only thing a fork run actually lacks is the ref *string*,
+          # and that string is already committed in-repo as PINNED_TAG. So fall back to it
+          # and give fork contributors real signal. Same escape-hatch shape as
+          # rosetta-audit.yml's `vars.KEYWORD_ROSETTA_REF || 'main'`, but pinned exactly
+          # rather than floating on main. See tests/_crucible_pin.py's docstring for why the
+          # pin lives in two places, and remember to bump BOTH when moving it.
           ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
           if [ -z "$ref" ]; then
-            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
+            echo "::notice title=Corpus pin read from the repo::LANGUAGE_CRUCIBLE_REF was empty -- expected on a pull_request run raised from a fork -- so this audit pinned its corpus to '$ref', read from tests/_crucible_pin.py."
+          fi
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::Could not resolve a corpus pin from either the LANGUAGE_CRUCIBLE_REF repository variable or PINNED_TAG in gitgalaxy/tests/_crucible_pin.py. If PINNED_TAG was renamed or its formatting changed, update the sed fallback in this workflow to match. See CONTRIBUTING.md, 'Corpus-backed checks'."
             exit 1
           fi
           git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible

--- a/.github/workflows/release-crucible-archive.yml
+++ b/.github/workflows/release-crucible-archive.yml
@@ -57,7 +57,23 @@ jobs:
 
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF, same as CI)
         run: |
-          git clone --branch "${{ vars.LANGUAGE_CRUCIBLE_REF }}" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
+          # This workflow only ever runs from `release`/`workflow_dispatch` in this repo, so
+          # the repository variable is always available -- unlike the fork PR case the audit
+          # workflows guard against. The in-repo PINNED_TAG fallback is here anyway so the
+          # archive can never be silently cut against an EMPTY ref (a deleted or renamed
+          # variable would otherwise make `git clone --branch ""` the failure mode, and
+          # would blank the tag out of the archive PR body below).
+          ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
+          if [ -z "$ref" ]; then
+            ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
+            echo "::notice title=Corpus pin read from the repo::LANGUAGE_CRUCIBLE_REF was empty, so this archive pinned its corpus to '$ref', read from tests/_crucible_pin.py."
+          fi
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::Could not resolve a corpus pin from either the LANGUAGE_CRUCIBLE_REF repository variable or PINNED_TAG in gitgalaxy/tests/_crucible_pin.py."
+            exit 1
+          fi
+          echo "CRUCIBLE_REF=$ref" >> "$GITHUB_ENV"
+          git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible
 
       - name: Run GalaxyScope against the crucible corpus
         env:
@@ -101,7 +117,7 @@ jobs:
           title: "chore: archive ${{ env.RELEASE_TAG }} crucible baseline"
           body: |
             Automated archive of GitGalaxy `${{ env.RELEASE_TAG }}`'s output against the pinned
-            `data/` corpus (`${{ vars.LANGUAGE_CRUCIBLE_REF }}` tag), for release-over-release comparison.
+            `data/` corpus (`${{ env.CRUCIBLE_REF }}` tag), for release-over-release comparison.
 
             The remaining artifacts (SQLite DB, graph, SARIF, SBOM, GPU payload, LLM brief) are
             attached to the release itself rather than committed here:

--- a/.github/workflows/tree-sitter-accuracy-audit.yml
+++ b/.github/workflows/tree-sitter-accuracy-audit.yml
@@ -53,9 +53,22 @@ jobs:
       # a fresh clone (see tests/tools/tree_sitter_accuracy_audit.py's own CORPUS section).
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
         run: |
+          # GitHub withholds repository variables (like secrets) from pull_request runs
+          # raised from a fork, so `vars.LANGUAGE_CRUCIBLE_REF` is empty there. That used to
+          # fail this job before any code ran. But the corpus repo is PUBLIC and clones with
+          # no credentials -- the only thing a fork run actually lacks is the ref *string*,
+          # and that string is already committed in-repo as PINNED_TAG. So fall back to it
+          # and give fork contributors real signal. Same escape-hatch shape as
+          # rosetta-audit.yml's `vars.KEYWORD_ROSETTA_REF || 'main'`, but pinned exactly
+          # rather than floating on main. See tests/_crucible_pin.py's docstring for why the
+          # pin lives in two places, and remember to bump BOTH when moving it.
           ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
           if [ -z "$ref" ]; then
-            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
+            echo "::notice title=Corpus pin read from the repo::LANGUAGE_CRUCIBLE_REF was empty -- expected on a pull_request run raised from a fork -- so this audit pinned its corpus to '$ref', read from tests/_crucible_pin.py."
+          fi
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::Could not resolve a corpus pin from either the LANGUAGE_CRUCIBLE_REF repository variable or PINNED_TAG in gitgalaxy/tests/_crucible_pin.py. If PINNED_TAG was renamed or its formatting changed, update the sed fallback in this workflow to match. See CONTRIBUTING.md, 'Corpus-backed checks'."
             exit 1
           fi
           git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible

--- a/.github/workflows/tree-sitter-accuracy-history.yml
+++ b/.github/workflows/tree-sitter-accuracy-history.yml
@@ -76,9 +76,22 @@ jobs:
 
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
         run: |
+          # GitHub withholds repository variables (like secrets) from pull_request runs
+          # raised from a fork, so `vars.LANGUAGE_CRUCIBLE_REF` is empty there. That used to
+          # fail this job before any code ran. But the corpus repo is PUBLIC and clones with
+          # no credentials -- the only thing a fork run actually lacks is the ref *string*,
+          # and that string is already committed in-repo as PINNED_TAG. So fall back to it
+          # and give fork contributors real signal. Same escape-hatch shape as
+          # rosetta-audit.yml's `vars.KEYWORD_ROSETTA_REF || 'main'`, but pinned exactly
+          # rather than floating on main. See tests/_crucible_pin.py's docstring for why the
+          # pin lives in two places, and remember to bump BOTH when moving it.
           ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
           if [ -z "$ref" ]; then
-            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
+            echo "::notice title=Corpus pin read from the repo::LANGUAGE_CRUCIBLE_REF was empty -- expected on a pull_request run raised from a fork -- so this audit pinned its corpus to '$ref', read from tests/_crucible_pin.py."
+          fi
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::Could not resolve a corpus pin from either the LANGUAGE_CRUCIBLE_REF repository variable or PINNED_TAG in gitgalaxy/tests/_crucible_pin.py. If PINNED_TAG was renamed or its formatting changed, update the sed fallback in this workflow to match. See CONTRIBUTING.md, 'Corpus-backed checks'."
             exit 1
           fi
           git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible

--- a/.github/workflows/tri-comparison-audit.yml
+++ b/.github/workflows/tri-comparison-audit.yml
@@ -78,9 +78,22 @@ jobs:
       # that corpus rather than a fresh clone.
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
         run: |
+          # GitHub withholds repository variables (like secrets) from pull_request runs
+          # raised from a fork, so `vars.LANGUAGE_CRUCIBLE_REF` is empty there. That used to
+          # fail this job before any code ran. But the corpus repo is PUBLIC and clones with
+          # no credentials -- the only thing a fork run actually lacks is the ref *string*,
+          # and that string is already committed in-repo as PINNED_TAG. So fall back to it
+          # and give fork contributors real signal. Same escape-hatch shape as
+          # rosetta-audit.yml's `vars.KEYWORD_ROSETTA_REF || 'main'`, but pinned exactly
+          # rather than floating on main. See tests/_crucible_pin.py's docstring for why the
+          # pin lives in two places, and remember to bump BOTH when moving it.
           ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
           if [ -z "$ref" ]; then
-            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
+            echo "::notice title=Corpus pin read from the repo::LANGUAGE_CRUCIBLE_REF was empty -- expected on a pull_request run raised from a fork -- so this audit pinned its corpus to '$ref', read from tests/_crucible_pin.py."
+          fi
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::Could not resolve a corpus pin from either the LANGUAGE_CRUCIBLE_REF repository variable or PINNED_TAG in gitgalaxy/tests/_crucible_pin.py. If PINNED_TAG was renamed or its formatting changed, update the sed fallback in this workflow to match. See CONTRIBUTING.md, 'Corpus-backed checks'."
             exit 1
           fi
           git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible

--- a/.github/workflows/tri-comparison-history.yml
+++ b/.github/workflows/tri-comparison-history.yml
@@ -87,9 +87,22 @@ jobs:
 
       - name: Fetch Language Crucible corpus (pinned via LANGUAGE_CRUCIBLE_REF)
         run: |
+          # GitHub withholds repository variables (like secrets) from pull_request runs
+          # raised from a fork, so `vars.LANGUAGE_CRUCIBLE_REF` is empty there. That used to
+          # fail this job before any code ran. But the corpus repo is PUBLIC and clones with
+          # no credentials -- the only thing a fork run actually lacks is the ref *string*,
+          # and that string is already committed in-repo as PINNED_TAG. So fall back to it
+          # and give fork contributors real signal. Same escape-hatch shape as
+          # rosetta-audit.yml's `vars.KEYWORD_ROSETTA_REF || 'main'`, but pinned exactly
+          # rather than floating on main. See tests/_crucible_pin.py's docstring for why the
+          # pin lives in two places, and remember to bump BOTH when moving it.
           ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
           if [ -z "$ref" ]; then
-            echo "::error title=Corpus pin unavailable::LANGUAGE_CRUCIBLE_REF resolved to an empty value, so this corpus-backed audit cannot pin its corpus and did not run. GitHub withholds repository variables (like secrets) from pull_request runs raised from a fork, so this is expected on a fork PR and is NOT a problem with the contributor's changes -- a maintainer re-runs these audits from a branch in this repo before merge. See CONTRIBUTING.md, 'Checks that cannot run on fork PRs'."
+            ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
+            echo "::notice title=Corpus pin read from the repo::LANGUAGE_CRUCIBLE_REF was empty -- expected on a pull_request run raised from a fork -- so this audit pinned its corpus to '$ref', read from tests/_crucible_pin.py."
+          fi
+          if [ -z "$ref" ]; then
+            echo "::error title=Corpus pin unavailable::Could not resolve a corpus pin from either the LANGUAGE_CRUCIBLE_REF repository variable or PINNED_TAG in gitgalaxy/tests/_crucible_pin.py. If PINNED_TAG was renamed or its formatting changed, update the sed fallback in this workflow to match. See CONTRIBUTING.md, 'Corpus-backed checks'."
             exit 1
           fi
           git clone --branch "$ref" --depth 1 https://github.com/squid-protocol/language-crucible.git language-crucible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,25 +96,36 @@ If your PR touches any baseline fixtures, **explain why in the PR description** 
 
 ---
 
-## 🍴 Checks that cannot run on fork PRs
+## 🍴 Corpus-backed checks
 
-If you opened your PR from a fork, expect these four checks to fail immediately, before your code
-is ever exercised:
+Four checks scan the [language-crucible](https://github.com/squid-protocol/language-crucible)
+corpus rather than just this repo:
 
 - `crucible-audit (full-precision)` and `crucible-audit (zero-dependency)`
 - `tree-sitter-accuracy-audit`
 - `tri-comparison-audit`
 
-**This is not a problem with your changes.** These audits clone the
-[language-crucible](https://github.com/squid-protocol/language-crucible) corpus at a ref pinned in
-the `LANGUAGE_CRUCIBLE_REF` Actions variable, and GitHub withholds repository variables — like
-secrets — from `pull_request` runs raised from a fork. The pin resolves to an empty string and the
-clone fails. A maintainer re-runs these audits from a branch in this repo before merging, so there
-is nothing for you to do.
+**These now run normally on fork PRs.** They clone the corpus at a ref taken from the
+`LANGUAGE_CRUCIBLE_REF` Actions variable, and GitHub withholds repository variables — like
+secrets — from `pull_request` runs raised from a fork. The corpus repo is public and needs no
+credentials to clone, though, so when that variable is unavailable the workflows fall back to
+`PINNED_TAG` in [`tests/_crucible_pin.py`](tests/_crucible_pin.py), which is committed here and
+therefore readable on a fork run. You will see a `Corpus pin read from the repo` notice in the
+job log when the fallback is used; the audit itself is the real thing, and a failure is a real
+failure worth reading.
 
-`rosetta-audit` is unaffected (it falls back to the corpus's `main`), and every other check —
-`full-suite`, the `smoke-test` matrix, `ruff-audit`, `mypy-audit`, `ast-accuracy-audit` — runs
-normally on a fork PR and is worth taking seriously.
+> **Historical note.** Before this fallback existed these four checks failed instantly on every
+> fork PR, and CONTRIBUTING told you to ignore them because a maintainer would re-run them from
+> a branch in this repo. That is no longer necessary — treat a red corpus-backed audit on your
+> fork PR as genuine signal.
+
+If you are moving the pin, bump it in **both** places — `tests/_crucible_pin.py` and the
+`LANGUAGE_CRUCIBLE_REF` repository variable. Nothing enforces that they match; see that file's
+docstring for why the pin is deliberately duplicated.
+
+`rosetta-audit` uses the same escape hatch against a different corpus (it falls back to
+keyword-rosetta's `main`), and every other check — `full-suite`, the `smoke-test` matrix,
+`ruff-audit`, `mypy-audit`, `ast-accuracy-audit` — runs normally on a fork PR too.
 
 ---
 

--- a/tests/_crucible_pin.py
+++ b/tests/_crucible_pin.py
@@ -1,19 +1,33 @@
-"""
+r"""
 Single source of truth for "which language-crucible tag does GitGalaxy's CI
 currently pin to" -- see language-crucible's own RELEASING.md for the full
 bump checklist (regenerate golden masters, then update the pin, in that
 order).
 
 This constant is the source of truth for every *human-facing* mention of the
-pin (skip-reason messages, docstrings, README prose). It intentionally is
-NOT the source of truth CI itself clones against -- that's the
-`LANGUAGE_CRUCIBLE_REF` GitHub Actions repository variable (Settings ->
-Secrets and variables -> Actions -> Variables), read directly by every
-workflow step that does `git clone --branch`. Two places instead of one
+pin (skip-reason messages, docstrings, README prose). CI normally clones
+against the `LANGUAGE_CRUCIBLE_REF` GitHub Actions repository variable
+(Settings -> Secrets and variables -> Actions -> Variables) instead, read by
+every workflow step that does `git clone --branch`. Two places instead of one
 because a GitHub Actions variable isn't importable from a local pytest run
 or a docstring, and a Python constant isn't visible to workflow YAML -- but
 two is a large, deliberate improvement over the ~11 independently-hardcoded
 copies (6 workflow files, 4 scripts, 4 docs) this replaced.
+
+Since the fork-PR fallback landed, this constant is ALSO a real CI input, not
+just a human-facing one: GitHub withholds repository variables from
+`pull_request` runs raised from a fork, so on those runs the corpus-backed
+workflows scrape `PINNED_TAG` out of this file with
+
+    sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py
+
+and clone the (public, credential-free) corpus at whatever it says. Practical
+consequence: **keep the assignment below on one line, in exactly that
+literal form.** Reformatting it -- black-style line wrapping, single quotes,
+a type annotation, a trailing comment -- silently breaks the fork-PR corpus
+clone. If you must change the shape, update the sed in all six workflows
+(golden-crucible, tree-sitter-accuracy-audit, tri-comparison-audit, the two
+*-history workflows, release-crucible-archive) to match.
 
 **When bumping the pin: update both.** This constant, and the
 `LANGUAGE_CRUCIBLE_REF` repo variable (`gh variable set LANGUAGE_CRUCIBLE_REF


### PR DESCRIPTION
## Summary

The four corpus-backed audits — `crucible-audit (full-precision)`, `crucible-audit (zero-dependency)`, `tree-sitter-accuracy-audit` and `tri-comparison-audit` — fail instantly on **every** PR raised from a fork, before any code is exercised. They clone language-crucible at `${{ vars.LANGUAGE_CRUCIBLE_REF }}`, and GitHub withholds repository variables (like secrets) from fork `pull_request` runs, so the ref resolves to an empty string and the guard exits 1. #2664 is the latest instance.

The key observation: **the corpus repo is public and clones with no credentials.** The only thing a fork run actually lacks is the ref *string* — and that string is already committed here as `PINNED_TAG` in `tests/_crucible_pin.py`, which a fork run can read. So fall back to it when the variable is empty:

```bash
ref="${{ vars.LANGUAGE_CRUCIBLE_REF }}"
if [ -z "$ref" ]; then
  ref=$(sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' gitgalaxy/tests/_crucible_pin.py)
  echo "::notice title=Corpus pin read from the repo::..."
fi
```

Same escape-hatch shape as `rosetta-audit.yml`'s `vars.KEYWORD_ROSETTA_REF || 'main'`, but pinned exactly rather than floating on `main`.

Fork contributors get real signal from these audits instead of noise, and maintainers stop hand-verifying every fork PR from a branch in this repo.

## Also in this PR

- **`release-crucible-archive.yml`** gets the same fallback. It can never hit the fork case (it only runs on `release`/`workflow_dispatch`), but it had no guard at all — a deleted or renamed variable would have made `git clone --branch ""` the failure mode and blanked the tag out of the archive PR body. The resolved ref now goes through `$GITHUB_ENV` so the body cites the ref actually used.
- **`tests/_crucible_pin.py`** — note that `PINNED_TAG` is now a real CI input, not just a human-facing constant. The assignment must stay on one line in its current literal form or the sed fallback silently breaks; reformatting it (black-style wrapping, single quotes, a type annotation) is the hazard. Docstring made raw so the embedded sed expression does not trip ruff's W605.
- **`CONTRIBUTING.md`** — the "Checks that cannot run on fork PRs" section told contributors to ignore these four checks. Rewritten as "Corpus-backed checks": they are trustworthy on a fork PR now.

## Security note

Deliberately **not** `pull_request_target`, which would run fork code with a write-scoped token against a repo whose whole job is scanning untrusted input. These jobs consume no secrets, and the clone URL stays hardcoded to `squid-protocol/language-crucible`. The worst a malicious fork PR can do is point the corpus at a different ref of that same public repo and make its own audit fail.

## Test plan

- [x] All workflow YAML parses (`yaml.safe_load` over `.github/workflows/*.yml`)
- [x] `sed -n 's/^PINNED_TAG = "\(.*\)"/\1/p' tests/_crucible_pin.py` → `v1.2.0`
- [x] Fork path simulated end-to-end in the CI workspace layout (`ref=""` → resolves `v1.2.0`); `git ls-remote` confirms that ref is clonable with **zero** credentials
- [x] Hard-fail path verified: a reformatted `PINNED_TAG` yields an empty `ref` and exits 1 with the new error, rather than silently cloning an empty ref
- [x] `ruff check` + `ruff format --check` clean on `tests/_crucible_pin.py`; module compiles with no `SyntaxWarning`
- [x] Verified against #2664's head before writing this: `crucible_check.py` → `full_precision: PASS`, `zero_dependency: PASS`
- [ ] After merge: confirm the next fork PR shows these four checks running (look for the `Corpus pin read from the repo` notice) instead of failing at the clone step

Note that this PR is itself from a branch in this repo, so its own audits take the **unchanged** variable path — the fallback is exercised by the simulation above, and for real by the next fork PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)