### PR TITLE
fix(detector): a COBOL paragraph's ENTRY ... USING is its parameter declaration and belongs inside its args window (#2863)

### DIFF
--- a/gitgalaxy/core/detector.py
+++ b/gitgalaxy/core/detector.py
@@ -792,6 +792,18 @@ _ASSEMBLY_DATA_DIRECTIVE_RE = re.compile(
 # physical line (never unbounded input), so this stays a fixed-cost check.
 _DOCKERFILE_HEREDOC_OPENER_RE = re.compile(r"<<-?[ \t]*(?:['\"]?)([A-Za-z_][A-Za-z0-9_]{0,60})(?:['\"]?)[ \t]*$")
 
+# #2863: matches a COBOL `ENTRY` statement at the start of a physical line,
+# tolerating the fixed-format sequence area (cols 1-6) and indicator column
+# (col 7) the same way cobol's own `func_start`/`class_start` patterns do.
+# A paragraph's alternate entry point is declared by an `ENTRY 'NAME' USING
+# ...` statement on the line(s) AFTER the paragraph label -- the label is
+# terminated by its own period, so the declaration is a separate statement --
+# and this is what lets _mode_a_args_window_end reach it without reaching
+# anything else. Deliberately anchored to the line's first token: a `CALL
+# ... USING` (an invocation, which passes arguments rather than declaring
+# them) can never match, which is the distinction the window exists to keep.
+_COBOL_ENTRY_STATEMENT_RE = re.compile(r"^(?:[0-9a-zA-Z \t]{6}[ \-]?)?[ \t]*ENTRY\b", re.IGNORECASE)
+
 
 def _resolve_class_start_match(match: re.Match, groups_count: int) -> tuple[Optional[int], str, list[str]]:
     """Given a `class_start` regex match and its pattern's total capture-group
@@ -3111,7 +3123,11 @@ class StructuralExtractor:
     # primary_lang_id. Deliberately NOT a generic "any trailing symbol"
     # rule -- cobol's fixed-format continuation is a column-7 indicator on
     # the CONTINUING line, not a trailing marker on the line before, so
-    # cobol legitimately gets no entry here and stays single-line-only.
+    # cobol legitimately gets no entry here. #2863: that is still correct,
+    # and it is also not the whole story -- a COBOL paragraph declares its
+    # parameters in a separate `ENTRY` statement on the following line, not
+    # in a continuation of the label line, so cobol is routed to
+    # `_cobol_args_window_end` before this map is consulted.
     # jcl's marker is a bare trailing comma: any `//` statement line ending in
     # `,` continues onto the next `//` line by real JCL syntax (no separate
     # indicator column the way cobol/fixed-format languages use) -- this
@@ -3135,7 +3151,11 @@ class StructuralExtractor:
         inside a still-open Dockerfile heredoc body (`<<EOF ... EOF`) --
         stopping at the first line that's neither, which is the real end of
         the label's own signature/statement. A language with no
-        continuation marker (cobol) never extends past its own first line.
+        continuation marker never extends past its own first line -- which
+        is why cobol no longer comes through here at all: its parameter
+        declaration is a separate `ENTRY` statement rather than a
+        continuation of the label line, so it needs a window rule of its own
+        (`_cobol_args_window_end`, #2863) rather than a marker entry.
         For fortran specifically, a blank line, a full `!...` comment line,
         or a C-preprocessor line (`#ifdef`/`#endif`/etc. -- real-world `.F`
         files like WRF's are cpp-preprocessed) carries no continuation
@@ -3155,6 +3175,8 @@ class StructuralExtractor:
         regex backtracking), so a generous cap costs nothing at the common
         (short) case and only matters for genuinely pathological input.
         """
+        if self.primary_lang_id == "cobol":
+            return self._cobol_args_window_end(code, start_idx, hard_limit_idx)
         marker = self._MODE_A_ARGS_CONTINUATION_MARKER.get(self.primary_lang_id)
         is_fortran = self.primary_lang_id == "fortran"
         pos = start_idx
@@ -3199,6 +3221,73 @@ class StructuralExtractor:
                 continue
             return min(line_end + 1, hard_limit_idx)
         return min(pos, hard_limit_idx)
+
+    # #2863: how many physical lines of leading `ENTRY` statements one COBOL
+    # paragraph may declare before the scan gives up. A paragraph declares one
+    # alternate entry point in practice and a handful at the very most; this is
+    # only here so a pathological file cannot turn a per-label check into a
+    # whole-file walk.
+    _COBOL_ENTRY_SCAN_LINES: ClassVar[int] = 24
+
+    def _cobol_args_window_end(self, code: str, start_idx: int, hard_limit_idx: int) -> int:
+        """Bound a COBOL paragraph's args-search window to the label line PLUS
+        any `ENTRY` statements that immediately follow it (#2863).
+
+        COBOL is the one Mode A language whose parameter declaration cannot sit
+        on the label's own line. A paragraph name is terminated by its own
+        period, so the `ENTRY 'PARA-NAME' USING <linkage-item>` that declares
+        the paragraph's alternate entry point is necessarily a SEPARATE
+        statement on the next line. The generic
+        `_mode_a_args_window_end` walk extends only across a language's
+        line-continuation marker, and cobol correctly has none (its
+        fixed-format continuation is a column-7 indicator on the CONTINUING
+        line, not a trailing marker on the line before), so the window was
+        exactly the label line and the declaration always fell one line
+        outside it -- `hit_vector['args']` counted the clause while the
+        function's own `args` read 0, in the same record.
+
+        Only leading `ENTRY` lines extend the window, and that narrowness is
+        the whole point rather than caution. Measured over the real-world
+        crucible COBOL corpus (570 files, 10155 paragraphs), 158 paragraphs
+        have a `USING`/`RETURNING` somewhere inside their greedy Mode A block
+        and NONE of them is a parameter declaration: 123 are `CALL ... USING`
+        (an invocation -- it passes arguments to a subprogram rather than
+        declaring the paragraph's own), 26 are the program-level `PROCEDURE
+        DIVISION USING` swallowed by a preceding label's greedy block, 3 are
+        `XML PARSE ... RETURNING`, and the rest are `CALL` continuation lines
+        and a `MOVE "USING OPERANDS"` string literal. Widening this window to
+        the block -- the unbounded behaviour #1973/#2483 removed -- would
+        therefore manufacture 158 wrong per-paragraph parameter counts to fix
+        nothing, which is exactly why the bound exists and why `CALL` cannot
+        match `_COBOL_ENTRY_STATEMENT_RE`.
+
+        Blank lines are transparent, for a concrete reason rather than for
+        symmetry with the fortran branch above: `prism` blanks comment lines
+        in place to preserve line numbering, so a banner comment between a
+        paragraph label and its `ENTRY` -- ordinary COBOL house style --
+        reaches this scan as an empty line. Stopping on it would make the fix
+        depend on whether the author commented the paragraph.
+        """
+        window_end = code.find("\n", start_idx)
+        if window_end == -1 or window_end >= hard_limit_idx:
+            return hard_limit_idx
+        window_end += 1
+        scan = window_end
+        for _ in range(self._COBOL_ENTRY_SCAN_LINES):
+            if scan >= hard_limit_idx:
+                break
+            line_end = code.find("\n", scan)
+            if line_end == -1 or line_end >= hard_limit_idx:
+                break
+            line = code[scan:line_end]
+            if not line.strip():
+                scan = line_end + 1
+                continue
+            if _COBOL_ENTRY_STATEMENT_RE.match(line):
+                scan = window_end = line_end + 1
+                continue
+            break
+        return min(window_end, hard_limit_idx)
 
     def _slice_by_labels(
         self,

--- a/tests/core_engine/test_detector.py
+++ b/tests/core_engine/test_detector.py
@@ -4617,3 +4617,98 @@ def test_synthesizes_all_function_names_is_the_reportable_form_of_the_same_rule(
 
     # markdown qualifies on rule absence; sqlite must qualify on slicing mode.
     assert StructuralExtractor("sqlite", LANGUAGE_DEFINITIONS)._slices_by_terminator
+
+
+def test_cobol_paragraph_entry_using_is_inside_the_args_window_2863():
+    """
+    #2863: a COBOL paragraph declares its parameters in an `ENTRY 'NAME'
+    USING <item>` statement on the line AFTER the label -- a paragraph name is
+    terminated by its own period, so the declaration is necessarily a separate
+    statement. `_mode_a_args_window_end` extends only across a language's
+    line-continuation marker and cobol correctly has none (its fixed-format
+    continuation is a column-7 indicator on the CONTINUING line), so the
+    window used to be exactly the label line and the declaration always fell
+    one line outside it. The symptom was a single function record disagreeing
+    with itself: `hit_vector["args"] == 1` (the block's own rule tally, which
+    sees the clause) while `args == 0` (the bounded per-function count, which
+    `avg_func_args` averages).
+
+    `_cobol_args_window_end` now extends the window across leading `ENTRY`
+    statements only. This test pins both halves of that -- what must now be
+    reached, and what must still be out of reach:
+
+    - `PROBE-GLOBALS` declares one operand and must measure 1.
+    - `PROBE-MULTI` declares three (`USING A, B, C`) and must measure 3, which
+      is also what proves #2830's `_count_cobol_using_operands` reaches the
+      per-function path and not just the file-level count.
+    - `PROBE-COMMENTED` has a banner comment between its label and its `ENTRY`.
+      `prism` blanks comment lines in place to preserve line numbering, so that
+      reaches the window scan as an empty line; blank lines must be transparent
+      or the measurement would depend on whether the author commented the
+      paragraph.
+    - `PROBE-CALLER` must stay at 0. `CALL ... USING` is an INVOCATION -- it
+      passes arguments to a subprogram rather than declaring the paragraph's
+      own -- and is by far the dominant shape in real COBOL: over the
+      language-crucible corpus (570 files, 10155 paragraphs) 123 of the 158
+      unattributed `USING`/`RETURNING` clauses are `CALL`, and none of the 158
+      is a parameter declaration. Widening this window to the block would
+      manufacture wrong per-paragraph counts, which is exactly what the bound
+      added by #1973/#2483 exists to prevent.
+    - `PROBE-LATE` must stay at 0: only LEADING `ENTRY` statements extend the
+      window, so an `ENTRY` that appears after an ordinary statement is not
+      swept in.
+    """
+    from gitgalaxy.standards.gitgalaxy_config import LEXICAL_FAMILY_HEURISTICS
+    from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+    from gitgalaxy.core.prism import Prism
+
+    source = (
+        "       PROBE-GLOBALS.\n"
+        "           ENTRY 'PROBE-GLOBALS' USING ARGV-BLOCK.\n"
+        "           DISPLAY REGION-ITEM.\n"
+        "       PROBE-MULTI.\n"
+        "           ENTRY 'PROBE-MULTI' USING WS-A, WS-B, WS-C.\n"
+        "           DISPLAY REGION-ITEM.\n"
+        "       PROBE-COMMENTED.\n"
+        "      * banner comment between the label and its ENTRY\n"
+        "           ENTRY 'PROBE-COMMENTED' USING ARGV-BLOCK.\n"
+        "           DISPLAY REGION-ITEM.\n"
+        "       PROBE-CALLER.\n"
+        "           CALL 'CSUTLDTC' USING WS-A, WS-B, WS-C.\n"
+        "           DISPLAY REGION-ITEM.\n"
+        "       PROBE-LATE.\n"
+        "           DISPLAY REGION-ITEM.\n"
+        "           ENTRY 'PROBE-LATE' USING ARGV-BLOCK.\n"
+    )
+    prism = Prism(LEXICAL_FAMILY_HEURISTICS, LANGUAGE_DEFINITIONS)
+    code = prism.split_streams(source, "cobol")["code_stream"]
+    result = StructuralExtractor("cobol", LANGUAGE_DEFINITIONS).splice(code, "")
+
+    found = {fn["name"]: fn for fn in result.get("functions", [])}
+    for name in ("PROBE-GLOBALS", "PROBE-MULTI", "PROBE-COMMENTED", "PROBE-CALLER", "PROBE-LATE"):
+        assert name in found, f"{name} should be extracted as a paragraph, got {sorted(found)}"
+
+    assert found["PROBE-GLOBALS"]["args"] == 1, (
+        "a paragraph's own ENTRY ... USING must be inside its args window, "
+        f"got {found['PROBE-GLOBALS']['args']}"
+    )
+    assert found["PROBE-MULTI"]["args"] == 3, (
+        "#2830's operand counting must reach the per-function path, "
+        f"got {found['PROBE-MULTI']['args']}"
+    )
+    assert found["PROBE-COMMENTED"]["args"] == 1, (
+        "a blanked comment line between the label and its ENTRY must be transparent, "
+        f"got {found['PROBE-COMMENTED']['args']}"
+    )
+    assert found["PROBE-CALLER"]["args"] == 0, (
+        "CALL ... USING is an invocation, not a declaration, and must never be "
+        f"counted as the paragraph's own parameters, got {found['PROBE-CALLER']['args']}"
+    )
+    assert found["PROBE-LATE"]["args"] == 0, (
+        "only LEADING ENTRY statements extend the window, "
+        f"got {found['PROBE-LATE']['args']}"
+    )
+
+    # The defect's signature: the block's rule tally saw the clause all along.
+    # PROBE-CALLER keeps that disagreement, and it is correct for it to.
+    assert found["PROBE-CALLER"]["hit_vector"].get("args", 0) == 1


### PR DESCRIPTION
Closes #2863.

COBOL is the one Mode A language whose parameter declaration cannot sit on the label's own line. A paragraph name is terminated by its own period, so the `ENTRY 'PARA-NAME' USING <linkage-item>` that declares the paragraph's alternate entry point is necessarily a **separate statement on the next line**.

`_mode_a_args_window_end` extends a label's args-search window only across the language's line-continuation marker, and cobol correctly has none — its fixed-format continuation is a column-7 indicator on the *continuing* line, not a trailing marker on the line before. So the window was exactly the label line and the declaration always fell one line outside it. The symptom was one function record disagreeing with itself:

```
PROBE-GLOBALS: args=0   hit_vector.args=1
```

`hit_vector`, the block's own rule tally, saw the clause all along. The bounded per-function `args` field — the one `avg_func_args` averages (`signal_processor.py` ~L589) — read 0.

**The gap was total, not marginal:** not one of the **10,155 paragraphs across the 570-file** language-crucible COBOL corpus had a nonzero per-function args count. `avg_func_args` was structurally 0 for the language.

## The fix

cobol routes to a new `_cobol_args_window_end`, which extends the window from the label line across **leading `ENTRY` statements only**, treating blank lines as transparent.

### Only `ENTRY` — the narrowness is the point, not caution

I measured what a wider window would actually pick up. Over the crucible corpus, 158 paragraphs carry a `USING`/`RETURNING` somewhere inside their greedy Mode A block, and **not one of them is a parameter declaration**:

| count | construct | what it is |
|---|---|---|
| 123 | `CALL … USING` | an **invocation** — passes arguments to a subprogram, does not declare the paragraph's own |
| 26 | `PROCEDURE DIVISION USING` | the program-level linkage, swallowed by a preceding label's greedy block |
| 3 | `XML PARSE … RETURNING` | a statement clause |
| 6 | `CALL` continuation lines, and a `MOVE "USING OPERANDS"` string literal | |

Widening this window to the block — the unbounded behaviour #1973/#2483 removed — would manufacture **158 wrong per-paragraph parameter counts to fix nothing**. `_COBOL_ENTRY_STATEMENT_RE` is anchored to the line's first token, so `CALL` can never match it; the distinction is structural rather than incidental.

### Blank lines are transparent for a concrete reason

Not for symmetry with the fortran branch: `prism` blanks comment lines **in place** to preserve line numbering, so a banner comment between a paragraph label and its `ENTRY` — ordinary COBOL house style — reaches the scan as an empty line. Stopping on it would make the measurement depend on whether the author commented the paragraph.

## Verification

- **Golden masters: `crucible_check.py` PASS on both venvs, zero diff.** The real corpus contains no `ENTRY … USING` at all, so no real-world count moves and the 158 correctly-unattributed clauses stay unattributed — a *provable* zero-diff on real COBOL, not an unreviewed bless.
- **keyword-rosetta shell** (corpus `main`, which plants the construct): `avg_func_args` **0.0 → 0.6923** (9 of 13 paragraphs declare one operand).
- **Full pytest suite green** — 8,156 passed, 0 failed. `audit_check.py` all clear (ruff 70-finding baseline + format clean, mypy 2-error baseline, dead-key, ast-accuracy).
- New regression test `test_cobol_paragraph_entry_using_is_inside_the_args_window_2863` pins **both halves** — what must now be reached (1 operand; 3 operands, which also proves #2830's `_count_cobol_using_operands` reaches the per-function path; a comment-separated `ENTRY`) and what must stay out of reach (`CALL … USING` at 0; a non-leading `ENTRY` at 0). Confirmed it **fails on `main`** (`got 0`) and passes here.

## Corpus

**No re-bless owed** — `verify_language.py cobol` passes unchanged (81 assertions), because this moves a derived metric and no planted manifest count. That is why this PR does not carry `rosetta:rebless-owed`.

keyword-rosetta owes a **ledger** change instead, which I'll open right after this merges: retire `cobol-entry-args-outside-mode-a-window` (its gap is fixed) and replace it with a live entry for the residual, per GATING.md's rule that a retired entry explains nothing.

`avg_func_args` lands at **−30.8%** against the 1.0 median rather than green, and that residue is honest morphology already priced in #2804: main.cbl's four paragraphs carry no `ENTRY`, and giving them one measures **api 1 → 5** (screened), trading a planted, scored column to move a derived one.

Related: #2804 (parent), #2830 (the operand-count fix this completes), #1973 / #2483 (why the bound exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
