### PR TITLE
safety contract (#2869): stated sentence + corollaries, 15 rules edited, two open cells to zero, golden masters re-blessed

### DIFF
--- a/docs/safety_rule_contract.md
+++ b/docs/safety_rule_contract.md
@@ -1,0 +1,316 @@
+# The `safety` rule contract (#2869)
+
+> **A site that handles or forestalls a runtime failure at the value level —
+> a guarded region's opener or its typed handler, a runtime assertion or
+> validation call, a fallback or handled-absence form, an installed failure
+> handler or watchdog, or a hardening instruction — in a form an ordinary
+> identifier, type annotation or constructor cannot match.**
+
+Stated 2026-09-07 by the #2869 audit (roadmap Phase 3, epic #2812).
+Precedents: `docs/api_rule_contract.md` (#2730), `docs/args_rule_contract.md`
+(#2773), `docs/state_mutation_rule_contract.md` (#2765),
+`docs/branch_rule_contract.md` (#2822), `docs/io_rule_contract.md` (#2841),
+`docs/test_rule_contract.md` (#2852), `docs/func_start_rule_contract.md` and
+`docs/class_start_rule_contract.md` (#2856), `docs/globals_rule_contract.md`
+(#2858). The machine-readable row is `gitgalaxy/standards/signal_contracts.py`
+(`status="stated"`, `doc="docs/safety_rule_contract.md"`, `issue=2869`); the
+cross-language pins are
+`tests/extraction/languages/test_safety_contract_2869.py`.
+
+`safety` is a **site**-kind signal. Its consumers: the high_risk×safety
+proximity pair's silencer dampeners (`spatial_correlation.py:215` — safety
+positions dampen amplified-RCE hits), `_calc_safety` (`WEIGHT_DEFENSE`,
+fidelity-weighted), the safety_score formula (`verification·fid_test +
+safety·fid_safety − bypassed·2.0`), `FIDELITY_SIGNALS`, the "Error &
+Exception Exposure" report row, the `statistical_auditor` extraction-density
+group. Before this contract it carried 2 of the report's 19 open-defect
+cells (embedded_python, haskell — both `extraction` in the cause table);
+after it, every corpus language reads **2**.
+
+## Corollaries
+
+**C1 · Value-level, not declaration-level.** A type name, constructor or
+annotation is invisible to the rule; the runtime call, guarded arm or
+handled-absence form is the shape that counts. haskell's bare data
+constructors (`Just`, `Nothing`, `Right`, `Left`) drop — a constructor in an
+ordinary expression is not a handled-absence site — leaving the value-level
+forms `fromMaybe` and the total-match `Nothing ->` arm. rust drops the type
+names (`Option`, `Result`) and the smart-pointer group (`Mutex`, `RwLock`,
+`Arc`, `Rc`, `Box`, `RefCell`) and the bare constructors (`Ok`, `Err`,
+`Some`, `None`), keeping the fallback family (`unwrap_or`, `unwrap_or_else`,
+`unwrap_or_default`, `ok_or`, `ok_or_else`, `map_or`, `map_or_else`) and the
+handled `None =>` arm. scala drops `Option`/`Some`/`None`/`Success`/`Failure`/
+`Either`/`Left`/`Right`/`sealed`/`| Null`, keeping `require`/`assert`/
+`assume`/`Try(`. java and groovy drop `Optional` (a type name); python drops
+`dataclass`/`Field`/`TypeGuard`/`override` (declaration/type-level markers,
+#2822's boundary restated on the safety side). This is #2822's `typescript
+unknown|never|void` finding (`typescript-type-keywords-count-as-safety`,
+already retired) generalized: a type annotation is not a defensive construct
+any more than `IORef Int` in a signature is a write
+(`docs/state_mutation_rule_contract.md` C2).
+
+**C2 · Raising is not handling.** A construct that signals a failure outward
+is not the same as one that handles or forestalls it. go drops
+`errors.New` (constructs an error, does not handle one) while keeping
+`errors.Is`/`errors.As`/`errors.Join` and `recover()`. lua drops `error(`
+(raises) while keeping `pcall`/`xpcall`/`assert`. kotlin drops `error()`
+(throws `IllegalStateException`) while keeping `require`/`requireNotNull`/
+`check`/`checkNotNull`. livecode drops its `throw` alternative — the last
+remaining half of the batch4 `livecode throw (safety+branch)` dual
+(`batch4-dual-keyword-overlaps`) — retiring that entry's safety side.
+
+**C3 · One verified owner.** A token that also belongs to another signal's
+contract is that signal's alone unless the ledger names a genuine dual
+(the fortran-COMMON shape, `docs/globals_rule_contract.md` C5). haskell's
+`bracket`/`finally`/`onException` are cleanup's (`cleanup`:
+`\b(hClose|close|free|bracket|finally|onException)\b`) — resolving
+`haskell-finally-dual-cleanup-safety`, which still reproduced through
+#2858. lua's `<close>`/`<toclose>` are cleanup's; `<const>` is
+immutability's. go's `sync.Once`/`sync.WaitGroup` are concurrency-adjacent
+and drop with the smart-pointer-style group; `context.Context` is a type
+name (C1). cobol's `ON ERROR`/`AT END`/`INVALID KEY` stay branch's — the
+`branch-contract-2822` disposition, verified unchanged, not touched here.
+
+**C4 · Structure and reflection are not safety.** cobol's `END-IF`/
+`END-PERFORM`/`END-EVALUATE`/`END-READ`/`END-WRITE`/`END-COMPUTE`/`END-CALL`
+are block closers, not runtime guards — `DECLARATIVES`/`VALIDATE`/`CHECK`
+are the value-level forms, hyphen-guarded in the #2622 shape
+(`(?<!-)\b(...)\b(?!-)`, so `PARA-VALIDATE.` stays an identifier). assembly's
+`enter`/`leave`/`.align`/`.p2align` are frame/alignment structure; the
+CFI and pointer-authentication hardening instructions (`endbr64`,
+`paciasp`, `autiasp`, `bti`, `retab`) stay — a hardening instruction is
+exactly the sentence's last clause. python's bare `getattr` is
+reflection_metaprogramming's (mass conserved: `hasattr` stays, `getattr`
+alone is a read, not a guard).
+
+**C5 · The ambiguity anchor.** An everyday word or an ordinary quoting form
+fires only in its runtime-guard shape:
+
+- **shell** — a bare `"$@"`/`"$*"` or any `"${...}"` quoted expansion is
+  ordinary shell quoting, not a guard; the fallback operator
+  (`${VAR:-default}`, `${VAR:=default}`, `${VAR:?msg}`) is the value-level
+  form and stays, alongside `set -e`/`set -eu`/`set -o pipefail`, a `trap`
+  on `ERR`/`EXIT`/`INT`/`TERM`, and `command -v`. Crucible 2,985 → 777.
+- **objective-c** — bare `nil`/`Nil` is every null literal in the language,
+  not a safety-specific site; `NSError` is a type name (C1). The ARC
+  qualifiers (`__weak`, `__strong`, `__auto_type`) and the assertion macros
+  (`NSAssert`, `NSParameterAssert`) stay — zeroing weak references are a
+  runtime crash-prevention mechanism, kept under this corollary rather than
+  retired with the bare-null noise. Crucible 31 → 0 (an honest zero: the
+  corpus sample carried no ARC/assertion vocabulary, only bare `nil`).
+- **kotlin** — a bare `fold` is an ordinary fold over a collection or
+  string, not a `Result`-handling call; it drops with `sealed` and `Result`
+  (C1) and `error()` (C2), leaving `require`/`requireNotNull`/`check`/
+  `checkNotNull`/`is`/`!is`/`onSuccess`/`onFailure`/`runCatching`.
+
+**C6 · Deliberate duals are kept, not retired.** A token verified as a
+genuine two-construct site stays in both rules; only the disproven pairings
+(C2's `throw`, C3's cleanup/concurrency tokens) leave.
+
+| token | rules | why both are right | disposition |
+|---|---|---|---|
+| dockerfile `HEALTHCHECK` | func_start + safety | it is both the container's declared entry point and its installed watchdog | pre-existing, `docs/func_start_rule_contract.md`/`docs/class_start_rule_contract.md` (#2856) |
+| rust `if let` | branch + safety | `if` is a decision point (branch's) and the `let`-pattern match is the handled-absence form (safety's) | pre-existing, `docs/branch_rule_contract.md` (#2822) |
+| scala `Try(...)`/`Try {` | safety + immutability_locks | a guarded region opener is also `val`-adjacent immutable-binding vocabulary in scala's rule table | deferred to #2772 |
+| go `errors.Is`/`errors.As`/`errors.Join` | safety + encapsulation | the comparison/wrap form is both a runtime guard and an encapsulation-boundary call | deferred to #2766 |
+
+fortran's `COMMON` is a `globals` + `safety_bypasses` dual, not a safety one
+(`docs/globals_rule_contract.md` C5 table) — noted here only because the
+batch4 collective ledger entry (`batch4-dual-keyword-overlaps`) lists it
+alongside the safety-side duals this contract resolves; it does not move.
+
+## The two open cells
+
+- **embedded_python 4 → 2.** a.py's single planted guard
+  `assert isinstance(value, int)` is canonical at **2**: the bare `assert`
+  and the bare `isinstance` both fire on one defensive statement — one
+  guard, two value-level forms, correctly two hits (pinned in
+  `test_safety_contract_2869.py`'s `COUNTS`). The excess was b.py's two bare
+  `except:` — the `safety_bypasses` plant, the anti-safety marker — which
+  also counted as safety because `except` sat in both rules. A swallowed
+  exception is the opposite of a runtime guard; the twin-parity fix (C2 in
+  `python.py`'s own edit, applied here for its embedded twin per #2852's
+  lesson) anchors `except` to a named, non-`(Base)?Exception` type:
+  `\bexcept\s+(?!(?:Base)?Exception\b)[A-Za-z_]\w*`. `except:` and
+  `except Exception:` now fire zero; `except ValueError:` still fires one.
+  One owner, mass conserved: `safety_bypasses` still reads the bare
+  `except:` alone.
+- **haskell 3 → 2.** a.hs's plant was only a **type signature**:
+  `probeSafety :: Maybe Int -> Either Int Int` (body `= 0`, nothing
+  defensive at the value level), which recorded 2 via the `Maybe`/`Either`
+  type constructors — not a runtime defensive construct any more than a
+  `typescript unknown`/`never` annotation is (C1). The plant is re-planted
+  at the value level as a `fromMaybe`-shaped guard, and the type-signature
+  form is the contract's negative pin
+  (`probeSafety :: Maybe Int -> Either Int Int` — `COUNTS` == 0). c.hs's
+  `finally` was cleanup's plant, double-counting as safety
+  (`haskell-finally-dual-cleanup-safety`, still reproduced through #2858);
+  C3 gives it one owner — cleanup — and the ledger dual is resolved, not
+  merely re-verified.
+
+## Measured with no red cell
+
+The full sweep moved several languages' crucible counts with no open-defect
+cell attached — narrower, more honest rules the corpus corroborates rather
+than contradicts:
+
+- **cobol** `END-*` closers out: 2,500 → 68, leaving `DECLARATIVES`/
+  `VALIDATE`/`CHECK` (the #2622 hyphen-guard shape, C4).
+- **shell** quoted-expansion out: 2,985 → 777, keeping `set`/`trap`/
+  `command -v`/`${VAR:-fallback}` (C5).
+- **rust** type-and-constructor tokens out: 3,182 → 316, leaving
+  `if-let`/`while-let`/`let-else`/the `unwrap_or` family/`None =>` arms
+  (C1).
+- **lua** `error`/`type`/`pairs`-class introspection out: 4,438 → 3,660
+  (C2/C4).
+- **scala** 321 → 1, the type/constructor group leaving almost the entire
+  count (C1) — the crucible's one remaining hit is a genuine `require(`.
+- **python** typed-except plus dropped declaration-level tokens: 3,304 →
+  2,999.
+- **livecode** `throw` leaving `panics_and_aborts`: 295 → 173 (C2).
+- **objective-c** bare `nil` out: 31 → 0, and **assembly** frame mechanics
+  out: 54 → 0 — both now honest zeros on the sampled corpus files rather
+  than noise-inflated counts, the same shape as `docs/globals_rule_contract.md`'s
+  makefile/yaml rows (a narrow, correctly-scoped rule reading zero on a
+  sample that happens to carry none of its vocabulary is not a defect).
+
+## The 46-language audit
+
+`rule_probe.py safety all --samples 8` before → after. crucible = hits
+across the control corpus; keyword-rosetta = hits across the
+keyword-rosetta shell files (median plant: 2). Languages not listed: rule
+`None` by stated absence or no safety morphology declared (batch, blp, csv,
+glsl, hlo, json, markdown, mlir, nix, pbtxt, plaintext, proto, td, xml).
+
+| language | crucible | keyword-rosetta |
+|---|---|---|
+| `abap` | 86 | 2 |
+| `ada` | -- | 2 |
+| `agc_assembly` | 70 | 2 |
+| `apex` | 19 | 2 |
+| `assembly` | 54 -> 0 | 2 |
+| `batch` | rule is `None` | n/a |
+| `blp` | rule is `None` | n/a |
+| `c` | 1363 | 2 |
+| `cobol` | 2500 -> 68 | 2 |
+| `cpp` | 278 | 2 |
+| `csharp` | 718 | 2 |
+| `css` | 515 | 2 |
+| `csv` | rule is `None` | n/a |
+| `dart` | 4760 | 2 |
+| `dockerfile` | 9 | 2 |
+| `embedded_python` | 247 -> 155 | 4 -> 2 |
+| `fortran` | 1700 | 2 |
+| `glsl` | rule is `None` | n/a |
+| `go` | 268 -> 195 | 2 |
+| `groovy` | 88 -> 83 | 2 |
+| `haskell` | 159 -> 22 | 3 -> 2 |
+| `hlo` | rule is `None` | n/a |
+| `html` | 109 | 2 |
+| `java` | 87 -> 85 | 2 |
+| `javascript` | 2003 | 2 |
+| `jcl` | 33 | 2 |
+| `json` | rule is `None` | n/a |
+| `kotlin` | 7 | 2 |
+| `livecode` | 295 -> 173 | 2 |
+| `lua` | 4438 -> 3660 | 2 |
+| `m4` | 116 | 2 |
+| `makefile` | -- | 2 |
+| `markdown` | rule is `None` | n/a |
+| `matlab` | 296 | 2 |
+| `mlir` | rule is `None` | n/a |
+| `nix` | rule is `None` | n/a |
+| `objective-c` | 31 -> 0 | 2 |
+| `pbtxt` | rule is `None` | n/a |
+| `perl` | 160 | 2 |
+| `php` | 1401 | 2 |
+| `plaintext` | rule is `None` | n/a |
+| `powershell` | 575 | 2 |
+| `proto` | rule is `None` | n/a |
+| `python` | 3304 -> 2999 | 2 |
+| `ruby` | 10 | 2 |
+| `rust` | 3182 -> 316 | 2 |
+| `scala` | 321 -> 1 | 2 |
+| `scheme` | 125 | 2 |
+| `shell` | 2985 -> 777 | 2 |
+| `solidity` | 33 | 2 |
+| `sqlite` | 301 | 2 |
+| `swift` | 152 | 2 |
+| `tcl` | 406 | 2 |
+| `td` | rule is `None` | n/a |
+| `typescript` | 399 | 2 |
+| `xml` | rule is `None` | n/a |
+| `yacc` | 1 | 2 |
+| `yaml` | 0 | 2 |
+| `zig` | 14039 | 2 |
+
+## Deliberate duals kept
+
+- **dockerfile `HEALTHCHECK`** — func_start + safety, pre-existing
+  (`docs/func_start_rule_contract.md`/`docs/class_start_rule_contract.md`,
+  #2856): it is simultaneously the container's declared entry point and its
+  installed watchdog.
+- **rust `if let`** — branch + safety, pre-existing
+  (`docs/branch_rule_contract.md`, #2822): `if` opens the decision, the
+  `let`-pattern is the handled-absence arm.
+- **scala `Try`** — safety + immutability_locks, deferred to #2772: the
+  one-owner call belongs to the immutability rule's half of the audit.
+- **go `errors.Is`** — safety + encapsulation, deferred to #2766: the
+  one-owner call belongs to the encapsulation-formula audit.
+- **fortran `COMMON`** — globals + safety_bypasses (not a safety dual;
+  cross-referenced here only because `batch4-dual-keyword-overlaps` lists
+  it beside the safety-side entries this contract resolves;
+  `docs/globals_rule_contract.md` C5 is its home).
+
+## Known limits
+
+An import line that names a guard fires the token rule the same as a
+value-level use — `import Data.Maybe (fromMaybe)` fires haskell's `safety`
+once on `fromMaybe`, `from pydantic import BaseModel` fires python's
+`safety` once on `BaseModel`. This is the same cross-signal import
+morphology `docs/test_rule_contract.md` C4 already names for test-framework
+mentions (`import unittest` splits into `import`'s hit on the keyword and
+`test`'s hit on the framework name) — pre-existing, not introduced by this
+contract, and not worth gating: the import statement is genuine evidence
+the file has the guard vocabulary in scope.
+
+livecode's lens has a block-structure sensitivity found only by one-file
+scans during this audit: `catch tError` is safe to re-plant with (a
+`catch` line only ends a `try`/`catch`/`end try` region, matching the
+language's existing structure), but a bare `try` line on its own shifts the
+lens's block-structure accounting and manufactures a phantom `arch_api` hit
+downstream (`api_orphan_credit`) — invisible on the aggregate corpus,
+visible only when scanning the changed file in isolation. The corpus
+re-plant for livecode uses `catch tError`, not `try`, for this reason.
+
+## Deferred by design
+
+Forms measured adjacent to this contract with no open-defect cell to move
+and no evidence to act on now are filed with #2870: cpp's
+`std::atomic`/RAII-pointer group boundary, dart's declaration-modifier
+guards (`late`/`required`/`@immutable`/`@mustCallSuper`), csharp's
+`required`/`nameof`, javascript/typescript's `===`/`!==` "type-safe
+equality" morphology, swift's `Sendable` type marker, objective-c's ARC
+qualifier boundary, rust's `?` operator (propagation, not handling — an
+absence by design), scala's `Try`/immutability_locks and go's
+`errors.Is`/encapsulation one-owner questions (both listed above as kept
+duals, tracked to their respective issues), fortran's declaration-time
+strictness versus its uncounted `IOSTAT=`/`STAT=` runtime forms, makefile's
+zero-crucible narrowness, and python's dropped `Field(` call-form surface.
+None of these move a corpus cell today; #2870 records them so the next
+audit does not re-derive the same list. Parent: #2812 Phase 3.
+
+## Bless scope
+
+Corpus PR pairs with #2869: the engine PR carries the 15 rule edits above
+plus the strict-pin flips in each edited language's
+`tests/extraction/languages/test_<lang>_strict.py`; the corpus PR carries
+the re-plants named in "The two open cells" (embedded_python's twin-parity
+`except`, haskell's value-level `fromMaybe` guard) and livecode's
+`catch tError` re-plant, with both open-defect ledger entries
+(`haskell-finally-dual-cleanup-safety`, and embedded_python's `safety`/
+`safety_bypasses` `except` overlap) resolved. Golden-master movement is
+confined to the `safety` signal and the formulas that read it (the
+high_risk×safety proximity dampeners, `_calc_safety`, `safety_score`);
+watch the layer boundary named in the original issue: `safety_bypasses`
+(planted in the same files) must not move.

--- a/docs/signal_contracts.md
+++ b/docs/signal_contracts.md
@@ -60,7 +60,7 @@ written.** Corollaries every audited contract has needed so far:
 
 ## Signals
 
-9 stated, 59 draft. A **draft** row is the schema comment transcribed as-is; a **stated** row has been audited across the corpus languages and has a contract doc. `planted` = the keyword-rosetta corpus plants a known count of it (so the cross-language gate can hold it equal); unplanted signals that feed a risk formula are the ones the roadmap's Phase 3 must plant or declare absent.
+10 stated, 58 draft. A **draft** row is the schema comment transcribed as-is; a **stated** row has been audited across the corpus languages and has a contract doc. `planted` = the keyword-rosetta corpus plants a known count of it (so the cross-language gate can hold it equal); unplanted signals that feed a risk formula are the ones the roadmap's Phase 3 must plant or declare absent.
 
 | signal | phase | kind | status | planted | contract | doc |
 |---|---|---|---|---|---|---|
@@ -74,7 +74,7 @@ written.** Corollaries every audited contract has needed so far:
 | `doc` | safety | `annotation` | draft | yes | Structured documentation meant to be parsed by IDEs or generators |  |
 | `high_risk_execution` | safety | `site` | draft | yes | Process-killing commands and catastrophic runtime vulnerabilities |  |
 | `io` | safety | `site` | stated | yes | An operation that moves data between the program and a system outside its own runtime | [io_rule_contract.md](../docs/io_rule_contract.md) #2841 |
-| `safety` | safety | `site` | draft | yes | Defensive programming constructs that prevent crashes at runtime |  |
+| `safety` | safety | `site` | stated | yes | A site that handles or forestalls a runtime failure at the value level -- a guarded region's opener or its typed handler, a runtime assertion or validation call, a fallback or handled-absence form, an installed failure handler or watchdog, or a hardening instruction -- in a form an ordinary identifier, type annotation or constructor cannot match | [safety_rule_contract.md](../docs/safety_rule_contract.md) #2869 |
 | `safety_bypasses` | safety | `site` | draft | yes | Syntax that actively bypasses type safety, swallows errors, or relies on unpredictable state |  |
 | `state_mutation` | safety | `site` | stated | yes | A statement that writes a new value into state that already exists | [state_mutation_rule_contract.md](../docs/state_mutation_rule_contract.md) #2765 |
 | `test` | safety | `site` | stated | yes | A site that engages a testing framework: a test-case or fixture declaration, a framework assertion or expectation, or the framework named as such | [test_rule_contract.md](../docs/test_rule_contract.md) #2852 |

--- a/gitgalaxy/standards/how_to_add_a_language.md
+++ b/gitgalaxy/standards/how_to_add_a_language.md
@@ -162,7 +162,7 @@ Generate a valid Python dictionary matching this exact structure.
         "class_start": re.compile(r""), 
 
         # --- PHASE 2: SAFETY & EXECUTION RISK ---
-        # safety: Defensive programming constructs that prevent crashes at runtime. Includes: try/catch, explicit null checks, guard. EXCLUDES: Immutability.
+        # safety: A site that handles or forestalls a runtime failure at the value level -- a guarded region's opener or its typed handler, a runtime assertion or validation call, a fallback or handled-absence form, an installed failure handler or watchdog, or a hardening instruction -- in a form an ordinary identifier, type annotation or constructor cannot match. Includes: try/typed catch, assert/require/precondition, fromMaybe/unwrap_or fallbacks, trap/watchdogs, endbr64. EXCLUDES: type annotations and constructors (Maybe, Option, sealed), blanket handlers (bare except -- safety_bypasses'), release combinators (finally -- cleanup's), raising (throw/error), block closers (END-IF), frame mechanics, immutability (#2772's axis).
         "safety": re.compile(r""), 
         # safety_bypasses: Syntax that actively bypasses type safety, swallows errors, or relies on unpredictable state. Includes: Force unwrapping (!), any, raw memory casting, linter bypasses (@ts-ignore).
         "safety_bypasses": re.compile(r""), 

--- a/gitgalaxy/standards/language_standards/languages/assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/assembly.py
@@ -138,8 +138,9 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety (Defensive Programming / Validation)
         # Stack preservation and defensive frame setups.
+        # C2: frame mechanics/alignment are structure; CFI/pointer-auth hardening stays.
         "safety": re.compile(
-            r"\b(enter|leave|endbr64|paciasp|autiasp|bti|retab|\.align|\.p2align)\b|\b(?:stp|ldp)\s+x29,\s*x30",
+            r"\b(endbr64|paciasp|autiasp|bti|retab)\b",
             re.I,
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)

--- a/gitgalaxy/standards/language_standards/languages/cobol.py
+++ b/gitgalaxy/standards/language_standards/languages/cobol.py
@@ -289,8 +289,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety: Defensive Programming. Defensive scope terminators and declarative blocks.
+        # C2: END-* closers are structure. C4: hyphen guards (#2622 shape). ON ERROR/AT END/INVALID KEY stay branch's (verified owner, #2822 disposition).
         "safety": re.compile(
-            r"\b(END-IF|END-PERFORM|END-EVALUATE|END-READ|END-WRITE|END-COMPUTE|END-CALL|DECLARATIVES|VALIDATE|CHECK)\b",
+            r"(?<!-)\b(DECLARATIVES|VALIDATE|CHECK)\b(?!-)",
             re.I,
         ),
         # 7. safety_neg: Safety Bypasses. Bypassing logic or unpredictable jumps.

--- a/gitgalaxy/standards/language_standards/languages/embedded_python.py
+++ b/gitgalaxy/standards/language_standards/languages/embedded_python.py
@@ -80,8 +80,9 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety (Defensive Programming / Validation)
         # Hardware watchdogs and standard Python safety checks.
+        # C3 twin-parity with python (#2852 lesson). Fixes b.py: bare except x2 → 0.
         "safety": re.compile(
-            r"\b(try|except|finally|assert|machine\.WDT|isinstance|issubclass|hasattr|getattr|alloc_emergency_exception_buf)\b"
+            r"\b(try|finally|assert|machine\.WDT|isinstance|issubclass|hasattr|alloc_emergency_exception_buf)\b|\bexcept\s+(?!(?:Base)?Exception\b)[A-Za-z_]\w*"
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         # Bare excepts and blocking the event loop (detrimental in embedded async).

--- a/gitgalaxy/standards/language_standards/languages/go.py
+++ b/gitgalaxy/standards/language_standards/languages/go.py
@@ -98,9 +98,8 @@ DEFINITION: dict[str, Any] = {
         # BUG FIX: `recover\(\)` ends on `)` (non-word), so the shared
         # trailing \b could never fire -- the classic
         # `defer func() { recover() }()` idiom never matched.
-        "safety": re.compile(
-            r"err\s*!=\s*nil|\b(?:errors\.(?:Is|As|New|Join)|sync\.(?:Once|WaitGroup)|context\.Context)\b|\brecover\(\)"
-        ),
+        # C2: errors.New constructs. C3: sync.* is concurrency's. C1: context.Context is a type.
+        "safety": re.compile(r"err\s*!=\s*nil|\b(?:errors\.(?:Is|As|Join))\b|\brecover\(\)"),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         # Explicitly ignoring errors via blank identifier.
         # BUG FIX (#2542): the import alternation made the dot OPTIONAL

--- a/gitgalaxy/standards/language_standards/languages/groovy.py
+++ b/gitgalaxy/standards/language_standards/languages/groovy.py
@@ -257,9 +257,8 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK ENGINE (Structural Integrity) ---
         # 6. safety (Defensive Programming / Validation)
-        "safety": re.compile(
-            r"\b(try|catch|finally|assert|instanceof|Optional)\b|@(?:Valid|Validated|NotNull|NonNull|Immutable)"
-        ),
+        # C1: Optional is a type name; @Immutable is not runtime validation (twin of java.py).
+        "safety": re.compile(r"\b(try|catch|finally|assert|instanceof)\b|@(?:Valid|Validated|NotNull|NonNull)"),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         "safety_bypasses": re.compile(
             r"\b(null)\b|return\s+null|catch\s*\(\s*(?:Exception|Throwable)\b|@SuppressWarnings|@SneakyThrows|\.get\(\)"

--- a/gitgalaxy/standards/language_standards/languages/haskell.py
+++ b/gitgalaxy/standards/language_standards/languages/haskell.py
@@ -228,9 +228,8 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # safety: Defensive Programming. Functional safety (Maybe/Either) and exception brackets.
-        "safety": re.compile(
-            r"\b(Maybe|Either|Just|Nothing|Right|Left|try|catch|bracket|finally|onException|SafeT|mask|pure|return)\b"
-        ),
+        # C1: type/data constructors invisible; the handled-absence ARM (Nothing ->) is the form. C2: pure/return are plumbing. C3: bracket/finally/onException are cleanup's (verified owner). Resolves haskell-finally-dual-cleanup-safety.
+        "safety": re.compile(r"\b(try|catch|mask|fromMaybe)\b|Nothing\s*->"),
         # safety_neg: Safety Bypasses. Bypassing purity (unsafePerformIO) and partial functions.
         "safety_bypasses": re.compile(
             r"\b(unsafePerformIO|unsafeCoerce|error|undefined|fromJust|head|tail|init|last|throw|unsafeFixIO)\b"

--- a/gitgalaxy/standards/language_standards/languages/java.py
+++ b/gitgalaxy/standards/language_standards/languages/java.py
@@ -180,8 +180,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety (Defensive Programming / Validation)
+        # C1: Optional is a type name; @Immutable/@Transactional are not runtime validation.
         "safety": re.compile(
-            r"\b(try|catch|finally|assert|Optional|Objects\.requireNonNull|instanceof)\b|@(Valid|Validated|NotNull|NonNull|NotBlank|Immutable|Transactional)\b"
+            r"\b(try|catch|finally|assert|Objects\.requireNonNull|instanceof)\b|@(Valid|Validated|NotNull|NonNull|NotBlank)\b"
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         "safety_bypasses": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/kotlin.py
+++ b/gitgalaxy/standards/language_standards/languages/kotlin.py
@@ -138,8 +138,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety (Defensive Programming / Validation)
+        # C2: error() raises. C1: sealed/Result type-level. C4: bare fold is an ordinary fold.
         "safety": re.compile(
-            r"\?\.(?!.)|as\?|\b(require|requireNotNull|check|checkNotNull|error|sealed|is|!is|Result|onSuccess|onFailure|fold|runCatching)\b|\?:"
+            r"\?\.(?!.)|as\?|\b(require|requireNotNull|check|checkNotNull|is|!is|onSuccess|onFailure|runCatching)\b|\?:"
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         # Force unwrapping, unsafe casts, and suppression.

--- a/gitgalaxy/standards/language_standards/languages/livecode.py
+++ b/gitgalaxy/standards/language_standards/languages/livecode.py
@@ -131,8 +131,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety: Defensive Programming. Defensive programming and screen/message locking.
+        # C2: throw raises, not handles. (batch4's livecode throw safety+branch pair retires.)
         "safety": re.compile(
-            r"\b(try|catch|finally|throw|lock\s+screen|lock\s+messages|lock\s+errordialogs|assert|strict\s+compilation|is\s+a|is\s+strictly)\b",
+            r"\b(try|catch|finally|lock\s+screen|lock\s+messages|lock\s+errordialogs|assert|strict\s+compilation|is\s+a|is\s+strictly)\b",
             re.I,
         ),
         # 7. safety_neg: Safety Bypasses. Actively bypassing safety (disabling messages, raw do).

--- a/gitgalaxy/standards/language_standards/languages/lua.py
+++ b/gitgalaxy/standards/language_standards/languages/lua.py
@@ -80,9 +80,8 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety: Defensive Programming. Protected calls, assertions, and type checks.
-        "safety": re.compile(
-            r"\b(pcall|xpcall|assert|error|type|getmetatable|rawequal|ipairs|pairs|next)\b|<\s*(?:const|close|toclose)\s*>"
-        ),
+        # C2: error( raises; type/getmetatable/rawequal/ipairs/pairs/next are introspection/iteration. C3: <close|toclose> cleanup's (verified owner); <const> immutability's.
+        "safety": re.compile(r"\b(pcall|xpcall|assert)\b"),
         # 7. safety_neg: Safety Bypasses. Actively bypassing safety (environment manipulation/raw access).
         # BUG FIX (#2675): dropped `_G`/`_ENV` (a bare reference to the global
         # table -- `globals` owns it via `\b(_G|_ENV|_VERSION|arg)\b`) and

--- a/gitgalaxy/standards/language_standards/languages/objectivec.py
+++ b/gitgalaxy/standards/language_standards/languages/objectivec.py
@@ -239,9 +239,8 @@ DEFINITION: dict[str, Any] = {
         # 6. safety: Defensive Programming. ARC memory qualifiers and Cocoa/NeXT Assertions.
         # BUG FIX: @try/@catch/@finally never matched -- same \b-before-@
         # shape as branch's fix above.
-        "safety": re.compile(
-            r"@(try|catch|finally)\b|\b(__weak|__strong|__auto_type|NSAssert|NSParameterAssert|NSError|nil|Nil)\b"
-        ),
+        # C4: bare nil is every null literal. C1: NSError is a type name. ARC qualifiers stay: zeroing weak refs are a runtime crash-prevention mechanism (C5 note).
+        "safety": re.compile(r"@(try|catch|finally)\b|\b(__weak|__strong|__auto_type|NSAssert|NSParameterAssert)\b"),
         # 7. safety_neg: Safety Bypasses. Bypassing ARC, raw void pointers, and dangerous dynamic selectors.
         # BUG FIX: `void\s*\*` (trailing \b after a literal `*`) and
         # `performSelector:` (trailing \b after a literal `:`) only

--- a/gitgalaxy/standards/language_standards/languages/python.py
+++ b/gitgalaxy/standards/language_standards/languages/python.py
@@ -165,8 +165,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety (Defensive Programming / Validation)
+        # C3: blanket except is safety_bypasses'; bare getattr is reflection_metaprogramming's. C1: dataclass/Field/TypeGuard/override are declaration/type-level.
         "safety": re.compile(
-            r"\b(try|except(?:\*)?|finally|assert|isinstance|issubclass|hasattr|getattr|dataclass|BaseModel|Field|TypeGuard|override)\b"
+            r"\b(try|finally|assert|isinstance|issubclass|hasattr|BaseModel)\b|\bexcept\*?\s+(?!(?:Base)?Exception\b)[A-Za-z_]\w*"
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         # Swallowed errors, wildcard imports, and Any bypasses.

--- a/gitgalaxy/standards/language_standards/languages/rust.py
+++ b/gitgalaxy/standards/language_standards/languages/rust.py
@@ -112,8 +112,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety (Defensive Programming / Validation)
+        # C1: type names/constructors invisible; fallback family + handled None arm are the forms. C3: bare match is branch's; Mutex/Arc concurrency-adjacent. (if let keeps its pre-existing branch dual — doc-noted.)
         "safety": re.compile(
-            r"\b(Option|Result|Mutex|RwLock|Arc|Rc|Box|RefCell|match|if\s+let|while\s+let|let\s+else|Ok|Err|Some|None)\b"
+            r"\b(if\s+let|while\s+let|let\s+else)\b|\b(?:unwrap_or|unwrap_or_else|unwrap_or_default|ok_or|ok_or_else|map_or|map_or_else)\b|None\s*=>"
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         # Actively bypasses type safety (unwraps and forced expectations).

--- a/gitgalaxy/standards/language_standards/languages/scala.py
+++ b/gitgalaxy/standards/language_standards/languages/scala.py
@@ -118,9 +118,8 @@ DEFINITION: dict[str, Any] = {
         ),
         # --- PHASE 2: RISK & STRUCTURAL INTEGRITY ---
         # 6. safety: Defensive Programming. Monadic error handling (Option/Try) and assertions.
-        "safety": re.compile(
-            r"\b(Option|Some|None|Try|Success|Failure|Either|Left|Right|sealed|require|assert|assume)\b|\|\s*Null\b"
-        ),
+        # C1: constructors/types/sealed/| Null invisible. Try kept: guarded-region opener (immutability_locks dual pre-exists — doc-noted).
+        "safety": re.compile(r"\b(require|assert|assume)\b|\bTry\s*[({]"),
         # 7. safety_neg: Safety Bypasses. Actively bypassing type safety (asInstanceOf, .get).
         # BUG FIX: `@unchecked` is `@`-prefixed -- the shared leading
         # \b could only fire when a word char immediately preceded the

--- a/gitgalaxy/standards/language_standards/languages/shell.py
+++ b/gitgalaxy/standards/language_standards/languages/shell.py
@@ -127,8 +127,9 @@ DEFINITION: dict[str, Any] = {
         # {0,300}; the `${...}` clauses use the one-level-nesting form so a
         # realistic nested default like `${LOG_LEVEL:-${DEFAULT:-info}}` is
         # captured in full instead of truncating at the inner `}`.
+        # C4: quoted expansion is ordinary shell. The ${VAR:-default} fallback form stays (C1).
         "safety": re.compile(
-            r'\b(set\s+-(?:[a-zA-Z]*e[a-zA-Z]*|u|o\s+pipefail)|trap\s+[^\n]{0,300}(?:ERR|EXIT|INT|TERM))\b|"\$[@*]"|"\$\{(?:[^{}]|\{[^{}]*\})+\}"|\bcommand\s+-v\b|\$\{[a-zA-Z0-9_]+:[-=?](?:[^{}]|\{[^{}]*\})*\}'
+            r"\b(set\s+-(?:[a-zA-Z]*e[a-zA-Z]*|u|o\s+pipefail)|trap\s+[^\n]{0,300}(?:ERR|EXIT|INT|TERM))\b|\bcommand\s+-v\b|\$\{[a-zA-Z0-9_]+:[-=?](?:[^{}]|\{[^{}]*\})*\}"
         ),
         # 7. safety_neg (Safety Bypasses / Unchecked Types)
         # Unquoted variables, dynamic evaluation, and blind network-to-shell piping.

--- a/gitgalaxy/standards/signal_contracts.py
+++ b/gitgalaxy/standards/signal_contracts.py
@@ -186,7 +186,16 @@ _ROWS = [
         planted=True,
     ),
     # --- PHASE 2: SAFETY & EXECUTION RISK ---
-    _c("safety", "safety", "site", "Defensive programming constructs that prevent crashes at runtime", planted=True),
+    _c(
+        "safety",
+        "safety",
+        "site",
+        "A site that handles or forestalls a runtime failure at the value level -- a guarded region's opener or its typed handler, a runtime assertion or validation call, a fallback or handled-absence form, an installed failure handler or watchdog, or a hardening instruction -- in a form an ordinary identifier, type annotation or constructor cannot match",
+        status="stated",
+        doc="docs/safety_rule_contract.md",
+        issue=2869,
+        planted=True,
+    ),
     _c(
         "safety_bypasses",
         "safety",

--- a/tests/extraction/languages/test_cobol_strict.py
+++ b/tests/extraction/languages/test_cobol_strict.py
@@ -68,7 +68,8 @@ _COBOL_SIMPLE_CASES = [
     ("structural_boundaries", "PROCEDURE DIVISION.", "MOVE X TO Y."),
     ("func_start", "       100-PROCESS-RECORDS SECTION.", "       01  WS-POLICY-RECORD."),
     ("class_start", "       PROGRAM-ID. MYPROG.", "       100-PROCESS-RECORDS SECTION."),
-    ("safety", "END-IF", "MOVE X TO Y."),
+    # #2869 contract: C2, END-* scope terminators are structure's, not safety's
+    ("safety", "VALIDATE REC.", "END-IF"),
     ("safety_bypasses", "GO TO PARA-X", "MOVE X TO Y."),
     ("high_risk_execution", "STOP RUN.", "MOVE X TO Y."),
     ("io", "READ CUSTOMER-FILE", "MOVE X TO Y."),

--- a/tests/extraction/languages/test_embedded_python_strict.py
+++ b/tests/extraction/languages/test_embedded_python_strict.py
@@ -431,16 +431,20 @@ def test_embedded_python_func_start_vs_macros_no_collision():
 def test_embedded_python_safety_and_reflection_metaprogramming_intentional_double_classification():
     """
     Ambiguity sweep: `safety` and `reflection_metaprogramming` both list
-    `hasattr`/`getattr` and both fire on the same
-    `hasattr(sensor, 'read')`/`getattr(sensor, 'read')` call. Confirmed
-    genuine, intentional double-classification (present identically in
-    python's own already-hardened rules dict, not an embedded_python-only
-    accident): a runtime attribute-existence probe is simultaneously a
-    defensive validation technique (safety) AND a dynamic/reflective
-    attribute access (reflection_metaprogramming) -- both are structurally
-    true at once, the same accepted double-classification shape used
-    elsewhere in this codebase (e.g. dockerfile's ENV firing both `globals`
-    and `state_mutation`).
+    `hasattr` and both fire on the same `hasattr(sensor, 'read')` call.
+    Confirmed genuine, intentional double-classification (present
+    identically in python's own already-hardened rules dict, not an
+    embedded_python-only accident): a runtime attribute-existence probe is
+    simultaneously a defensive validation technique (safety) AND a
+    dynamic/reflective attribute access (reflection_metaprogramming) --
+    both are structurally true at once, the same accepted
+    double-classification shape used elsewhere in this codebase (e.g.
+    dockerfile's ENV firing both `globals` and `state_mutation`).
+
+    #2869 contract: bare `getattr` dropped from `safety` (C3 twin-parity
+    with python -- it's reflection_metaprogramming's alone now, the
+    unchecked/no-default attribute pull is not itself a defensive form).
+    `hasattr` keeps its dual role; `getattr` no longer does.
     """
     safety = EP_RULES["safety"]
     reflection = EP_RULES["reflection_metaprogramming"]
@@ -450,7 +454,7 @@ def test_embedded_python_safety_and_reflection_metaprogramming_intentional_doubl
     assert reflection.search(line)
 
     line2 = "value = getattr(sensor, 'read', None)"
-    assert safety.search(line2)
+    assert not safety.search(line2), "getattr must no longer count as safety (#2869 C3 twin-parity)"
     assert reflection.search(line2)
 
 

--- a/tests/extraction/languages/test_haskell_strict.py
+++ b/tests/extraction/languages/test_haskell_strict.py
@@ -85,7 +85,8 @@ _HS_SIMPLE_CASES = [
     ("api", "module MyLib (foo, bar) where", "import MyLib (foo, bar)"),
     ("branch", "if x then y else z", "x = y"),
     ("structural_boundaries", "module Foo where", "mod = 5"),
-    ("safety", "case result of\n  Just x -> x\n  Nothing -> 0", "x = 5"),
+    # #2869 contract: C1, bare constructors (Just x) are invisible now; fromMaybe/Nothing-> are the forms
+    ("safety", "fromMaybe 0 result", "Just x -> x"),
     ("safety_bypasses", "fromJust maybeValue", "fromJustified"),
     ("high_risk_execution", "exitWith (ExitFailure 1)", "exitWithout"),
     ("io", 'contents <- readFile "f.txt"', "readFiles = True"),

--- a/tests/extraction/languages/test_lua_strict.py
+++ b/tests/extraction/languages/test_lua_strict.py
@@ -149,16 +149,14 @@ def test_lua_listeners_on_call_boundary_regression():
 
 def test_lua_ambiguity_sweep_shared_literals_are_not_bugs():
     """
-    Documents 7 pairs the automated ambiguity sweep flagged, mostly
+    Documents pairs the automated ambiguity sweep flagged, mostly
     centered on Lua 5.4's `<const>`/`<close>` attribute syntax
-    (cleanup<->concurrency, cleanup<->safety, cleanup<->
-    structural_boundaries, concurrency<->safety, concurrency<->
-    structural_boundaries, safety<->structural_boundaries) plus
+    (cleanup<->concurrency, cleanup<->structural_boundaries) plus
     dead_code<->doc (sharing "return"). All confirmed non-bugs:
-    - A `<close>`-attributed local variable is genuinely triple-
-      classified by design (it's simultaneously a safety mechanism, a
-      structural declaration modifier, and a cleanup signal) -- verified
-      directly, not a false collision.
+    - A `<close>`-attributed local variable is genuinely dual-
+      classified by design (it's simultaneously a structural declaration
+      modifier and a cleanup signal) -- verified directly, not a false
+      collision.
     - "close" appearing in both `uv.close` (concurrency) and `io.close`/
       `ffi.C.free` (cleanup) are different, correctly-namespaced tokens
       that don't actually collide on the same real code.
@@ -166,6 +164,10 @@ def test_lua_ambiguity_sweep_shared_literals_are_not_bugs():
       disambiguates it from doc's `---@return` EmmyLua tag (three
       dashes, not two) -- confirmed neither matches the other's positive
       case.
+
+    #2869 contract: `<close>`/`<toclose>` dropped from `safety` (C3 --
+    cleanup is the verified owner). `<close>` is no longer triple-
+    classified; it's cleanup<->structural_boundaries only now.
     """
     dead_code = LUA_RULES["dead_code"]
     doc = LUA_RULES["doc"]
@@ -183,7 +185,8 @@ def test_lua_ambiguity_sweep_shared_literals_are_not_bugs():
     assert not doc.search(commented_return)
 
     close_var = "local f <close> = io.open(path)"
-    assert cleanup.search(close_var) and safety.search(close_var) and structural_boundaries.search(close_var)
+    assert cleanup.search(close_var) and structural_boundaries.search(close_var)
+    assert not safety.search(close_var), "<close> must no longer count as safety (#2869 C3, cleanup owns it)"
 
     uv_close = "uv.close(handle)"
     assert concurrency.search(uv_close)

--- a/tests/extraction/languages/test_rust_strict.py
+++ b/tests/extraction/languages/test_rust_strict.py
@@ -40,7 +40,8 @@ _RUST_SIMPLE_CASES = [
     ("structural_boundaries", "let x = 1;", "x + 1;"),
     ("func_start", "fn foo() {}", "struct Foo {}"),
     ("class_start", "struct Foo {}", "fn foo() {}"),
-    ("safety", "match x {", "let x = 1;"),
+    # #2869 contract: C1/C3, bare match is branch's now; the fallback family is the form
+    ("safety", "let v = x.unwrap_or(0);", "match x {"),
     ("safety_bypasses", "x.unwrap()", "let x = 1;"),
     ("high_risk_execution", 'panic!("oops")', "let x = 1;"),
     ("io", "std::fs::read(path)", "let x = 1;"),

--- a/tests/extraction/languages/test_safety_contract_2869.py
+++ b/tests/extraction/languages/test_safety_contract_2869.py
@@ -1,0 +1,307 @@
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+"""
+The `safety` contract (#2869, docs/safety_rule_contract.md), held across
+every edited corpus language in one place.
+
+    A site that handles or forestalls a runtime failure at the value level --
+    a guarded region's opener or its typed handler, a runtime assertion or
+    validation call, a fallback or handled-absence form, an installed
+    failure handler or watchdog, or a hardening instruction -- in a form an
+    ordinary identifier, type annotation or constructor cannot match.
+
+The per-language strict suites keep their one positive/negative pair per
+signal; this module pins the contract's corollaries -- exactly the shapes the
+audit found the old rules disagreeing on:
+
+  C1 value-level, not declaration-level: a type name, constructor or
+     annotation is invisible (haskell's `Just x`, rust's `Option<T>`,
+     scala's `Option[Int]`, python's `TypeGuard`/`@override`, java's
+     `Optional<T>`); the runtime call, guarded arm or handled-absence form
+     is the shape that counts.
+  C2 raising is not handling: `errors.New`, lua's `error(`, kotlin's
+     `error(`, haskell's `throw`, livecode's `throw` -- all raise a failure,
+     none handle or forestall one.
+  C3 one verified owner: a token that also belongs to another signal's
+     contract is that signal's alone unless the ledger names a genuine dual
+     -- haskell's `finally`/`bracket`/`onException` are cleanup's, lua's
+     `<close>`/`<toclose>` are cleanup's, go's `sync.*` is concurrency's,
+     cobol's `ON ERROR`/`AT END`/`INVALID KEY` stay branch's.
+  C4 structure and reflection are not safety: cobol's `END-*` closers,
+     assembly's frame/alignment mechanics, shell's quoted-expansion form,
+     python's bare `getattr` (reflection_metaprogramming's) are dropped.
+  C5 the ambiguity anchor: an everyday word fires only in its runtime-guard
+     form -- shell's `${VAR:-fallback}` behind the fallback operator (a
+     bare `"${VAR}"` is ordinary quoting), objective-c's bare `nil` is every
+     null literal so only the ARC/assertion vocabulary stays, kotlin's bare
+     `fold` is an ordinary fold.
+  C6 deliberate duals are kept, not retired: scala's `Try` (immutability_locks
+     dual, #2772), rust's `if let` (branch dual, pre-existing), go's
+     `errors.Is` (encapsulation dual, #2766), dockerfile's `HEALTHCHECK`
+     (func_start dual, #2856).
+
+Each language lists (positives, negatives). A positive must match at least
+once; a negative must not match at all. `COUNTS` pins one-site-one-hit
+shapes. `DUALS` pins the tokens that fire a different signal, never safety.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _strict_harness import assert_redos_immune  # type: ignore
+
+
+def _rule(lang, signal="safety"):
+    return LANGUAGE_DEFINITIONS[lang]["rules"][signal]
+
+
+# lang -> (positives, negatives)
+CASES = {
+    # --- C1: value-level, not declaration-level -----------------------------------
+    "python": (
+        [
+            "try:",
+            "assert x > 0",
+            "isinstance(x, int)",
+            "except ValueError:",
+            "issubclass(C, Base)",
+            "hasattr(obj, 'x')",
+            "class M(BaseModel):",
+        ],
+        [
+            "except:",
+            "except Exception:",
+            "except BaseException:",
+            "getattr(obj, 'x')",
+            "@dataclass",
+            "x: TypeGuard[int]",
+            "@override",
+        ],
+    ),
+    "embedded_python": (
+        [
+            "try:",
+            "assert x",
+            "isinstance(x, int)",
+            "except ValueError:",
+            "machine.WDT()",
+            "alloc_emergency_exception_buf()",
+        ],
+        ["except:", "except Exception:", "getattr(obj, 'x')"],
+    ),
+    "haskell": (
+        ["try (evaluate x)", "catch handler onErr", "fromMaybe 0 y", "Nothing ->", "mask $ \\restore -> restore act"],
+        [
+            "Just x -> x",
+            "Right y",
+            "bracket open close use",
+            "onException act handler",
+            "probeSafety :: Maybe Int -> Either Int Int",
+        ],
+    ),
+    "rust": (
+        ["if let Some(x) = y {", "while let Some(x) = it.next() {", "let x = y.unwrap_or(0);", "None => {"],
+        ["match x {", "Some(x) => x,", "let x: Option<i32> = None;", "fn f() -> Result<T, E> {"],
+    ),
+    "scala": (
+        ["require(x > 0)", "assert(x > 0)", "assume(x > 0)", "Try(risky())", "Try {"],
+        ["val x: Option[Int] = None", "sealed trait X", "Some(x)", "x | Null"],
+    ),
+    "java": (
+        [
+            "try {",
+            "catch (Exception e) {",
+            "finally {",
+            "assert x > 0;",
+            "Objects.requireNonNull(x)",
+            "instanceof String",
+            "@Valid",
+            "@NotNull",
+        ],
+        ["Optional<String> x", "@Immutable", "@Transactional"],
+    ),
+    # --- C2: raising is not handling -----------------------------------------------
+    "go": (
+        ["err != nil", "errors.Is(err, target)", "errors.Join(e1, e2)", "recover()"],
+        ['errors.New("x")', "sync.WaitGroup", "sync.Once", "context.Context"],
+    ),
+    "lua": (
+        ["pcall(f, x)", "xpcall(f, handler)", "assert(x)"],
+        ['error("x")', "type(x)", "getmetatable(x)", "pairs(t)", "ipairs(t)", "<const>", "<close>"],
+    ),
+    "kotlin": (
+        [
+            "require(x > 0)",
+            "requireNotNull(x)",
+            "check(x)",
+            "checkNotNull(x)",
+            "x is String",
+            "x !is String",
+            "runCatching { f() }",
+            "result.onSuccess { }",
+            "result.onFailure { }",
+            "as?",
+        ],
+        ['error("x")', "sealed class X", "val r: Result<Int>", "list.fold(0) { acc, x -> acc + x }"],
+    ),
+    "livecode": (
+        [
+            "try",
+            "catch tError",
+            "finally",
+            "lock screen",
+            "lock messages",
+            "lock errordialogs",
+            "assert pValue",
+            "strict compilation",
+            "is a",
+            "is strictly",
+        ],
+        ["throw x"],
+    ),
+    # --- C4: structure and reflection are not safety --------------------------------
+    "cobol": (
+        ["VALIDATE REC-A.", "CHECK REC-B.", "DECLARATIVES."],
+        ["END-IF", "END-PERFORM", "END-EVALUATE", "PARA-VALIDATE.", "VALIDATE-X"],
+    ),
+    "assembly": (
+        ["endbr64", "paciasp", "autiasp", "bti", "retab"],
+        ["enter", "leave", ".align", ".p2align", "stp x29, x30"],
+    ),
+    "groovy": (
+        ["try {", "catch (Exception e) {", "finally {", "assert x > 0", "instanceof String", "@Valid", "@NotNull"],
+        ["Optional<String> x", "@Immutable"],
+    ),
+    # --- C5: the ambiguity anchor ----------------------------------------------------
+    "shell": (
+        ["set -e", "set -eu", "trap cleanup EXIT", "command -v gcc", "${HOME:-/root}"],
+        ['"${HOME}"', '"$@"', '"$*"'],
+    ),
+    "objective-c": (
+        [
+            "@try {",
+            "@catch (NSException *e) {",
+            "@finally {",
+            "__weak id x",
+            "__strong id x",
+            "__auto_type x",
+            'NSAssert(x, @"y")',
+            "NSParameterAssert(x)",
+        ],
+        ["nil", "Nil", "NSError *err"],
+    ),
+    # --- conformant anchors -----------------------------------------------------------
+    "zig": (
+        ["errdefer unlock();"],
+        ["unreachable;", "@intCast(x)"],
+    ),
+    "swift": (
+        ["precondition(value > 0)"],
+        ["default:", "let x = 5"],
+    ),
+}
+
+# (lang, text, expected hits): one guarded site is one hit; the canonical
+# dual-form site (an assertion whose argument is itself a runtime type
+# check) is two.
+COUNTS = [
+    ("python", "assert isinstance(v, int)", 2),
+    ("embedded_python", "except:", 0),
+    ("embedded_python", "except ValueError:", 1),
+    ("haskell", "probeSafety :: Maybe Int -> Either Int Int", 0),
+    ("haskell", "x = fromMaybe 0 y", 1),
+    ("typescript", "try {\n} catch {\n}", 2),
+    ("cobol", "END-IF", 0),
+    ("cobol", "VALIDATE REC-A.", 1),
+    ("shell", '"${HOME}"', 0),
+    ("shell", "${HOME:-/root}", 1),
+    ("rust", "match x {", 0),
+    ("rust", "None => {", 1),
+]
+
+# (lang, text, dual_signal): a token the #2869 audit verified belongs to
+# another signal alone -- it must never fire safety.
+DUALS = [
+    ("haskell", "hClose `finally` conn", "cleanup"),
+    ("livecode", "throw x", "panics_and_aborts"),
+    ("go", "sync.WaitGroup", None),
+    ("scala", "val x: Option[Int]", None),
+]
+
+PAYLOADS = [
+    "try " * 20000,
+    "except" + " " * 50000 + "Exception",
+    "except " * 20000,
+    "assert " * 20000,
+    "None => " * 20000,
+    "unwrap_or_else " * 20000,
+    "fromMaybe " * 20000,
+    "Nothing" + " " * 50000 + "->",
+    "err != nil " * 20000,
+    "require(" * 20000,
+    "Try" + " " * 50000 + "(",
+    "DECLARATIVES" * 20000,
+    "VALIDATE-" * 20000,
+    "set -" + "e" * 50000,
+    "trap " + "x" * 100000 + " EXIT",
+    "${" + "a" * 30000 + ":-" + "b" * 30000 + "}",
+    "endbr64 " * 20000,
+    "__weak " * 20000,
+    "instanceof " * 20000,
+    "runCatching " * 20000,
+    "lock screen " * 20000,
+    "pcall(" * 20000,
+]
+
+
+@pytest.mark.parametrize("lang", sorted(CASES))
+def test_safety_contract_positive_and_negative(lang):
+    rule = _rule(lang)
+    positives, negatives = CASES[lang]
+    for text in positives:
+        assert rule.search(text), f"{lang}: contract positive did not match: {text!r}"
+    for text in negatives:
+        hits = [m.group(0) for m in rule.finditer(text)]
+        assert not hits, f"{lang}: contract negative matched {hits!r} in {text!r}"
+
+
+@pytest.mark.parametrize("lang,text,expected", COUNTS)
+def test_safety_one_site_is_one_hit(lang, text, expected):
+    hits = [m.group(0) for m in _rule(lang).finditer(text)]
+    assert len(hits) == expected, f"{lang}: expected {expected} hits, got {hits!r}"
+
+
+@pytest.mark.parametrize("lang,text,dual_signal", DUALS)
+def test_safety_deliberate_duals_never_fire_safety(lang, text, dual_signal):
+    """C3: a token verified to belong to another signal's contract must
+    never fire safety, whether or not that other signal is itself pinned
+    here (mass conserved, the fortran-COMMON shape read in reverse)."""
+    hits = [m.group(0) for m in _rule(lang).finditer(text)]
+    assert not hits, f"{lang}: safety fired on the verified {dual_signal or 'other-owner'} dual {text!r}: {hits!r}"
+    if dual_signal is not None:
+        assert _rule(lang, dual_signal).search(text), f"{lang}: expected {dual_signal!r} to own {text!r}"
+
+
+def test_safety_markdown_has_no_rule():
+    """C4/absence: markdown has no runtime-guard morphology; the rule stays
+    unset, not an empty pattern."""
+    assert LANGUAGE_DEFINITIONS["markdown"]["rules"].get("safety") is None
+
+
+@pytest.mark.parametrize("lang", sorted(CASES))
+def test_safety_contract_rules_are_redos_immune(lang):
+    rule = _rule(lang)
+    for payload in PAYLOADS:
+        assert_redos_immune(rule, payload, timeout_sec=3.0)

--- a/tests/extraction/languages/test_scala_strict.py
+++ b/tests/extraction/languages/test_scala_strict.py
@@ -64,7 +64,8 @@ _SCALA_SIMPLE_CASES = [
     ("structural_boundaries", "import scala.util.Try", "extendedInfo = fetch()"),
     ("func_start", "def foo() = {}", "if (x) foo()"),
     ("class_start", "class Foo {", "Class.forName(name)"),
-    ("safety", "val x: Option[Int] = None", "optional = true"),
+    # #2869 contract: C1, constructors/types (Option[Int]) are invisible now; require() is the form
+    ("safety", "require(x > 0)", "val x: Option[Int] = None"),
     ("safety_bypasses", "x.asInstanceOf[String]", "x.getClass"),
     ("high_risk_execution", "System.exit(1)", "System.currentTimeMillis()"),
     ("io", "Source.fromFile(path)", "sourceMap = generate()"),

--- a/tests/extraction/languages/test_shell_strict.py
+++ b/tests/extraction/languages/test_shell_strict.py
@@ -223,14 +223,20 @@ def test_shell_structural_boundaries_dot_source_leading_boundary_regression():
 
 def test_shell_safety_nested_default_expansion_regression():
     """
-    Nested-delimiter regression (Rule 11): both `${...}` clauses in `safety`
-    (the quoted and unquoted default-value forms) used a flat `[^}]+`/
-    `[^}]*` delimiter matcher, which cannot represent one level of nesting.
-    A realistic nested default-value expansion -- e.g.
+    Nested-delimiter regression (Rule 11): the `${...}` default-value clause
+    in `safety` used a flat `[^}]*` delimiter matcher, which cannot represent
+    one level of nesting. A realistic nested default-value expansion -- e.g.
     `${LOG_LEVEL:-${DEFAULT_LEVEL:-info}}`, a common multi-level fallback
     idiom -- truncated at the first (inner) `}` instead of capturing the
     full expression. Upgraded to the one-level-nesting form from the
     project's Rule 11 playbook.
+
+    #2869 contract: C4, the dedicated quoted-string alternative (`"${...}"`)
+    was dropped from `safety` -- quoted expansion is ordinary shell, not a
+    defensive form. The bare `${VAR:-default}` fallback clause still fires
+    inside a quoted string (it doesn't require an unquoted context), so the
+    nested match is still found there -- it just no longer captures the
+    enclosing quote characters themselves.
     """
     pattern = SHELL_RULES["safety"]
     m = pattern.search("${LOG_LEVEL:-${DEFAULT_LEVEL:-info}}")
@@ -238,8 +244,8 @@ def test_shell_safety_nested_default_expansion_regression():
         f"nested default expansion truncated: {m.group() if m else None!r}"
     )
     m2 = pattern.search('"${LOG_LEVEL:-${DEFAULT_LEVEL:-info}}"')
-    assert m2 and m2.group() == '"${LOG_LEVEL:-${DEFAULT_LEVEL:-info}}"', (
-        f"nested quoted default expansion truncated: {m2.group() if m2 else None!r}"
+    assert m2 and m2.group() == "${LOG_LEVEL:-${DEFAULT_LEVEL:-info}}", (
+        f"nested default expansion (inside quotes) truncated: {m2.group() if m2 else None!r}"
     )
     assert pattern.search("${VAR:-default}"), "non-nested form regressed"
 

--- a/tests/signal_contract_audit_baseline.json
+++ b/tests/signal_contract_audit_baseline.json
@@ -46,7 +46,6 @@
   "draft:rce_funnel",
   "draft:reflection_metaprogramming",
   "draft:regex_execution",
-  "draft:safety",
   "draft:safety_bypasses",
   "draft:scientific",
   "draft:serialization_parsing",


### PR DESCRIPTION
Roadmap Phase 3 (epic #2812): the `safety` row goes draft → **stated** (10/68). One layer: rule regexes + their strict pins + the sheet + the doc.

Closes #2869

## The contract

> **A site that handles or forestalls a runtime failure at the value level — a guarded region's opener or its typed handler, a runtime assertion or validation call, a fallback or handled-absence form, an installed failure handler or watchdog, or a hardening instruction — in a form an ordinary identifier, type annotation or constructor cannot match.**

`docs/safety_rule_contract.md` (corollaries C1–C6, the 46-row audit table, known limits, deferred menu #2870). Sheet row flipped in `gitgalaxy/standards/signal_contracts.py`; `how_to_add_a_language.md`'s safety comment now contains the sentence; `signal_contract_audit.py --ci` green with a smaller baseline (59 findings). Cross-language pins: `tests/extraction/languages/test_safety_contract_2869.py` (51 tests, incl. ReDoS detonations and the deliberate-dual pins).

## The two open cells (both `extraction`, now 0)

- **embedded_python 4 → 2** — b.py's two bare `except:` (the **safety_bypasses plant**) counted as safety. `except` now counts only in its typed-handler form (`except ValueError:`); blanket forms stay bypasses' (C3). python's rule got the twin fix (the #2852 twin-parity lesson) — python's own cell never showed it only because python's bypass plant uses `Any`/`cast`.
- **haskell 3 → 2** — a.hs's plant was only a **type signature** (`probeSafety :: Maybe Int -> Either Int Int`, counted via the `Maybe`/`Either` constructors: the `typescript-type-keywords-count-as-safety` question, generalized as C1) and c.hs's `finally` was **cleanup's plant** counting twice (`haskell-finally-dual-cleanup-safety`, resolved: cleanup owns `bracket|finally|onException`, verified).

## Measured with no red cell, fixed in the same layer (15 rules edited)

cobol END-* block closers 2500 → 68 (DECLARATIVES/VALIDATE/CHECK stay, hyphen-guarded; ON ERROR/AT END stay **branch's** per #2822's disposition); shell quoted-expansion 2985 → 777 (`${VAR:-fallback}` stays — it is the value-level fallback form); rust type/constructor tokens 3182 → 316 (keeps if-let/while-let/let-else, the `unwrap_or` family, `None =>` arms); lua `error(`/`type`/iteration 4438 → 3660; scala 321 → 1 (`Try` counts in call/block form only); python drops declaration-level tokens and bare `getattr` (reflection_metaprogramming's); go drops `errors.New` (C2), `sync.*` (C3), `context.Context` (C1); java/groovy drop bare `Optional`, `@Immutable`, `@Transactional`; kotlin drops `error`/`sealed`/`Result`/`fold`; livecode drops `throw` (C2 — panics_and_aborts keeps the raise, batch4's last safety-side dual retires); objective-c drops bare `nil`/`Nil`/`NSError` (31 → 0, an honest zero) and assembly drops frame mechanics for the hardening instructions (54 → 0, same shape).

## Bless scope (golden masters re-blessed from crucible v1.2.0)

1429 diffs, 0 topological, newly parsed/excluded **none**. Leaf keys: Defensive Programming Constructs, Error & Exception Exposure, safety_score/avg_safety_score, verification/Testing Exposure (`_calc_verification` reads safety per-function — verified in source), and the high_risk×safety dampener trio (Mitigated Danger / High-Risk Weighted View / Contextual Mitigations) — exactly the signal and the formulas that read it.

## Gauntlet

Full suite green except the two known-baseline items (security_auditor ML deps; `test_committed_fidelity_table_is_fresh_against_the_corpus`, stale on main since keyword-rosetta#74 — the epic's housekeeping item, not this layer). ruff/mypy/dead-key audits: no new findings. `rosetta_audit` vs the corpus branch: **46/46**.

## Cross-repo

Corpus re-bless PR: squid-protocol/keyword-rosetta#101 — re-plants for the six plants authored to removed tokens (haskell value-level, rust fallback forms, go `recover()`×2 keeping `context.Context` for encapsulation 4, assembly hardening instructions, scala require/assume, groovy assert, livecode `catch tError` — a bare `try` line shifts livecode's lens block structure and creates a phantom `api_orphan_credit`, found by one-file scans), the two manifest cell moves, and the ledger verdicts. Merge order: engine first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6GxeANZdsik3h7xNzophv
