### PR TITLE
test(swift): pin bare-import rejection and _dependency_capture ReDoS

### DIFF
--- a/tests/extraction/languages/test_swift.py
+++ b/tests/extraction/languages/test_swift.py
@@ -241,6 +241,9 @@ DEPENDENCY_CASES: dict[str, Any] = {
     ],
     "invalid": [
         "var importData = true",
+        # #2543 follow-up: relaxing the module-name tail to `*` (so `import a` captures)
+        # must not go so far that a bare `import` with no module name matches at all.
+        "import",
     ],
     "pathological": [
         (
@@ -268,3 +271,10 @@ def test_swift_dependency_capture_pathological(payload, expected_path):
     assert_pathological_dependency_match(
         SWIFT_RULES["_dependency_capture"], payload, expected_path, "swift._dependency_capture"
     )
+
+
+def test_swift_dependency_capture_redos_immunity():
+    # The dotted-module tail `[\w.]*` is the one unbounded quantifier in this rule, so it is
+    # the part worth pinning: a long `a.a.a...` module path must stay linear. func_start and
+    # args already have this coverage; _dependency_capture did not.
+    assert_redos_immune(SWIFT_RULES["_dependency_capture"], "import " + "a." * 50000, timeout_sec=3.0)


### PR DESCRIPTION
## Summary

Salvages the two test cases from #2628 that `main` does not already have. That PR's regex fix — `[\w.]+` → `[\w.]*` in swift's `_dependency_capture`, so `import a` captures — was superseded by #2641 (`5813a9cb`) landing the byte-identical change first, along with the `("import a", "a")` regression case. Credit to @kanishk083, who filed #2628 for issue #2543 before the sweep landed; retained as `Co-Authored-By`.

What was left, and is added here:

- **`"import"` as an explicit invalid case.** Relaxing the module-name tail from `+` to `*` is exactly the kind of change that could go one step too far and start matching a bare `import` with no module name. This pins that it does not.
- **A ReDoS immunity test for `_dependency_capture`.** The dotted-module tail is the one unbounded quantifier in that rule. `func_start` and `args` already have this coverage; `_dependency_capture` did not.

## Test plan

- [x] `pytest tests/extraction/languages/test_swift.py` → **39 passed**
- [x] `ruff check` introduces no new findings — the 7 reported (E402, S101) are pre-existing and identical on `main`
- [x] `ruff format --check` clean
- [x] Both assertions verified against the current engine before writing them: bare `import` does not match, and the 100k-char `"import " + "a." * 50000` payload completes in ~0.001s against a 3.0s budget
- [x] No production code changes, so no golden-master or baseline movement expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)