### PR TITLE
fix(core-engine): the orphan census counts references, not name repetitions (#2727, #2728)

### DIFF
--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -7491,7 +7491,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -7605,7 +7605,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7692,7 +7692,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7732,7 +7732,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -7836,7 +7836,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8028,7 +8028,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -8144,7 +8144,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 189,
       "last_seen_examples": [
         {
@@ -8257,7 +8257,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -8361,7 +8361,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T13:22:21Z",
+      "last_reconciled_at": "2026-09-05T15:43:36Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -14915,7 +14915,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14957,7 +14957,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -15069,7 +15069,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -15129,7 +15129,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -15162,7 +15162,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -15249,7 +15249,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 204,
       "last_seen_examples": [
         {
@@ -15363,7 +15363,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 2226,
       "last_seen_examples": [
         {
@@ -15479,7 +15479,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15520,7 +15520,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15562,7 +15562,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15605,7 +15605,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T13:23:36Z",
+      "last_reconciled_at": "2026-09-05T15:43:40Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -15815,7 +15815,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-05T13:23:46Z",
+      "last_reconciled_at": "2026-09-05T15:43:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -15850,7 +15850,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-05T13:23:46Z",
+      "last_reconciled_at": "2026-09-05T15:43:45Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15893,7 +15893,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-05T13:23:46Z",
+      "last_reconciled_at": "2026-09-05T15:43:45Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/docs/self_scan/tri_comparison_ledger.json
+++ b/docs/self_scan/tri_comparison_ledger.json
@@ -7491,7 +7491,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 93,
       "last_seen_examples": [
         {
@@ -7605,7 +7605,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -7692,7 +7692,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -7732,7 +7732,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 45,
       "last_seen_examples": [
         {
@@ -7836,7 +7836,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 13,
       "last_seen_examples": [
         {
@@ -7950,7 +7950,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 6,
       "last_seen_examples": [
         {
@@ -8028,7 +8028,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 265,
       "last_seen_examples": [
         {
@@ -8144,7 +8144,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 189,
       "last_seen_examples": [
         {
@@ -8257,7 +8257,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 194,
       "last_seen_examples": [
         {
@@ -8361,7 +8361,7 @@
       "investigated_at": "2026-08-21",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "javascript",
-      "last_reconciled_at": "2026-09-05T15:43:36Z",
+      "last_reconciled_at": "2026-09-05T13:22:21Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -14915,7 +14915,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -14957,7 +14957,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 501,
       "last_seen_examples": [
         {
@@ -15069,7 +15069,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 4,
       "last_seen_examples": [
         {
@@ -15129,7 +15129,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -15162,7 +15162,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 7,
       "last_seen_examples": [
         {
@@ -15249,7 +15249,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 204,
       "last_seen_examples": [
         {
@@ -15363,7 +15363,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 2226,
       "last_seen_examples": [
         {
@@ -15479,7 +15479,7 @@
       "investigated_at": "2026-08-24T04:14:26Z",
       "investigated_by": "Antigravity (direct sweep)",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15520,7 +15520,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15562,7 +15562,7 @@
       "investigated_at": "2026-08-26T16:02:21Z",
       "investigated_by": "Claude (Sonnet 5), tri-comparison-ledger-sweep skill",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15605,7 +15605,7 @@
       "investigated_at": "2026-08-26T00:00:00Z",
       "investigated_by": "Claude (Sonnet 5), dispatched via tri-comparison-ledger-sweep",
       "language": "typescript",
-      "last_reconciled_at": "2026-09-05T15:43:40Z",
+      "last_reconciled_at": "2026-09-05T13:23:36Z",
       "last_seen_count": 183,
       "last_seen_examples": [
         {
@@ -15815,7 +15815,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-05T15:43:45Z",
+      "last_reconciled_at": "2026-09-05T13:23:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {
@@ -15850,7 +15850,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-05T15:43:45Z",
+      "last_reconciled_at": "2026-09-05T13:23:46Z",
       "last_seen_count": 2,
       "last_seen_examples": [
         {
@@ -15893,7 +15893,7 @@
       "investigated_at": "2026-08-23T18:02:16Z",
       "investigated_by": "Antigravity",
       "language": "zig",
-      "last_reconciled_at": "2026-09-05T15:43:45Z",
+      "last_reconciled_at": "2026-09-05T13:23:46Z",
       "last_seen_count": 1,
       "last_seen_examples": [
         {

--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -841,6 +841,77 @@ _SYNTHETIC_SATELLITE_SUFFIXES = ("_[Truncated]", "_[Unterminated]")
 # the identical call for the identical reason; this is that list, in the engine.
 _UNCOUNTABLE_SLICE_NAMES = frozenset({"Anonymous_Block", "__global_context__"})
 
+# #2728: a THIRD family of slicer-synthesized names, distinct from both sets
+# above. Where a language's `func_start` capture group is a closed set of
+# literal keywords -- css `@(media|supports|container|layer|keyframes|
+# -webkit-keyframes)`, dockerfile `(RUN|CMD|ENTRYPOINT|HEALTHCHECK)`, html
+# `(script|style)` -- the "name" the slicer stores is the language's own
+# keyword, not an identifier anyone wrote. Two consequences were measured on the
+# corpus before this existed: dockerfile's four same-bodied `RUN` slices scored
+# `state_slop_duplicates` 1 -- the ONLY nonzero duplicate cell in 46 languages,
+# and a phantom -- and css's three `keyframes` slices cleared each other's
+# orphan flag purely by repeating the keyword.
+#
+# DERIVED from each rule, never hand-listed, so the two cannot drift: a
+# hand-written list would silently rot the moment a language's `func_start`
+# alternation gained a keyword. `_closed_literal_capture` returns the empty set
+# for any rule whose capture can produce an author-written identifier (a
+# character class, a quantifier, anything but a fixed alternation), so a
+# language only opts in by having a rule that provably cannot.
+#
+# Deliberately NOT added to `_UNCOUNTABLE_SLICE_NAMES`: that set governs the
+# FUNCTION POPULATION (#2691), and removing css's ~150 at-rule slices from it
+# would take `functions_found` to 0 and make every per-function descriptor
+# undefined for the language -- the markdown/html shape from #2689's bucket A.
+# That is a real question (keyword-rosetta's `slicer-segments-statements-not-
+# functions` ledger entry owns it) and it is NOT this issue's: #2728's measured
+# harm is entirely in the duplicate/orphan classification, so that is all this
+# changes.
+_ALTERNATION_ONLY = re.compile(r"[\w@.\-]+(?:\|[\w@.\-]+)*")
+
+
+def _first_capture_source(pattern: str) -> Optional[str]:
+    """Raw source text of `pattern`'s first *capturing* group, or None."""
+    i = 0
+    while i < len(pattern):
+        if pattern[i] == "\\":
+            i += 2
+            continue
+        if pattern[i] == "(" and not pattern.startswith("(?", i):
+            depth, j = 1, i + 1
+            while j < len(pattern) and depth:
+                if pattern[j] == "\\":
+                    j += 2
+                    continue
+                if pattern[j] == "(":
+                    depth += 1
+                elif pattern[j] == ")":
+                    depth -= 1
+                j += 1
+            return pattern[i + 1 : j - 1]
+        i += 1
+    return None
+
+
+def _closed_literal_capture(pattern: str) -> frozenset[str]:
+    """Every name a `func_start` capture can yield, when that set is finite.
+
+    Empty (the safe default) unless the capture is a bare alternation of
+    literals -- one leading `@` and a trailing `\\b` tolerated, since that is
+    how css spells its at-rules. `_extract_name` strips the `@` before storing,
+    so both spellings are returned.
+    """
+    group = _first_capture_source(pattern)
+    if group is None:
+        return frozenset()
+    body = group[1:] if group.startswith("@") else group
+    body = body.replace("(?:", "").replace(")", "").replace("\\b", "")
+    if not _ALTERNATION_ONLY.fullmatch(body):
+        return frozenset()
+    names = set(body.split("|"))
+    return frozenset(names | {"@" + n for n in names})
+
+
 # #2692: a colon with whitespace on either side marks a type annotation
 # (`Env : Integer`, `x: int`), i.e. ONE parameter -- as opposed to a bare colon
 # inside a Lisp identifier (`foo:bar`), which is just part of the name.
@@ -930,6 +1001,15 @@ class StructuralExtractor:
         lang_config: dict[str, Any] = self.languages.get(self.primary_lang_id, {})
         self.primary_rules: dict[str, Any] = lang_config.get("rules", {})
         self.primary_family = lang_config.get("lexical_family", "c_style_comment")
+
+        # #2728: the names this language's own `func_start` can synthesize from a
+        # closed keyword alternation rather than capture from source. Empty for
+        # every language whose rule can produce a real identifier -- see
+        # `_closed_literal_capture`. Computed once here rather than per function.
+        _fs = self.primary_rules.get("func_start")
+        self._keyword_bucket_names: frozenset[str] = (
+            _closed_literal_capture(_fs.pattern) if _fs is not None else frozenset()
+        )
 
         # #1949: `END-PERFORM`/`END-IF` were removed entirely -- both are block
         # *closers*, never a real function/paragraph-terminating statement in
@@ -1343,9 +1423,10 @@ class StructuralExtractor:
             import collections
             import hashlib
 
-            # Fast, C-backed word frequency counter for the entire file
-            token_counts = collections.Counter(re.findall(r"\b\w+\b", code_stream))
-
+            # #2727 retired the file-wide token counter that used to live here:
+            # the orphan test is now scoped to each function's own span (see
+            # `_is_orphan`), so a single whole-file frequency table can no longer
+            # answer it.
             orphan_count = 0
             duplicate_count = 0
             orphan_names: list[str] = []
@@ -1392,7 +1473,18 @@ class StructuralExtractor:
                 # Mode E's "<KEYWORD>_Statement"/"Declarative_Block", etc.) are never
                 # real callable identifiers -- skip them for BOTH the duplicate and
                 # orphan checks below, not just the orphan one.
-                if func_name and not _is_synthetic_satellite_name(func_name):
+                # #2728 extends that to the igniter-keyword buckets the slicer names
+                # after the matched keyword itself (dockerfile `RUN`, css
+                # `keyframes`, html `script`). Same argument, different family: a
+                # keyword cannot be orphaned or duplicated, and counting it as
+                # either measures the slicer's bucketing, not the code. The set is
+                # derived from this language's own `func_start`, so it cannot drift
+                # away from what the slicer actually emits.
+                if (
+                    func_name
+                    and not _is_synthetic_satellite_name(func_name)
+                    and func_name not in self._keyword_bucket_names
+                ):
                     # Check for Duplicates: same name AND materially the same body,
                     # defined multiple times in the same file.
                     if (
@@ -1401,8 +1493,8 @@ class StructuralExtractor:
                     ):
                         usage_status = 2  # 2 = Duplicate
                         duplicate_count += 1
-                    elif len(func_name) > 3 and token_counts[func_name] <= 1:
-                        # If the function name only exists where it was defined, it's an orphan
+                    elif len(func_name) > 3 and self._is_orphan(code_stream, func, func_name):
+                        # Nothing outside the function's own definition names it.
                         orphan_count += 1
                         orphan_names.append(func_name)
                         usage_status = 1  # 1 = Orphan / Unused
@@ -6759,6 +6851,44 @@ class StructuralExtractor:
             "token_mass": get_token_mass(block),
         }
         return sat, magnitude
+
+    @staticmethod
+    def _is_orphan(code_stream: str, func: "FunctionNode", func_name: str) -> bool:
+        """Does `func_name` occur anywhere outside its own definition?
+
+        #2727: the old test was `token_counts[func_name] <= 1` over the WHOLE
+        code stream, so whether a function read as orphaned depended on how many
+        times the language's syntax writes the name, not on whether anything
+        calls it. Ada closes with `end Probe_Globals;`, LiveCode ends a handler
+        by name, Haskell writes `probeGlobals :: Int -> Int` above the equation:
+        the count is already 2 before anything calls it, and the function can
+        never be orphaned. Measured across the language-crucible: livecode
+        reported 3 orphans where the span-scoped test finds 127.
+
+        Counting outside `[start_idx, end_idx)` is the fix, with one correction
+        the issue's own fix shape missed. The span does NOT reliably contain the
+        function's declaration -- shell's Mode-B spans start at the `{`, so a
+        K&R `make_module()` on the previous line sits outside its own body, and
+        ruby's spans are offset outright (66 of 132 sampled functions). Counting
+        naively there makes the DECLARATION read as a reference and clears the
+        flag: ruby fell 51 -> 44 orphans, html 5 -> 2, shell 8 -> 3, losing real
+        ones. So when the span contains no occurrence of the name at all, the
+        definition site is outside it by construction and exactly one outside
+        occurrence is that declaration -- discount it. With the correction no
+        language decreases; the crucible total moves 7397 -> 8385.
+
+        A recursive self-call stays inside the span, so a recursive-but-uncalled
+        function still reads as unused. A call from anywhere else in the file is
+        outside, and clears the flag exactly as before.
+        """
+        start_idx = func.get("start_idx", 0)
+        end_idx = func.get("end_idx", start_idx)
+        word = re.compile(r"\b" + re.escape(func_name) + r"\b")
+        inside = len(word.findall(code_stream[start_idx:end_idx]))
+        outside = len(word.findall(code_stream[:start_idx])) + len(word.findall(code_stream[end_idx:]))
+        if inside == 0:
+            outside -= 1  # the declaration itself, which fell outside the span
+        return outside <= 0
 
     def _extract_name(self, raw_match: str) -> str:
         """

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -3985,3 +3985,121 @@ def test_detector_yacc_grammar_without_a_union_declares_no_class():
 
     assert result.get("classes") == [], f"a grammar with no %union must declare no class, got {result.get('classes')}"
     assert not result["equations"].get("class_start"), "no %union directive means no class_start signal"
+
+
+# ==============================================================================
+# #2727 / #2728: THE ORPHAN & DUPLICATE CENSUS
+# ==============================================================================
+def test_orphan_test_is_scoped_to_the_function_own_span():
+    """#2727: an orphan is a function nothing outside its own definition names.
+
+    The old test counted the name over the WHOLE code stream, so whether a
+    function read as orphaned depended on how many times the language's syntax
+    writes it. Ada closes with `end Probe_Globals;` and LiveCode ends a handler
+    by name -- count 2 before anything calls it, so neither language could ever
+    report an orphan (measured: livecode reported 3 across the crucible where
+    the scoped test finds 127).
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    ada = StructuralExtractor("ada", LANGUAGE_DEFINITIONS)
+    uncalled = "procedure Probe_Globals (Env : Integer) is\nbegin\n   null;\nend Probe_Globals;\n"
+    assert ada.splice(uncalled, "")["equations"].get("orphaned_logic", 0) == 1, (
+        "a procedure whose only other mention is its own `end Name;` is an orphan"
+    )
+
+    called = uncalled + "procedure Caller is\nbegin\n   Probe_Globals (1);\nend Caller;\n"
+    eq = ada.splice(called, "")["equations"]
+    assert eq.get("orphaned_logic", 0) == 1, (
+        "a real call from another procedure must clear the flag -- only Caller stays orphaned"
+    )
+
+
+def test_orphan_test_discounts_a_declaration_that_falls_outside_the_span():
+    """#2727, the correction the issue's own fix shape missed.
+
+    The span does not reliably contain the function's declaration: shell's
+    Mode-B spans start at the `{`, so a K&R `make_module()` on the PREVIOUS line
+    sits outside its own body. Counting outside the span naively makes the
+    declaration itself read as a reference and clears the flag -- measured on
+    the crucible, ruby fell 51 -> 44 orphans that way, html 5 -> 2, shell 8 -> 3,
+    all real ones lost. When the span holds no occurrence of the name, the
+    definition site is outside it by construction, so exactly one outside
+    occurrence is that declaration and is discounted.
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    shell = StructuralExtractor("shell", LANGUAGE_DEFINITIONS)
+    kr_style = 'make_module()\n{\n        MODULES="${MODULES} ${1}"\n}\n'
+    assert shell.splice(kr_style, "")["equations"].get("orphaned_logic", 0) == 1, (
+        "K&R shell function, never called: its own declaration line must not count as a reference"
+    )
+
+    called = kr_style + "make_module foo\n"
+    assert shell.splice(called, "")["equations"].get("orphaned_logic", 0) == 0, (
+        "a real invocation outside the body must still clear the flag"
+    )
+
+
+def test_orphan_test_finds_names_containing_non_word_characters():
+    """#2727 fixes a third defect neither issue named.
+
+    The old whole-file counter tokenized with `\\b\\w+\\b`, which cannot produce a
+    token containing `-`, `:` or `.`. A name holding any of them therefore had a
+    count of ZERO and satisfied `<= 1` unconditionally -- every C++ `Class::method`,
+    PowerShell `Verb-Noun`, Tcl `::ns::proc`, Scheme/Lisp hyphenated define and
+    COBOL paragraph in the corpus was classified as an orphan no matter how many
+    times it was called. Measured on the language-crucible: cpp 1054 -> 720
+    orphans, tcl 210 -> 148, powershell 56 -> 3, scheme 60 -> 10, abap 41 -> 8.
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    scheme = StructuralExtractor("scheme", LANGUAGE_DEFINITIONS)
+    code = "(define (probe-globals env) env)\n(export probe-globals)\n"
+    assert scheme.splice(code, "")["equations"].get("orphaned_logic", 0) == 0, (
+        "a hyphenated name named again elsewhere in the file is not an orphan"
+    )
+
+    uncalled = "(define (probe-globals env) env)\n"
+    assert scheme.splice(uncalled, "")["equations"].get("orphaned_logic", 0) == 1, (
+        "the same hyphenated name with nothing else naming it still is one"
+    )
+
+
+def test_closed_literal_capture_is_generated_not_hand_listed():
+    """#2728: the igniter-keyword bucket set is derived from each language's own
+    `func_start`, so it cannot drift away from what the slicer emits.
+
+    A rule whose capture can produce an author-written identifier must yield the
+    empty set -- that is what keeps the mechanism from swallowing real functions.
+    """
+    from gitgalaxy.core.detector import _closed_literal_capture
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    closed = {
+        lang: _closed_literal_capture(rules["rules"]["func_start"].pattern)
+        for lang, rules in LANGUAGE_DEFINITIONS.items()
+        if rules.get("rules", {}).get("func_start") is not None
+    }
+    assert {lang for lang, names in closed.items() if names} == {"css", "dockerfile", "html"}, (
+        "exactly three languages have a func_start capture that is a closed keyword set"
+    )
+    assert {"RUN", "CMD", "ENTRYPOINT", "HEALTHCHECK"} <= closed["dockerfile"]
+    assert {"keyframes", "media", "supports", "container", "layer"} <= closed["css"]
+    assert {"script", "style"} <= closed["html"]
+    for lang in ("python", "go", "cobol", "assembly", "jcl", "yaml"):
+        assert not closed.get(lang, frozenset()), f"{lang} captures real identifiers -- must opt out"
+
+
+def test_keyword_buckets_are_neither_duplicates_nor_orphans():
+    """#2728: four same-bodied `RUN` instructions are one Dockerfile, not
+    copy-pasted logic. `state_slop_duplicates` = 1 for dockerfile was the only
+    nonzero duplicate cell across 46 corpus languages, and it was a phantom.
+    """
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    docker = StructuralExtractor("dockerfile", LANGUAGE_DEFINITIONS)
+    code = "FROM debian\nRUN apt-get update\nRUN apt-get update\nRUN apt-get update\nRUN apt-get update\n"
+    eq = docker.splice(code, "")["equations"]
+    assert not eq.get("duplicate_logic"), "identical RUN instructions are not duplicated functions"
+    assert not eq.get("orphaned_logic"), "a RUN bucket is a keyword, and a keyword cannot be orphaned"


### PR DESCRIPTION
Closes #2727.
Closes #2728.
Part of #2669 (F.4).

`orphaned_logic` was decided by one line — `token_counts[name] <= 1` over the whole code stream —
so whether a function read as orphaned depended on how many times the language's syntax writes its
name, not on whether anything calls it. Three distinct defects fall out of that, two filed and one
found while fixing them.

## 1. #2727 — syntax that repeats the name masked every orphan

Ada closes with `end Probe_Globals;`, LiveCode ends a handler by name, Haskell writes the type
signature above the equation. The count is already 2 before anything calls the function, so those
languages could never report one: `livecode` found **3** orphans across the crucible where the
scoped test finds **127**; `ada` and `livecode` read 0 per file in keyword-rosetta against a 2.50
baseline.

**The fix shape as filed was unsafe, and I corrected it.** "Count outside `[start_idx, end_idx)`"
assumes the span contains the function's declaration. It often doesn't:

* `shell` — Mode-B spans start at the `{`, so a K&R `make_module()` on the previous line sits
  outside its own body (`curl/initscript.sh`);
* `ruby` — spans are offset outright; 66 of 132 sampled functions have the declaration outside.

Counting naively there makes the **declaration itself** read as a reference and clears the flag —
measured: `ruby` 51 → 44 orphans, `html` 5 → 2, `shell` 8 → 3, all real ones lost. So when the span
holds no occurrence of the name, the definition site is outside it by construction and exactly one
outside occurrence is discounted. With the correction, no language decreases for that reason.

I also tried `span ∪ start_line`; it fixes ruby and html but not shell, because `start_line` points
at the `{` rather than the line carrying the name — a separate metadata observation worth its own
issue.

**The Haskell caveat the issue raised is moot**: the span *does* start at the type signature
(`probeGlobals`'s span begins at `probeGlobals :: Int -> Int`). Haskell still reads ~0 orphans, but
for a reason the issue didn't anticipate — its module export list names every probe outside every
span. That's keyword-rosetta's already-ledgered `api-export-names-suppress-orphan-credit` shape,
corpus-side, not an engine gap. The one orphan it does find (`entry`, unexported and uncalled) is
correct.

## 2. A third defect neither issue named

`\b\w+\b` cannot produce a token containing `-`, `:` or `.`. Any name holding one therefore counted
**zero** and satisfied `<= 1` unconditionally — it was an orphan however many times it was called:

| language | before | after | name shape |
|---|---|---|---|
| `cpp` | 1054 | **720** | `Class::method` |
| `tcl` | 210 | **148** | `::ns::proc` |
| `powershell` | 56 | **3** | `Verb-Noun` |
| `scheme` | 60 | **10** | hyphenated `define` |
| `abap` | 41 | **8** | hyphenated names |
| `cobol` | 52 | **45** | hyphenated paragraphs |

This also corrects part of #2727's own analysis. Its third table row — abap, cobol, jcl, m4,
makefile, objective-c, scheme at 3.25 orphans/file — is attributed there to names "written once,
invoked by other means". For the hyphenated members the cause was **tokenization**: the counter
could not represent the name at all. `scheme` goes 3.25 → 0.25 orphans/file in the corpus on that
alone.

## 3. #2728 — igniter-keyword buckets entered the checks as ordinary functions

dockerfile's four same-bodied `RUN` slices scored `state_slop_duplicates` **1** — the only nonzero
duplicate cell across all 46 corpus languages, and a phantom. css's `keyframes` slices cleared each
other's orphan flag by repeating the keyword.

The bucket set is **derived from each language's own `func_start`**, never hand-listed, so it cannot
drift: `_closed_literal_capture()` returns names only when the capture is provably a fixed literal
alternation and the empty set otherwise. Exactly three languages qualify — `css`, `dockerfile`,
`html` — and `test_closed_literal_capture_is_generated_not_hand_listed` pins that membership, so a
new keyword in any of those alternations is picked up automatically and a rule that can produce a
real identifier can never opt in by accident.

**Deliberately not added to `_UNCOUNTABLE_SLICE_NAMES`**, as the issue suggested. That set governs
the function *population* (#2691); removing css's ~150 at-rule slices would take `functions_found`
to 0 and make every per-function descriptor undefined — #2689's markdown/html shape. That is a real
question, owned by keyword-rosetta's `slicer-segments-statements-not-functions` entry, and it is not
#2728's measured harm. Recorded in the code rather than silently skipped.

## Verification

* Full suite **7632 passed** serially (CI's mode); 5 new detector tests, one per behaviour above.
* `tree_sitter_accuracy_audit --ci --all` 30/30 OK; `tri_comparison_chart --all --ci` 3/3 OK;
  `audit_check.py` clear; ruff and mypy at baseline.

**Golden masters re-blessed: 2278 / 2277 differences.** The scoping proof is what moved *inside*
`7. Structural Signatures`: **Orphaned Logic 581 + Public Exports 71 = 652 of 652**. No other
structural signal moved at all, which is exactly what a change confined to the orphan census should
look like. Everything else is that signal's known consumers:

| class | count |
|---|---|
| Tech Debt Exposure / `tech_debt` (orphans are dead weight) | 649 + 101 |
| Topological Coordinates X/Y/Z (corpus-wide mass re-solve) | 489 |
| API Exposure / Documentation Exposure (via the Contextual Baseline Fix) | 98 + 82 |
| Structural Magnitude / `Public Exports` | 71 + 71 |
| group + ecosystem + forensic roll-ups | 388 |

Net crucible orphans **7397 → 7803** (+5.5%): increases where the span fix removes a mask
(`typescript` +333, `livecode` +124, `php` +100, `jcl` +50, `go`/`rust` +46), decreases where the
tokenization fix stops manufacturing them.

## Cross-repo

Companion: **squid-protocol/keyword-rosetta** re-bless, owed after this merges — carries the
`rosetta:rebless-owed` label per `keyword-rosetta/docs/GATING.md`'s cross-repo flow.

Corpus impact is unusually small for a change this size: **4 cells**, `api_orphan_credit` on
`dockerfile/a.dockerfile` (1 → 0) and `scheme/{a,b,c}.scm` (3 → 0). The rosetta manifests do not
gate orphan counts directly — they see them only through the orphan→api conversion — so the
languages whose orphans move but whose api rule already declares them (ada, livecode, haskell)
record no manifest change at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfeHRWra1d6Z5uSReFajSq
