### PR TITLE
docs: auto-update tree-sitter accuracy data

### DIFF
--- a/docs/self_scan/tree_sitter_accuracy_chart.svg
+++ b/docs/self_scan/tree_sitter_accuracy_chart.svg
@@ -646,7 +646,8 @@
 <text class="value-label" x="642.0" y="1358.5">842/842</text>
 <rect x="545" y="1361.0" width="92.0" height="8" rx="2.5" fill="#2929d6"/>
 <text class="value-label" x="642.0" y="1368.5">842/842</text>
-<text class="na-dash" x="551" y="1386.5">n/a</text>
+<rect x="545" y="1379.0" width="92.0" height="8" rx="2.5" class="bar-neutral"/>
+<text class="value-label" x="642.0" y="1386.5">0 found</text>
 <text class="na-dash" x="551" y="1396.5">n/a</text>
 <rect x="545" y="1407.0" width="92.0" height="8" rx="2.5" class="bar-neutral"/>
 <text class="value-label" x="642.0" y="1414.5">0 found</text>


### PR DESCRIPTION
Automated update from the latest tree-sitter accuracy measurement on `main`.

## Notable changes since the previous batch
_No metric moved ≥1pp since the previous batch._

- Appends one row per language to `docs/self_scan/tree_sitter_accuracy_history.csv`.
- Regenerates the summary table in `gitgalaxy/standards/language_standards/__init__.py`.
- Re-renders `docs/self_scan/tree_sitter_accuracy_chart.svg` from that same batch.

Never touches `tests/tree_sitter_accuracy_baseline_*.json` -- those stay
human-reviewed via `tree_sitter_accuracy_audit.py --regenerate`.