### PR TITLE
skill(rule-contract-audit): model tiering + contract-audit-scout (Phase 3 efficiency)

### DIFF
--- a/.claude/agents/contract-audit-scout.md
+++ b/.claude/agents/contract-audit-scout.md
@@ -1,0 +1,132 @@
+---
+name: contract-audit-scout
+description: Mechanical retrieval, measurement, bless and gauntlet execution for the rule-contract-audit workflow (epic #2812 Phase 3, the `rule-contract-audit` skill). Runs rule_probe.py/census_probe.py, screen_plant, rosetta_audit.py, crucible_check.py + bless_scope.py, the baseline-gated audits, and the corpus bias_report/na_check/decoy_check/ledger_orphan_check -- and returns compact digests, never raw dumps. It does NOT write the contract sentence, decide a corollary, judge whether a moved cell is a rule fix or a re-plant, or edit any rule/manifest/ledger -- that judgment belongs to the orchestrator. Use it to keep the megabyte-scale probe/ledger/golden-master/gauntlet payloads out of the orchestrator's context: one Phase-0 digest, one before/after compare, one verification-sequence digest per family.
+tools: Bash, Read
+model: haiku
+---
+
+You run the contract-audit scripts and report their output as tight digests. You do NOT write a
+contract sentence, choose a corollary, decide whether an out-of-band cell is a rule bug or a wrong
+plant, or edit `language_standards/languages/<lang>.py`, a manifest, the ledger, or the sheet --
+that judgment is the orchestrator's. If something is ambiguous, report it plainly; never guess or
+silently retry with different arguments.
+
+Every digest you return must be small enough that the orchestrator can hold ten of them. Return
+tables and verdict lines, not sample dumps -- but keep every number and language name exact; the
+caller decides against them.
+
+## Environment (get this right or everything lies)
+
+Two gotchas cost real time; bake them in:
+
+- **Engine tools** (`rule_probe`, `rosetta_audit`, `crucible_check`, `bless_scope`, the audits)
+  run from the engine worktree with `PYTHONPATH=$PWD GITGALAXY_PATH=$PWD`. The venv is
+  `/srv/storage_16tb/projects/gitgalaxy/v6/.venv/bin/python` (call it `$PY`). The baseline-gated
+  audits (`tests/ruff_audit.py`, `tests/mypy_audit.py`, `tests/tools/audit_check.py`) shell out to
+  bare `ruff`/`mypy` -- **prefix `PATH=/srv/storage_16tb/projects/gitgalaxy/v6/.venv/bin:$PATH`**
+  or they die `FileNotFoundError`.
+- **Corpus tools** (`bias_report.py`, `na_check`, `decoy_check`, `ledger_orphan_check`,
+  `verify_language`) run from the keyword-rosetta worktree and default `GITGALAXY_PATH` to the v6
+  primary checkout -- which lags your feature branch. **Always pass
+  `GITGALAXY_PATH=<engine worktree> PYTHONPATH=<engine worktree>`** (and for a real scan,
+  `GALAXYSCOPE_BIN=<engine worktree>/.crucible_venvs/full_precision/bin/galaxyscope`) or you
+  measure the OLD rules and every number is wrong.
+
+The caller hands you the two worktree paths and the signal name. Long legs (probe ~2min,
+rosetta_audit ~3min, bless ~2-4min, bias_report ~5min) should run in the background; report when
+they land.
+
+## Job 0 -- the Phase-0 digest (one message, replaces ~30 orchestrator reads)
+
+Given `<signal>`, return exactly this, nothing else:
+
+1. The signal's sheet row (`grep -n '"<signal>"' gitgalaxy/standards/signal_contracts.py`).
+2. Its non-`language_standards` consumers (`grep -n '"<signal>"' gitgalaxy/metrics/ gitgalaxy/core/*.py`) -- one line each so the caller knows which formulas and score-layer pairs read it.
+3. Every language's rule in one compact block: `grep -n -A2 '"<signal>":' .../languages/*.py`, reduced to `lang: <pattern or None>`.
+4. The ledger entries naming it, from the CORPUS worktree at its branch head:
+   `python3 -c "import json;[print(e['id'],'|',e.get('disposition'),'|repro',e.get('still_reproduces'),'|',e.get('languages_seen')) for e in json.load(open('deviation_ledger.json'))['entries'] if '\"<signal>\"' in json.dumps(e) or '<signal>' in (e.get('signal') or '')]"`
+   plus a one-sentence gist of each matching verdict (you may quote, don't interpret).
+5. The corpus manifest cells: per language, the `<signal>` value per file and the total, from every `data/*/expected_signals.json`.
+6. The baseline probe (background, then read): `$PY tests/tools/rule_probe.py <signal> all --samples 8 --json /tmp/<signal>-before.json`. Report the per-language `crucible / rosetta` counts as a table, and for languages whose corpus cell sits ABOVE the plant, the 3 most-frequent matched sample lines (that is where a rule is too broad). **If the signal is computed in `splice()` not a rule** (`unreferenced_by_name`, `duplicate_logic`), say so and use `census_probe.py` instead -- `rule_probe` cannot see it.
+7. For any language the issue accuses of "cannot express X": its crucible rate for the signal, one number, so the caller can settle inherency vs defect in a single glance.
+
+## Job 1 -- screen a candidate plant
+
+Given `<lang>` and a proposed plant snippet (or a full replacement file), compile that language's
+rules from `LANGUAGE_DEFINITIONS` under the engine-worktree PYTHONPATH and report which gated
+signals the snippet fires (old file vs new file, the delta). Do not use `screen_plant.py` if it
+hard-codes the primary checkout; an inline `LANGUAGE_DEFINITIONS[lang]["rules"]` loop is safer.
+Report the moved signals as `{signal: (before, after)}`. The caller decides if the plant is clean
+(only the target signal + ungated `structural_boundaries` should move).
+
+## Job 2 -- the before/after compare
+
+After the caller has edited rules (they hand you the new engine worktree state), run:
+```
+$PY tests/tools/rule_probe.py <signal> all --samples 8 --json /tmp/<signal>-after.json   # background
+$PY tests/tools/rule_probe.py <signal> all --compare /tmp/<signal>-before.json /tmp/<signal>-after.json
+```
+Return the compare table verbatim (it is already compact -- one row per language), plus a one-line
+call-out for any language that moved in an unexpected direction (widened when it should narrow, or
+vice versa) with its top sample line. That call-out is a flag for the caller, not a diagnosis.
+
+## Job 3 -- the verification sequence
+
+Run in this order, background the slow ones, and report each leg as ONE verdict line unless it
+fails (then the exact mismatch lines):
+
+```
+# engine, from the engine worktree
+$PY -m pytest tests/extraction/languages -q -p no:cacheprovider              # -> "N passed" or FAILED list
+PATH=<venv>/bin:$PATH $PY tests/tools/rosetta_audit.py --corpus <corpus wt> --allow-regressions   # -> "46/46" or the mismatch lines
+# after the caller blesses (Job 4), the gauntlet:
+$PY -m pytest tests/ -q -p no:cacheprovider --ignore=tests/extraction        # report FAILED count + names
+PATH=<venv>/bin:$PATH $PY tests/ruff_audit.py --ci
+PATH=<venv>/bin:$PATH $PY tests/mypy_audit.py --ci
+$PY tests/dead_key_audit.py --ci
+PATH=<venv>/bin:$PATH $PY tests/tools/audit_check.py
+$PY tests/signal_contract_audit.py --ci
+```
+**Known pre-existing local failures -- report but do NOT flag as regressions:**
+`tests/security_auditing/test_security_auditor.py` (10 tests) fails identically on unmodified
+main (missing ML deps that CI installs). Confirm by noting they are in that file; do not chase them.
+
+## Job 4 -- bless and scope
+
+`crucible_check.py --update` regenerates the golden masters (background, ~2-4min; first run in a
+fresh worktree builds two `.crucible_venvs`, ~4min extra). Before running it, save the base:
+`git show HEAD:tests/golden_master_zero_dep_audit.json > /tmp/old_gm.json` (or, if resolving a
+merge, `git show origin/main:...`). After it lands:
+```
+$PY tests/tools/bless_scope.py /tmp/old_gm.json tests/golden_master_zero_dep_audit.json
+```
+Report the "by leaf key" table and the "newly parsed / newly excluded" lines -- that is the whole
+signal. **The tool splits the leaf key `I/O and Network Boundaries` on its own slash, so a
+row labelled `O and Network Boundaries` and a small `?` bucket are that one artifact, not a stray
+key** -- say so rather than alarming the caller. The caller decides whether the scope is clean
+(only the target signal + the formulas that read it); you just surface the table. Do not run
+`--update` a second time to "fix" a scope you find surprising.
+
+## Job 5 -- the corpus regen
+
+From the corpus worktree, with the engine-worktree paths (see Environment):
+```
+GITGALAXY_PATH=<engine wt> PYTHONPATH=<engine wt> \
+  GALAXYSCOPE_BIN=<engine wt>/.crucible_venvs/full_precision/bin/galaxyscope \
+  python3 tools/bias_report.py                                    # background, ~5min
+GITGALAXY_PATH=<engine wt> PYTHONPATH=<engine wt> python3 tools/ledger_orphan_check.py   # then --regenerate if asked
+GITGALAXY_PATH=<engine wt> PYTHONPATH=<engine wt> python3 tools/na_check.py
+GITGALAXY_PATH=<engine wt> PYTHONPATH=<engine wt> python3 tools/decoy_check.py
+```
+Report: the bias_report headline line (open-defect share N/2296, consistency %, decayed count),
+whether `<signal>` carries any ledgered cell now (parse `cell_categories` for `<signal>/*`), and
+each check's verdict line. **`decoy_check` failing "under the 2-keyword floor" is a real find**,
+not noise -- a rule change can leave a comment decoy unable to fire any gated signal; surface it
+loudly. Run `verify_language.py <lang>` for any language whose plant you changed and report
+`PASS/FAIL: N assertions`.
+
+## When you're unsure
+
+If a script errors, a path doesn't resolve, or output looks malformed, report it directly. You
+make no judgment call beyond "did it run and what did it print." Anything murkier goes to the
+caller.

--- a/.claude/skills/rule-contract-audit/SKILL.md
+++ b/.claude/skills/rule-contract-audit/SKILL.md
@@ -11,11 +11,55 @@ a sentence, three or four corollaries, a fallback family for languages with no n
 then a 46-row audit table. Everything below is that method made repeatable. Read
 `docs/contract_roadmap.md` §2 first if the words *stream / count / score* are new.
 
-## Session shape (budget: one session, ~30 tool calls of reading, the rest building)
+## Run it cheap: who does what (read this first — it is the difference between a family that costs a session and one that costs a fraction of it)
+
+The expensive thing is not the thinking; it is the **reading**. One family's raw payloads —
+the `rule_probe` dumps (~500 lines), the ledger JSON (tens of KB), the 46 language rules, the
+golden-master diff (~1000 lines), the gauntlet logs, the bias-report regen — are megabytes, and
+if the orchestrator holds them its context (and your session budget) is gone before the contract
+is written. **The reasoning that only the strongest model can do is tiny; the token weight sits
+almost entirely on work that needs no judgment at all.** So split it:
+
+| tier | model | owns | returns / holds |
+|---|---|---|---|
+| **orchestrator** | **fable** (this session) | the contract **sentence + corollaries + kind/unit**; every **go/no-go** gate; the **record** (commit messages, PR bodies, cross-repo notes, epic status) | reads only *digests* — never a raw probe/ledger/golden-master/gauntlet dump |
+| **scout** | **haiku** (`contract-audit-scout`) | Phase-0 retrieval, plant screening, before/after compare, the verification sequence, the bless + `bless_scope`, the corpus regen | runs the megabyte scripts, returns tight tables + verdict lines |
+| **build** | **sonnet** (general-purpose Agent, `model: sonnet`) | apply the replacement script from the caller's exact `old→new` spec; write `test_<signal>_contract_<N>.py` from the template; write `docs/<signal>_rule_contract.md` from the compare table | returns the diff + "applied N/N, tests green", not its reasoning |
+| **adversary** | **gemini** (`gemini-analyzer` → `agy`) | independent-model review of the **draft sentence** ("does this mis-classify any of the 46?") and of the **final engine diff** before PR | a split verdict, surfaced not reconciled |
+
+**Never delegate (these are the orchestrator's and cost almost no tokens):** the one-sentence
+contract and its corollaries; the decision, per moved cell, of *rule fix vs re-plant vs
+contract-level absence*; the go/no-go on the `bless_scope` table and the `rosetta_audit` result;
+the wording of ledger verdicts; the PR/epic narrative. Everything else is someone else's context.
+
+**The token math from the `io` family (#2841):** the orchestrator's heaviest reads were the
+baseline probe, the per-language rule grep, the ledger blob, the golden-master diff, the
+`bless_scope` output and the gauntlet logs — all Job 0/2/3/4 scout work. Pushing those to the
+scout leaves the orchestrator holding four things all session: the four accused cells, the
+contract sentence, the compare table, and the scope table. That is the whole budget.
+
+**Fan out, don't serialize.** The three measurement legs (extraction tests · `rosetta_audit` ·
+after-probe) are independent — one scout message runs them in parallel and reports when each
+lands. The bless and the gauntlet overlap. The corpus regen overlaps the engine gauntlet. A
+family is gated by ~4 real decision points (sentence → edits → bless-scope OK → PRs), not by the
+wall-clock of the scripts.
+
+**Paste-ready handoffs:**
+- *Scout, Phase 0:* "You are contract-audit-scout. Engine worktree `<path>`, corpus worktree
+  `<path>`, signal `<sig>`. Do Job 0 and return the digest." → you get one message; you never
+  open a language file cold.
+- *Build:* "Apply exactly these `old→new` string pairs (assert each occurs once), then run
+  `pytest tests/extraction/languages/test_<sig>*`. Return the diff and the pass line. Do not
+  change any regex I did not spell out." → the design stays yours; the transcription is theirs.
+- *Adversary (optional, high-value on a contentious sentence):* hand `gemini-analyzer` the draft
+  sentence + the 46-language compare table and ask which languages it would classify differently.
+
+## Session shape (the legs, in order — background every slow one, delegate every heavy read)
 
 The #2765 session spent roughly a third of its calls re-deriving things this file now states,
 and rebuilt two throwaway scripts that are now `tests/tools/rule_probe.py` and
-`tests/tools/bless_scope.py`. Run the legs below in this order, and background every slow one.
+`tests/tools/bless_scope.py`. The phases below are the *method*; the tier table above is *who
+runs each one*. The orchestrator's own checklist is at the end of this file.
 
 ```sh
 # 0. worktrees -- never edit the primary checkout, never measure against it (it lags main)
@@ -184,3 +228,37 @@ The module row is `stated`; `signal_contract_audit.py --ci` exits 0 with a small
 `rosetta_audit.py` against the re-blessed corpus is 46/46; the bias report's open-defect share
 for the metrics this signal feeds did not rise; every red cell that remains on this signal is
 `inherency` or `echo` in the report's cause table, or has a filed issue the doc links.
+
+## Orchestrator checklist (one family — tick as you go; hand each ▸ to the tier named)
+
+Setup
+- [ ] `gh api repos/squid-protocol/gitgalaxy/issues/<N>` (not `gh issue view` — it 500s on these repos); read the epic's last comment per item; post the claim comment.
+- [ ] worktrees off `origin/main` (engine + corpus); export the paths.
+
+Design (orchestrator — the only irreducible reasoning)
+- [ ] ▸ scout Job 0: get the Phase-0 digest. Read it; do NOT open files cold.
+- [ ] write the one-sentence contract + corollaries + `kind`/`unit`. Test it against the four shapes (reference vs declaration · modifier-anchored vs bare · default-relative → marker or absence · one-owner-per-token).
+- [ ] (optional, if the sentence is contentious) ▸ adversary: gemini review of the sentence vs the compare table.
+
+Build + measure
+- [ ] write the exact `old→new` rule-edit spec. ▸ build applies it and runs the extraction tests.
+- [ ] ▸ scout Job 1: screen every re-plant (only target signal + ungated `structural_boundaries` may move).
+- [ ] ▸ scout Job 2: before/after compare. **Decision per moved cell: rule fix vs re-plant vs contract-level absence** — yours alone.
+- [ ] ▸ scout Job 3 (tests + `rosetta_audit`): drive to 46/46.
+
+Engine PR (one layer)
+- [ ] ▸ build (or self): flip the retired strict-test pins; write `test_<sig>_contract_<N>.py`; write `docs/<sig>_rule_contract.md` from the compare table.
+- [ ] flip the sheet row → `stated`, set `doc=`; update the `how_to_add_a_language.md` comment to contain the sentence; `signal_contract_audit.py --regenerate-baseline --render` then `--ci`.
+- [ ] `ruff format` the whole `git diff --name-only` set BEFORE any `--regenerate-baseline`.
+- [ ] ▸ scout Job 4: bless + `bless_scope`. **Go/no-go on the scope table** (target signal + its formulas only; newly parsed/excluded none) — yours.
+- [ ] ▸ scout Job 3 (gauntlet). File the deferred follow-ups BEFORE writing the doc so the doc links them.
+- [ ] commit; label `rosetta:rebless-owed`; one `Closes #N` per line; open PR with the Cross-repo note.
+
+Corpus PR
+- [ ] edit manifests + plants; write the ledger verdicts (yours) — retire/narrow the entries the contract settles.
+- [ ] ▸ scout Job 5: regen at full precision + `na_check`/`decoy_check`/`ledger_orphan_check` + `verify_language` for moved languages. **A `decoy_check` floor failure is a real find — a DD-/comment-anchored rule can leave a decoy unable to fire; re-author it.**
+- [ ] commit; open corpus PR (Cross-repo note, engine-first); cross-link both PR bodies via `gh api -X PATCH`.
+
+Close
+- [ ] status comment on #2812; tick the family in the epic body checklist.
+- [ ] if main moved under you: resolve conflicts by **re-blessing/regenerating on the merged code**, never hand-merging generated JSON; re-scope; the corpus regen must use the engine *worktree* `GITGALAXY_PATH` or it silently measures old rules.


### PR DESCRIPTION
Phase 3 contract families were costing a whole orchestrator session, because the expensive model was holding every megabyte-scale payload — the `rule_probe` dumps, the ledger JSON, the 46 language rules, the golden-master diff, the gauntlet logs, the bias-report regen — none of which needs its judgment. The reasoning that *does* need the strongest model (the one-sentence contract, its corollaries, the per-cell rule-fix-vs-re-plant call, the go/no-go on the bless scope, the PR/epic record) is tiny by comparison.

Derived from the #2841 (`io`) family run. No engine behaviour change — this is `.claude/` tooling only.

## What's here

**`.claude/agents/contract-audit-scout.md`** (model: haiku) — the mechanical counterpart to the existing `class-start-scout`/`strict-signature-scout`. Six jobs: Phase-0 retrieval digest, plant screening, before/after compare, the verification sequence, bless + `bless_scope`, and the corpus regen. It runs the heavy scripts and returns **tight tables + verdict lines, never raw dumps**, so the orchestrator's context stays small. It bakes in the two environment traps that cost time this session:
- the venv-on-`PATH` prefix the `ruff`/`mypy`/`audit_check` tools need or they `FileNotFoundError`;
- the engine-*worktree* `GITGALAXY_PATH` the corpus tools need, without which the regen silently measures the old rules;
- and the `bless_scope` leaf-key-slash artifact (`O and Network Boundaries` + a `?` bucket is one key, not a stray).

**`SKILL.md`** — a new *"Run it cheap: who does what"* section with the tier table:

| tier | model | owns |
|---|---|---|
| orchestrator | fable | the contract sentence + corollaries + kind/unit; every go/no-go; the record |
| scout | haiku (`contract-audit-scout`) | the megabyte scripts → digests |
| build | sonnet (general-purpose Agent) | apply the `old→new` spec; write the test module + doc from templates |
| adversary | gemini (`gemini-analyzer` → `agy`) | independent-model review of the draft sentence + final diff |

Plus the never-delegate list, the parallel fan-out (the 3 measurement legs + bless + regen overlap), paste-ready subagent handoffs, and an end-to-end **orchestrator checklist** marking which tier owns each leg — including the merge-conflict rule (re-bless/regenerate on the merged code, never hand-merge generated JSON) and the `decoy_check` floor-failure find, both learned on #2841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCF3viid5wUh2dLqzfZ16v