### PR TITLE
fix(core-engine): give the api rule a stated contract and audit all 46 languages against it (#2730)

### DIFF
--- a/docs/api_rule_contract.md
+++ b/docs/api_rule_contract.md
@@ -1,0 +1,188 @@
+# The `api` rule's contract
+
+> Filed as [#2730](https://github.com/squid-protocol/gitgalaxy/issues/2730). This document is the
+> stated contract the issue asked for, plus the audit of all 46 corpus languages against it.
+> `gitgalaxy/standards/how_to_add_a_language.md` carries the one-line form next to the rule in the
+> output schema; this file carries the reasoning, the fallback family, and the per-language verdicts.
+
+## The contract
+
+> **`api` matches a declaration that makes a named function or type visible outside the file it is
+> declared in.**
+
+Three corollaries, each of which the audit below found a language violating:
+
+1. **A reference is not a declaration.** A call site, an import, a struct-literal field key, a
+   `switch` case on the keyword, a package segment that happens to be spelled `internal` — none of
+   these publish a name, they consume one. (`cobol` counted `CALL`; `go` counted `Protocol:
+   protocol,`; `kotlin` counted `import okhttp3.internal.X`; `powershell` counted `return (`.)
+2. **A modifier counts where it modifies a declaration, not wherever it appears.** `\bpublic\b`
+   against a raw code stream is not a measurement of public surface; it is a measurement of how
+   often the word occurs, string literals included. The modifier must be anchored to the
+   declaration it applies to. (`java`, `csharp`, `kotlin`, `php`, `groovy`, `swift`, `typescript`.)
+3. **Where the language makes things public by default, the declaration itself IS the marker.**
+   `python` has always read `def <name>` this way, and `lua`, `scala`, `livecode`, `fortran` and
+   `powershell` follow it. A language whose functions are public unless marked otherwise must count
+   the declaration, or it measures 0 forever. (`abap` `FORM`, `perl` `sub`, `matlab` `function`,
+   `dart`'s top-level function, `ada`'s library-level subprogram.)
+
+### The documented fallback family
+
+Some languages have no per-function visibility concept at all. For those, `api` counts the
+**file-level declaration that exposes the file's surface**, and that substitution is deliberate,
+not a defect:
+
+| language | stands in for a public function declaration |
+|---|---|
+| `dockerfile` | `EXPOSE <port>` |
+| `yaml` | a workflow `on:` trigger block |
+| `css` | `:root`, `@property`, a `--custom-property:` definition |
+| `html` | `id=`/`name=`/`itemprop=`/`<slot>`/`og:`/`twitter:` — the document's addressable surface |
+| `yacc` | `%define`/`%code`/`%provides`/`%requires` |
+| `m4` | `AC_SUBST`/`AC_DEFINE`/`AC_PROVIDE`/`m4_provide` |
+| `cobol` | `ENTRY`, `LINKAGE SECTION` |
+| `agc_assembly` | `<LABEL> EQUALS` |
+| `makefile` | `.PHONY`, `export`, the conventional public targets |
+| `sqlite` | `CREATE [TEMP] VIEW` / `CREATE VIRTUAL TABLE` |
+| `matlab` | a column-0 `function` declaration (a function file's callable surface) |
+
+`matlab` is the one place where the fallback is knowingly approximate: a `.m` function file
+publishes only its *leading* function, and local functions after it are file-private, but nothing
+in the syntax distinguishes them — the file's name does. Counting every column-0 `function` is the
+same order of approximation as `python` counting a nested `def`, and it is strictly better than the
+0 the rule reported before, which said a file full of callable functions had no public surface at
+all.
+
+## What this is used for
+
+`api` feeds `_calc_api_exposure` and `_calc_documentation` in `signal_processor.py`, both of which
+land in scored risk, and `galaxyscope.py`'s Contextual Baseline Fix converts an imported file's
+uncalled orphans into `api` on top of the rule's own count (see #2731/#2734 for why the conversion
+now subtracts the orphans the rule already declared). A rule that is too narrow reads 0 for a file
+that exposes everything it defines; a rule that is too broad turns a modifier's word frequency into
+scored risk. Both directions are wrong in the same units.
+
+## The audit — all 46 corpus languages
+
+Counts are `api` matches over the **code stream** (comments stripped, exactly what the engine
+scans), on the `language-crucible` corpus at `v1.2.0` and on the `keyword-rosetta` control corpus.
+`a → b` is this change; a single number means the rule was already inside the contract and is
+untouched.
+
+| language | crucible | keyword-rosetta |
+|---|---|---|
+| `abap` | 6 | 0 → 13 |
+| `ada` | 0 | 0 → 13 |
+| `agc_assembly` | 367 → 44 | 4 |
+| `apex` | 0 | 12 |
+| `assembly` | 284 → 281 | 12 |
+| `c` | 8675 → 1141 | 29 → 15 |
+| `cobol` | 1396 → 553 | 10 |
+| `cpp` | 4 | 12 |
+| `csharp` | 387 | 12 |
+| `css` | 3618 | 4 |
+| `dart` | 174 → 149 | 0 → 13 |
+| `dockerfile` | 0 | 4 |
+| `embedded_python` | 123 | 13 |
+| `fortran` | 0 | 13 |
+| `go` | 614 → 438 | 12 |
+| `groovy` | 16 → 12 | 12 |
+| `haskell` | 3 | 4 |
+| `html` | 514 | 5 |
+| `java` | 220 | 12 |
+| `javascript` | 267 | 12 |
+| `jcl` | rule is `None` | n/a |
+| `kotlin` | 17 → 5 | 12 |
+| `livecode` | 607 | 13 |
+| `lua` | 288 → 272 | 13 |
+| `m4` | 242 | 12 |
+| `makefile` | 0 | 13 |
+| `markdown` | rule is `None` | n/a |
+| `matlab` | 0 → 23 | 0 → 13 |
+| `objective-c` | 5 → 13 | 0 |
+| `perl` | 20 → 840 | 0 → 13 |
+| `php` | 1153 → 1146 | 12 |
+| `powershell` | 199 → 154 | 12 |
+| `python` | 4086 | 13 |
+| `ruby` | 0 | 12 |
+| `rust` | 943 | 12 |
+| `scala` | 354 | 13 |
+| `scheme` | 1 | 12 |
+| `shell` | 178 | 12 |
+| `solidity` | 49 | 12 |
+| `sqlite` | 2 | 0 |
+| `swift` | 214 → 212 | 12 |
+| `tcl` | 24 | 12 |
+| `typescript` | 3730 → 3726 | 12 |
+| `yacc` | 0 | 4 |
+| `yaml` | 0 | 4 |
+| `zig` | 3880 | 12 |
+
+### Verdicts, by finding
+
+**Too narrow — the language's own visibility idiom was invisible (7, the issue's table):**
+
+| language | the idiom | what was added |
+|---|---|---|
+| `abap` | `FORM` subroutines and function modules are public by default | `^FORM\|FUNCTION <name>`, line-anchored so `CALL FUNCTION '...'` cannot match |
+| `ada` | a library-level subprogram is its own compilation unit | a `procedure`/`function` at **column 0**; nested (body-local, private) ones are indented |
+| `dart` | a top-level function whose name has no leading `_` | a column-0 return-type + public name + `(` |
+| `matlab` | a function file is callable by name | a column-0 `function` (the fallback family above) |
+| `objective-c` | a method declared in an `@interface` | a `-`/`+` method line terminated by `;` rather than a `{` body |
+| `ruby` | `public :name` (a top-level `def` is private on `Object`) | `public`/`public_class_method` followed by a symbol |
+| `shell` | `export -f name` | the flag run between `export` and the name |
+
+Two more of the same family, from the issue's closing paragraph:
+
+* `yaml` — `workflow_call`, the trigger that makes a workflow callable by another repository, was
+  missing from the trigger set.
+* `perl` — every alternative was a module-level export *list*, and each also lands on a rule that
+  already owns it (`@EXPORT_OK = (...)` is a `state_mutation`; `use Exporter|parent|base` is an
+  `import`), so `api` could only move by moving another planted count with it. A Perl `sub` is
+  package-scoped and callable as `Pkg::name` — public by default, corollary 3.
+
+**Too broad — a token counted where no declaration exists (11):**
+
+| language | what it counted | evidence |
+|---|---|---|
+| `c` | any indented declaration-shaped line, so every body-local declaration and every two-word statement | `return NULL;` alone was 513 crucible matches; 7534 of 8675 were not file-scope declarations |
+| `cobol` | `CALL`/`INVOKE` call sites, plus `END-CALL` via the hyphen boundary | 843 of 1396 |
+| `agc_assembly` | the `EXTEND` opcode | 323 of 367 |
+| `powershell` | `<name>(` at line start — a .NET method call or a statement | 61 of 199, every one a statement; #2656's exclusion set was lowercase against an `re.I` pattern, so `If (`/`Param(` matched anyway |
+| `go` | any line starting with an exported identifier — struct-literal keys, method calls on exported vars | 176 of 614 |
+| `lua` | `function ()`, an anonymous function that declares no name | 16 of 288 |
+| `assembly` | `EXTERN`/`IMPORT`, which import a name rather than publish one | 3 |
+| `dart` | `@pragma(...)`, a compiler hint | 34 of 174 |
+| `java`, `csharp`, `kotlin`, `php`, `groovy`, `swift`, `typescript` | a bare access modifier anywhere in the code stream | `import okhttp3.internal.X` (kotlin), `let package = Package(...)` (swift), `$public` and `'path.public'` (php), `case "public":` (typescript/csharp), prose in a log message (groovy) |
+
+`java` and `csharp` move zero matches on either corpus: real Java and C# put `public` in front of a
+declaration nearly always, so the anchor is a precision guard rather than a recount. That is the
+answer to "why did a real fix produce no diff" for those two — the strict tests
+(`test_java_api_contract_2730`, `test_csharp_api_contract_2730`) hold the guard in place.
+
+**Already inside the contract (23, untouched):** `apex`, `cpp`, `css`, `dockerfile`,
+`embedded_python`, `fortran`, `haskell`, `html`, `javascript`, `jcl` (`None`), `livecode`, `m4`,
+`makefile`, `markdown` (`None`), `python`, `rust`, `scala`, `scheme`, `solidity`, `sqlite`, `tcl`,
+`yacc`, `zig`.
+
+Two of these are worth naming, because they look like violations and are not:
+
+* `cpp` counts `public:` — a section label, so one hit per access section rather than one per
+  member. That is C++'s only file-visible marker short of parsing the class body, and it is
+  under-counting, not over-counting.
+* `rust`/`zig`/`solidity` count a bare `pub`/`export`/`public`/`external`. In all three the token is
+  a reserved word that can *only* introduce a declaration, so it is already anchored by the
+  grammar.
+
+## Adding a language after this
+
+When you write a new language's `api` rule, answer these in order:
+
+1. Does the language have an explicit per-function visibility marker? Anchor it to the declaration
+   it modifies — never `\b<modifier>\b` on its own.
+2. If not, is the language public-by-default? Then match the declaration itself (corollary 3), with
+   the language's private-by-convention prefix excluded if it has one (`_`, in python/lua/perl/dart).
+3. If the language has no per-function concept at all, pick the file-level declaration that exposes
+   the file, add it to the fallback table above, and say so in the rule's comment.
+4. Never match a call site, an import, or a literal that merely mentions the keyword. If a corpus
+   measurement shows the rule firing on one, that is a bug in the rule, not a quirk of the corpus.

--- a/gitgalaxy/standards/how_to_add_a_language.md
+++ b/gitgalaxy/standards/how_to_add_a_language.md
@@ -155,7 +155,7 @@ Generate a valid Python dictionary matching this exact structure.
         "high_risk_execution": re.compile(r""), 
         # io: Interaction with the disk, network, or external systems. Includes: File writing/reading, HTTP clients, sockets. EXCLUDES: Logging/printing.
         "io": re.compile(r""), 
-        # api: Code exposed to the outside world. Captures explicit visibility markers (export, public) AND implicit architectural defaults.
+        # api: A DECLARATION THAT MAKES A NAMED FUNCTION OR TYPE VISIBLE OUTSIDE THIS FILE. Anchor an explicit visibility marker (export, public) to the declaration it modifies -- never `\bpublic\b` on its own, which counts the word, not the surface. Where the language is public-by-default, match the declaration itself; where it has no per-function visibility concept, match the file-level declaration that exposes the file and record it in the fallback table. EXCLUDES call sites, imports, and references to an exported name. Full contract, corollaries and the 46-language audit: docs/api_rule_contract.md (#2730).
         "api": re.compile(r""), 
         # state_mutation: Reassignment of variables or modifying collections. Includes: let, mut, volatile, .push(), .set().
         "state_mutation": re.compile(r""), 

--- a/gitgalaxy/standards/language_standards/languages/abap.py
+++ b/gitgalaxy/standards/language_standards/languages/abap.py
@@ -110,9 +110,19 @@ DEFINITION: dict[str, Any] = {
         # leading \b could only fire when a word char immediately
         # preceded the `@`, never true for how this annotation is
         # actually written. Never matched at all.
+        # BUG FIX #2730 (api contract): every alternative above needs a
+        # CLASS, RFC metadata or a CDS definition, so a classic ABAP report
+        # -- whose public surface is its `FORM` subroutines (callable from
+        # any program via `PERFORM ... IN PROGRAM`) and its function-module
+        # `FUNCTION` blocks -- measured 0. Both are public by default, which
+        # puts ABAP in the same family as python/lua/scala: the declaration
+        # itself IS the visibility marker. Anchored to the start of a line so
+        # `CALL FUNCTION 'RFC_PING'` (a call site, not a declaration) cannot
+        # match. Needs re.M for that anchor (Rule 13).
         "api": re.compile(
-            r"\b(?:REMOTE\s+FUNCTION|DEFINE\s+VIEW|DEFINE\s+SERVICE|EXPOSED|PUBLIC\s+SECTION)\b|@OData\.publish",
-            re.I,
+            r"\b(?:REMOTE\s+FUNCTION|DEFINE\s+VIEW|DEFINE\s+SERVICE|EXPOSED|PUBLIC\s+SECTION)\b|@OData\.publish|"
+            r"^[ \t]*(?:FORM|FUNCTION)[ \t]+[A-Za-z_]",
+            re.M | re.I,
         ),
         # 11. flux: State Mutation. State mutation (The core of ABAP data manipulation).
         "state_mutation": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/ada.py
+++ b/gitgalaxy/standards/language_standards/languages/ada.py
@@ -152,9 +152,20 @@ DEFINITION: dict[str, Any] = {
         # "package X is new ..." (generic package instantiation, not a
         # spec declaration -- both use negative lookaheads, not an
         # optional group, per Rule 15).
+        # BUG FIX #2730 (api contract): a package spec is a separate `.ads`
+        # compilation unit, so a corpus of `.adb` bodies measured 0 even when
+        # every subprogram in it is a library-level unit. Added the
+        # library-level subprogram declaration: a `procedure`/`function` at
+        # COLUMN 0 is a compilation unit of its own, visible to any unit that
+        # `with`s it, while every nested (package-body-local, therefore
+        # private) subprogram is indented under its enclosing declarative
+        # part. Column-0 anchoring is the same shape go's rule already uses;
+        # `^[ \t]*` here would count the private ones too. Needs re.M
+        # (Rule 13).
         "api": re.compile(
-            r"\bpackage[ \t]+(?!body\b)(?:private[ \t]+)?([A-Za-z_][A-Za-z0-9_.]*)[ \t\n]+is\b(?![ \t\n]*new\b)",
-            re.I,
+            r"\bpackage[ \t]+(?!body\b)(?:private[ \t]+)?([A-Za-z_][A-Za-z0-9_.]*)[ \t\n]+is\b(?![ \t\n]*new\b)|"
+            r"^(?:procedure|function)[ \t]+[A-Za-z_]",
+            re.M | re.I,
         ),
         # state_mutation: Ada's assignment operator `:=` is lexically
         # distinct from `=` (equality) -- no ambiguity to guard against.

--- a/gitgalaxy/standards/language_standards/languages/agc_assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/agc_assembly.py
@@ -117,10 +117,16 @@ DEFINITION: dict[str, Any] = {
         "io": re.compile(r"\b(DSKY|CHANNEL|READ|WRITE|V\d+N\d+|OUT\d+|IN\d+)\b", re.I),
         # 10. api (Public Surface Area)
         # Global labels and externally visible entry points.
-        "api": re.compile(
-            r"^[A-Z0-9_-]+\s+EQUALS|^[ \t]*(?:SUBROUTINE|BEXT|EXTEND)\b",
-            re.M | re.I,
-        ),
+        # BUG FIX #2730 (api contract): the second alternative counted
+        # `EXTEND` and `BEXT`, which are AGC *instructions* (the extracode
+        # prefix and a bank-extended branch), not declarations that make a
+        # name visible outside the file -- 323 of the crucible corpus's 367
+        # matches were the bare `EXTEND` opcode. `SUBROUTINE` never fired
+        # at all (0 occurrences corpus-wide). Removed the whole alternative;
+        # `EQUALS` (the erasable/symbol equate that publishes a label) is
+        # AGC assembly's real named-surface declaration and is what
+        # docs/api_rule_contract.md records for this language.
+        "api": re.compile(r"^[A-Z0-9_-]+\s+EQUALS", re.M | re.I),
         # 11. flux (State Mutation)
         # Direct state mutation and register storage.
         "state_mutation": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/assembly.py
@@ -130,8 +130,14 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Linker-visible global exports.
+        # BUG FIX #2730 (api contract): `EXTERN`/`IMPORT` declare a symbol
+        # defined in *another* translation unit -- they make an outside name
+        # visible HERE, the opposite direction from the contract ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Dropped; the remaining directives all publish a local
+        # symbol to the linker.
         "api": re.compile(
-            r"^[ \t]*(?:\.global|\.globl|global|EXPORT|PUBLIC|EXTERN|IMPORT)\b",
+            r"^[ \t]*(?:\.global|\.globl|global|EXPORT|PUBLIC)\b",
             re.M | re.I,
         ),
         # 11. flux (State Mutation)

--- a/gitgalaxy/standards/language_standards/languages/c.py
+++ b/gitgalaxy/standards/language_standards/languages/c.py
@@ -187,10 +187,25 @@ DEFINITION: dict[str, Any] = {
             # is a word character, never true for the realistic form
             # (whitespace/newline before the return type follows). Pulled
             # both out of the shared boundary group.
+            # BUG FIX #2730 (api contract): the two declaration-shaped
+            # alternatives allowed leading indentation, so every BODY-LOCAL
+            # declaration and every two-word statement counted as public
+            # surface -- `return NULL;` alone was 513 of the crucible
+            # corpus's 8675 matches, with `goto error;`, `int i;` and
+            # `PyObject *value;` behind it; 7534 of the 8675 were not
+            # file-scope declarations at all. (#2734 documented this shape
+            # from the other side, where the span form suppressed all 73
+            # orphans in `ceval.c`.) Anchored to column 0 -- C puts
+            # file-scope declarations there and indents everything inside a
+            # function -- and excluded the statement keywords that can
+            # legitimately start a line. `[ \t\n]` rather than `\s` keeps
+            # the K&R two-line form (`PyObject *\nfoo(void)`) matching, which
+            # is the reason the separator was allowed to span lines at all.
             r"\bextern\b|__declspec\(dllexport\)|"
             r'__attribute__\(\(visibility\("default"\)\)\)|'
-            r"^[ \t]*(?!static\b)[a-zA-Z_]\w*(?:\s*[*&]+\s*|\s+)[a-zA-Z_]\w*(?:\[[^\]]*\])?\s*=?|"
-            r"^[ \t]*[a-zA-Z_]\w*(?:\s*[*&]+\s*|\s+)[a-zA-Z_]\w*\s*\([^)]*\)\s*;",
+            r"^(?!static\b)(?!(?:return|goto|else|case|break|continue|do|while|if|for|switch|sizeof)\b)"
+            r"[a-zA-Z_]\w*(?:[ \t]*[*&]+[ \t\n]*|[ \t\n]+)[a-zA-Z_]\w*(?:\[[^\]\n]*\])?[ \t]*=?|"
+            r"^[a-zA-Z_]\w*(?:[ \t]*[*&]+[ \t]*|[ \t]+)[a-zA-Z_]\w*[ \t]*\([^)\n]*\)[ \t]*;",
             re.M,
         ),
         # 11. flux (State Mutation)

--- a/gitgalaxy/standards/language_standards/languages/cobol.py
+++ b/gitgalaxy/standards/language_standards/languages/cobol.py
@@ -251,7 +251,14 @@ DEFINITION: dict[str, Any] = {
             re.I,
         ),
         # 10. api: Public Surface Area. Exposed linkage points and external entries.
-        "api": re.compile(r"\b(ENTRY|LINKAGE\s+SECTION|CALL|INVOKE|EXPORT)\b", re.I),
+        # BUG FIX #2730 (api contract): `CALL`/`INVOKE` are call SITES -- a
+        # reference to a name declared elsewhere, not a declaration that
+        # publishes one. They also swept up `END-CALL` (`\b` fires after the
+        # hyphen), which alone was 108 of the crucible corpus's 1396 matches;
+        # 843 of the 1396 came from this pair. `ENTRY` (a secondary entry
+        # point) and `LINKAGE SECTION` (the called program's parameter
+        # contract) are COBOL's real published surface.
+        "api": re.compile(r"\b(ENTRY|LINKAGE\s+SECTION|EXPORT)\b", re.I),
         # 11. flux: State Mutation. State mutation (The core of COBOL data manipulation).
         "state_mutation": re.compile(
             r"\b(MOVE|COMPUTE|ADD|SUBTRACT|MULTIPLY|DIVIDE|SET|INITIALIZE|REPLACE|STRING|UNSTRING)\b",

--- a/gitgalaxy/standards/language_standards/languages/csharp.py
+++ b/gitgalaxy/standards/language_standards/languages/csharp.py
@@ -279,8 +279,28 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Public exposure surface. Explicit visibility + Controller mapping.
+        # BUG FIX #2730 (api contract): a bare `\bpublic|internal\b` counted the
+        # access modifier ANYWHERE in the code stream -- inside a string
+        # literal, a `switch` case, a dotted name -- not only where it
+        # declares something. The alternatives below anchor it to the
+        # declaration it modifies, per docs/api_rule_contract.md ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Every quantifier is bounded (Rule 5) and the modifier
+        # stepper is `{0,5}`, not `*`, so the `[ \t\n]+`-separated
+        # alternation cannot nest unboundedly (the ReDoS shape swift's `open`
+        # alternative was already written against).
+        # The type slot also accepts a tuple type (`(bool ok, int n)?`) and
+        # the name slot a generic argument list, both of which real Roslyn
+        # source puts between the modifier and the `(`. Measured: 387
+        # crucible matches before, 387 after.
         "api": re.compile(
-            r"\b(public|internal)\b|\[(?:HttpGet|HttpPost|HttpPut|HttpDelete|Route|ApiController|HubMethodName)\]|\bapp\.Map(?:Get|Post|Put|Delete|Group)\b"
+            r"\b(?:public|internal)[ \t\n]+"
+            r"(?:(?:static|virtual|override|abstract|sealed|async|unsafe|partial|new|extern|readonly|const|volatile|required|ref|event|delegate|implicit|explicit|file)[ \t\n]+){0,5}"
+            r"(?:class|interface|struct|record|enum|delegate|event|void\b"
+            r"|(?:\((?:[^()\n]|\([^()\n]*\))*\)\??|[@A-Za-z_][\w.]*(?:[ \t\n]*<(?:[^<>]|<[^<>]*>){0,200}>)?\??(?:\[[ \t\n,]*\])*)"
+            r"[ \t\n]+[@A-Za-z_]\w*(?:[ \t\n]*<(?:[^<>]|<[^<>]*>){0,200}>)?[ \t\n]*[({=;,]"
+            r"|[@A-Za-z_]\w*[ \t\n]*\()"
+            r"|\[(?:HttpGet|HttpPost|HttpPut|HttpDelete|Route|ApiController|HubMethodName)\]|\bapp\.Map(?:Get|Post|Put|Delete|Group)\b"
         ),
         # 11. flux (State Mutation)
         # Mutation of state. EXCLUDES const/readonly (freeze_hits).

--- a/gitgalaxy/standards/language_standards/languages/dart.py
+++ b/gitgalaxy/standards/language_standards/languages/dart.py
@@ -245,8 +245,25 @@ DEFINITION: dict[str, Any] = {
             re.I,
         ),
         # 10. api: Public Surface Area. Exposed visibility (Lack of _ prefix) and routing decorators.
+        # BUG FIX #2730 (api contract), two halves:
+        #  * `@pragma` is a compiler hint (`@pragma('vm:prefer-inline')`),
+        #    not a visibility marker -- 34 of the crucible corpus's 174
+        #    matches were pragmas. Dropped.
+        #  * Dart's primary public surface is a TOP-LEVEL function whose name
+        #    does not start with `_`, which none of the remaining
+        #    alternatives could see (they count class-like declarations and
+        #    `export` directives), so a library of free functions measured 0.
+        #    Added at column 0: a top-level declaration is unindented, while
+        #    every method and nested function sits inside a body. The leading
+        #    negative lookahead keeps statement and declaration keywords out
+        #    of the return-type slot, and `[A-Za-z]` on the name keeps Dart's
+        #    `_`-prefixed private convention excluded.
         "api": re.compile(
-            r"\b(export|part\s+of)\b|@(Route|Get|Post|Mapping|visibleForTesting|pragma)\b|^[ \t]*(?:class|mixin|enum|extension|typedef)\s+(?![_])[A-Za-z]\w*",
+            r"\b(export|part\s+of)\b|@(Route|Get|Post|Mapping|visibleForTesting)\b|"
+            r"^[ \t]*(?:class|mixin|enum|extension|typedef)\s+(?![_])[A-Za-z]\w*|"
+            r"^(?!(?:import|export|part|library|class|mixin|enum|extension|typedef|abstract|final|const|var|late|external|covariant|static|return|if|for|while|switch|do|try|catch|throw|new|assert|case|default|break|continue|yield|await|async|with|implements|extends|on|in|is|as|super|this|null|true|false)\b)"
+            r"(?:void|[A-Za-z_$][\w$]*(?:<(?:[^<>]|<[^<>]*>){0,100}>)?\??(?:\[\])?)[ \t]+"
+            r"(?:get[ \t]+|set[ \t]+)?[A-Za-z]\w*[ \t]*[(<]",
             re.I | re.M,
         ),
         # 11. flux: State Mutation. State mutation (setState and reactive collection mutators).

--- a/gitgalaxy/standards/language_standards/languages/go.py
+++ b/gitgalaxy/standards/language_standards/languages/go.py
@@ -145,8 +145,23 @@ DEFINITION: dict[str, Any] = {
         # `DoSomething(`) -- `\b` forces the lookahead to apply at the
         # true word boundary, where backtracking can't produce a
         # second valid stopping point.
+        # BUG FIX #2730 (api contract): the indented alternative only
+        # excluded a following `(`, so any line STARTING with an exported
+        # identifier counted -- a struct-literal field key (`Protocol:
+        # protocol,`), a method call on an exported package var
+        # (`DefaultServeMux.register(...)`). Those are references to an
+        # exported name, not declarations of one; 176 of the crucible
+        # corpus's 614 matches were exactly that. The alternative now
+        # requires what a grouped `var (...)`/`const (...)` member or a
+        # struct field actually looks like -- `Name = value`, `Name Type`, or
+        # a bare embedded type on its own line -- which keeps every real
+        # top-level declaration the #2651 fix was written to preserve
+        # (`\tBurstReplicas = 500`) and drops the references. The optional
+        # `, Name` run needs a literal comma per step, so it cannot backtrack
+        # ambiguously.
         "api": re.compile(
-            r"^func\s+(?:\([^)]*\)[ \t]+)?[A-Z]\w+|^(?:type|var|const)\s+[A-Z]\w+|^[ \t]+\b[A-Z]\w+\b(?!\()",
+            r"^func\s+(?:\([^)]*\)[ \t]+)?[A-Z]\w+|^(?:type|var|const)\s+[A-Z]\w+|"
+            r"^[ \t]+[A-Z]\w*(?:[ \t]*,[ \t]*[A-Z]\w*)*(?:[ \t]*=[^=]|[ \t]+[\w\[\*\.]|[ \t]*$)",
             re.M,
         ),
         # 11. flux (State Mutation)

--- a/gitgalaxy/standards/language_standards/languages/groovy.py
+++ b/gitgalaxy/standards/language_standards/languages/groovy.py
@@ -201,8 +201,29 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Groovy classes/methods are implicitly public by default, making the whole file highly exposed.
+        # BUG FIX #2730 (api contract): a bare `\bpublic\b` counted the
+        # access modifier ANYWHERE in the code stream -- inside a string
+        # literal, a `switch` case, a dotted name -- not only where it
+        # declares something. The alternatives below anchor it to the
+        # declaration it modifies, per docs/api_rule_contract.md ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Every quantifier is bounded (Rule 5) and the modifier
+        # stepper is `{0,5}`, not `*`, so the `[ \t\n]+`-separated
+        # alternation cannot nest unboundedly (the ReDoS shape swift's `open`
+        # alternative was already written against).
+        # Measured: 16 crucible matches before, 12 after -- the four dropped
+        # were prose and string literals ("Could not open the public key
+        # ring.", `accepted-public-api-changes.json`, a `website/public/3.x`
+        # path). Groovy declarations are implicitly public, so this rule's
+        # own docstring still holds: the explicit modifier is the exception,
+        # not the measure.
         "api": re.compile(
-            r"\b(public)\b|@(RestController|Controller|Service|Component|Bean|RequestMapping|GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\b"
+            r"\bpublic[ \t\n]+"
+            r"(?:(?:static|final|abstract|synchronized|native|strictfp|transient|volatile|@[\w.]+(?:\([^)\n]{0,200}\))?)[ \t\n]+){0,5}"
+            r"(?:class|interface|trait|enum|@interface|void\b|def\b"
+            r"|[A-Za-z_$][\w$.]*(?:[ \t\n]*<(?:[^<>]|<[^<>]*>){0,200}>)?(?:\[[ \t\n]*\])*[ \t\n]+[A-Za-z_$][\w$]*[ \t\n]*[({=;,]"
+            r"|[A-Za-z_$][\w$]*[ \t\n]*\()"
+            r"|@(RestController|Controller|Service|Component|Bean|RequestMapping|GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\b"
         ),
         # 11. flux (State Mutation)
         # BUG FIX: the trailing bare `=` matched the first `=` of `==`,

--- a/gitgalaxy/standards/language_standards/languages/java.py
+++ b/gitgalaxy/standards/language_standards/languages/java.py
@@ -199,8 +199,27 @@ DEFINITION: dict[str, Any] = {
             r"\b(File|InputStream|OutputStream|Reader|Writer|Scanner|Files\.|Path|Socket|RestTemplate|WebClient|RestClient|HttpClient|Connection|ResultSet|Statement|EntityManager|DataSource|Repository)\b"
         ),
         # 10. api (Public Surface Area)
+        # BUG FIX #2730 (api contract): a bare `\bpublic|protected\b` counted the
+        # access modifier ANYWHERE in the code stream -- inside a string
+        # literal, a `switch` case, a dotted name -- not only where it
+        # declares something. The alternatives below anchor it to the
+        # declaration it modifies, per docs/api_rule_contract.md ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Every quantifier is bounded (Rule 5) and the modifier
+        # stepper is `{0,5}`, not `*`, so the `[ \t\n]+`-separated
+        # alternation cannot nest unboundedly (the ReDoS shape swift's `open`
+        # alternative was already written against).
+        # Measured on the language-crucible corpus: 220 matches before, 220
+        # after -- real Java writes `public` almost only in front of a
+        # declaration, so this is a precision guard, not a recount.
         "api": re.compile(
-            r"\b(public|protected)\b|@(RestController|Controller|Service|Component|Bean|Produces|Consumes|RequestMapping|GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping|Endpoint|WebFilter)\b"
+            r"\b(?:public|protected)[ \t\n]+"
+            r"(?:(?:static|final|abstract|synchronized|native|strictfp|default|sealed|non-sealed|transient|volatile|@[\w.]+(?:\([^)\n]{0,200}\))?)[ \t\n]+){0,5}"
+            r"(?:<(?:[^<>]|<[^<>]*>){0,200}>[ \t\n]*)?"
+            r"(?:class|interface|enum|record|@interface|void\b"
+            r"|[A-Za-z_$][\w$.]*(?:[ \t\n]*<(?:[^<>]|<[^<>]*>){0,200}>)?(?:\[[ \t\n]*\])*[ \t\n]+[A-Za-z_$][\w$]*[ \t\n]*[({=;,]"
+            r"|[A-Za-z_$][\w$]*[ \t\n]*\()"
+            r"|@(RestController|Controller|Service|Component|Bean|Produces|Consumes|RequestMapping|GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping|Endpoint|WebFilter)\b"
         ),
         # 11. flux (State Mutation)
         # Mutation of state. EXCLUDES final (freeze_hits).

--- a/gitgalaxy/standards/language_standards/languages/kotlin.py
+++ b/gitgalaxy/standards/language_standards/languages/kotlin.py
@@ -151,8 +151,26 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Exposed surface. Implicit public/internal defaults + Ktor/Spring routes.
+        # BUG FIX #2730 (api contract): a bare `\bpublic|internal\b` counted the
+        # access modifier ANYWHERE in the code stream -- inside a string
+        # literal, a `switch` case, a dotted name -- not only where it
+        # declares something. The alternatives below anchor it to the
+        # declaration it modifies, per docs/api_rule_contract.md ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Every quantifier is bounded (Rule 5) and the modifier
+        # stepper is `{0,5}`, not `*`, so the `[ \t\n]+`-separated
+        # alternation cannot nest unboundedly (the ReDoS shape swift's `open`
+        # alternative was already written against).
+        # Kotlin always spells the declaration out with a keyword, so the
+        # anchor is just that keyword set. Measured: 17 crucible matches
+        # before, 5 after -- the 12 dropped were all the package segment in
+        # `import okhttp3.internal.<name>`, i.e. a reference to another
+        # module's internals, the exact opposite of a public declaration.
         "api": re.compile(
-            r"\b(public|internal)\b|@(RestController|Controller|Service|Component|RequestMapping|GetMapping|PostMapping|Route)\b"
+            r"\b(?:public|internal)[ \t\n]+"
+            r"(?:(?:open|abstract|final|override|suspend|inline|tailrec|infix|operator|external|expect|actual|data|sealed|enum|annotation|inner|companion|lateinit|const|value|vararg|@[\w.]+(?:\([^)\n]{0,200}\))?)[ \t\n]+){0,5}"
+            r"(?:class|interface|object|fun|val|var|typealias|constructor)\b"
+            r"|@(RestController|Controller|Service|Component|RequestMapping|GetMapping|PostMapping|Route)\b"
         ),
         # 11. flux (State Mutation)
         # CRITICAL FIX: Added re.M so it scans every line, not just the first line of the file!

--- a/gitgalaxy/standards/language_standards/languages/lua.py
+++ b/gitgalaxy/standards/language_standards/languages/lua.py
@@ -97,8 +97,14 @@ DEFINITION: dict[str, Any] = {
         # 10. api: Public Surface Area. Functions NOT marked local or explicit module returns.
         # BUG FIX #2657: The 'return M' module-export idiom is anchored to column 0 (^return)
         # to avoid false positives on indented function-body returns, which spiked risk_api_exposure.
+        # BUG FIX #2730 (api contract): `[^_]` accepted ANY non-underscore
+        # character, so `function ()` -- an anonymous function, which
+        # declares no name at all -- counted as a public declaration (16 of
+        # the crucible corpus's 288 matches). Requiring a letter keeps the
+        # `_`-prefixed private-by-convention exclusion the class was written
+        # for while demanding a real name.
         "api": re.compile(
-            r"^[ \t]*function\s+[^_][\w.:]*|^return[ \t]+[a-zA-Z_]\w*[ \t]*$|---@public|\bexport\b",
+            r"^[ \t]*function\s+[A-Za-z][\w.:]*|^return[ \t]+[a-zA-Z_]\w*[ \t]*$|---@public|\bexport\b",
             re.M,
         ),
         # 11. flux: State Mutation. State mutation (assignments and table mutators).

--- a/gitgalaxy/standards/language_standards/languages/matlab.py
+++ b/gitgalaxy/standards/language_standards/languages/matlab.py
@@ -119,8 +119,19 @@ DEFINITION: dict[str, Any] = {
         # anywhere in a (possibly multi-attribute) attribute list, while still
         # matching bare `methods` (implicitly public by MATLAB default) and
         # explicit `Access = public`. Bounded to 200 chars per Rule 5.
+        # BUG FIX #2730 (api contract): a MATLAB *function file* has no
+        # visibility syntax at all -- the function it declares is callable by
+        # name from anywhere on the path -- so a corpus of function files
+        # measured 0 against a rule that could only see a `classdef` methods
+        # block. Added the column-0 `function` declaration as MATLAB's
+        # file-level surface (the documented fallback family, see
+        # docs/api_rule_contract.md). Column 0 deliberately: a `function`
+        # inside a `classdef` is indented under its `methods` block and is
+        # already counted by the alternative above, so the two cannot
+        # double-count the same declaration.
         "api": re.compile(
-            r"^[ \t]*methods\b(?![ \t]*\([^)]{0,200}\bAccess[ \t]*=[ \t]*(?:private|protected)\b)",
+            r"^[ \t]*methods\b(?![ \t]*\([^)]{0,200}\bAccess[ \t]*=[ \t]*(?:private|protected)\b)|"
+            r"^function\b",
             re.M | re.I,
         ),
         # flux: Mutation of state via assignment.

--- a/gitgalaxy/standards/language_standards/languages/objectivec.py
+++ b/gitgalaxy/standards/language_standards/languages/objectivec.py
@@ -206,7 +206,19 @@ DEFINITION: dict[str, Any] = {
             r"\b(NSFileHandle|NSFileManager|NSURLSession|NSURLConnection|NSData|NXNetPath|NXSocket|NXStream|NXFile|HTLoad|HyperText|HTGet|socket|connect|send|recv)\b"
         ),
         # 10. api: Public Surface Area. Exposed interface/C-level exports and Interface Builder hooks.
-        "api": re.compile(r"\b(FOUNDATION_EXPORT|UIKIT_EXTERN|OBJC_EXPORT|extern)\b|@(property)\b|IBOutlet|IBAction"),
+        # BUG FIX #2730 (api contract): Objective-C's primary way of making a
+        # method visible outside its file is declaring it in an `@interface`
+        # -- a `-`/`+` method line terminated by `;` rather than a `{` body.
+        # None of the C-level export macros above can see it, so a header's
+        # entire published method list measured 0. The type-cast shape
+        # (`\([ \t]*[A-Za-z_]...\)` then an identifier) is required so a
+        # wrapped arithmetic continuation line (`+ ((slot/10)%3)* 40;`) cannot
+        # match. Needs re.M for the new `^` anchor (Rule 13).
+        "api": re.compile(
+            r"\b(FOUNDATION_EXPORT|UIKIT_EXTERN|OBJC_EXPORT|extern)\b|@(property)\b|IBOutlet|IBAction|"
+            r"^[ \t]*[-+][ \t]*\([ \t]*[A-Za-z_][\w \t*<>,]{0,120}\)[ \t]*[A-Za-z_]\w*[^;{\n]{0,300};",
+            re.M,
+        ),
         # 11. flux: State Mutation. State mutation (Property setters and raw assignments).
         "state_mutation": re.compile(r"\b(?:self\.)?[a-zA-Z_]\w*[ \t]*=|\[self\s+set[A-Z]\w*:|(?:\+\+|--)"),
         # 12. dead_code (Commented Logic / Deprecated Trails) Commented out structural code.

--- a/gitgalaxy/standards/language_standards/languages/perl.py
+++ b/gitgalaxy/standards/language_standards/languages/perl.py
@@ -195,8 +195,20 @@ DEFINITION: dict[str, Any] = {
             r"\b(open|close|sysopen|sysread|syswrite|opendir|closedir|DBI->connect|Mojo::UserAgent|HTTP::Tiny|LWP::UserAgent|socket|connect|bind)\b|<[A-Z_0-9]+>|<>"
         ),
         # 10. api: Public Surface Area. Exposed surface area (Exports and modern routing).
+        # BUG FIX #2730 (api contract): every alternative above is a
+        # module-level export *list*, and each one also lands on a rule that
+        # already owns it (`@EXPORT_OK = (...)` is a state_mutation, `use
+        # Exporter|parent|base` an import), so the only way to move `api` was
+        # to move another planted count with it. A Perl `sub` is
+        # package-scoped and callable as `Pkg::name` from anywhere -- public
+        # by default, the same family as python/lua/scala -- so the
+        # declaration itself is the visibility marker. Leading letter
+        # required, which keeps the `_`-prefixed private-by-convention
+        # exclusion python's rule uses. Needs re.M for the `^` (Rule 13).
         "api": re.compile(
-            r'\b(?:get|post|put|del|any|patch)\s+[\'"]/[^\'"]*[\'"]|@(?:EXPORT|EXPORT_OK|EXPORT_TAGS|ISA)\b|use\s+(?:Exporter|parent|base)\b|:\s*(?:reader|writer|param)\b'
+            r'\b(?:get|post|put|del|any|patch)\s+[\'"]/[^\'"]*[\'"]|@(?:EXPORT|EXPORT_OK|EXPORT_TAGS|ISA)\b|use\s+(?:Exporter|parent|base)\b|:\s*(?:reader|writer|param)\b|'
+            r"^[ \t]*sub[ \t]+[A-Za-z]\w*",
+            re.M,
         ),
         # 11. flux: State Mutation. State mutation (assignments, array mutators, substitutions).
         # UPDATED: Removed '.=' and '=~' / '!~' to prevent massive string-builder false positives.

--- a/gitgalaxy/standards/language_standards/languages/php.py
+++ b/gitgalaxy/standards/language_standards/languages/php.py
@@ -132,7 +132,26 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Exposed surface. Explicit public markers + attribute routes.
-        "api": re.compile(r"\b(public)\b|#\[(?:ApiResource|Route|Get|Post|Put|Delete|Patch)[^\]]*\]"),
+        # BUG FIX #2730 (api contract): a bare `\bpublic\b` counted the
+        # access modifier ANYWHERE in the code stream -- inside a string
+        # literal, a `switch` case, a dotted name -- not only where it
+        # declares something. The alternatives below anchor it to the
+        # declaration it modifies, per docs/api_rule_contract.md ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Every quantifier is bounded (Rule 5) and the modifier
+        # stepper is `{0,5}`, not `*`, so the `[ \t\n]+`-separated
+        # alternation cannot nest unboundedly (the ReDoS shape swift's `open`
+        # alternative was already written against).
+        # PHP always follows the modifier with `function`, `const`, a `$`
+        # property (optionally typed), or another modifier. Measured: 1153
+        # crucible matches before, 1146 after -- the seven dropped were a
+        # `$public` variable, a `'path.public'` container key and a
+        # `->public` property read.
+        "api": re.compile(
+            r"\bpublic[ \t\n]+(?:(?:static|final|abstract|readonly)[ \t\n]+){0,4}"
+            r"(?:function\b|const\b|\$[a-zA-Z_]|\??[\\A-Za-z_][\w\\|]*[ \t\n]+\$[a-zA-Z_])"
+            r"|#\[(?:ApiResource|Route|Get|Post|Put|Delete|Patch)[^\]]*\]"
+        ),
         # 11. flux (State Mutation)
         # Mutation of state. Variable reassignments and array mutators.
         # QUADRATIC BLOWUP FIX: the optional `(?:\w+)?` before the

--- a/gitgalaxy/standards/language_standards/languages/powershell.py
+++ b/gitgalaxy/standards/language_standards/languages/powershell.py
@@ -169,10 +169,19 @@ DEFINITION: dict[str, Any] = {
         # BUG FIX: Issue #2656. The bare-identifier alternative lacked the keyword-exclusion
         # negative lookahead that func_start and args carry, causing 'param(', 'if (',
         # and 'switch (' lines to miscount as API surface. Added the exclusion set.
-        "api": re.compile(
-            r"\b(Export-ModuleMember|New-Alias|CmdletBinding)\b|^[ \t]*(?!hidden\s+)(?!(?:if|elseif|switch|while|for|foreach|until|trap|catch|param)\b)[a-zA-Z_]\w*\s*\(",
-            re.I | re.M,
-        ),
+        # BUG FIX #2730 (api contract): the bare-identifier alternative
+        # matched `<name>(` at the start of a line, which in PowerShell is a
+        # .NET method CALL or a control-flow statement -- a reference, never
+        # a declaration (a PowerShell function is declared `function Name`,
+        # a class method `[type] Name(`). #2656's keyword exclusion could not
+        # fix that, and could not even hold the line it was written for: the
+        # exclusion set is lowercase while the pattern is `re.I`, so `If (`
+        # and `Param(` matched anyway. All 61 of its crucible matches were
+        # statements (`return (`, `throw (`, `Param(`, `If (`). Removed;
+        # PowerShell's real published surface is `Export-ModuleMember` (and
+        # the `New-Alias`/`CmdletBinding` markers), which the first
+        # alternative already owns.
+        "api": re.compile(r"\b(Export-ModuleMember|New-Alias|CmdletBinding)\b", re.I),
         # 11. flux (State Mutation)
         # Mutation of state. Captures assignments, scoped variables, array indexing, and anchored increments.
         "state_mutation": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/ruby.py
+++ b/gitgalaxy/standards/language_standards/languages/ruby.py
@@ -128,8 +128,15 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Implicit public defaults (undercased defs) + explicit module functions.
+        # BUG FIX #2730 (api contract): a top-level `def` in Ruby becomes a
+        # PRIVATE method on Object, so the declaration alone publishes
+        # nothing; the idiom that publishes one by name is `public :name`
+        # (and `public_class_method :name` for singleton methods). Neither
+        # was reachable -- `module_function` was the only per-method export
+        # form the rule could see.
         "api": re.compile(
-            r'\b(module_function)\b|^[ \t]*(?:get|post|put|patch|delete|resources?)\s+[:\'"]',
+            r'\b(module_function)\b|^[ \t]*(?:get|post|put|patch|delete|resources?)\s+[:\'"]|'
+            r'^[ \t]*public(?:_class_method)?[ \t]+[:&\'"]',
             re.M,
         ),
         # 11. flux (State Mutation)

--- a/gitgalaxy/standards/language_standards/languages/shell.py
+++ b/gitgalaxy/standards/language_standards/languages/shell.py
@@ -149,7 +149,14 @@ DEFINITION: dict[str, Any] = {
         "io": re.compile(r">|>>|<|\|(?:&)?|\b(curl|wget|nc|ssh|scp|ftp|rsync|cat|tail|grep|find|xargs|jq)\b"),
         # 10. api (Public Surface Area)
         # Exported variables and identifiers modifying the global environment.
-        "api": re.compile(r"^[ \t]*export\s+[a-zA-Z_]\w*", re.M),
+        # BUG FIX #2730 (api contract): the way a shell script makes a
+        # FUNCTION visible to its children is `export -f name`; the old
+        # pattern demanded a bare identifier straight after `export`, so the
+        # `-f` form (and every other flag spelling) never matched and the
+        # rule could only ever see exported variables. The flag run is
+        # bounded to one token each so it cannot chew through an argument
+        # list.
+        "api": re.compile(r"^[ \t]*export[ \t]+(?:-[a-zA-Z]+[ \t]+)*[a-zA-Z_]\w*", re.M),
         # 11. flux (State Mutation)
         # Mutation of state via assignment or arithmetic.
         # QUADRATIC BLOWUP FIX: the arithmetic-expansion branch's two

--- a/gitgalaxy/standards/language_standards/languages/swift.py
+++ b/gitgalaxy/standards/language_standards/languages/swift.py
@@ -151,12 +151,20 @@ DEFINITION: dict[str, Any] = {
         # modifier and declaration lists on purpose; backtracking resolves it. The
         # stepper is `{0,4}` not `*` -- an unbounded nested quantifier over a
         # `[ \t]+`-separated alternation is a ReDoS shape (see
-        # test_swift_api_open_redos_immunity). `public`/`package` are untouched.
+        # test_swift_api_open_redos_immunity).
+        # BUG FIX #2730 (api contract): `public`/`package` were the two
+        # alternatives this rule did NOT anchor, so they counted the bare
+        # token anywhere -- including `let package = Package(...)` in a
+        # SwiftPM manifest and the word inside a diagnostic string. Folded
+        # into `open`'s alternative, which was already written to exactly the
+        # contract's shape (a modifier followed by the declaration it
+        # modifies); `typealias`/`associatedtype`/`case`/`operator`/
+        # `precedencegroup` join the declaration set, all of which take an
+        # access modifier in Swift.
         "api": re.compile(
-            r"\b(?:public|package)\b"
-            r"|\bopen\b[ \t]+"
+            r"\b(?:public|package|open)\b[ \t]+"
             r"(?:(?:final|override|weak|unowned|lazy|static|class|mutating|nonmutating|convenience|required|dynamic|indirect|(?:private|internal|fileprivate|public)\(set\))[ \t]+){0,4}"
-            r"(?:class|func|var|let|subscript|init\??|actor|struct|enum|protocol|extension)\b"
+            r"(?:class|func|var|let|subscript|init\??|actor|struct|enum|protocol|extension|typealias|associatedtype|case|operator|precedencegroup)\b"
             r"|@usableFromInline|@objc|@objcMembers|@_exported|@IBAction|@IBOutlet|@Published"
         ),
         # 11. flux (State Mutation)

--- a/gitgalaxy/standards/language_standards/languages/typescript.py
+++ b/gitgalaxy/standards/language_standards/languages/typescript.py
@@ -494,8 +494,27 @@ DEFINITION: dict[str, Any] = {
         ),
         # 10. api (Public Surface Area)
         # Captures explicit exports and public visibility.
+        # BUG FIX #2730 (api contract): a bare `\bexport|public|module.exports|exports.\b` counted the
+        # access modifier ANYWHERE in the code stream -- inside a string
+        # literal, a `switch` case, a dotted name -- not only where it
+        # declares something. The alternatives below anchor it to the
+        # declaration it modifies, per docs/api_rule_contract.md ("a
+        # declaration that makes a named function or type visible outside
+        # this file"). Every quantifier is bounded (Rule 5) and the modifier
+        # stepper is `{0,5}`, not `*`, so the `[ \t\n]+`-separated
+        # alternation cannot nest unboundedly (the ReDoS shape swift's `open`
+        # alternative was already written against).
+        # `export` stays bare -- it is a declaration keyword in its own
+        # right and cannot appear anywhere else -- while `public` (a class
+        # member / parameter-property modifier, and a legal property name)
+        # gets the anchor. Measured: 3730 crucible matches before, 3726
+        # after; the four dropped were the string `"public"` and a
+        # `case "public":` in a compiler that parses the keyword.
         "api": re.compile(
-            r"\b(export|public|module\.exports|exports\.)\b|@(Controller|Resolver|Get|Post|Put|Delete)\b"
+            r"\b(?:export|module\.exports|exports\.)\b"
+            r"|\bpublic[ \t\n]+(?:(?:static|readonly|abstract|override|async)[ \t\n]+){0,4}"
+            r"(?:get\b|set\b|[A-Za-z_$#][\w$]*[ \t\n]*[(:?<=;,])"
+            r"|@(Controller|Resolver|Get|Post|Put|Delete)\b"
         ),
         # 11. flux (State Mutation)
         # Mutation of state. EXCLUDES const (freeze_hits).

--- a/gitgalaxy/standards/language_standards/languages/yaml.py
+++ b/gitgalaxy/standards/language_standards/languages/yaml.py
@@ -79,7 +79,11 @@ DEFINITION: dict[str, Any] = {
         ),
         # Webhook/Workflow triggers
         "api": re.compile(
-            r"^[ \t]*on:[ \t]*(?:#.*)?\n(?:[ \t]*(?:#.*)?\n){0,10}[ \t]+(?:push|pull_request|workflow_dispatch|issues):",
+            # BUG FIX #2730 (api contract): `workflow_call` -- the trigger that
+            # makes a workflow callable BY ANOTHER REPOSITORY, i.e. the only
+            # one of these that is literally a published interface -- was
+            # missing from the trigger set.
+            r"^[ \t]*on:[ \t]*(?:#.*)?\n(?:[ \t]*(?:#.*)?\n){0,10}[ \t]+(?:push|pull_request|workflow_dispatch|workflow_call|issues):",
             re.M | re.I,
         ),
         "state_mutation": re.compile(

--- a/tests/extraction/languages/test_abap_strict.py
+++ b/tests/extraction/languages/test_abap_strict.py
@@ -407,3 +407,28 @@ def test_abap_redos_immunity_sweep():
     assert ABAP_RULES["func_start"].search("METHOD do_thing.")
     assert ABAP_RULES["class_start"].search("CLASS zcl_foo DEFINITION.")
     assert ABAP_RULES["concurrency"].search("CALL FUNCTION 'ENQUEUE_FOO'.")
+
+
+def test_abap_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    FORM subroutines and function modules are public by default and were
+    invisible to a rule that needed a CLASS, RFC metadata or a CDS definition.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = ABAP_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('FORM probe_globals CHANGING cv_env.'), 'FORM subroutine (public by default)'
+    assert api.search('FUNCTION z_get_flight.'), 'function module'
+    assert api.search('PUBLIC SECTION.'), 'class public section (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search("  CALL FUNCTION 'RFC_PING'."), 'CALL FUNCTION is a call site'

--- a/tests/extraction/languages/test_ada_strict.py
+++ b/tests/extraction/languages/test_ada_strict.py
@@ -467,3 +467,30 @@ def test_ada_argument_fallback_does_not_regress_space_separated_languages():
     assert count("foo:bar baz:qux") == 2
     assert count("") == 0
     assert count("self") == 1
+
+
+def test_ada_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A subprogram declared at column 0 is a library-level compilation unit,
+    visible to anything that `with`s it; the old rule could only see a package
+    spec, which lives in a separate `.ads` file.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = ADA_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('procedure Probe_Globals (Env : Integer) is'), 'library-level procedure'
+    assert api.search('function Compute (X : Integer) return Integer is'), 'library-level function'
+    assert api.search('package Foo is'), 'package spec (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('   procedure Helper (X : Integer) is'), 'nested (body-local) procedure'
+    assert not api.search('package body Foo is'), 'package body'

--- a/tests/extraction/languages/test_agc_assembly_strict.py
+++ b/tests/extraction/languages/test_agc_assembly_strict.py
@@ -245,3 +245,27 @@ def test_agc_assembly_ambiguity_doc_vs_ownership_author_no_collision():
     assert not AGC_RULES["doc"].search(header)
     m = AGC_RULES["ownership"].search(header)
     assert m and m.group(1) == "Jane Doe"
+
+
+def test_agc_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `EXTEND`/`BEXT` are AGC instructions, not declarations -- 323 of the
+    crucible corpus's 367 matches were the bare `EXTEND` opcode.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = AGC_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('SBIT1\t\tEQUALS\tBIT1'), 'EQUALS symbol equate'
+
+    # Not declarations -- must not match.
+    assert not api.search('\tEXTEND'), 'EXTEND is an instruction'
+    assert not api.search('EXTEND'), 'EXTEND at column 0'

--- a/tests/extraction/languages/test_assembly_strict.py
+++ b/tests/extraction/languages/test_assembly_strict.py
@@ -394,3 +394,28 @@ def test_assembly_redos_immunity_sweep():
     assert ASM_RULES["func_start"].search("myFunc:\n\tret")
     assert ASM_RULES["api"].search("\tglobal main")
     assert ASM_RULES["encapsulation"].search("\t.local myVar")
+
+
+def test_assembly_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `EXTERN`/`IMPORT` declare a name defined ELSEWHERE -- the opposite
+    direction from the contract.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = ASM_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('\t.globl\tmain'), 'GAS .globl'
+    assert api.search('GLOBAL _greet:function'), 'NASM GLOBAL'
+
+    # Not declarations -- must not match.
+    assert not api.search('EXTERN _printf'), 'EXTERN imports a name'
+    assert not api.search('\tIMPORT foo'), 'IMPORT imports a name'

--- a/tests/extraction/languages/test_c_strict.py
+++ b/tests/extraction/languages/test_c_strict.py
@@ -481,3 +481,37 @@ def test_c_doc_block_redos_immune_regression():
     """#2672 ReDoS probes: unterminated `/**` and a very long unterminated `///` line must fail closed quickly."""
     assert_redos_immune(C_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
     assert_redos_immune(C_RULES["doc"], "///" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_c_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    The declaration-shaped alternatives allowed indentation, so body-local
+    declarations and two-word statements counted: 7534 of the crucible corpus's
+    8675 matches were not file-scope declarations at all.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = C_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('int main(int argc, char **argv)'), 'file-scope definition'
+    assert api.search('PyObject *\nfoo(void)'), 'K&R two-line return type'
+    assert api.search('void write_rtf_header(NXStream *s);'), 'file-scope prototype'
+    assert api.search('extern int errno;'), 'extern declaration (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('    return NULL;'), 'indented return statement'
+    assert not api.search('return NULL;'), 'column-0 return statement'
+    assert not api.search('\tgoto error;'), 'indented goto'
+    assert not api.search('    PyObject *value;'), 'body-local declaration'
+    assert not api.search('static int helper(void)'), 'static definition'
+
+    # ReDoS detonation on an unterminated declaration-shaped run.
+    assert_redos_immune(api, "a" * 40000 + " " + "*" * 40000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_cobol_strict.py
+++ b/tests/extraction/languages/test_cobol_strict.py
@@ -463,3 +463,28 @@ def test_cobol_doc_planted_construct_counts_once_regression():
     assert len(doc.findall(corpus_shaped)) == 2
 
     assert_redos_immune(doc, "      *> @author" + " " * 200000, timeout_sec=3.0)
+
+
+def test_cobol_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `CALL`/`INVOKE` are call sites, not declarations, and swept up
+    `END-CALL` as well (108 crucible matches on their own).
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = COBOL_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search("       ENTRY 'SUBPROG'."), 'secondary entry point'
+    assert api.search('       LINKAGE SECTION.'), 'linkage section'
+
+    # Not declarations -- must not match.
+    assert not api.search('           END-CALL.'), 'END-CALL scope terminator'
+    assert not api.search("           CALL 'CEE3ABD'."), 'CALL is a call site'

--- a/tests/extraction/languages/test_csharp_strict.py
+++ b/tests/extraction/languages/test_csharp_strict.py
@@ -677,3 +677,33 @@ def test_csharp_doc_line_marker_swallows_line_regression():
 def test_csharp_doc_line_marker_redos_immune_regression():
     """#2672 ReDoS probe: a very long unterminated `///` line must fail closed quickly, not hang."""
     assert_redos_immune(CSHARP_RULES["doc"], "///" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_csharp_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A bare `public`/`internal` counted the modifier anywhere in the code
+    stream, including inside a string literal and a `switch` case.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = CSHARP_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public static SyntaxTree ParseText('), 'public static method'
+    assert api.search('public sealed partial class CSharpCompilation : Compilation'), 'public class'
+    assert api.search('internal (bool ok, int n)? TryGet(SimpleNameSyntax x)'), 'tuple return type'
+    assert api.search('internal TNode ParseWithStackGuard<TNode>(Func<int> f)'), 'generic method name'
+
+    # Not declarations -- must not match.
+    assert not api.search('case "public":'), 'keyword in a switch case'
+    assert not api.search('return "public";'), 'keyword in a string literal'
+
+    # ReDoS detonation on a modifier run that never reaches a declaration.
+    assert_redos_immune(api, "public " + "static " * 20000 + "@", timeout_sec=3.0)

--- a/tests/extraction/languages/test_dart_strict.py
+++ b/tests/extraction/languages/test_dart_strict.py
@@ -411,3 +411,34 @@ def test_dart_doc_block_redos_immune_regression():
     """#2672 ReDoS probes: unterminated `/**` and a very long unterminated `///` line must fail closed quickly."""
     assert_redos_immune(DART_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
     assert_redos_immune(DART_RULES["doc"], "///" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_dart_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `@pragma` is a compiler hint, not a visibility marker, and Dart's real
+    public surface -- a top-level function without a leading underscore -- was
+    invisible.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = DART_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('int probeGlobals(int env) {'), 'top-level public function'
+    assert api.search('Future<void> main() async {'), 'generic return type'
+    assert api.search("export 'src/foo.dart';"), 'export directive (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search("@pragma('vm:prefer-inline')"), 'compiler pragma'
+    assert not api.search('  int helper(int x) {'), 'indented method'
+    assert not api.search('int _private(int x) {'), 'underscore-private top-level function'
+
+    # ReDoS detonation on an unclosed generic argument list.
+    assert_redos_immune(api, "int " + "<" * 40000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_go_strict.py
+++ b/tests/extraction/languages/test_go_strict.py
@@ -212,6 +212,16 @@ def test_go_api_and_encapsulation_column_zero_and_keyword_regression():
        `\\b` before that final lookahead, since plain greedy `\\w+`
        backtracking can otherwise dodge the `(?!\\()` check by matching one
        character short of the true identifier end.
+    4. #2730 (api contract): excluding a following `(` was not enough --
+       ANY line starting with an exported identifier counted, so a
+       struct-literal field key (`Group: "apps",`) and a method call on an
+       exported package var (`DefaultServeMux.register(...)`) both scored as
+       public surface. Those are references to an exported name, not
+       declarations of one. The indented alternative now requires what a
+       grouped `var`/`const` member or a struct field actually looks like
+       (`Name = value`, `Name Type`, or a bare embedded type alone on its
+       line), which is why the struct-literal assertion below is now
+       negative.
     """
     api = GO_RULES["api"]
     encap = GO_RULES["encapsulation"]
@@ -238,7 +248,23 @@ def test_go_api_and_encapsulation_column_zero_and_keyword_regression():
     assert not encap.search("\tBurstReplicas = 500")
     assert encap.search("\tenableFoo = true"), "encapsulation failed on an indented grouped-var member"
     assert not api.search("\tenableFoo = true")
-    assert api.search('\t\tGroup:    "apps",'), "api failed on an indented struct-literal field"
+    # Struct TYPE fields and embedded types are declarations -- they stay.
+    assert api.search("\tName string"), "api failed on an indented exported struct field"
+    assert api.search("\tItems []Thing"), "api failed on an indented exported slice field"
+    assert api.search("\tMaxSize, MinSize int"), "api failed on a multi-name field declaration"
+    assert api.search("\tReader"), "api failed on a bare embedded exported type"
+
+    # #2730: references to an exported name are not declarations.
+    assert not api.search('\t\tGroup:    "apps",'), "api counted a struct-literal field key"
+    assert not api.search("\tDefaultServeMux.register(pattern, handler)"), (
+        "api counted a method call on an exported package var"
+    )
+    assert not api.search("\tAlpha,"), "api counted a composite-literal element"
+
+    # The new multi-name run (`Name, Name, ... Type`) repeats an alternation
+    # that needs a literal comma per step, so it cannot backtrack ambiguously.
+    # Detonated on a run that never reaches a type or an `=`.
+    assert_redos_immune(api, "\tA" + ", A" * 40000, timeout_sec=3.0)
 
 
 def test_go_closures_redos_immunity_and_bare_return_type():

--- a/tests/extraction/languages/test_groovy_strict.py
+++ b/tests/extraction/languages/test_groovy_strict.py
@@ -862,3 +862,28 @@ def test_groovy_doc_bare_tag_outside_block_still_counts_regression():
 def test_groovy_doc_block_redos_immune_regression():
     """#2672 ReDoS probe: an unterminated `/**` must fail closed quickly, not hang."""
     assert_redos_immune(GROOVY_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_groovy_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A bare `public` counted the word in prose and string literals.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = GROOVY_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public static void setText(Element e, String v) {'), 'public method'
+
+    # Not declarations -- must not match.
+    assert not api.search('log.warn("Could not open the public key ring.")'), 'keyword in a string'
+
+    # ReDoS detonation on a modifier run that never reaches a declaration.
+    assert_redos_immune(api, "public " + "static " * 20000 + "@", timeout_sec=3.0)

--- a/tests/extraction/languages/test_java_strict.py
+++ b/tests/extraction/languages/test_java_strict.py
@@ -385,3 +385,34 @@ def test_java_doc_bare_tag_outside_block_still_counts_regression():
 def test_java_doc_block_redos_immune_regression():
     """#2672 ReDoS probe: an unterminated `/**` must fail closed quickly, not hang."""
     assert_redos_immune(JAVA_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_java_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A bare `public`/`protected` counted the modifier anywhere in the code
+    stream, not only where it declares something.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = JAVA_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public void setResourceLoader(ResourceLoader r) {'), 'public method'
+    assert api.search('public @Nullable String getName() {'), 'annotated return type'
+    assert api.search('protected abstract Long processUptime();'), 'abstract method'
+    assert api.search('public Binder(Iterable<ConfigurationPropertySource> sources) {'), 'constructor'
+    assert api.search('public static void main(String[] args) throws Exception {'), 'main'
+
+    # Not declarations -- must not match.
+    assert not api.search('String mode = "public";'), 'keyword in a string literal'
+    assert not api.search('case "public":'), 'keyword in a switch case'
+
+    # ReDoS detonation on a modifier run that never reaches a declaration.
+    assert_redos_immune(api, "public " + "static " * 20000 + "@", timeout_sec=3.0)

--- a/tests/extraction/languages/test_kotlin_strict.py
+++ b/tests/extraction/languages/test_kotlin_strict.py
@@ -372,3 +372,31 @@ def test_kotlin_doc_bare_tag_outside_block_still_counts_regression():
 def test_kotlin_doc_block_redos_immune_regression():
     """#2672 ReDoS probe: an unterminated `/**` must fail closed quickly, not hang."""
     assert_redos_immune(KOTLIN_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_kotlin_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A bare `internal` matched the package segment of
+    `import okhttp3.internal.<name>` -- a reference to another module's
+    internals, the exact opposite of a public declaration.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = KOTLIN_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public override fun clone(): Call'), 'public override fun'
+    assert api.search('internal val lock = Any()'), 'internal val'
+
+    # Not declarations -- must not match.
+    assert not api.search('import okhttp3.internal.CONST_VERSION'), '`internal` inside an import path'
+
+    # ReDoS detonation on a modifier run that never reaches a declaration.
+    assert_redos_immune(api, "public " + "open " * 20000 + "@", timeout_sec=3.0)

--- a/tests/extraction/languages/test_lua_strict.py
+++ b/tests/extraction/languages/test_lua_strict.py
@@ -259,3 +259,27 @@ def test_lua_safety_bypasses_globals_and_cleanup_ownership_regression():
     assert safety_bypasses.search("debug.getinfo(1)"), "debug.* must still count as safety_bypasses"
     assert safety_bypasses.search("getfenv(1)"), "getfenv must still count as safety_bypasses"
     assert safety_bypasses.search("setfenv(1, t)"), "setfenv must still count as safety_bypasses"
+
+
+def test_lua_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `[^_]` accepted any non-underscore character, so `function ()` -- an
+    anonymous function, which declares no name -- counted.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = LUA_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('function Writer(doc, opts)'), 'named global function'
+
+    # Not declarations -- must not match.
+    assert not api.search('function ()'), 'anonymous function'
+    assert not api.search('local function helper()'), 'local function'

--- a/tests/extraction/languages/test_matlab_strict.py
+++ b/tests/extraction/languages/test_matlab_strict.py
@@ -664,3 +664,27 @@ def test_matlab_return_channel_scan_is_linear_on_pathological_input():
         start = time.perf_counter()
         d.coding_analysis([("matlab", payload, 0)])
         assert time.perf_counter() - start < 10.0, "return-channel scan went superlinear"
+
+
+def test_matlab_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A MATLAB function file has no visibility syntax; the rule could only see
+    a `classdef` methods block, so a corpus of function files measured 0.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = MATLAB_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('function out = probe_globals(env)'), 'column-0 function file entry'
+    assert api.search('    methods'), 'public methods block (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('        function y = helper(x)'), 'indented classdef method'

--- a/tests/extraction/languages/test_objectivec_strict.py
+++ b/tests/extraction/languages/test_objectivec_strict.py
@@ -317,3 +317,32 @@ def test_objectivec_doc_block_redos_immune_regression():
     assert_redos_immune(OBJC_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
     assert_redos_immune(OBJC_RULES["doc"], "/*!" + "x" * 200000, timeout_sec=3.0)
     assert_redos_immune(OBJC_RULES["doc"], "///" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_objectivec_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A method declared in an `@interface` -- Objective-C's primary public
+    surface -- was invisible to the C-level export macros.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = OBJC_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('- (void) linkTo:(Anchor *)destination;'), '@interface method declaration'
+    assert api.search('+ (BOOL) follow;'), 'class method declaration'
+    assert api.search('extern int HTAccMgr;'), 'extern declaration (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('+ ((slotNumber/10)%3)* 40;'), 'wrapped arithmetic continuation'
+    assert not api.search('- (void) doWork {'), '@implementation method body'
+
+    # ReDoS detonation on an unclosed method type cast.
+    assert_redos_immune(api, "- (" + "a " * 40000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_perl_strict.py
+++ b/tests/extraction/languages/test_perl_strict.py
@@ -594,3 +594,28 @@ def test_perl_doc_unterminated_opener_still_counts_regression():
 def test_perl_doc_pod_block_redos_immune_regression():
     """#2672 ReDoS probe: an unterminated `=pod` must fail closed quickly, not hang."""
     assert_redos_immune(PERL_RULES["doc"], "=pod\n" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_perl_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    Every alternative was a module-level export list that also lands on a
+    rule which already owns it, so `api` could only move by moving another
+    planted count. A Perl `sub` is package-public by default.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = PERL_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('sub probe_globals {'), 'package-public sub'
+    assert api.search('@EXPORT_OK = qw(foo);'), 'export list (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('sub _private_helper {'), 'underscore-private sub'

--- a/tests/extraction/languages/test_php_strict.py
+++ b/tests/extraction/languages/test_php_strict.py
@@ -417,3 +417,32 @@ def test_php_doc_bare_tag_outside_block_still_counts_regression():
 def test_php_doc_block_redos_immune_regression():
     """#2672 ReDoS probe: an unterminated `/**` must fail closed quickly, not hang."""
     assert_redos_immune(PHP_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_php_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A bare `public` matched a `$public` variable and the word inside a
+    string key.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = PHP_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public function __construct('), 'public method'
+    assert api.search('public readonly int $x;'), 'typed readonly property'
+    assert api.search('public const FOO = 1;'), 'public constant'
+
+    # Not declarations -- must not match.
+    assert not api.search("$public = (bool) get_option('blog_public');"), 'variable named $public'
+    assert not api.search("$this->instance('path.public', $path);"), 'keyword inside a string key'
+
+    # ReDoS detonation on a modifier run that never reaches a declaration.
+    assert_redos_immune(api, "public " + "static " * 20000 + "@", timeout_sec=3.0)

--- a/tests/extraction/languages/test_powershell_strict.py
+++ b/tests/extraction/languages/test_powershell_strict.py
@@ -486,10 +486,20 @@ def test_powershell_return_not_counted_as_branch_regression():
 
 
 def test_powershell_api_no_control_flow_false_positives():
-    """#2656: the api rule's bare-identifier alternative lacked keyword exclusions,
-    causing control-flow lines ('param(', 'if (', 'switch (') to miscount as API
-    surface. It must not match control-flow; a real exported function or
-    Export-ModuleMember must still match."""
+    """#2656, superseded by #2730: the api rule's bare-identifier alternative
+    (`^<name>(`) lacked keyword exclusions, so control-flow lines ('param(',
+    'if (', 'switch (') miscounted as API surface. #2656 added an exclusion
+    set; #2730 removed the alternative outright, because `<name>(` at the
+    start of a PowerShell line is a .NET method CALL or a statement -- a
+    reference to a name, never a declaration that publishes one (a function
+    is declared `function Name`, a class method `[type] Name(`). #2656's
+    exclusion set could not even hold its own line: it is lowercase while
+    the pattern is `re.I`, so `If (` and `Param(` matched anyway. All 61 of
+    its matches across the language-crucible corpus were statements.
+
+    The control-flow cases below must therefore still not match, and now
+    neither may a bare call. `Export-ModuleMember` -- PowerShell's actual
+    published surface -- must still match."""
     api = POWERSHELL_RULES["api"]
 
     # Must NOT count as API
@@ -497,10 +507,15 @@ def test_powershell_api_no_control_flow_false_positives():
     assert not api.search("if ($x) {"), "if ( must not count as API"
     assert not api.search("switch ($x) {"), "switch ( must not count as API"
     assert not api.search("while ($true) {"), "while ( must not count as API"
+    # #2656's exclusion set was case-mismatched against its own re.I pattern.
+    assert not api.search("If ("), "If ( must not count as API"
+    assert not api.search("Param("), "Param( must not count as API"
+    # #2730: a bare call is a reference, not a declaration.
+    assert not api.search("GetFoo ("), "a bare call must not count as API"
+    assert not api.search("return (Get-PSOptions).Output"), "return ( must not count as API"
+    assert not api.search("throw ($packages | Out-String)"), "throw ( must not count as API"
 
     # Must STILL count as API
     assert api.search("Export-ModuleMember -Function 'Get-Foo'"), "Export-ModuleMember must count as API"
-    # NB: the bare-identifier alternative's [a-zA-Z_]\w* never matched hyphenated
-    # Verb-Noun cmdlet names (pre-existing, unrelated to #2656) -- use a plain
-    # identifier here to test the exclusion fix in isolation.
-    assert api.search("GetFoo ("), "Real bare-identifier function call should count as API"
+    assert api.search("New-Alias -Name gf -Value Get-Foo"), "New-Alias must count as API"
+    assert api.search("[CmdletBinding()]"), "CmdletBinding must count as API"

--- a/tests/extraction/languages/test_ruby_strict.py
+++ b/tests/extraction/languages/test_ruby_strict.py
@@ -241,3 +241,28 @@ def test_ruby_redos_immunity_sweep():
     assert_redos_immune(RUBY_RULES["args"], "def foo('" + "a" * 100000, timeout_sec=3.0)
     assert_redos_immune(RUBY_RULES["args"], 'def foo("' + "a" * 100000, timeout_sec=3.0)
     assert_redos_immune(RUBY_RULES["spec_exposure"], "[SPEC-" + "1" * 100000, timeout_sec=3.0)
+
+
+def test_ruby_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A top-level `def` is a PRIVATE method on Object; the idiom that
+    publishes one by name is `public :name`, which was unreachable.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = RUBY_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public :probe_globals'), 'public :name'
+    assert api.search('public_class_method :new'), 'public_class_method :name'
+    assert api.search('module_function :probe_io'), 'module_function (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('def probe_globals(env)'), 'top-level def is private on Object'

--- a/tests/extraction/languages/test_shell_strict.py
+++ b/tests/extraction/languages/test_shell_strict.py
@@ -546,3 +546,30 @@ def test_shell_ambiguity_sweep_shared_literals_are_not_bugs():
     kill_call = "kill -HUP $pid"
     assert high_risk_execution.search(kill_call)
     assert panics_and_aborts.search(kill_call)
+
+
+def test_shell_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `export -f name` -- the way a shell publishes a FUNCTION -- could never
+    match, so the rule only ever saw exported variables.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = SHELL_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('export -f probe_globals'), 'exported function'
+    assert api.search('export PROBE_GLOBALS=1'), 'exported variable (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('exported=1'), 'identifier starting with export'
+
+    # ReDoS detonation on an unterminated flag run.
+    assert_redos_immune(api, "export " + "-f " * 40000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_swift_strict.py
+++ b/tests/extraction/languages/test_swift_strict.py
@@ -440,3 +440,29 @@ def test_swift_doc_block_redos_immune_regression():
     """#2672 ReDoS probes: unterminated `/**` and a very long unterminated `///` line must fail closed quickly."""
     assert_redos_immune(SWIFT_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
     assert_redos_immune(SWIFT_RULES["doc"], "///" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_swift_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `public`/`package` were the two alternatives this rule did not anchor,
+    so they matched `let package = Package(...)` and the word in a string.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = SWIFT_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public var description: String {'), 'public property'
+    assert api.search('package func helper() {}'), 'package-level function'
+    assert api.search('open class Foo {'), 'open class (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('let package = Package(name: "Alamofire",'), 'variable named package'
+    assert not api.search('"No public keys were found."'), 'keyword in a string literal'

--- a/tests/extraction/languages/test_typescript_strict.py
+++ b/tests/extraction/languages/test_typescript_strict.py
@@ -476,3 +476,32 @@ def test_typescript_doc_bare_tag_outside_block_still_counts_regression():
 def test_typescript_doc_block_redos_immune_regression():
     """#2672 ReDoS probe: an unterminated `/**` must fail closed quickly, not hang."""
     assert_redos_immune(TYPESCRIPT_RULES["doc"], "/**" + "x" * 200000, timeout_sec=3.0)
+
+
+def test_typescript_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    A bare `public` matched the string `"public"` in a compiler that parses
+    the keyword.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = TYPESCRIPT_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('public dispose(): void {'), 'public method'
+    assert api.search('public expression: Expression,'), 'parameter property'
+    assert api.search('export function f() {}'), 'export (kept)'
+
+    # Not declarations -- must not match.
+    assert not api.search('return "public";'), 'keyword in a string literal'
+    assert not api.search('case "public":'), 'keyword in a switch case'
+
+    # ReDoS detonation on a modifier run that never reaches a declaration.
+    assert_redos_immune(api, "public " + "static " * 20000 + "@", timeout_sec=3.0)

--- a/tests/extraction/languages/test_yaml_strict.py
+++ b/tests/extraction/languages/test_yaml_strict.py
@@ -698,3 +698,25 @@ def test_yaml_spec_exposure_redos_immunity():
     assert_redos_immune(spec_exposure, "# " + "[" * 100000, timeout_sec=3.0)
 
     assert spec_exposure.search("# [SPEC-4412] traceable")
+
+
+def test_yaml_api_contract_2730():
+    """
+    #2730: the api rule's stated contract is *a declaration that makes a
+    named function or type visible outside this file* (see
+    docs/api_rule_contract.md). Two failure directions are in scope: a
+    declaration the rule cannot see, and a token the rule counts where no
+    declaration exists.
+
+    `workflow_call` -- the trigger that makes a workflow callable by another
+    repository -- was missing from the trigger set.
+
+    Every case below was verified against the real compiled rule before
+    being written down (AGENTS.md rule 3).
+    """
+    api = YAML_RULES["api"]
+
+    # Declarations that publish a name -- must match.
+    assert api.search('on:\n  workflow_call:\n'), 'reusable-workflow trigger'
+    assert api.search('on:\n  push:\n'), 'push trigger (kept)'
+


### PR DESCRIPTION
Resolves #2730.
Part of #2669.

## The problem

`api` had a one-line description ("Code exposed to the outside world. Captures explicit
visibility markers AND implicit architectural defaults") and no contract, so 46 languages
disagreed about what a public surface is, in both directions at once. #2729's corpus wave
measured it: seven languages cannot see the idiom their own language uses to make a function
public, and five count a bare `public` token anywhere in the code stream.

`api` feeds `_calc_api_exposure` and `_calc_documentation`, so both directions land in scored
risk. On the control corpus it reads as language bias with nothing wrong in the corpus:
identical planted intent, `api` 0 in one language and 3 in its neighbour, purely from what the
regex accepts.

## The contract

Stated in the new **`docs/api_rule_contract.md`**, and in one line next to the rule in
`how_to_add_a_language.md`'s output schema:

> **`api` matches a declaration that makes a named function or type visible outside the file it
> is declared in.**

Three corollaries, each of which the audit found a language violating:

1. **A reference is not a declaration** — a call site, an import, a struct-literal field key, a
   `switch` case on the keyword.
2. **A modifier counts where it modifies a declaration**, not wherever the word appears.
3. **Where the language is public-by-default, the declaration itself IS the marker** — the rule
   `python` has always used, extended to the languages that needed it.

Plus a documented **fallback family** for languages with no per-function visibility concept at
all (`dockerfile` `EXPOSE`, `yaml` `on:`, `css` `@property`, `html` `id=`, `yacc` `%define`,
`m4` `AC_SUBST`, `cobol` `ENTRY`, `agc_assembly` `EQUALS`, `makefile`, `sqlite`, and now
`matlab`), so the substitution is a recorded decision rather than an accident.

## The audit — all 46 corpus languages

Full table with per-language counts is in `docs/api_rule_contract.md`. 23 languages were
already inside the contract and are untouched; 18 changed.

### Too narrow — the language's own visibility idiom was invisible

| language | the idiom | what was added | crucible | rosetta |
|---|---|---|---|---|
| `abap` | `FORM`/`FUNCTION` are public by default | line-anchored, so `CALL FUNCTION '...'` cannot match | 6 | 0 → 13 |
| `ada` | a library-level subprogram is its own compilation unit | `procedure`/`function` at **column 0**; nested (private) ones are indented | 0 | 0 → 13 |
| `dart` | a top-level function with no leading `_` | column-0 return type + public name + `(` | 174 → 149 | 0 → 13 |
| `matlab` | a function file is callable by name | column-0 `function` (the fallback family) | 0 → 23 | 0 → 13 |
| `objective-c` | a method declared in an `@interface` | a `-`/`+` method line ending `;` rather than `{` | 5 → 13 | 0 |
| `ruby` | `public :name` (a top-level `def` is private on `Object`) | `public`/`public_class_method` + symbol | 0 | 12 |
| `shell` | `export -f name` | the flag run between `export` and the name | 178 | 12 |
| `yaml` | `workflow_call` | added to the trigger set | 0 | 4 |
| `perl` | a `sub` is package-public | `^sub <name>` | 20 → 840 | 0 → 13 |

`perl` is the case the issue called out separately: every alternative it had was an export
*list* that also lands on a rule which already owns it (`@EXPORT_OK = (...)` is a
`state_mutation`, `use Exporter|parent|base` an `import`), so `api` could only move by moving
another planted count with it.

### Too broad — a token counted where no declaration exists

| language | what it counted | share of its crucible matches |
|---|---|---|
| `c` | any indented declaration-shaped line, so every body-local declaration and every two-word statement | **7534 of 8675** (`return NULL;` alone was 513) |
| `cobol` | `CALL`/`INVOKE` call sites, plus `END-CALL` via the hyphen boundary | 843 of 1396 |
| `agc_assembly` | the `EXTEND` opcode (`SUBROUTINE`/`BEXT` never fired at all) | 323 of 367 |
| `go` | any line starting with an exported identifier — struct-literal keys, calls on exported vars | 176 of 614 |
| `powershell` | `<name>(` at line start — a .NET call or a statement | 61 of 199 |
| `lua` | `function ()`, an anonymous function that declares no name | 16 of 288 |
| `dart` | `@pragma(...)`, a compiler hint | 34 of 174 |
| `assembly` | `EXTERN`/`IMPORT`, which import a name rather than publish one | 3 |
| `java` `csharp` `kotlin` `php` `groovy` `swift` `typescript` | a bare access modifier anywhere in the code stream | see below |

The bare-modifier family, with what each one was actually matching:
`import okhttp3.internal.X` (kotlin, 12 of 17), `let package = Package(...)` in a SwiftPM
manifest (swift), `$public` and `'path.public'` (php, 7), `case "public":` in a compiler that
parses the keyword (typescript, csharp), a log message about a "public key ring" (groovy, 4).

`java` and `csharp` move **zero** matches on either corpus — real Java and C# put `public` in
front of a declaration nearly always, so the anchor is a precision guard rather than a recount.
That is the answer to "why did a real fix produce no diff" for those two; the strict tests hold
the guard in place.

Two findings surfaced while doing this that are **not** #2730's shape and are not fixed here:
`powershell`'s #2656 keyword-exclusion set is lowercase against an `re.I` pattern, so `If (` and
`Param(` matched anyway (moot now — the alternative is gone, and the test records it), and
`go`/`java`'s `encapsulation` rules carry the same unanchored shape their `api` rules had.
`encapsulation` is a different rule with its own contract question and is left alone.

## Verification

* **7619 tests pass** serially, the mode CI runs (`pytest tests/ -v`).
* **91 new strict cases** across 21 `test_<lang>_strict.py` files, in a
  `test_<lang>_api_contract_2730` function each. Every case was run against the real compiled
  regex before being written down (AGENTS.md rule 3) — the harness reported 0 mismatches across
  all 91 before a line of test code was committed.
* **ReDoS**: detonation on every rule that gained a new quantifier shape (`c`, `go`, `dart`,
  `objective-c`, `shell`, `java`, `csharp`, `kotlin`, `groovy`, `php`, `typescript`), plus a
  geometric scaling sweep at n = 2k/4k/8k/16k/32k on all of them — every one ~2.0x per doubling
  (linear), none above 5ms at n=32000. Rules that gained no new quantifier deliberately got no
  detonation: 16 extra spawn-context subprocesses measurably perturb the ratio-based
  `spec_exposure` timing tests elsewhere in the suite.
* `ruff_audit --ci`, `mypy_audit --ci`, `audit_check.py` — all clear against their baselines.
* `tree_sitter_accuracy_audit --ci --all` — 30/30 OK, no baseline regeneration needed.
* `tri_comparison_chart --all --ci` — 3/3 committed baselines OK (`api` does not feed
  func/class precision, so no movement was expected and none occurred).

### Golden masters

Both re-blessed. **3384 differences per mode, identical in structure between them, every one
attributed and zero off-target:**

| class | count |
|---|---|
| Topological Coordinates X/Y/Z (corpus-wide mass re-solve) | 2120 |
| API Exposure | 300 |
| Documentation Exposure | 257 |
| Structural Magnitude | 255 |
| `Exposed API / Public Exports` | 255 |
| Directory Group Magnitude / `total_mass` | 45 + 45 |
| ecosystem `api_exposure` / `documentation` / `composition/*/impact` | 45 + 41 + 16 |
| forensic top-3 rankings, `health/avg_documentation` | 4 + 1 |

The X/Y/Z bucket is why a language-scoped `scope_check --expect` cannot be the gate here:
`api` feeds Structural Magnitude, which feeds total mass, which the 3D topology solver uses to
position **every** file in the corpus. So the scoping claim is made on the other 1264 instead —
every per-file signal/risk diff resolves to a file the engine detected as one of the 23 touched
languages. Two looked off-target and are not: `cpp/godot/object.h` is detected as **C**
(Identity Proof: `Sibling Anchor (.c)`), and the extensionless `perl/exiftool/exiftool` is
detected as **Perl** by shebang. Both go through a rule this PR changed.

Direction of change matches intent everywhere — narrowed rules negative, widened rules positive:

| | Δ `Public Exports` | | Δ `Public Exports` |
|---|---|---|---|
| `c` | −11501 | `perl` | **+914** |
| `cobol` | −907 | `matlab` | **+23** |
| `cpp/godot/object.h` (C) | −391 | `objective-c` | **+3** |
| `agc_assembly` | −323 | | |
| `go` | −240 | | |
| `dart` −31, `powershell` −25, `lua` −16, `kotlin` −9, `php` −8, `assembly`/`groovy` −3, `swift`/`typescript` −2 | | | |

## Cross-repo

Companion: **squid-protocol/keyword-rosetta#56** (*"corpus owes a re-bless against engine main"*,
already open before this PR).

This PR is corpus-visible per AGENTS.md rule 8 and #2669's paired-work rule, so it carries the
`rosetta:rebless-owed` label per `keyword-rosetta/docs/GATING.md`'s cross-repo flow. Its
`rosetta-audit` is red **as designed**, and its classification is exactly right:

```
rosetta_audit: 46 language(s) checked -- 5 regression(s), 21 pre-existing, 0 broken.
```

* **5 regressions, all this PR's:** `abap`, `ada`, `dart`, `matlab`, `perl` — the five languages
  whose own idiom this PR makes visible. Each goes `api` 0 → 3 per file (4 in `main`), and four
  of them also go `api_orphan_credit` 3 → 0, because a declaration the rule now counts is no
  longer new orphan surface (#2734's `api_declared_orphans`). `ada` keeps its credit at 0 either
  way: its syntax repeats the subprogram name (`end Probe_Globals;`), so its probes were never
  orphans.
* **21 pre-existing**, including `c` — these are #56's existing debt from the already-merged
  #2734, not this PR. `c` also moves its raw `api` here (6/9/7/7 → 4/5/3/3), which the re-bless
  picks up in the same pass.
* Verified locally against this branch with `tools/verify_language.py` across all 46: the same
  26 languages, 97 cells, and the same split. No language outside those 26 moves.

Per GATING.md's flow, **nothing in the corpus repo is edited beforehand**:

1. This PR merges first (labelled, audit advisory).
2. Corpus re-bless PR against engine `main`: the 97 manifest cells, plus the ledger —
   `api-no-plantable-idiom` narrows from seven languages to `objective-c` + `sqlite`
   (`objective-c` stays 0 because planting an `@interface` would break SPEC.md rule 2's
   `class_start == 0` tripwire, even though the rule can now see one), and
   `api-double-count-inflates-scored-api` flips `still_reproduces` to false — its own verdict
   says it "resolves when #2731 credits only the orphans the rule did not already count", which
   is what the 3 → 0 cells are. Also swaps `shell`'s plant from `export PROBE_X=1` to
   `export -f probe_x`, so shell's `api` measures an exported *function* rather than a
   similarly-named variable.
3. `bias-history.yml` regenerates the report on that merge and closes #56; then
   `tools/issue_status.py` for the languages that moved, per #2669 F.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfeHRWra1d6Z5uSReFajSq
