### PR TITLE
docs: KEYWORD_ROSETTA_REF must be a full SHA (it broke rosetta-audit today) + two golden-master tooling traps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,44 @@ produced a false "zero diff" pass locally while CI correctly failed on real outp
 confirming which checkout its editable install actually resolves to
 (`python -c "import gitgalaxy; print(gitgalaxy.__file__)"` from inside that venv).
 
+**Scoping a bless: `crucible_check.py` shows you only a fraction of the diff.** Its output is
+capped twice -- `tests/golden_diff.py` prints 50 differences, and `crucible_check.py`'s wrapper
+keeps a 4000-char window of that -- so a run reporting "581 differences" surfaces about 28.
+GATING-style scoped-diff review ("every unrelated mover is attributed to a named PR, or the
+bless waits") is therefore **impossible from its output alone**: on 2026-09-02 all 28 surfaced
+diffs were groovy and said nothing about the other 18 languages that had moved. Regenerate the
+audit and diff it yourself:
+
+```sh
+.crucible_venvs/zero_dependency/bin/galaxyscope <language-crucible>/data \
+    --output /tmp/gm/ --file-speed --splicing-speed          # same flags as tests/test_golden_crucible.py
+python -c "
+import sys; sys.path.insert(0,'tests'); import golden_diff as gd
+g=gd.load_and_sanitize('tests/golden_master_zero_dep_audit.json')
+a=gd.load_and_sanitize('/tmp/gm/data_galaxy_audit.json')
+for d in gd.deep_compare(g,a): print(d)"
+```
+
+Expect most of the volume to be topological `X`/`Y`/`Z` coordinates: the 3D layout re-solves
+corpus-wide whenever any node's mass changes, so a single-language fix ripples coordinates
+across every language in the corpus. Those are attributable as a class; filter them out and
+scope the remainder, which is what actually needs a per-language explanation.
+
+**The two accuracy audits exit 0 while doing nothing if `galaxyscope` is off `PATH`.**
+`tests/tools/tree_sitter_accuracy_audit.py` and `tests/tools/tri_comparison_chart.py` report
+`galaxyscope not found on PATH` per language, skip every one, and still print
+`all OK` with exit code 0 -- a false green that looks exactly like a pass. They need the **main
+`.venv`**, which has both `galaxyscope` and `tree_sitter_language_pack`; neither crucible venv
+does (`full_precision` has `galaxyscope` but not the tree-sitter pack). Always run them as:
+
+```sh
+PATH="$PWD/.venv/bin:$PATH" .venv/bin/python tests/tools/tree_sitter_accuracy_audit.py --ci --all
+PATH="$PWD/.venv/bin:$PATH" .venv/bin/python tests/tools/tri_comparison_chart.py --all --ci
+```
+
+and confirm the summary line names a plausible language count (30 and 3 respectively as of
+2026-09-02) -- "0 languages checked, all OK" is a failure wearing a pass.
+
 ## Logging cases where GitGalaxy beats tree-sitter/AST ground truth
 
 The general rule, stated plainly in `README.md`'s "One Graph, Not Five Separate Tools" section, is

--- a/docs/self_scan/BUMPING_THE_ROSETTA_PIN.md
+++ b/docs/self_scan/BUMPING_THE_ROSETTA_PIN.md
@@ -4,10 +4,46 @@ The `rosetta-audit` CI check (`.github/workflows/rosetta-audit.yml`, issue #2557
 [keyword-rosetta](https://github.com/squid-protocol/keyword-rosetta) control corpus's verifier —
 all 46 language folders plus its baseline-gated n/a review audit — against every PR that touches
 engine code, with the corpus checked out at the **`KEYWORD_ROSETTA_REF`** GitHub Actions
-variable (a commit SHA or tag; falls back to `main` if unset). This is the cross-language
+variable (falls back to `main` if unset). This is the cross-language
 *consistency* twin of the crucible pin (`docs/self_scan/BUMPING_THE_CRUCIBLE_PIN.md`), and the
 same principle applies: the pin makes the gate deterministic, and bumping it is a deliberate,
 reviewed act — never a way to make a red check go away.
+
+## The value MUST be a full 40-character SHA
+
+`actions/checkout` only treats a **40-character** hex string as a commit SHA. Anything
+shorter -- an abbreviated `357345f`, a branch name, a tag -- it treats as a ref *name* and
+resolves by fetching `refs/heads/<value>*`. An abbreviated SHA matches no ref, so the job
+dies in **Checkout keyword-rosetta (pinned)** before running a single verification:
+
+```
+# a full SHA -- fetched directly, works
+git fetch --depth=1 origin 6b1efab63f70bc9f4bb315915e58935e88bd427d
+
+# an abbreviated SHA -- treated as a ref name, matches nothing, retries twice, fails
+git fetch --depth=1 origin +refs/heads/357345f*:refs/remotes/origin/357345f*
+```
+
+This is not hypothetical: on 2026-09-02 the pin was bumped to the 7-character `357345f`
+after keyword-rosetta#32 merged, and `rosetta-audit` failed on `main` and on every engine PR
+until it was repaired -- silently, because a checkout failure and a real gate failure look
+identical in the checks list. Always pass `git rev-parse origin/main`, never `--short`:
+
+```sh
+cd <keyword-rosetta> && git fetch origin && git rev-parse origin/main   # 40 chars
+```
+
+## rosetta-audit is red -- did it actually run?
+
+Check this **before** assuming corpus drift. A red check has two very different causes:
+
+1. **The job never ran the verifier** -- it failed in `Checkout keyword-rosetta (pinned)`.
+   Almost always a malformed pin (see above). Nothing about your PR is implicated.
+2. **The verifier ran and disagreed** -- that is the gate working; go to the next section.
+
+```sh
+gh run view <run-id> --log-failed | grep -m1 'Checkout keyword-rosetta'   # empty => it ran
+```
 
 ## When rosetta-audit fails on your PR
 
@@ -22,12 +58,13 @@ That is the gate working: your change shifts what the engine observes on the pla
       a validated `deviation_ledger.json` entry (or `still_reproduces` flip) justifying every
       changed number — with the committed **`ENGINE_REF`** file set to `pull/<N>/head` for
       YOUR engine PR `N`, so its gates run against your unmerged build and go green now.
-   3. Restore `ENGINE_REF` to `main` and merge the corpus PR (once your engine PR is approved).
-   4. In your engine PR: update `KEYWORD_ROSETTA_REF` to the corpus repo's new main SHA —
-      `gh api -X PATCH repos/squid-protocol/gitgalaxy/actions/variables/KEYWORD_ROSETTA_REF -f value=<sha>`
+   2. Restore `ENGINE_REF` to `main` and merge the corpus PR (once your engine PR is approved).
+   3. In your engine PR: update `KEYWORD_ROSETTA_REF` to the corpus repo's new main SHA —
+      `gh api -X PATCH repos/squid-protocol/gitgalaxy/actions/variables/KEYWORD_ROSETTA_REF -f value=$(git -C <keyword-rosetta> rev-parse origin/main)`
+      -- the **full 40-character** SHA; an abbreviated one breaks the checkout (see above)
       (needs repo admin; in a review, request the maintainer do it) — and note the bump + the
       companion corpus PR in the PR body's **Cross-repo** section.
-   5. `rosetta-audit` reruns green → merge.
+   4. `rosetta-audit` reruns green → merge.
 
 3. **A new rule absence** (you nulled/removed a rule): `na_check --ci` fails until the corpus
    PR ships a validated ledger entry naming the language and signal — absence is either real
@@ -36,6 +73,7 @@ That is the gate working: your change shifts what the engine observes on the pla
 
 ## Invariants
 
+- The variable is always a **full 40-character SHA** -- never abbreviated, never a branch name.
 - The variable always points at a keyword-rosetta commit whose gates pass against the engine
   `main` that existed when it was set (the brief corpus-ahead-of-engine window during step 2
   is covered by this gate's own pin).


### PR DESCRIPTION
Docs only — no engine change, so no bless, no corpus PR, no pin bump.

Three things that produced confident wrong answers during gitgalaxy#2669's batch-B work, written down so the next session doesn't rediscover them.

### 1. The pin must be a full 40-character SHA — this broke `rosetta-audit` today

`actions/checkout` treats a 40-char hex string as a commit SHA and **anything shorter as a ref name**, resolved via `refs/heads/<value>*`:

```
# full SHA -- fetched directly, works
git fetch --depth=1 origin 6b1efab63f70bc9f4bb315915e58935e88bd427d

# abbreviated -- treated as a ref name, matches nothing, retries twice, fails
git fetch --depth=1 origin +refs/heads/357345f*:refs/remotes/origin/357345f*
```

When the pin was bumped to the 7-character `357345f` after keyword-rosetta#32 merged, `rosetta-audit` began failing on `main` and on every engine PR — **before running a single verification**. It was invisible for hours because a checkout failure and a genuine gate failure are indistinguishable in the checks list, and because the abbreviated value still compares equal to `git rev-parse --short origin/main`, so the documented pin check passes on it.

`BUMPING_THE_ROSETTA_PIN.md` now states the requirement with both fetch commands side by side, uses `git rev-parse` (not `--short`) in the PATCH recipe, carries it as an invariant, and adds a **"rosetta-audit is red — did it actually run?"** triage step so cause 1 (couldn't fetch the corpus) is separated from cause 2 (the verifier disagreed). Also fixed the re-baseline procedure's numbering, which ran 1., 3., 4., 5.

### 2. `crucible_check.py` shows ~28 of N differences

Capped twice — `golden_diff.py` prints 50, and the wrapper keeps a 4000-char window of that. A run reporting **581 differences surfaces about 28**, so GATING's scoped-diff rule ("every unrelated mover is attributed, or the bless waits") **cannot be satisfied from its output**. For #2677 all 28 shown were groovy and said nothing about the other 18 languages that had moved.

`CLAUDE.md` now carries the regenerate-and-`deep_compare` recipe, plus the observation that most of the volume is topological `X`/`Y`/`Z`: the 3D layout re-solves corpus-wide whenever any node's mass changes, so a single-language fix ripples coordinates through every language. That is attributable as a class and should be filtered before scoping what remains (for #2677: 433 coordinate, 148 substantive).

### 3. Both accuracy audits exit 0 while doing nothing

`tree_sitter_accuracy_audit.py` and `tri_comparison_chart.py` print `galaxyscope not found on PATH` per language, skip all of them, and still emit `all OK` with exit code 0. They need the main `.venv` — `.crucible_venvs/full_precision` has `galaxyscope` but not `tree_sitter_language_pack`, and the zero-dep venv has neither. `CLAUDE.md` now has the correct invocations and a "check the summary names a plausible language count" rule; *0 languages checked, all OK* is a failure wearing a pass.

### Cross-repo

Companion PR keyword-rosetta#34 adds the corresponding rules on the corpus side (green corpus ≠ green golden master; filling a `None` rule is corpus-visible; measure over a language's whole file set). No merge ordering — neither touches code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)