### PR TITLE
fix(core-engine): freeze the security frame's dead func_internal_density read (#2714)

### DIFF
--- a/gitgalaxy/security/security_auditor.py
+++ b/gitgalaxy/security/security_auditor.py
@@ -382,7 +382,22 @@ class SecurityAuditor:
                     "log_max_func_complexity": np.log1p(np.maximum(max_func_comp, 0)),
                     "log_avg_func_args": np.log1p(np.maximum(avg_func_args, 0)),
                     "func_complexity_gini": float(tel.get("func_complexity_gini", 0.0)),
-                    "func_internal_density": float(tel.get("func_internal_density", 0.0)),
+                    # func_internal_density (#2714): a permanent 0.0 placeholder,
+                    # not a live feature. No telemetry writer has ever emitted
+                    # this key -- signal_processor's telemetry_payload, the
+                    # galaxyscope augmentation block and the ecosystem pass all
+                    # skip it, and the density is computed only inside
+                    # record_keeper.py (~L496) while the file_data row is
+                    # written. The old tel.get(...) read therefore took its 0.0
+                    # default for every file, every scan, exactly like the
+                    # prompt_injection/agentic_rce placeholders documented in
+                    # analysis_lens.py. The column is frozen rather than deleted
+                    # because audit_repository aligns the frame by name via
+                    # df.reindex(columns=self.feature_names, fill_value=np.nan):
+                    # dropping it would feed a trained model NaN where it has
+                    # always seen 0.0. Populating it for real is a scored-model
+                    # input change that needs a retrain, not this fix.
+                    "func_internal_density": 0.0,
                     "orphaned_logic": float(hit_dict.get("orphaned_logic", 0)),
                     "duplicate_logic": float(hit_dict.get("duplicate_logic", 0)),
                     "log_direct_upstream": np.log1p(np.maximum(dep.get("direct_upstream", 0), 0)),

--- a/tests/ruff_audit_baseline.json
+++ b/tests/ruff_audit_baseline.json
@@ -44,7 +44,7 @@
   "gitgalaxy/recorders/record_keeper.py:965: W291": "Trailing whitespace",
   "gitgalaxy/recorders/sbom_recorder.py:221: PERF401": "Use `list.extend` to create a transformed list",
   "gitgalaxy/security/security_auditor.py:359: RUF046": "Value being cast to `int` is already an integer",
-  "gitgalaxy/security/security_auditor.py:426: PERF203": "`try`-`except` within a loop incurs performance overhead",
+  "gitgalaxy/security/security_auditor.py:441: PERF203": "`try`-`except` within a loop incurs performance overhead",
   "gitgalaxy/security/security_lens.py:443: SIM102": "Use a single `if` statement instead of nested `if` statements",
   "gitgalaxy/standards/config_resolver.py:254: UP045": "Use `X | None` for type annotations",
   "gitgalaxy/standards/config_resolver.py:255: UP045": "Use `X | None` for type annotations",

--- a/tests/security_auditing/test_security_auditor.py
+++ b/tests/security_auditing/test_security_auditor.py
@@ -93,6 +93,29 @@ def test_construct_feature_matrix(mock_artifacts):
     assert "log_logic_loc" in df.columns
 
 
+def test_func_internal_density_is_a_frozen_placeholder(mock_artifacts):
+    """#2714: the frame's func_internal_density column is a permanent 0.0.
+
+    Nothing ever writes that key into artifact telemetry -- the density is
+    computed only inside record_keeper.py while the file_data row is written --
+    so the column has been a constant 0.0 in every frame the model was ever
+    scored or trained against. Making it vary is a scored-model input change
+    that needs a retrain, so this pins the constant: if some future pass does
+    start emitting the telemetry key, the security frame must not silently
+    start moving with it.
+    """
+    auditor = SecurityAuditor()
+    auditor.SIGNAL_SCHEMA = ["high_risk_execution", "io", "state_mutation", "safety", "dead_code"]
+
+    mock_artifacts[0]["telemetry"]["func_internal_density"] = 0.87
+
+    auditor._resolve_dependency_graph(mock_artifacts)
+    df = auditor._construct_feature_matrix(mock_artifacts)
+
+    assert "func_internal_density" in df.columns
+    assert (df["func_internal_density"] == 0.0).all()
+
+
 def test_construct_feature_matrix_exception_fallback():
     """Proves a corrupted artifact payload generates a safe, empty fallback row."""
     auditor = SecurityAuditor()


### PR DESCRIPTION
Closes #2714.

## The bug

`security_auditor._construct_feature_matrix` (L385) read `func_internal_density` out of artifact telemetry, but **nothing has ever written that key there**. Telemetry is assembled in three places and none of them emit it:

* `signal_processor.telemetry_payload` (~L829)
* the galaxyscope augmentation block (`galaxyscope.py` L2311 — `control_flow_ratio`, `popularity`, identity keys)
* the ecosystem pass (`signal_processor.py` L1197-1200 — `ecosystem_*`, `dist_to_N`)

The density is computed only inside `record_keeper.py` (~L496) while the `file_data` row is written. So the `.get` default fired for every file on every scan: the column has been a constant 0.0 in the security frame since it was added — the same shape as the `prompt_injection` / `agentic_rce` placeholders documented in `analysis_lens.py` (#1020).

I swept the rest of the row for the same defect. `control_flow_ratio`, `func_complexity_gini`, `ownership_entropy`, `author_distribution`, `densities.cog_raw`, `ecosystem_baseline_cluster`, `ecosystem_z_score` and `dist_to_0..10` all have live writers. This was the only dead read.

## The fix: freeze, don't delete

The issue offered two options; this takes the conservative one, with a wrinkle worth recording.

**Deleting the key is not a no-op.** `audit_repository` aligns the frame *by name* — `df.reindex(columns=self.feature_names, fill_value=np.nan)` — so dropping the column would hand a trained model `np.nan` where it has always seen `0.0`, and XGBoost routes NaN down a tree's default branch. That is identical only if no tree splits on the feature, which is near-certain for a constant training column but **unverifiable here**: `gitgalaxy_malware_xgb_multiclass.json` has never existed in this repo (no file, no git history, no training script, not shipped by `pyproject`/`MANIFEST.in`), so the model is an external artifact users supply.

So the key stays, as an explicit `0.0` with a comment naming it a permanent placeholder and pointing at `record_keeper` as the metric's real home. Output is byte-identical for any model, and the code no longer implies a live feature.

**Populating it stays open, deliberately.** Making the column vary is a scored-model input change: it needs a retrain and a look at what consumes the frame, and it does not belong in a cleanup PR.

## Verification

* New test `test_func_internal_density_is_a_frozen_placeholder` pins the constant against a telemetry payload that *does* carry the key — so the frame cannot start moving by accident if some future pass begins emitting it. Confirmed it fails against the old `tel.get(...)` read and passes on the fix.
* `tests/security_auditing` + `tests/core_engine/test_zero_dependency.py`: 200 passed.
* `audit_check.py`: all clear (the one ruff finding was a pure line-shift of the pre-existing `PERF203` in this file, baseline regenerated).
* **No golden-master bless owed.** The feature matrix is only built when a model loads (`audit_repository` returns early otherwise), and no fixture records this column.

Related: #2705 (where this was found), #1020 (placeholder-feature precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
