### PR TITLE
fix(detector): enforce #1295's css/html class-extraction scope decision (#2798)

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -434,6 +434,35 @@ class ScopeParsingRegistry:
 # needs the same kind of per-language hardening pass
 # epic #813 already did for func_start/args/class_start's OWN extraction
 # gauntlets -- tracked as a follow-up (#1295), not attempted wholesale here.
+# #1295: languages permanently OUT OF SCOPE for named class extraction, whatever
+# their own `class_start` rule matches. Their rule targets something that is not an
+# OOP-shaped entity at all, so the `class_data` schema it would populate
+# (`class_name`, `inheritance_parents`, `method_count`, `state_entanglement` --
+# record_keeper.py) has nowhere to put a real answer: every row would carry
+# `method_count=0`/`inheritance_parents=[]` forever. css's rule matches *selectors*
+# (`.foo`, `#bar`); html's matches a curated risk-relevant TAG list (`form`, `table`,
+# `svg`, custom elements) chosen for attack surface, not for class-likeness. The full
+# reasoning, and the instruction to re-derive from it rather than re-open the question
+# cold, is tests/extraction/how_to_extend_class_start_named_extraction.md's "Decided:
+# not extending css or html" section.
+#
+# This gate exists because the decision was documented but never *enforced*, and so was
+# silently reversed: #1824 (a css `class_start` REGEX improvement) added "css" to the
+# allowlist below five days after the decision was written, with no mention of it, and
+# css's crucible `found_classes` went 0 -> 90 in the same commit. Nothing caught it --
+# the two tools that reconcile class extraction (tree_sitter_accuracy_audit.py,
+# tri_comparison_chart.py) each force css/html's class panels to N/A *for this very
+# decision*, so the one place the reversal would have shown up was already blind to it.
+# Both now import this set instead of keeping their own copy, and
+# `test_class_extraction_scope_decision_is_enforced` fails if a language is ever added
+# to the allowlist without removing it here.
+#
+# The numeric `class_start` SIGNAL is deliberately NOT affected: the decision says so in
+# as many words ("unaffected by this decision and stays exactly as-is for both
+# languages"). css still counts 1 class_start for `.rosetta-risk {`, and that count still
+# feeds the risk equations -- what it must not do is claim a selector is a named class.
+_CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS = frozenset({"css", "html"})
+
 _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset(
     {
         # #1904: ABAP can't go through this epic's own documented
@@ -477,7 +506,6 @@ _CLASS_START_NAMED_EXTRACTION_LANGS = frozenset(
         "cobol",
         "cpp",
         "csharp",
-        "css",
         "dart",
         "fortran",
         "go",
@@ -1293,7 +1321,14 @@ class StructuralExtractor:
             # stays on the legacy fallback until their own class_start is
             # hardened for this use (see the frozenset's comment).
             rules = self.languages.get(self.primary_lang_id, {}).get("rules", {})
-            if "class_start" in rules and rules["class_start"] is None:
+            if (
+                "class_start" in rules and rules["class_start"] is None
+            ) or self.primary_lang_id in _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS:
+                # No rule at all, or a rule whose matches are not named entities
+                # (#1295: css selectors, html tags -- see
+                # _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS). Both mean "nothing to put in
+                # class_data", and the second must skip the legacy fallback too rather
+                # than rely on it happening to miss.
                 class_matches = []
                 class_start_groups = 0
             else:

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -4424,3 +4424,76 @@ def test_yaml_steps_take_their_name_from_the_adjacent_name_key():
 
     # The job-level `name:` belongs to the job, not to any step.
     assert "My Job" not in names, "a job-level name: must not be captured as a step name"
+
+
+# ==============================================================================
+# TEST: #1295'S CSS/HTML CLASS-EXTRACTION SCOPE DECISION IS ENFORCED (#2798)
+# ==============================================================================
+def test_css_selectors_never_reach_named_class_extraction():
+    """
+    Regression for #2798 / the #1824 reversal.
+
+    Epic #1295 decided permanently that css and html are out of scope for NAMED
+    class extraction: `class_data`'s schema is `class_name`/`inheritance_parents`/
+    `method_count`/`state_entanglement`, and a CSS selector has none of those, so
+    every row it produced would carry `method_count=0`/`inheritance_parents=[]`
+    forever (tests/extraction/how_to_extend_class_start_named_extraction.md,
+    "Decided: not extending css or html").
+
+    The decision was written but never enforced in the extractor, and #1824 -- a
+    css `class_start` REGEX improvement, five days later -- added "css" to
+    `_CLASS_START_NAMED_EXTRACTION_LANGS` without mentioning it, taking css's
+    crucible `found_classes` 0 -> 90 in the same commit. Nothing caught that: both
+    tools that reconcile class extraction force css/html's class panels to N/A for
+    this very decision, so the reversal landed in the one blind spot the decision
+    itself created.
+    """
+    from gitgalaxy.core.detector import (
+        _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS,
+        _CLASS_START_NAMED_EXTRACTION_LANGS,
+    )
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    assert _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS == {"css", "html"}
+    overlap = _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS & _CLASS_START_NAMED_EXTRACTION_LANGS
+    assert not overlap, (
+        f"{sorted(overlap)} is both allowlisted for named class extraction and decided "
+        "permanently out of scope for it (#1295) -- exactly how #1824 regressed. Remove it "
+        "from one set or re-derive the decision from the how-to doc's own section first"
+    )
+
+    css = StructuralExtractor("css", LANGUAGE_DEFINITIONS)
+    result = css.splice(".rosetta-risk { x: expression(1); }\n#probe-id { color: red; }\n", "")
+
+    assert result.get("classes") == [], (
+        f"css selectors reached class_data: {result.get('classes')} -- #1295 ruled named "
+        "class extraction permanently out of scope for css"
+    )
+    # The numeric signal is deliberately untouched: the decision says so in as many
+    # words ("unaffected by this decision and stays exactly as-is for both
+    # languages"). It still feeds the risk equations; what it must not do is claim a
+    # selector is a named class.
+    assert result["equations"].get("class_start") == 2, (
+        "the class_start SIGNAL must still count both selectors -- #1295 scoped its "
+        "decision to named extraction only"
+    )
+
+
+def test_html_tags_never_reach_named_class_extraction():
+    """#2798's other half. html's `class_start` matches a curated, risk-relevant TAG
+    list (`form`, `table`, `svg`, custom elements) chosen for attack surface, not for
+    class-likeness -- so an extracted `<table>` would be as wrong as an extracted
+    `.foo`. html was never in the allowlist, so today the legacy generic fallback is
+    what happens to return nothing; this pins the intent rather than the accident."""
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+    html = StructuralExtractor("html", LANGUAGE_DEFINITIONS)
+    result = html.splice("<form action='/x'>\n<table>\n<tr><td>1</td></tr>\n</table>\n</form>\n", "")
+
+    assert result.get("classes") == [], (
+        f"html tags reached class_data: {result.get('classes')} -- #1295 ruled named "
+        "class extraction permanently out of scope for html"
+    )
+    assert result["equations"].get("class_start") == 2, (
+        "the class_start SIGNAL must still count the risk-relevant tags"
+    )

--- a/tests/extraction/how_to_extend_class_start_named_extraction.md
+++ b/tests/extraction/how_to_extend_class_start_named_extraction.md
@@ -97,6 +97,22 @@ for both languages -- this is specifically about *named* extraction into `class_
 and html don't belong. **Decision: permanently out of scope for this epic.** If this gets
 revisited later, re-derive from this section rather than re-opening the question cold.
 
+**Now enforced in code (#2798).** For its first three weeks this decision lived only in prose and
+in the two *reporting* tools (`tree_sitter_accuracy_audit.py`, `tri_comparison_chart.py`, which
+each force css/html's class panels to N/A because of it) -- nothing stopped the extractor itself
+from doing the thing the decision forbade. #1824, a css `class_start` regex improvement five days
+later, added `"css"` to `_CLASS_START_NAMED_EXTRACTION_LANGS` with no mention of this section, and
+css's crucible `found_classes` went 0 -> 90 in the same commit. It went unnoticed for three weeks
+precisely *because* the class panels were already N/A: the decision had blinded the only two views
+that would have shown the reversal. It surfaced from the other end, as `classes_found[css] = 1` on
+the keyword-rosetta bias chart (gitgalaxy#2798).
+
+The decision now lives in `detector.py` as `_CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS`, checked *before*
+the allowlist and before the legacy fallback, and both reporting tools import that set instead of
+keeping their own copy. `test_css_selectors_never_reach_named_class_extraction` fails if a language
+is ever in both sets at once. To genuinely revisit the decision, edit that frozenset -- and
+re-derive from this section first, as above.
+
 ## Optional follow-up (not blocking, epic is otherwise complete)
 
 **ruby's `singleton_class`** (`class << self`/`class << @var`) is already in `NODE_MAPS["ruby"]`

--- a/tests/tools/tree_sitter_accuracy_audit.py
+++ b/tests/tools/tree_sitter_accuracy_audit.py
@@ -331,6 +331,7 @@ import tree_sitter_language_pack
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _crucible_pin import PINNED_TAG
 
+from gitgalaxy.core.detector import _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS
 from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -2779,10 +2780,23 @@ _INFORMATIONAL_METRICS = ("args_comparable",)
 _ALL_BASELINE_KEYS = (*[k for k, _ in _GATED_METRICS], *_GROUND_TRUTH_METRICS, *_INFORMATIONAL_METRICS)
 
 
-def _regressions(current: dict, baseline: dict) -> list[str]:
+def _regressions(current: dict, baseline: dict, lang: str | None = None) -> list[str]:
+    """Gated-metric regressions, minus the class metrics for a language whose class
+    panels are already forced N/A above (#2798).
+
+    Those two sets disagreed until now: the summary table and the chart refused to
+    SHOW css/html class recall because #1295 ruled named extraction out of scope for
+    them, while this gate went on requiring `found_classes` never to fall -- so the
+    gate was still pulling toward an extraction the reports had already disowned. It
+    is also what made the correct fix un-blessable: removing css from the extraction
+    allowlist reads here as `found_classes: 227 -> 0`, a "regression" toward exactly
+    the number the decision asks for.
+    """
     regressions = []
     for key, direction in _GATED_METRICS:
         if key not in baseline:
+            continue
+        if lang in _CLASS_EXTRACTION_OUT_OF_SCOPE and key.endswith("_classes"):
             continue
         cur, base = current[key], baseline[key]
         worse = cur < base if direction == "higher_is_better" else cur > base
@@ -2840,7 +2854,7 @@ def run_full_report(lang: str) -> int:
         for line in drift:
             print(f"  {line}")
 
-    regressions = _regressions(current, baseline)
+    regressions = _regressions(current, baseline, lang)
     if regressions:
         print(f"\ntree_sitter_accuracy_audit: {len(regressions)} regression(s) against the baseline:")
         for line in regressions:
@@ -2867,7 +2881,7 @@ def run_ci_check(lang: str) -> int:
         print("This means the corpus changed. Investigate before regenerating.")
         return 1
 
-    regressions = _regressions(current, baseline)
+    regressions = _regressions(current, baseline, lang)
     if regressions:
         print(f"tree_sitter_accuracy_audit: {len(regressions)} regression(s) against the baseline:")
         for line in regressions:
@@ -2891,7 +2905,7 @@ def run_regenerate(lang: str) -> int:
     _print_report(current, baseline)
 
     if baseline:
-        regressions = _regressions(current, baseline)
+        regressions = _regressions(current, baseline, lang)
         if regressions:
             print(f"\ntree_sitter_accuracy_audit: refusing to regenerate -- {len(regressions)} regression(s) present:")
             for line in regressions:
@@ -2959,7 +2973,10 @@ def run_all(mode_fn) -> int:
 # missed everything" rather than "GitGalaxy never attempts this by design". func_recall/
 # func_precision are NOT touched by this set -- func_start extraction is in scope and
 # genuinely measured for both languages.
-_CLASS_EXTRACTION_OUT_OF_SCOPE = frozenset({"css", "html"})
+# Imported, not re-declared: detector.py is where the decision is now ENFORCED (a
+# hand-kept second copy here is what let #1824 add css to the extraction allowlist
+# while this tool went on reporting its class panels as N/A for the same decision).
+_CLASS_EXTRACTION_OUT_OF_SCOPE = _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS
 
 _TABLE_BEGIN = "<!-- TREE_SITTER_ACCURACY_TABLE:BEGIN -->"
 _TABLE_END = "<!-- TREE_SITTER_ACCURACY_TABLE:END -->"

--- a/tests/tools/tri_comparison_chart.py
+++ b/tests/tools/tri_comparison_chart.py
@@ -204,8 +204,11 @@ _GG_ONLY_LANGS = (
 
 # See module docstring's CSS/HTML CLASS PANELS section -- class_start there targets
 # selector/tag-shaped entities, not OOP classes; excluded from class reconciliation entirely
-# (epic #1295 precedent), not scored and hidden.
-_CLASS_SCOPE_EXCLUDED_LANGS = frozenset({"css", "html"})
+# (epic #1295 precedent), not scored and hidden. Imported from detector.py, which is where
+# the decision is enforced, rather than kept as a third hand-copy of the same two names.
+from gitgalaxy.core.detector import (  # noqa: E402
+    _CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS as _CLASS_SCOPE_EXCLUDED_LANGS,
+)
 
 # ARGS GRANULARITY: "args" doesn't mean the same unit across every language, even when a real
 # comparison tool exists for existence. See .claude/skills/tri-comparison-ledger-sweep/SKILL.md's

--- a/tests/tree_sitter_accuracy_baseline_css.json
+++ b/tests/tree_sitter_accuracy_baseline_css.json
@@ -5,7 +5,7 @@
   "extra_classes": 0,
   "extra_functions": 0,
   "files_scanned": 21,
-  "found_classes": 227,
+  "found_classes": 0,
   "found_functions": 25,
   "real_classes": 227,
   "real_functions": 25


### PR DESCRIPTION
Closes #2798.

## What #2798 assumed, and what turned out to be there

#2798 read `classes_found[css] = 1` as a **reporting** gap: #1295 already ruled css out of scope on the tri-comparison and accuracy charts, the bias chart just never wired it in. Reading the decision itself ([`how_to_extend_class_start_named_extraction.md`, "Decided: not extending css or html"](../blob/main/tests/extraction/how_to_extend_class_start_named_extraction.md)) says otherwise:

> The `class_start` *numeric signal* (used in risk-scoring equations, a different consumer entirely) **is unaffected by this decision and stays exactly as-is** for both languages — this is specifically about *named* extraction into `class_data`.

So #1295 covers `classes_found` (which **is** `len(class_data)` — `record_keeper.py:758`) and explicitly **not** `class_start`. Those were the two rows the issue wanted marked n/a together.

## The actual defect: the decision was documented, never enforced, and silently reversed

`class_data` for the rosetta css corpus holds exactly what #1295 refused:

```
{'class_name': '.rosetta-risk', 'inheritance_parents': '[]', 'method_count': 0, 'state_entanglement': 0.0}
```

css is in `_CLASS_START_NAMED_EXTRACTION_LANGS`. It **was not** when the decision was written (2026-08-12, `6eb16c05`). **#1824** (`e46bf45d`, 2026-08-17) — a css `class_start` *regex* improvement — added one line, `"css",`, with no mention of #1295 anywhere in its description, and in the same commit:

```diff
 tests/tree_sitter_accuracy_baseline_css.json
-  "found_classes": 0,
+  "found_classes": 90,
```

Nothing caught it for three weeks **because of** the decision: `tree_sitter_accuracy_audit.py` and `tri_comparison_chart.py` each force css/html's class panels to N/A *citing #1295*, so the reversal landed in the one blind spot the decision itself created. The golden master could not catch it either — it records the `class_start` **signal** (`"Class/Entity Declarations"`), not `class_data`. It finally surfaced from the far end of the pipeline, as a red dot on keyword-rosetta's bias chart.

## The change

- **`detector.py`**: new `_CLASS_EXTRACTION_OUT_OF_SCOPE_LANGS = {"css", "html"}`, checked **before** the allowlist and **before** the legacy fallback — pinning the intent rather than relying on the generic `class|struct|interface|trait|enum` regex happening to miss. css removed from the allowlist.
- **Both reporting tools import that set** instead of each keeping a hand-copy. Three copies of the same two names is what let the extractor drift away from them.
- **`_regressions()` skips the class metrics for out-of-scope languages.** That gate was requiring `found_classes` never to fall for a language whose class panels it already refuses to show — it both pulled toward an extraction the reports had disowned and made this fix un-blessable, reading as `227 -> 0`, a "regression" toward exactly the number the decision asks for.
- Two regression tests; the decision doc records the enforcement and the #1824 history.

**The numeric `class_start` signal is deliberately untouched.** css still counts 1 for `.rosetta-risk {`, still feeding the risk equations. What it no longer does is claim a selector is a named class.

## Verification

| Check | Result |
| --- | --- |
| `pytest tests/` | **8009 passed**, 0 failed |
| `audit_check.py` (ruff/mypy/dead-key/ast-accuracy/format) | all clear |
| `crucible_check.py` (both modes) | **PASS — no golden-master bless owed** |
| `tree_sitter_accuracy_audit.py --ci --all` | 30 languages, all OK |
| `tri_comparison_chart.py --all --ci` | 3 languages, all OK |

Direct effect: css `classes` `[]` / `class_start` signal still 1; rosetta corpus `classes_found` css **1 → 0**, html 0.

The one baseline edit, css's `found_classes` 227 → 0, **is the point of the change**, not a regression — it restores the pre-#1824 number.

## Two halves of #2798 deliberately declined

1. **`class_start` for css** — #1295 explicitly exempts the numeric signal. css's `class_start` 1 is a correct reading of a real construct and stays ledgered under `container-construct-reads-as-class-start`. Marking it n/a would misquote the decision.
2. **html on either row** — html was never in the allowlist; both its cells read an honest 0 that agrees with the corpus median. Marking them n/a would delete two real green cells.

The issue's predicted outcome still lands — `classes_found` loses its css cell — without adding a second, non-mechanical n/a source (a documented scope decision, not rule absence) to the corpus tooling.

## Cross-repo

**Companion:** keyword-rosetta owes one follow-up PR, opened **after** this merges (AGENTS.md hard rule 4, no pins in either direction): narrow `container-construct-reads-as-class` by one language, since `classes_found[css]` 1 → 0 is now the corpus median and in band. No plant change, no manifest change (css's manifest pins `class_start`, which does not move), no re-bless owed; `bias-history.yml` regenerates the chart and `bias_data.json` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
