### PR TITLE
docs: rosetta capstones for the two languages that qualify (#2669 E.3)

### DIFF
--- a/docs/language_status/abap.md
+++ b/docs/language_status/abap.md
@@ -476,3 +476,44 @@ zero-dependency modes) and required regenerating both golden master fixtures; #1
 entirely in the SQLite recorder's named-class-list path, which those fixtures don't exercise at
 all — `crucible_check.py` passed with zero drift both before and after those two, confirmed via
 the tri-comparison gatherer and a direct `--db-only` scan instead.
+
+---
+
+## 10. Rosetta cross-language consistency (control-corpus capstone)
+
+This section is the [keyword-rosetta](https://github.com/squid-protocol/keyword-rosetta)
+counterpart of §9: where §9 asks "is ABAP extraction *accurate* on real code?", the rosetta control
+corpus asks "does GitGalaxy measure *identical planted intent* the same in ABAP as in the other 45
+languages?" Every deviation from the 46-language median is measured bias, tracked in
+[#2561](https://github.com/squid-protocol/gitgalaxy/issues/2561) (epic
+[#2560](https://github.com/squid-protocol/gitgalaxy/issues/2560)) and validated in the corpus's
+[deviation ledger](https://github.com/squid-protocol/keyword-rosetta/blob/main/deviation_ledger.json).
+
+**Summary (2026-09-03).** ABAP opened at **3🔴 / 3🟡** and is now **fully in band: zero
+out-of-band metrics across all 57 comparable columns** — the only language in the corpus with no
+deviation of any kind. Tracking issue [#2561](https://github.com/squid-protocol/gitgalaxy/issues/2561)
+closed under Batch E.4 of [#2669](https://github.com/squid-protocol/gitgalaxy/issues/2669).
+
+ABAP's deviations were retired by corpus and engine work that was never ABAP-specific:
+
+1. **Corpus authoring, not morphology** — ABAP's original decoy carried the retired shared sentence
+   (`'IF TRUNCATE FAILS TRY SELECT AGAIN'`), whose `SELECT` is a live `io` keyword in this language,
+   so the decoy inflated the very signal it was meant to be inert against. Re-authored in Batch A.3
+   of #2669 (keyword-rosetta [#32](https://github.com/squid-protocol/keyword-rosetta/pull/32))
+   against the per-language template in keyword-rosetta#17, which screens a candidate keyword
+   against the seven non-planted signals that feed a `risk_*` formula before it is planted.
+2. **Median inflation by other languages' bugs** — the remainder was never ABAP's: the residual
+   `branch`/`state_mutation` standing moved when the return-counts-as-branch family
+   ([#2545](https://github.com/squid-protocol/gitgalaxy/issues/2545)) and the ×3 flux weighting
+   ([#2546](https://github.com/squid-protocol/gitgalaxy/issues/2546)) stopped skewing the
+   cross-language median.
+
+**Remaining out-of-band: none.** ABAP is the corpus's control case for what "clean" looks like —
+worth reading alongside a language with many ledgered deviations, because it shows the bands are
+achievable rather than aspirational.
+
+**Reading the close criterion correctly.** `tools/language_deviations.py abap` exiting 0 means every
+out-of-band cell is *accounted for*, not that none exists — for ABAP those happen to be the same
+thing, but for its neighbours they are not (see groovy §10). The distinction is enforced by the
+verdict machinery added in Batch E.1 (keyword-rosetta
+[#40](https://github.com/squid-protocol/keyword-rosetta/pull/40)).

--- a/docs/language_status/groovy.md
+++ b/docs/language_status/groovy.md
@@ -444,3 +444,49 @@ in the tool itself, not evidence against GitGalaxy) — see
 longer goes through tree-sitter comparison at all. The verified counts (661/718 functions,
 222/222 classes) are recorded in `docs/self_scan/manual_verification.json` under `"groovy"`,
 following the same `**`-badge convention abap/dockerfile/jcl/livecode/yaml already use.
+
+---
+
+## 10. Rosetta cross-language consistency (control-corpus capstone)
+
+This section is the [keyword-rosetta](https://github.com/squid-protocol/keyword-rosetta)
+counterpart of §9: where §9 asks "is Groovy extraction *accurate* on real code?", the rosetta
+control corpus asks "does GitGalaxy measure *identical planted intent* the same in Groovy as in the
+other 45 languages?" Every deviation from the 46-language median is measured bias, tracked in
+[#2576](https://github.com/squid-protocol/gitgalaxy/issues/2576) (epic
+[#2560](https://github.com/squid-protocol/gitgalaxy/issues/2560)) and validated in the corpus's
+[deviation ledger](https://github.com/squid-protocol/keyword-rosetta/blob/main/deviation_ledger.json).
+
+**Summary (2026-09-03).** Groovy opened at **2🔴 / 2🟡** and closed at **0 unexplained**, with two
+metrics still out of band and both accounted for. Tracking issue
+[#2576](https://github.com/squid-protocol/gitgalaxy/issues/2576) closed under Batch E.4 of
+[#2669](https://github.com/squid-protocol/gitgalaxy/issues/2669).
+
+1. **Two real engine bugs** (both fixed): `func_start` let statement keywords through as *prefix*
+   tokens, so `throw new IllegalArgumentException(msg)` read as a declaration named
+   `IllegalArgumentException` and `return acceptOrReject(x)` as one named `acceptOrReject`
+   ([#2676](https://github.com/squid-protocol/gitgalaxy/issues/2676), fixed in
+   [#2677](https://github.com/squid-protocol/gitgalaxy/pull/2677) — measured over the 306
+   Groovy-language files in language-crucible, `func_start` 1121 → 1028, and every one of the 93
+   removals a genuine non-declaration). The doc-block double-count
+   ([#2672](https://github.com/squid-protocol/gitgalaxy/issues/2672)) scored a single Javadoc block
+   twice by pairing its `/**` opener with its `@param` tags; fixed in
+   [#2681](https://github.com/squid-protocol/gitgalaxy/pull/2681) across the 18-language family.
+2. **Intended morphology, ledgered** (`ts-callparen-args`, validated): `args` measures 19 against a
+   planted 13 (+46%) because Groovy's call-paren shapes are counted the way the shared
+   TypeScript/Apex/Objective-C entry describes. Bakes in as engine-semantic.
+3. **Not comparable by construction** (`control-flow-ratio-denominator-is-a-vocabulary-tally`,
+   validated): `control_flow_ratio` is `branch / (branch + structural_boundaries)`, and the corpus
+   pins the numerator at 3–4 in every language while never planting, gating or reporting the
+   denominator — which cannot be equalised by planting, because it is a per-language *keyword
+   vocabulary* tally rather than a structural count. The metric is sound for comparing files
+   *within* one repository, which is its actual use; only this corpus's cross-language comparison
+   is meaningless. See [#2689](https://github.com/squid-protocol/gitgalaxy/issues/2689) bucket B,
+   whose original recommendation to plant the denominator was withdrawn once the rule was read.
+
+**Remaining out-of-band: two metrics, both ledgered, neither actionable at the Groovy level.**
+
+**Reading the close criterion correctly.** `tools/language_deviations.py groovy` exiting 0 means
+every out-of-band cell is *accounted for* — **not** that nothing deviates. Groovy still deviates on
+two metrics; what changed is that each now carries a recorded reason it is not a defect. On a corpus
+whose entire purpose is measuring deviation, that distinction is the whole point.


### PR DESCRIPTION
Batch **E.3** of #2669 — but not as the item specifies, and the reason matters.

## E.3 asks for 41 capstones. That is not deliverable.

The item says "generate the 41 missing §10 capstones from the same data via the `language-status`
skill template". That skill sets the opposite rule:

> **§10** — *only once the language's rosetta tracking issue has had a real sweep pass* … **Omit the
> section entirely until a sweep has actually run** — same "absent reads as not-attempted" rule as §9.

**41 languages have not had a sweep.** Generating a capstone for each would convert "not attempted
yet" into something that reads as verified — precisely what that rule exists to prevent. And the
section's stated purpose ("a future reader must be able to tell a deliberately-absent rule from an
unexamined gap without re-deriving the investigation") cannot be met by prose assembled from a band
table; jcl.md §10, the finished example, is a five-cause investigation, not a rendering of numbers.

A generator would have produced 41 files that pass review and mislead every later reader. That is a
worse outcome than an absent section, which is the skill's whole point.

## What is delivered

Two languages qualify today — both closed under Batch E.4 against the machine-checkable criterion
E.1 introduced:

| language | state |
|---|---|
| **abap** | zero out-of-band metrics across all 57 comparable columns — the only language in the corpus with no deviation of any kind |
| **groovy** | zero *unexplained*, with two metrics still out of band and both ledgered |

Together they document the distinction E.4's criterion turns on, which is the easiest thing to
misread about this whole epic: **"clean" means every deviation is accounted for, not that none
exists.** abap happens to be both; groovy is only the first, and its capstone says so in as many
words.

Each capstone follows the skill's structure — before/after summary, deviations grouped by the
five-cause taxonomy, and a "remaining out-of-band" statement — and cites the engine PRs, the ledger
entries and the corpus PRs that moved each number.

**shell** also closed under E.4 but has **no `language_status` doc at all**, so its capstone would
require §1–§9 to be written first. Out of scope for "generate the missing capstone"; recorded on
#2669 rather than stubbed.

## Suggested re-scoping of E.3

Retitle it from "generate the 41 missing capstones" to "**write a capstone whenever a language's
tracking issue closes**" — one capstone per closed issue, as part of closing it, which is how jcl's
came to exist. That makes E.3 a standing rule rather than a batch, and it cannot produce a
misleading section by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)