### PR TITLE
ownership contract (#2882): state the row, audit 46 rules over both streams, re-bless

### DIFF
--- a/docs/ownership_rule_contract.md
+++ b/docs/ownership_rule_contract.md
@@ -1,0 +1,240 @@
+# The `ownership` rule contract (#2882)
+
+Phase 3 of the contract roadmap (`docs/contract_roadmap.md`, epic #2812): the sheet row
+`ownership` goes from `draft` to `stated`. The precedents are `docs/api_rule_contract.md`
+(#2730), `docs/args_rule_contract.md` (#2773), `docs/state_mutation_rule_contract.md` (#2765),
+`docs/branch_rule_contract.md` (#2822), `docs/io_rule_contract.md` (#2841),
+`docs/globals_rule_contract.md` (#2858), `docs/safety_rule_contract.md` (#2869),
+`docs/import_rule_contract.md` (#2875) and `docs/high_risk_execution_rule_contract.md` (#2878).
+
+The sheet's draft sentence was "Authorship metadata. Includes: @author, Created by:". Forty-six
+rules read it forty-six ways: solidity counted the SPDX license identifier on every file, c,
+cpp and yacc counted the MIT license's own prose (`The above copyright notice`, `AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE`), shell counted every copyright notice, typescript and javascript
+counted the phrase `created by` wherever a sentence used it, go counted `owner as the given
+ReplicaSet`, objective-c's rule was literally a person's name (`Tim Berners-Lee`, copied into
+abap, apex and scala), kotlin counted `@since`, haskell could not see the GHC module header's
+`Maintainer  :` field, and five doc rules still counted the author tag a second time. Every one
+of those is a different answer to "what is one hit".
+
+This is the first contract stated for a **comment-stream rule**. The detector runs the six
+comment-stream rules (`dead_code`, `doc`, `ownership`, `planned_debt`, `fragile_debt`,
+`spec_exposure`) over the code stream in `coding_analysis` AND over the comment stream in
+`comment_analysis`, so a rule's incidence is the sum of both -- `tests/tools/rule_probe.py`
+measured only the code stream until this issue and read c's 51 crucible hits as 0. It now takes
+`--stream auto|code|comment|both` (auto = both for those six rules) and reports the split.
+
+## The contract
+
+> **One hit is a tag naming who is responsible for the unit -- an author, creator, maintainer,
+> owner, developer or contact -- with its value, in the form the language's tooling or header
+> convention reads as metadata: a doc-comment tag, a keyed header line, or the language's own
+> metadata field.**
+
+Kind `annotation`, unit `annotations` (the module's `KINDS` table): a marker attached to a
+comment or declaration. The score layer reads it once, at `ownership_weight` 0.5 as documentation
+defense in `_calc_documentation` (the "knowledge shield": a named person to ask), scaled by the
+per-signal fidelity coefficient; `detector._decode_comment_stream` also reads the rule's **last
+capture group** from the comment stream as the file's dominant author (`Architect` in the audit,
+`Unknown Architect` when nothing matches), and `signal_processor` names ghost clusters after it.
+
+## Corollaries
+
+**C1 -- the tag, not the word.** The forms are `@author X` (javadoc, jsdoc, phpdoc, apexdoc,
+kdoc, scaladoc, groovydoc, natspec, LDoc, YARD, doxygen, css/sqlite `/** @author */`),
+`\author X` (doxygen), `<author>X</author>` (C# XML docs), `Author: X` / `Created by: X` /
+`Maintainer: X` / `Owner: X` / `Developer: X` / `Contact: X` as a keyed header line (any case
+after the language's comment marker; on an unprefixed block-comment continuation line the tag
+must be capitalised -- `Author:` or `AUTHOR:` -- and its value must not end the way a field or
+literal line does), `=head1 AUTHOR(S)` (POD, the value on the next paragraph), `.AUTHOR X`
+(powershell help), `- Author: X` (swift markdown callouts), `AUTHOR. X.` (cobol's paragraph),
+`MOD BY - X` (agc's modification credit), `__author__ = "X"`, `.. moduleauthor:: X` and
+`:author: X` (python's module variable, Sphinx directive and docinfo field), `MAINTAINER X` /
+`LABEL maintainer=` / `LABEL org.opencontainers.image.authors=` (dockerfile), `author:` and
+`contact:` (yaml -- action.yml and OpenAPI), `<meta name="author">` / `<link rev="made">`
+(html), and Xcode's dated template `//  Created by X on <date>` (swift, objective-c, c, cpp)
+-- the one colon-less keyed form kept, because the date is its separator. The keyed form is
+anchored to the start of a comment line and needs its separator, and the separator is not
+`::` or `:=` (`Author::Author()` is a C++ scope, `AUTHOR := x` a make variable). Prose carrying
+the words is not a hit: typescript's `* created by the extension.` (11 of vscode's hits),
+javascript's `created by the renderer`, csharp's `being created by compiling all of the code`,
+go's `owner as the given ReplicaSet`; a substring is not a tag (python's unanchored `Author:`
+matched inside `.. moduleauthor::`, which now counts by its own form); a field or annotation
+named for the concept is not one (`owner: UserDB`, `owner: *Package.Module,`, `author:
+CommentAuthorInformation;`, react's `owner: task.debugOwner,`); a person's name is not a rule.
+
+**C2 -- rights are not responsibility.** A license identifier (`SPDX-License-Identifier`,
+`License:`, `=head1 LICENSE`) and a copyright notice (`Copyright (c) 2014 X`, `Copyright 2017
+The Kubernetes Authors`, `SPDX-FileCopyrightText`, `AC_COPYRIGHT`, `=head1 COPYRIGHT`, the keyed
+`Copyright:` that twenty rules carried and no real notice writes) say who holds rights and on
+what terms -- repo-wide boilerplate, identical on every file, that says nothing about who to ask
+about this one. Neither counts, in any form. Four languages counted the notice (c, cpp, yacc,
+objective-c), shell counted every one (131 of 256 crucible files), c/cpp/yacc counted the
+license text itself, and forty-one languages counted none of it; the contract sides with the
+forty-one. The visible consequence in the golden master: `Architect` for doom's c files was
+`(C) 1993-1996 by id Software, Inc` and is now `Unknown Architect`, which is the truth -- no one
+signed those files. A version tag (`@since`) is not ownership either.
+
+**C3 -- one tag is one hit, and the value is the name.** A file with `@author` and
+`Maintainer:` reads 2; two `@author` lines read 2; a block under one tag (yaml's `contact:`,
+perl's `=head1 AUTHORS` paragraph, a wrapped continuation) reads 1. Every alternative captures
+its value with the closing comment marker stripped (`/* Author: X */` yields `X`), because the
+detector reads `m.group(m.lastindex)` -- solidity's SPDX alternative had no group, so every
+solidity file's architect was the string `// SPDX-License-Identifier:`; m4's `AC_COPYRIGHT` and
+yaml's whole rule had none either.
+
+**C4 -- one owner: the author tag is ownership's.** `doc` counts the documentation block, never
+the author tag inside it -- the rule #2659 and #2672 applied to eighteen languages, finished:
+assembly (`@author`), cobol (`*> @author`), css (`/* @author`), dockerfile (`LABEL maintainer=`,
+`LABEL org.opencontainers.image.authors=`, `# Author:`, `# Maintainer:`), haskell (`-- @author`,
+whose ownership rule was pinned *not* to match it) and solidity's bare `@author` release it.
+html's `<meta name="author">` was already ownership's alone (#2659); the corpus ledger's
+`batch5-tier2-morphology-shapes` still called it a dual and loses the clause.
+
+**C5 -- absence.** markdown has no comment surface (the prose bypass routes the whole file to
+the doc stream) and no metadata field; its rule stays `None` and the cell is n/a. Every other
+corpus language has a comment surface or a metadata key, so no fallback family is manufactured.
+
+## The open cell
+
+`solidity` read 4 against a row of 1s: the SPDX line on every file (C2), through the
+group-less alternative (C3). The rule now counts natspec `/// @author` and the keyed line;
+`main.sol` plants `// Author: keyword-rosetta generator` (the `///` form was rejected because
+the doc rule counts every `///` line and doc would read 2) and `a`/`b`/`c` re-bless 1 -> 0.
+The SPDX lines stay in the files as furniture and count nothing.
+
+## Measured with no red cell
+
+The crucible (language-crucible v1.2.0, `rule_probe.py --stream auto`, raw hits over both
+Prism streams) before -> after, with the reason:
+
+- **c 51 -> 0, cpp 62 -> 1, yacc 6 -> 0**: the notice form and the MIT/BSD license prose (C2).
+  cpp's survivor is `// Owner: Builtin (local) administrator` -- a keyed line in a comment.
+- **shell 131 -> 5**: every `# Copyright ...` notice (C2); the five are `# Author:` and
+  `# Created by:` lines in the linux kernel's scripts.
+- **typescript 11 -> 0, javascript 4 -> 0, csharp 1 -> 0, go 1 -> 0**: `created by` and `owner`
+  in sentences (C1). react's `owner: task.debugOwner,` fields were caught by a first draft of
+  the bare form and are excluded by its terminator guard.
+- **m4 2 -> 0**: `AC_COPYRIGHT` (C2; it stays `doc`'s). **perl 2 -> 1**: `=head1 COPYRIGHT`
+  out, `=head1 AUTHORS` stays and now captures the paragraph. **php 17 -> 16**: `@copyright`.
+- **haskell 0 -> 7**: pandoc's GHC-style header `Maintainer  : John MacFarlane` -- spaces
+  before the colon, on an unprefixed line inside `{- |` (C1's bare form).
+- **cobol 61 -> 79**: `* Author     : ALDV` comment lines join the `AUTHOR.` paragraph.
+- **python 2 -> 5**: `:contact:` and two twisted `Maintainer:` docstring lines join;
+  `.. moduleauthor::` and `:author:` count by their own forms.
+- **sqlite 0 -> 8**: yii migrations' `* @author Qiang Xue` blocks. **matlab 3 -> 5**:
+  `% Authors:`. **fortran 1 -> 3**: `!  Author:Balwinder.Singh@pnl.gov` (no space after the
+  colon). **scheme 0 -> 2**: `;;; Authors: R. Kent Dybvig, ...`. **powershell 0 -> 1**:
+  `Maintainer: PowerShell Team` in a help block. **dockerfile 0 -> 1**: `# Maintainer:
+  @jhowardmsft` (released by doc, C4).
+- **objective-c 1 -> 0**: `//	TBL		Tim Berners-Lee CERN/CN` (a name is not a tag).
+
+`doc` on the crucible moved in one language: dockerfile 7 -> 6 (`LABEL maintainer=`, C4). The
+other five doc releases had no crucible hits.
+
+## The corpus (keyword-rosetta PR)
+
+| language | was | now | why |
+|---|---|---|---|
+| solidity `a/b/c.sol` | ownership 1 (SPDX) | 0 | C2 |
+| solidity `main.sol` | SPDX line | `// Author: keyword-rosetta generator` added | C1 |
+| csharp `main.cs`, objective-c `main.mm` | `// Created by keyword-rosetta generator` | `// Created by: keyword-rosetta generator` | C1 (the separator) |
+
+Each screened as a replacement pair (every rule of the language over both Prism streams, HEAD
+vs branch): only `ownership` moves. Ledger: `ownership-contract-2882` added;
+`batch5-tier2-morphology-shapes` loses `ownership`, solidity and html (their only itemised
+shapes). Every other language's plant already carried the keyed or doc-tag form and reads 1
+unchanged, with the generator's name as the captured value in all 45.
+
+## The 46-language audit
+
+Raw rule hits on both corpora before -> after (`rule_probe.py --compare`); a single number
+did not move. The keyword-rosetta column is the corpus cell (1 planted in `main`; markdown n/a).
+
+| language | crucible | keyword-rosetta |
+|---|---|---|
+| `abap` | 0 | 1 |
+| `ada` | -- | 1 |
+| `agc_assembly` | 16 | 1 |
+| `apex` | 0 | 1 |
+| `assembly` | 0 | 1 |
+| `c` | 51 -> 0 | 1 |
+| `cobol` | 61 -> 79 | 1 |
+| `cpp` | 62 -> 1 | 1 |
+| `csharp` | 1 -> 0 | 1 |
+| `css` | 0 | 1 |
+| `dart` | 0 | 1 |
+| `dockerfile` | 0 -> 1 | 1 |
+| `embedded_python` | 0 | 1 |
+| `fortran` | 1 -> 3 | 1 |
+| `go` | 1 -> 0 | 1 |
+| `groovy` | 14 | 1 |
+| `haskell` | 0 -> 7 | 1 |
+| `html` | 1 | 1 |
+| `java` | 42 | 1 |
+| `javascript` | 4 -> 0 | 1 |
+| `jcl` | 0 | 1 |
+| `kotlin` | 0 | 1 |
+| `livecode` | 0 | 1 |
+| `lua` | 0 | 1 |
+| `m4` | 2 -> 0 | 1 |
+| `makefile` | -- | 1 |
+| `markdown` | n/a | n/a |
+| `matlab` | 3 -> 5 | 1 |
+| `objective-c` | 1 -> 0 | 1 |
+| `perl` | 2 -> 1 | 1 |
+| `php` | 17 -> 16 | 1 |
+| `powershell` | 0 -> 1 | 1 |
+| `python` | 2 -> 5 | 1 |
+| `ruby` | 0 | 1 |
+| `rust` | 0 | 1 |
+| `scala` | 0 | 1 |
+| `scheme` | 0 -> 2 | 1 |
+| `shell` | 131 -> 5 | 1 |
+| `solidity` | 7 -> 0 | 4 -> 1 |
+| `sqlite` | 0 -> 8 | 1 |
+| `swift` | 0 | 1 |
+| `tcl` | 0 | 1 |
+| `typescript` | 11 -> 0 | 1 |
+| `yacc` | 6 -> 0 | 1 |
+| `yaml` | 0 | 1 |
+| `zig` | 0 | 1 |
+
+Every rule was rewritten to the shared shape (one replacement script, `# #2882 contract:` in
+each file's comment): the language's doc-tag form(s), the keyed line on the language's own
+comment markers, its metadata field(s), the bare capitalised form, every alternative capturing.
+Unchanged in effect on the crucible: the twenty-four languages whose files carry no tag at all.
+
+## Known limits
+
+- The stream contract: a string literal carrying a form at the start of a line counts (a
+  multi-line string beginning `Author: x`). Deliberate, corpus-wide.
+- cobol's `AUTHOR.` paragraph counts when its value is empty (NIST's `000400 AUTHOR.` with only
+  the sequence-area identifier), because the paragraph is declared; the captured "name" is
+  then the sequence text. The keyed form's value is captured verbatim, so `__author__ = "x"`
+  yields `"x"` with its quotes and `LABEL maintainer="x"` likewise -- the detector strips tags
+  and trailing punctuation, not quotes.
+- The bare capitalised form admits a capitalised field or annotation that does not end in
+  `,`, `;`, `{` or `(` (a pydantic model with `Owner: str`), and a comment line `// Owner:
+  Builtin (local) administrator` describing something else's owner. Measured at one hit.
+- The ghost meta reads the comment stream only, so python's `__author__`, dockerfile's
+  `MAINTAINER`, yaml's `author:` and html's `<meta>` count but never name the architect
+  (pre-existing; `_decode_comment_stream` is the consumer to widen).
+- yaml's Helm `maintainers:` list and `CODEOWNERS`-style files are not ownership forms yet
+  (no cell evidence; the value sits on the next line).
+
+## Deferred by design
+
+Nothing filed: the audit found no residue worth an issue. The ghost-meta limit above and the
+`maintainers:` list are named here for the next language that needs them.
+
+## Bless scope
+
+`tests/golden_master_*.json`: 489 differences, **0 topological**, all in-family -- the
+`Authorship Metadata` leaf (198), `Architect` in the artifact identity (194: doom's
+`(C) 1993-1996 by id Software, Inc` and haiku's `(c) 2010-2012 Haiku, Inc` become `Unknown
+Architect`; moby's `windows.Dockerfile` gains `@jhowardmsft`), `Documentation Exposure` /
+`documentation` (91, the 0.5-weight defense), and one dockerfile file whose `Structured
+Documentation Blocks` reads 1 instead of 2 (C4's `LABEL maintainer=` release) with the
+`Cognitive Load Exposure` that reads doc. By language: shell 181, c 68, cpp 59, cobol 49,
+solidity 16, haskell 14, sqlite 10. Newly parsed / newly excluded: none.

--- a/docs/signal_contracts.md
+++ b/docs/signal_contracts.md
@@ -60,7 +60,7 @@ written.** Corollaries every audited contract has needed so far:
 
 ## Signals
 
-12 stated, 56 draft. A **draft** row is the schema comment transcribed as-is; a **stated** row has been audited across the corpus languages and has a contract doc. `planted` = the keyword-rosetta corpus plants a known count of it (so the cross-language gate can hold it equal); unplanted signals that feed a risk formula are the ones the roadmap's Phase 3 must plant or declare absent.
+13 stated, 55 draft. A **draft** row is the schema comment transcribed as-is; a **stated** row has been audited across the corpus languages and has a contract doc. `planted` = the keyword-rosetta corpus plants a known count of it (so the cross-language gate can hold it equal); unplanted signals that feed a risk formula are the ones the roadmap's Phase 3 must plant or declare absent.
 
 | signal | phase | kind | status | planted | contract | doc |
 |---|---|---|---|---|---|---|
@@ -85,7 +85,7 @@ written.** Corollaries every audited contract has needed so far:
 | `generics` | architecture | `annotation` | draft |  | Type parameters indicating generic abstractions |  |
 | `globals` | architecture | `declaration` | stated | yes | A declaration of a binding with program lifetime -- file, module, class-static or process scope -- or a read or write of the process's ambient environment through its named handle | [globals_rule_contract.md](../docs/globals_rule_contract.md) #2858 |
 | `import` | architecture | `declaration` | stated | yes | A statement or directive that binds an external unit -- a module, package, header, library, file, stage or base image -- into the current unit, in the language's own dependency form | [import_rule_contract.md](../docs/import_rule_contract.md) #2875 |
-| `ownership` | architecture | `annotation` | draft | yes | Authorship metadata |  |
+| `ownership` | architecture | `annotation` | stated | yes | A tag naming who is responsible for the unit -- an author, creator, maintainer, owner, developer or contact -- with its value, in the form the language's tooling or header convention reads as metadata | [ownership_rule_contract.md](../docs/ownership_rule_contract.md) #2882 |
 | `reflection_metaprogramming` | architecture | `site` | draft |  | Metaprogramming, reflection, and dynamic property assignment |  |
 | `scientific` | architecture | `site` | draft |  | Math, data science, and complex rendering libraries |  |
 | `ui_framework` | architecture | `site` | draft |  | DOM manipulation, UI components |  |

--- a/gitgalaxy/standards/how_to_add_a_language.md
+++ b/gitgalaxy/standards/how_to_add_a_language.md
@@ -204,7 +204,7 @@ Generate a valid Python dictionary matching this exact structure.
         "import": re.compile(r""), 
         # _dependency_capture: Regex strictly capturing group 1 as the exact dependency path string.
         "_dependency_capture": re.compile(r""), 
-        # ownership: Authorship metadata. Includes: @author, Created by:.
+        # ownership: A tag naming who is responsible for the unit -- an author, creator, maintainer, owner, developer or contact -- with its value, in the form the language's tooling or header convention reads as metadata. Includes: @author, Author:, Created by:, Maintainer:, __author__ =, MAINTAINER. Not a license identifier or a copyright notice (#2882 C2), not the word in prose (C1).
         "ownership": re.compile(r""), 
 
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/abap.py
+++ b/gitgalaxy/standards/language_standards/languages/abap.py
@@ -216,8 +216,9 @@ DEFINITION: dict[str, Any] = {
         ),
         "_dependency_capture": re.compile(r"^[ \t]*(?:INCLUDE|TYPE-POOLS)[ \t\n]+([A-Za-z0-9_/]+)", re.I | re.M),
         # 25. ownership: Authorship indicators.
+        # #2882 contract: C1 the tag anchored to the `*`/`"` comment line; a person's name (`Tim Berners-Lee`) is not a rule
         "ownership": re.compile(
-            r"(?:AUTHOR|CREATED\s+BY|MAINTAINER|Tim Berners-Lee):\s+([^\n]+)",
+            r"^[ \t]*(?:\*+|\x22+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/ada.py
+++ b/gitgalaxy/standards/language_standards/languages/ada.py
@@ -272,7 +272,11 @@ DEFINITION: dict[str, Any] = {
         ),
         # ownership: header comment convention, same shape as the JCL/
         # COBOL entries.
-        "ownership": re.compile(r"^[ \t]*--[ \t]*(?:Author|Created by|Maintainer)[ \t]*:[ \t]*(.*)$", re.I | re.M),
+        # #2882 contract: C1 keyed line on `--`; @author joins
+        "ownership": re.compile(
+            r"^[ \t]*(?:--+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         "planned_debt": GLOBAL_PLANNED_DEBT,
         "fragile_debt": GLOBAL_FRAGILE_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/agc_assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/agc_assembly.py
@@ -213,8 +213,9 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C1 MOD BY / AUTHOR / Contact keyed lines on `#`; every alternative captures (C3)
         "ownership": re.compile(
-            r"^#\s*(?:MOD\s+BY|AUTHOR|CREATED\s+BY|MAINTAINER|Contact)\s*[:\-]\s*(.*)",
+            r"^[ \t]*#+[ \t]*MOD[ \t]+BY[ \t]*[:\-]+[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.M | re.I,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/apex.py
+++ b/gitgalaxy/standards/language_standards/languages/apex.py
@@ -299,8 +299,9 @@ DEFINITION: dict[str, Any] = {
         # alternative; the remaining prose-risky alternatives (Author|Created by|
         # Maintainer|Copyright|Tim Berners-Lee) stay colon-required so ordinary prose
         # ("the Author of this module") still can't false-positive.
+        # #2882 contract: C2 `Copyright:` out; a person's name is not a rule (C1)
         "ownership": re.compile(
-            r"(?:@author:?\s+|(?:Author|Created by|Maintainer|Copyright|Tim Berners-Lee):\s+)([^\n]+)",
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/assembly.py
@@ -194,7 +194,8 @@ DEFINITION: dict[str, Any] = {
         # 12. dead_code (Commented Logic / Deprecated Trails)
         "dead_code": re.compile(r"(?i)(?:;|#|//)[ \t]*(?:jmp|call|mov|push|pop|cmp|add|sub)\b"),
         # 13. doc (Structured Documentation)
-        "doc": re.compile(r"^[;#@/|]+\s*@(?:param|return|brief|author|note)", re.M | re.I),
+        # #2882 contract C4: doc counts the block, not the author tag -- @author is ownership's alone.
+        "doc": re.compile(r"^[;#@/|]+\s*@(?:param|return|brief|note)", re.M | re.I),
         # 14. test (Testing & Assertions)
         "test": re.compile(r"(?i)\b(?:describe|expect|assert|TestCase)\b|\bit[ \t]*\("),
         # --- PHASE 3: ARCHITECTURE & DOMAIN SENSORS ---
@@ -243,8 +244,9 @@ DEFINITION: dict[str, Any] = {
             re.M | re.I,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C2 `Copyright:` out; @author is ownership's (doc released it, C4)
         "ownership": re.compile(
-            r"^[;#@/|]+\s*(?:Author|Created by|Maintainer|Copyright):\s+(.*)",
+            r"^[ \t]*(?:[;#@|]+|//+|/\*+|\*+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.M | re.I,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/c.py
+++ b/gitgalaxy/standards/language_standards/languages/c.py
@@ -299,7 +299,11 @@ DEFINITION: dict[str, Any] = {
         "import": re.compile(r'^[ \t]*#[ \t]*(?:include|embed)\s*[<"][^>"]+[>"]', re.M),
         "_dependency_capture": re.compile(r'^[ \t]*#[ \t\n]*(?:include|embed)[ \t\n]*[<"]([^>"]+)[>"]', re.M),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:@author|\\author|Author:|Created by:|Copyright)\s+(.*)", re.I),
+        # #2882 contract: C2 the copyright notice and the license's own prose out (51 -> 0 on the crucible); \author, keyed lines, Xcode's dated `Created by` in
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|\\author[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*//+[ \t]*Created[ \t]+by[ \t]+(\S[^\n]*?)[ \t]+on[ \t]+\d[^\n]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/cobol.py
+++ b/gitgalaxy/standards/language_standards/languages/cobol.py
@@ -365,8 +365,9 @@ DEFINITION: dict[str, Any] = {
         # owns `AUTHOR` exclusively; drop it here and leave the other
         # header fields and the `*>` tags (including `@author` inline
         # comments, which are distinct from the AUTHOR paragraph) as-is.
+        # #2882 contract C4: doc counts the block, not the author tag -- `*> @author` is ownership's alone.
         "doc": re.compile(
-            r"^(?:[0-9a-zA-Z \t]{6}[ \-]?)?[ \t]*(?:DATE-WRITTEN|DATE-COMPILED|REMARKS|INSTALLATION)\.|\*>\s*@(?:param|return|author)",
+            r"^(?:[0-9a-zA-Z \t]{6}[ \-]?)?[ \t]*(?:DATE-WRITTEN|DATE-COMPILED|REMARKS|INSTALLATION)\.|\*>\s*@(?:param|return)",
             re.I | re.M,
         ),
         # 14. test: Testing & Assertions. Unit testing framework markers (ZUnit).
@@ -437,7 +438,11 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # 25. ownership: Authorship indicators.
-        "ownership": re.compile(r"^(?:[0-9a-zA-Z \t]{6}[ \-]?)?[ \t]*AUTHOR\.\s+([^\n]+)", re.I | re.M),
+        # #2882 contract: C1 `* Author :` comment lines join the AUTHOR. paragraph; `*> @author` is ownership's (doc released it, C4)
+        "ownership": re.compile(
+            r"^(?:[0-9a-zA-Z \t]{6}[ \-]?)?[ \t]*AUTHOR\.\s+([^\n]+)|\*>[ \t]*@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^(?:[0-9a-zA-Z \t]{6}[*/\-]|[ \t]*\*>)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt: The Promise. Future work markers.
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/cpp.py
+++ b/gitgalaxy/standards/language_standards/languages/cpp.py
@@ -399,7 +399,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:@author|\\author|Author:|Created by:|Copyright)\s+(.*)", re.I),
+        # #2882 contract: C2 the copyright notice and the license's own prose out (62 -> 1); \author, keyed lines, Xcode's dated `Created by` in
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|\\author[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*//+[ \t]*Created[ \t]+by[ \t]+(\S[^\n]*?)[ \t]+on[ \t]+\d[^\n]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/csharp.py
+++ b/gitgalaxy/standards/language_standards/languages/csharp.py
@@ -422,7 +422,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:<author>|Author:|Created by)\s*(.*)", re.I),
+        # #2882 contract: C1 colon-less `Created by` matched prose (`being created by compiling`); <author>, @author, keyed lines
+        "ownership": re.compile(
+            r"<author>[ \t]*([^<\n]+)|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/css.py
+++ b/gitgalaxy/standards/language_standards/languages/css.py
@@ -184,8 +184,9 @@ DEFINITION: dict[str, Any] = {
             re.I,
         ),
         # 13. doc (Structured Documentation)
+        # #2882 contract C4: doc counts the block, not the author tag -- `/* @author` is ownership's alone.
         "doc": re.compile(
-            r"/\*\*\s*|/\*\s*@(?:param|return|author|example|prop|define|theme)",
+            r"/\*\*\s*|/\*\s*@(?:param|return|example|prop|define|theme)",
             re.I,
         ),
         # 14. test (Testing & Assertions)
@@ -230,9 +231,10 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C2 `Copyright` out; @author is ownership's (doc released it, C4); the `*/` is stripped from the value (C3)
         "ownership": re.compile(
-            r"/\*\s*(?:@author|Author:|Created by|Maintainer|Copyright):?\s+([^*]*)\*/",
-            re.I | re.S,
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)

--- a/gitgalaxy/standards/language_standards/languages/dart.py
+++ b/gitgalaxy/standards/language_standards/languages/dart.py
@@ -367,7 +367,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership: Authorship indicators.
-        "ownership": re.compile(r"//\s*(?:Author|Created by|Maintainer|Copyright):\s+([^\n]+)", re.I),
+        # #2882 contract: C2 `Copyright:` out; @author joins; the keyed line needs its marker or a capitalised tag (a `owner:` named argument is not one, C1)
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt: The Promise. Future work markers.
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/dockerfile.py
+++ b/gitgalaxy/standards/language_standards/languages/dockerfile.py
@@ -155,8 +155,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # 13. doc (Structured Documentation)
         # Intent documentation meant for developers or image registries.
+        # #2882 contract C4: doc counts the block, not the author tag -- `LABEL maintainer=`, `org.opencontainers.image.authors=`, `# Author:`/`# Maintainer:` is ownership's alone.
         "doc": re.compile(
-            r"^[ \t]*LABEL[ \t]+(?:maintainer|org\.opencontainers|version|description)=|^[ \t]*#[ \t]*(?:Description|Usage|Author|Maintainer):",
+            r"^[ \t]*LABEL[ \t]+(?:org\.opencontainers\.image\.(?!authors=)|version|description)[\w.]*=|^[ \t]*#[ \t]*(?:Description|Usage):",
             re.M | re.I,
         ),
         # 14. test (Testing & Assertions)
@@ -223,8 +224,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # 25. ownership (Authorship Metadata)
         # Standard metadata tracing image ownership (legacy MAINTAINER or modern LABEL).
+        # #2882 contract: C1 `# Author:`/`# Maintainer:` comment lines join (doc released them, C4)
         "ownership": re.compile(
-            r"^[ \t]*(?:MAINTAINER|LABEL[ \t]+maintainer=|LABEL[ \t]+org\.opencontainers\.image\.authors=)[ \t]*(.*)",
+            r"^[ \t]*(?:MAINTAINER|LABEL[ \t]+maintainer=|LABEL[ \t]+org\.opencontainers\.image\.authors=)[ \t]*(.*)|^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.M | re.I,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/embedded_python.py
+++ b/gitgalaxy/standards/language_standards/languages/embedded_python.py
@@ -199,7 +199,11 @@ DEFINITION: dict[str, Any] = {
         ),
         "_dependency_capture": re.compile(r"^[ \t]*(?:import|from)\b\s+([\w.]+)", re.M),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:__author__[ \t]*=|Author:|Created by:)\s*(.*)", re.I),
+        # #2882 contract: C1 python parity: __author__, `.. moduleauthor::`, `:author:` docinfo, keyed lines; `owner: T` annotations are not tags
+        "ownership": re.compile(
+            r"^[ \t]*__author__[ \t]*=[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*\.\.[ \t]+(?:module|section)author::[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:#+|:)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/fortran.py
+++ b/gitgalaxy/standards/language_standards/languages/fortran.py
@@ -358,8 +358,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # 25. ownership (Authorship Metadata)
         # Identifying the developer, maintainer, or copyright holder natively.
+        # #2882 contract: C1 the keyed line tolerates indentation; `Developer:` joins the family; C2 `Copyright` never counted here
         "ownership": re.compile(
-            r"^[cCdD*!][ \t]*(?:Author|Created by|Maintainer|Developer):\s+(.*)",
+            r"^[ \t]*(?:!+|[cCdD*](?=[ \t]))[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/go.py
+++ b/gitgalaxy/standards/language_standards/languages/go.py
@@ -269,9 +269,10 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C1 colon-optional `Owner` matched `owner as the given ReplicaSet`; a composite-literal `Owner: x,` is a field, not a tag
         "ownership": re.compile(
-            r"(?://|#|/\*)\s*(?:Author|Maintainer|Created by|Owner):?\s+([a-zA-Z0-9_ -]+)",
-            re.I,
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)

--- a/gitgalaxy/standards/language_standards/languages/groovy.py
+++ b/gitgalaxy/standards/language_standards/languages/groovy.py
@@ -407,7 +407,11 @@ DEFINITION: dict[str, Any] = {
             r"^[ \t]*import[ \t\n\\]+(?:static[ \t\n\\]+)?([\w*]+(?:[ \t\n]*\.[ \t\n]*[\w*]+)*)[ \t]*;?", re.M
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"@author\s+(.*)", re.I),
+        # #2882 contract: C1 keyed lines join @author
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/haskell.py
+++ b/gitgalaxy/standards/language_standards/languages/haskell.py
@@ -294,7 +294,8 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # doc: Structured Documentation. Haddock documentation markers.
-        "doc": re.compile(r"--\s*\||--\s*\^|\{-\||--\s*@(?:param|return|author)"),
+        # #2882 contract C4: doc counts the block, not the author tag -- `-- @author` is ownership's alone.
+        "doc": re.compile(r"--\s*\||--\s*\^|\{-\||--\s*@(?:param|return)"),
         # test: Testing & Assertions. Verification framework keywords (QuickCheck/Hspec).
         "test": re.compile(
             r'\b(?:hspec|QuickCheck|prop_[a-zA-Z0-9_\']+|assertEqual|shouldBe|testGroup|testCase)\b|\b(?:describe|it|property)\s+"'
@@ -343,7 +344,11 @@ DEFINITION: dict[str, Any] = {
             r"^[ \t]*import\b[\s\S]{0,100}?(?:qualified\b[\s\S]{0,100}?)?([A-Z][a-zA-Z0-9_.]*)", re.M
         ),
         # ownership: Authorship indicators in comments.
-        "ownership": re.compile(r"--\s*\|?\s*(?:Author|Maintainer|Copyright|License):\s+([^\n]+)", re.I),
+        # #2882 contract: C2 `License:`/`Copyright:` out; C1 the GHC header's `Maintainer  :` (spaces before the colon, unprefixed inside `{- |`) in; `-- @author` is ownership's (doc released it, C4)
+        "ownership": re.compile(
+            r"^[ \t]*(?:--+(?:[ \t]*\|)?|\{-+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         "planned_debt": GLOBAL_PLANNED_DEBT,
         "fragile_debt": GLOBAL_FRAGILE_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/html.py
+++ b/gitgalaxy/standards/language_standards/languages/html.py
@@ -281,9 +281,10 @@ DEFINITION: dict[str, Any] = {
             re.IGNORECASE,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C3 the <link rev=made> alternative captures the address; `<!-- Author: -->` comment lines join
         "ownership": re.compile(
-            r"<meta\s+name=(?:\"(?:author|creator|publisher)\"|'(?:author|creator|publisher)')\s+content=(?:\"([^\"]+)\"|'([^']+)')|<link\s+rev=(?:\"made\"|'made')\s+href=(?:\"mailto:[^\"]+\"|'mailto:[^']+')",
-            re.I,
+            r"<meta\s+name=(?:\"(?:author|creator|publisher)\"|'(?:author|creator|publisher)')\s+content=(?:\"([^\"]+)\"|'([^']+)')|<link\s+rev=(?:\"made\"|'made')\s+href=(?:\"mailto:([^\"]+)\"|'mailto:([^']+)')|^[ \t]*(?:<!--+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)

--- a/gitgalaxy/standards/language_standards/languages/java.py
+++ b/gitgalaxy/standards/language_standards/languages/java.py
@@ -319,7 +319,11 @@ DEFINITION: dict[str, Any] = {
         "import": re.compile(r"^[ \t]*import\s+(?:static[ \t]+)?[\w.]+;", re.M),
         "_dependency_capture": re.compile(r"^[ \t]*import[ \t\n]+(?:static[ \t\n]+)?([\w.*]+)[ \t\n]*;", re.M),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"@author\s+(.*)", re.I),
+        # #2882 contract: C1 keyed lines join @author
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/javascript.py
+++ b/gitgalaxy/standards/language_standards/languages/javascript.py
@@ -336,7 +336,11 @@ DEFINITION: dict[str, Any] = {
         ),
         "_named_token_capture": re.compile(r"(?:import|export)\s+\{([^}]+)\}", re.M),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:@author|Created by)\s+(.*)", re.I),
+        # #2882 contract: C1 colon-less `Created by` matched prose four times; `owner: x,` object fields are not tags
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/jcl.py
+++ b/gitgalaxy/standards/language_standards/languages/jcl.py
@@ -293,7 +293,11 @@ DEFINITION: dict[str, Any] = {
         # so an Author line with the value wrapped to the next physical line
         # captured garbage from that *different* line (including its own "//*"
         # prefix) instead of correctly failing to match. Bounded to `[ \t]+`.
-        "ownership": re.compile(r"^//\*[ \t]*(?:Author|Created by|Maintainer):[ \t]+(.*)", re.I | re.M),
+        # #2882 contract: C1 keyed line on `//*`
+        "ownership": re.compile(
+            r"^[ \t]*(?://\*+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # #2610: MSGLEVEL= (what the job log records: statements/allocations)
         # and MSGCLASS= (where the log goes) are JCL's observability dials --
         # the closest native equivalent of configuring a logger. Unanchored

--- a/gitgalaxy/standards/language_standards/languages/kotlin.py
+++ b/gitgalaxy/standards/language_standards/languages/kotlin.py
@@ -263,9 +263,10 @@ DEFINITION: dict[str, Any] = {
         "import": re.compile(r"^[ \t]*import\s+(?:static[ \t]+)?[\w.]+;?", re.M),
         "_dependency_capture": re.compile(r"^[ \t]*import[ \t\n]+(?:static[ \t\n]+)?([\w.*]+)", re.M),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C2 `@since` is a version tag, `Copyright:` a notice -- neither is ownership
         "ownership": re.compile(
-            r"@(?:author|since)\s+(.*)|//\s*(?:Created by|Maintainer|Copyright):\s+(.*)",
-            re.I,
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)

--- a/gitgalaxy/standards/language_standards/languages/livecode.py
+++ b/gitgalaxy/standards/language_standards/languages/livecode.py
@@ -306,8 +306,9 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # 25. ownership: Authorship metadata in comments.
+        # #2882 contract: C2 `Copyright:` out
         "ownership": re.compile(
-            r"^[ \t]*(?:--|//|#)\s*(?:Author|Created by|Maintainer|Copyright):\s+([^\n]+)",
+            r"^[ \t]*(?:--+|//+|#+|/\*+|\*+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/lua.py
+++ b/gitgalaxy/standards/language_standards/languages/lua.py
@@ -199,8 +199,9 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership: Authorship metadata in comments.
+        # #2882 contract: C2 `Copyright:`/`License:` out
         "ownership": re.compile(
-            r"--\s*(?:Author|Copyright|License|Maintainer):\s+([^\n]+)|---\s*@author\s+([^\n]+)",
+            r"^[ \t]*(?:--+(?:\[\[)?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/m4.py
+++ b/gitgalaxy/standards/language_standards/languages/m4.py
@@ -173,8 +173,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # 25. ownership (Authorship Metadata)
         # Same comment-style completeness fix as dead_code above (Engine Rule 12).
+        # #2882 contract: C2 AC_COPYRIGHT is doc's alone (the intentional dual retired), `Copyright:`/`License:` out; every alternative captures (C3)
         "ownership": re.compile(
-            r"^[ \t]*(?:dnl[ \t]+|#[ \t]*)(?:Author|Maintainer|Copyright|License):|AC_COPYRIGHT",
+            r"^[ \t]*(?:dnl\b|#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- 🌌 PHASE 4: EXTENDED DIMENSIONS (Specialized Sub-Equations) ---

--- a/gitgalaxy/standards/language_standards/languages/makefile.py
+++ b/gitgalaxy/standards/language_standards/languages/makefile.py
@@ -204,8 +204,9 @@ DEFINITION: dict[str, Any] = {
         # same precedent as #843's identical call for yaml.
         "_dependency_capture": re.compile(r"^[ ]*-?(?:include|sinclude)[ \t\n]+([^\s#]+)", re.M),
         # Metadata anchoring authorship and structural domain owners.
+        # #2882 contract: C1 the keyed family on `#`; `AUTHOR := x` is a variable (the separator is not `:=`)
         "ownership": re.compile(
-            r"^[ \t]*#[ \t]*(?:@author\b|author:|maintainer:|created by:)",
+            r"^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --------------------------------------------------------------------------

--- a/gitgalaxy/standards/language_standards/languages/matlab.py
+++ b/gitgalaxy/standards/language_standards/languages/matlab.py
@@ -214,7 +214,11 @@ DEFINITION: dict[str, Any] = {
         "import": re.compile(r"^[ \t]*import[ \t]+[a-zA-Z0-9_.*]+", re.M),
         "_dependency_capture": re.compile(r"^[ \t]*import(?:[ \t]|\.\.\.[^\n]*\n)+([a-zA-Z0-9_.*]+)", re.M),
         # ownership: Standard MATLAB comment authorship signatures.
-        "ownership": re.compile(r"^[ \t]*%[ \t]*(?:Author|Created by|Copyright)[ \t]*:(.*)", re.M | re.I),
+        # #2882 contract: C2 `Copyright` out; `Authors:` joins
+        "ownership": re.compile(
+            r"^[ \t]*(?:%+\{?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.M | re.I,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/objectivec.py
+++ b/gitgalaxy/standards/language_standards/languages/objectivec.py
@@ -367,7 +367,11 @@ DEFINITION: dict[str, Any] = {
         # BUG FIX: `@author` (leading \b before non-word `@`) and
         # `Author:` (trailing \b after non-word `:`) never matched --
         # same shape as branch's @try fix above.
-        "ownership": re.compile(r"\b(?:Created by|Copyright|Tim Berners-Lee)\b|@author|\bAuthor:", re.I),
+        # #2882 contract: C1 a person's name (`Tim Berners-Lee`) is not a rule; C2 `Copyright` out; Xcode's dated `Created by X on <date>` is the colon-less form kept
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|\\author[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*//+[ \t]*Created[ \t]+by[ \t]+(\S[^\n]*?)[ \t]+on[ \t]+\d[^\n]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         "planned_debt": GLOBAL_PLANNED_DEBT,
         "fragile_debt": GLOBAL_FRAGILE_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/perl.py
+++ b/gitgalaxy/standards/language_standards/languages/perl.py
@@ -315,8 +315,9 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership: Authorship metadata.
+        # #2882 contract: C2 `=head1 COPYRIGHT|LICENSE` out; `=head1 AUTHORS` captures the paragraph (C3)
         "ownership": re.compile(
-            r"^=head1\s+(?:AUTHOR|COPYRIGHT|LICENSE)|#\s*(?:Author|Maintainer|Created by):\s+([^\n]+)",
+            r"^=head1[ \t]+AUTHORS?\b[^\n]*(?:\n+[ \t]*(\S[^\n]*))?|^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/php.py
+++ b/gitgalaxy/standards/language_standards/languages/php.py
@@ -290,7 +290,11 @@ DEFINITION: dict[str, Any] = {
             re.M | re.I,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"@(?:author|copyright)\s+(.*)|(?:Created by|Maintainer):?\s+(.*)", re.I),
+        # #2882 contract: C2 `@copyright` out; C1 colon-less `Created by`/`Maintainer` matched prose
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+|#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/powershell.py
+++ b/gitgalaxy/standards/language_standards/languages/powershell.py
@@ -304,8 +304,9 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # ownership: Authorship indicators in comments or metadata.
+        # #2882 contract: C2 `Copyright:` out; `<#` help blocks
         "ownership": re.compile(
-            r"^[ \t]*#\s*(?:Author|Created by|Maintainer|Copyright):\s+([^\n]+)|\.AUTHOR\s+([^\n]+)",
+            r"^[ \t]*(?:#+|<#)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*\.AUTHOR[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/python.py
+++ b/gitgalaxy/standards/language_standards/languages/python.py
@@ -299,7 +299,11 @@ DEFINITION: dict[str, Any] = {
         ),
         "_named_token_capture": re.compile(r"^[ \t]*from\s+[\w.]+\s+import\s+([^({\n]+)", re.M),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:__author__[ \t]*=|Author:|Created by:)\s*(.*)", re.I),
+        # #2882 contract: C1 `Author:` matched inside `.. moduleauthor::` by substring; the directive and the `:author:` docinfo field count by their own forms; `owner: T` annotations are not tags
+        "ownership": re.compile(
+            r"^[ \t]*__author__[ \t]*=[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*\.\.[ \t]+(?:module|section)author::[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:#+|:)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/ruby.py
+++ b/gitgalaxy/standards/language_standards/languages/ruby.py
@@ -252,7 +252,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"#\s*(?:Author|Created by|Maintainer|Copyright):\s+(.*)", re.I),
+        # #2882 contract: C2 `Copyright:` out; YARD @author joins
+        "ownership": re.compile(
+            r"^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/rust.py
+++ b/gitgalaxy/standards/language_standards/languages/rust.py
@@ -252,7 +252,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"//\s*(?:Author|Maintainer|Copyright):\s+(.*)", re.I),
+        # #2882 contract: C2 `Copyright:` out; `//!` inner doc lines
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/scala.py
+++ b/gitgalaxy/standards/language_standards/languages/scala.py
@@ -257,9 +257,10 @@ DEFINITION: dict[str, Any] = {
         # Javadoc, and how java's own ownership rule already handles
         # it) is `@author Jane Doe`, with no colon at all. The colon
         # requirement meant the real Scaladoc tag never matched.
+        # #2882 contract: C2 `Copyright:` out; a person's name is not a rule (C1)
         "ownership": re.compile(
-            r"@author\s+([^\n]+)|(?:Created by|Maintainer|Copyright|Tim Berners-Lee):\s+([^\n]+)",
-            re.I,
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt: The Promise. Future work markers.

--- a/gitgalaxy/standards/language_standards/languages/scheme.py
+++ b/gitgalaxy/standards/language_standards/languages/scheme.py
@@ -247,8 +247,9 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C2 `Copyright:` out; `Authors:` joins
         "ownership": re.compile(
-            r"^[ \t]*;+\s*(?:Author|Created by|Maintainer|Copyright):\s+(.*)",
+            r"^[ \t]*(?:;+|#\|)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- 🌌 PHASE 4: EXTENDED DIMENSIONS (Specialized Sub-Equations) ---

--- a/gitgalaxy/standards/language_standards/languages/shell.py
+++ b/gitgalaxy/standards/language_standards/languages/shell.py
@@ -302,8 +302,9 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C2 colon-optional `Copyright` counted every notice (131 of 256 crucible files)
         "ownership": re.compile(
-            r"^[ \t]*#\s*(?:Author|Created by|Maintainer|Copyright):?\s+(.*)",
+            r"^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.M | re.I,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/solidity.py
+++ b/gitgalaxy/standards/language_standards/languages/solidity.py
@@ -114,7 +114,8 @@ DEFINITION: dict[str, Any] = {
         # non-greedy span, the #2658 shape), then the line-marker form so
         # `/// @param x` is one hit per line, not two; bare tags stay last
         # so a tag outside any doc comment still counts.
-        "doc": re.compile(r"/\*\*[\s\S]{0,15000}?\*/|///[^\n]*|@(?:param|return|dev|notice|custom|title|author)"),
+        # #2882 contract C4: doc counts the block, not the author tag -- the bare `@author` tag is ownership's alone.
+        "doc": re.compile(r"/\*\*[\s\S]{0,15000}?\*/|///[^\n]*|@(?:param|return|dev|notice|custom|title)"),
         # 14. test: Testing & Assertions. Foundry/Forge testing hooks and assertions.
         "test": re.compile(
             r"\b(?:setUp|test[A-Za-z0-9_]*|assertEq|assertTrue|assertFalse|assertGt|assertLt|vm\.expectRevert)\b"
@@ -166,7 +167,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership: Authorship indicators. Strictly targets SPDX license tags and authorship notes.
-        "ownership": re.compile(r"//[ \t]*SPDX-License-Identifier:|(?:@author|Created by):\s+(.*)", re.I),
+        # #2882 contract: C2 the SPDX license identifier is not who is responsible (the open cell, 4 vs 1) and its alternative had no group (C3); natspec @author and keyed lines
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- 🌌 PHASE 4: EXTENDED DIMENSIONS (Specialized Sub-Equations) ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/sqlite.py
+++ b/gitgalaxy/standards/language_standards/languages/sqlite.py
@@ -303,7 +303,11 @@ DEFINITION: dict[str, Any] = {
             re.I | re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"--\s*(?:Author|Created by|Maintainer|Copyright):\s+(.*)", re.I),
+        # #2882 contract: C2 `Copyright:` out; `/** @author */` blocks join
+        "ownership": re.compile(
+            r"^[ \t]*(?:--+|/\*+|\*+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/swift.py
+++ b/gitgalaxy/standards/language_standards/languages/swift.py
@@ -251,7 +251,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"//\s*(?:Created by|Author:|Copyright):\s+(.*)", re.I),
+        # #2882 contract: C2 `Copyright:` out; `- Author:` callouts and Xcode's dated `Created by` in
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)(?:[ \t]*-|)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*//+[ \t]*Created[ \t]+by[ \t]+(\S[^\n]*?)[ \t]+on[ \t]+\d[^\n]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/tcl.py
+++ b/gitgalaxy/standards/language_standards/languages/tcl.py
@@ -172,8 +172,9 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
+        # #2882 contract: C2 `Copyright:` out
         "ownership": re.compile(
-            r"^[ \t]*#[ \t]*(?:Author|Created by|Maintainer|Copyright):\s+(.*)",
+            r"^[ \t]*(?:#+)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$|@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.I | re.M,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/typescript.py
+++ b/gitgalaxy/standards/language_standards/languages/typescript.py
@@ -689,7 +689,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership (Authorship Metadata)
-        "ownership": re.compile(r"(?:@author|Created by)\s+(.*)", re.I),
+        # #2882 contract: C1 colon-less `Created by` matched vscode's prose eleven times; `author: T;` interface fields are not tags
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt (Annotated Debt / TODOs)
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/yacc.py
+++ b/gitgalaxy/standards/language_standards/languages/yacc.py
@@ -144,7 +144,11 @@ DEFINITION: dict[str, Any] = {
         # ordinary C `#include`s in their prologue); both delimiters and the
         # quantifier are bounded (Engine Rule 14).
         "_dependency_capture": re.compile(r'^[ \t]*#[ \t]*include[ \t]*[<"]([^>"\n]{1,200})[>"]', re.M),
-        "ownership": re.compile(r"(?:@author|Author:|Created by:|Copyright)\s+(.*)", re.I),
+        # #2882 contract: C2 the copyright notice and the license's own prose out (6 -> 0)
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         "planned_debt": GLOBAL_PLANNED_DEBT,
         "fragile_debt": GLOBAL_FRAGILE_DEBT,

--- a/gitgalaxy/standards/language_standards/languages/yaml.py
+++ b/gitgalaxy/standards/language_standards/languages/yaml.py
@@ -215,9 +215,10 @@ DEFINITION: dict[str, Any] = {
         # both a generic "name:" line AND part of an ownership/contact block), not a
         # bug introduced here; `author:` itself has no such overlap since `doc` has no
         # `author:` alternative.
+        # #2882 contract: C3 both alternatives capture the value
         "ownership": re.compile(
-            r"^[ \t]*author:[ \t]+.*"
-            r"|^[ \t]*contact:[ \t]*(?:#.*)?\n(?:[ \t]*(?:#.*)?\n){0,10}[ \t]+(?:name|email):",
+            r"^[ \t]*author:[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$"
+            r"|^[ \t]*contact:[ \t]*(?:#.*)?\n(?:[ \t]*(?:#.*)?\n){0,10}[ \t]+(?:name|email):[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$",
             re.M | re.I,
         ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---

--- a/gitgalaxy/standards/language_standards/languages/zig.py
+++ b/gitgalaxy/standards/language_standards/languages/zig.py
@@ -176,7 +176,11 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 25. ownership: Authorship indicators in comments.
-        "ownership": re.compile(r"//\s*(?:Author|Created by|Maintainer|Copyright):\s+([^\n]+)", re.I),
+        # #2882 contract: C2 `Copyright:` out; `//!` doc lines
+        "ownership": re.compile(
+            r"@author:?[ \t]+(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?:/\*+|\*+|//+!?)[ \t]*(?:Authors?|Created[ \t]+by|Maintainers?|Owners?|Developers?|Contact)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)[ \t]*(?:\*/|-->)?[ \t]*$|^[ \t]*(?-i:(?:Author|AUTHOR)(?:s|S)?|Created[ \t]+by|CREATED[ \t]+BY|Maintainer(?:s)?|MAINTAINER(?:S)?|Owner(?:s)?|OWNER(?:S)?|Developer(?:s)?|DEVELOPER(?:S)?|Contact|CONTACT)[ \t]*:(?![:=])[ \t]*(\S[^\n]*?)(?<![,;{(])[ \t]*(?:\*/|-->)?[ \t]*$",
+            re.I | re.M,
+        ),
         # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
         # 26. planned_debt: The Promise. Future work markers.
         "planned_debt": GLOBAL_PLANNED_DEBT,

--- a/gitgalaxy/standards/signal_contracts.py
+++ b/gitgalaxy/standards/signal_contracts.py
@@ -290,7 +290,16 @@ _ROWS = [
         issue=2875,
         planted=True,
     ),
-    _c("ownership", "architecture", "annotation", "Authorship metadata", planted=True),
+    _c(
+        "ownership",
+        "architecture",
+        "annotation",
+        "A tag naming who is responsible for the unit -- an author, creator, maintainer, owner, developer or contact -- with its value, in the form the language's tooling or header convention reads as metadata",
+        status="stated",
+        doc="docs/ownership_rule_contract.md",
+        issue=2882,
+        planted=True,
+    ),
     # --- PHASE 4: SPECIALIZED SUB-SYSTEMS ---
     _c("planned_debt", "subsystems", "annotation", "Annotated future work", planted=True),
     _c("fragile_debt", "subsystems", "annotation", "Explicit admissions of fragile or dangerous logic", planted=True),

--- a/tests/extraction/languages/test_agc_assembly_strict.py
+++ b/tests/extraction/languages/test_agc_assembly_strict.py
@@ -263,7 +263,7 @@ def test_agc_assembly_ambiguity_doc_vs_ownership_author_no_collision():
     header = "# AUTHOR: Jane Doe"
     assert not AGC_RULES["doc"].search(header)
     m = AGC_RULES["ownership"].search(header)
-    assert m and m.group(1) == "Jane Doe"
+    assert m and m.group(m.lastindex) == "Jane Doe"  # #2882 C3: the last group is the value
 
 
 def test_agc_api_contract_2730():

--- a/tests/extraction/languages/test_apex_strict.py
+++ b/tests/extraction/languages/test_apex_strict.py
@@ -421,14 +421,14 @@ def test_apex_doc_and_ownership_author_colon_optional_split_regression():
     idiomatic = "/**\n * @author Joe\n */"
     assert len(doc.findall(idiomatic)) == 1
     m = ownership.search(idiomatic)
-    assert m and m.group(1).strip() == "Joe"
+    assert m and m.group(m.lastindex).strip() == "Joe"  # #2882 C3: the last group is the value
 
     # colon form outside any doc block: doc has nothing to match (no /**, @author isn't
     # a doc tag anymore); ownership still claims it via the colon-optional alternative.
     colon_form = "@author: Joe"
     assert not doc.search(colon_form)
     m2 = ownership.search(colon_form)
-    assert m2 and m2.group(1).strip() == "Joe"
+    assert m2 and m2.group(m2.lastindex).strip() == "Joe"
 
     # the real rosetta corpus construct (data/apex/main.cls): doc=1 comes from the
     # separate @description line, unaffected by dropping @author; ownership still
@@ -436,7 +436,7 @@ def test_apex_doc_and_ownership_author_colon_optional_split_regression():
     corpus = "// Author: keyword-rosetta generator\n// @description dispatch each probe once"
     assert len(doc.findall(corpus)) == 1
     m3 = ownership.search(corpus)
-    assert m3 and m3.group(1).strip() == "keyword-rosetta generator"
+    assert m3 and m3.group(m3.lastindex).strip() == "keyword-rosetta generator"
 
     # prose must never false-positive on either rule.
     prose = "the Author of this module"

--- a/tests/extraction/languages/test_cobol_strict.py
+++ b/tests/extraction/languages/test_cobol_strict.py
@@ -523,7 +523,9 @@ def test_cobol_doc_excludes_author_regression():
     assert doc.search("       REMARKS. Some remark.")
     assert doc.search("       INSTALLATION. Site X.")
     assert doc.search("      *> @return something")
-    assert doc.search("      *> @author Joe"), "the inline `*> @author` tag is distinct from the AUTHOR paragraph"
+    # #2882 C4: the inline `*> @author` tag is ownership's too -- doc counts the block, never the author tag.
+    assert not doc.search("      *> @author Joe")
+    assert ownership.search("      *> @author Joe")
 
 
 def test_cobol_doc_planted_construct_counts_once_regression():

--- a/tests/extraction/languages/test_dockerfile_strict.py
+++ b/tests/extraction/languages/test_dockerfile_strict.py
@@ -78,7 +78,7 @@ _DOCKERFILE_SIMPLE_CASES = [
     ("api", "EXPOSE 8080", "WORKDIR /app"),
     ("state_mutation", "RUN export NODE_ENV=production", "ENV NODE_ENV production"),  # #2765: ENV is `globals`
     ("dead_code", "# RUN old-command", "# just a note"),
-    ("doc", 'LABEL maintainer="dev@example.com"', "LABEL env=prod"),
+    ("doc", 'LABEL description="dev image"', "LABEL env=prod"),  # #2882 C4: maintainer= is ownership's alone
     ("test", "RUN pytest tests/", "RUN echo done"),
     # --- PHASE 3 ---
     ("concurrency", "RUN make -j4", "RUN echo hi"),

--- a/tests/extraction/languages/test_fortran_strict.py
+++ b/tests/extraction/languages/test_fortran_strict.py
@@ -397,22 +397,19 @@ def test_fortran_doc_vs_ownership_author_no_collision():
     assert m and m.group(1) == "Jane Doe"
 
 
-def test_fortran_ownership_column_anchor_stricter_than_doc():
+def test_fortran_ownership_keyed_line_tolerates_indentation():
     """
-    Positional-family accuracy check: `doc`'s Author/Description/Param/
-    Return alternative tolerates leading whitespace before the `!`
-    (`^[ \\t]*!`), but `ownership`'s equivalent alternative requires the
-    comment character literally in column 1 (`^[cCdD*!]`, no leading
-    whitespace group) -- an indented "! Author:" line matches `doc` but
-    not `ownership`. Confirmed intentional column-strictness difference,
-    not a bug: `ownership`'s docstring targets legacy fixed-form headers,
-    which are always unindented at file/routine scope.
+    #2882 C1 reversed the older column-1 pin: the keyed header line is the
+    tag wherever the comment sits (free-form `!` comments are routinely
+    indented inside a module), so `ownership` tolerates leading whitespace
+    exactly as `doc` does. A fixed-form `C` in column 1 still counts.
     """
     indented = "   ! Description: A thing"
     assert FORTRAN_RULES["doc"].search(indented), "doc should tolerate leading whitespace before '!'"
-    assert not FORTRAN_RULES["ownership"].search("   ! Author: Jane Doe"), (
-        "ownership requires column-1 anchoring -- indented form must not match"
-    )
+    m = FORTRAN_RULES["ownership"].search("   ! Author: Jane Doe")
+    assert m and m.group(m.lastindex) == "Jane Doe"
+    m = FORTRAN_RULES["ownership"].search("C Author: Jane Doe")
+    assert m and m.group(m.lastindex) == "Jane Doe"
 
 
 def test_fortran_globals_vs_safety_bypasses_common_intentional_double_classification():

--- a/tests/extraction/languages/test_haskell_strict.py
+++ b/tests/extraction/languages/test_haskell_strict.py
@@ -197,7 +197,10 @@ def test_haskell_doc_vs_ownership_no_overlap():
     doc = HS_RULES["doc"]
     ownership = HS_RULES["ownership"]
     assert not doc.search("-- Author: Jane Doe"), "doc incorrectly matched a Haddock Author: field"
-    assert not ownership.search("-- @author Jane Doe"), "ownership incorrectly matched a JSDoc-style @author tag"
+    # #2882 C4: the author tag is ownership's in every language; doc counts the Haddock block, not the tag.
+    assert not doc.search("-- @author Jane Doe"), "doc must not claim the @author tag"
+    m = ownership.search("-- @author Jane Doe")
+    assert m and m.group(m.lastindex) == "Jane Doe"
 
 
 def test_haskell_regex_execution_symbolic_operator_bug():

--- a/tests/extraction/languages/test_m4_strict.py
+++ b/tests/extraction/languages/test_m4_strict.py
@@ -259,16 +259,17 @@ def test_m4_dependency_injection_vs_structural_boundaries_ac_require_intentional
     assert M4_RULES["dependency_injection"].search(line)
 
 
-def test_m4_doc_vs_ownership_ac_copyright_intentional_double_classification():
+def test_m4_ac_copyright_is_doc_alone():
     """
-    Ambiguity sweep finding (mirrors the abap/fortran doc-vs-ownership
-    cases): `AC_COPYRIGHT(...)` legitimately fires both `doc` (it inserts
-    licensing documentation into the generated output) and `ownership`
-    (it's authorship/copyright metadata) -- both true at once, intentional.
+    #2882 C2 retired the intentional dual pinned here: `AC_COPYRIGHT(...)`
+    inserts a copyright notice into the generated output -- rights, not
+    responsibility -- so it is `doc`'s alone and `ownership` no longer
+    counts it. `dnl Author:` / `# Maintainer:` are the ownership forms.
     """
     line = "AC_COPYRIGHT([Copyright (C) 2026 Jane Doe])"
     assert M4_RULES["doc"].search(line)
-    assert M4_RULES["ownership"].search(line)
+    assert not M4_RULES["ownership"].search(line)
+    assert M4_RULES["ownership"].search("dnl Maintainer: Jane Doe")
 
 
 def test_m4_no_block_comment_family_confusion():

--- a/tests/extraction/languages/test_ownership_contract_2882.py
+++ b/tests/extraction/languages/test_ownership_contract_2882.py
@@ -1,0 +1,405 @@
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+"""
+The `ownership` contract (#2882, docs/ownership_rule_contract.md), held across
+every corpus language in one place.
+
+    One hit is a tag naming who is responsible for the unit -- an author,
+    creator, maintainer, owner, developer or contact -- with its value, in the
+    form the language's tooling or header convention reads as metadata: a
+    doc-comment tag, a keyed header line, or the language's own metadata field.
+
+The per-language strict suites keep their one positive/negative pair per
+signal; this module pins the contract's corollaries -- exactly the shapes the
+audit found the old rules disagreeing on:
+
+  C1 the tag, not the word: `@author X`, `Author: X`, `__author__ = X`,
+     `MAINTAINER X`, `author: X`, `<meta name="author">`. The keyed form is
+     anchored to the start of a comment line and needs its separator; prose
+     carrying the words (`created by the renderer`, `owner as the given
+     ReplicaSet`) is not a hit, nor is a field or annotation named `owner:`,
+     nor a person's name as a rule (`Tim Berners-Lee`). The one colon-less
+     keyed form kept is Xcode's dated template (`//  Created by X on <date>`).
+  C2 rights are not responsibility: a license identifier
+     (`SPDX-License-Identifier`, `License:`, `=head1 LICENSE`) and a copyright
+     notice (`Copyright (c) 2014 X`, `SPDX-FileCopyrightText`, `AC_COPYRIGHT`,
+     the keyed `Copyright:`) count in no form. A version tag (`@since`) is
+     not ownership either.
+  C3 one tag is one hit, and the value is the name: every alternative
+     captures, because the detector's ghost meta reads the last group as the
+     file's dominant author (an alternative with no group made the tag text
+     itself the author).
+  C4 one owner: the author tag is ownership's; `doc` counts the block, never
+     the tag (assembly, cobol `*> @author`, css, dockerfile `LABEL maintainer=`
+     and `# Author:`, haskell `-- @author`, solidity's bare `@author` released).
+  C5 absence: markdown has no comment surface and no metadata field; the rule
+     stays unset (n/a), no fallback family is manufactured.
+
+Each language lists (positives, negatives). A positive must match at least
+once; a negative must not match at all. `CAPTURES` pins C3's value, `COUNTS`
+one-tag-one-hit, `DUALS` the C2/C4 tokens that belong to another signal or to
+none.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gitgalaxy.standards.language_standards import LANGUAGE_DEFINITIONS
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _strict_harness import assert_redos_immune  # type: ignore
+
+
+def _rule(lang, signal="ownership"):
+    return LANGUAGE_DEFINITIONS[lang]["rules"][signal]
+
+
+LICENSE_PROSE = [
+    " * The above copyright notice and this permission notice shall be included in",
+    " * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER",
+]
+
+# lang -> (positives, negatives)
+CASES = {
+    # --- C2: rights are not responsibility ------------------------------------------
+    "solidity": (
+        ["/// @author Jane Doe", "// Author: Jane Doe", "// Maintainer: Jane Doe"],
+        ["// SPDX-License-Identifier: MIT", "// SPDX-FileCopyrightText: 2024 Acme", "pragma solidity ^0.8.0;"],
+    ),
+    "c": (
+        [
+            "// @author Jane",
+            " * \\author Jane Doe",
+            "/* Author: Jane */",
+            "   Author: John Doe",
+            " * Contact: jane@x.org",
+        ],
+        [" * Copyright (c) 2013 Damien P. George", "// Copyright (C) 1993-1996 by id Software, Inc.", *LICENSE_PROSE],
+    ),
+    "cpp": (
+        ["// @author Jane", "/* Author: Jane */", "// Owner: Jane Doe"],
+        [
+            "/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */",
+            "Author::Author() {}",
+            *LICENSE_PROSE,
+        ],
+    ),
+    "yacc": (["/* @author Jane */", "// Author: Jane"], [" * Copyright (c) 1988, 1993", *LICENSE_PROSE]),
+    "shell": (
+        [
+            "# Author: Will Deacon <will.deacon@arm.com>",
+            "# Created by:\tNicolas Pitre, August 2017",
+            "# Maintainer: Jane",
+        ],
+        [
+            "# Copyright 2017 The Kubernetes Authors.",
+            "# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.",
+            "#\tCopyright (c) 1984 AT&T",
+        ],
+    ),
+    "m4": (
+        ["dnl Author: Jane Doe", "# Maintainer: Jane Doe"],
+        ["AC_COPYRIGHT([Copyright (C) 2026 Jane Doe])", "dnl License: GPL"],
+    ),
+    "haskell": (
+        [
+            "-- Author: Jane Doe",
+            "-- Maintainer  :  libraries@haskell.org",
+            "Maintainer  : John MacFarlane <jgm@berkeley.edu>",
+            "-- @author Jane",
+        ],
+        ["-- License: BSD3", "-- Copyright: (c) 2010 Jane", "-- Authorized by"],
+    ),
+    "lua": (["-- Author: Jane Doe", "---@author Jane Doe"], ["-- License: MIT", "-- Copyright: 2020 Jane"]),
+    "perl": (["# Author: Jane Doe", "=head1 AUTHORS\n\nJane Doe <j@x>"], ["=head1 COPYRIGHT", "=head1 LICENSE"]),
+    "php": (
+        ["/** @author Fabien Potencier <fabien@symfony.com> */", "// Created by: Jane"],
+        ["@copyright 2020 Jane", "// Copyright (c) 2020 Jane"],
+    ),
+    "kotlin": (["@author Jane Doe", "// Created by: Jane Doe"], ["@since 1.2", "// Copyright: 2020 Jane"]),
+    # --- C1: the tag, not the word ---------------------------------------------------
+    "typescript": (
+        [" * @author Jane Doe", "// Maintainer: Jane", "   Author: Jane Doe"],
+        [
+            " * created by the extension.",
+            "// The node is an IIFE class wrapper created by the ts transform.",
+            "  author: CommentAuthorInformation;",
+            "Author: Jane {",
+        ],
+    ),
+    "javascript": (
+        ["// @author Jane Doe", "// Author: Jane"],
+        [
+            "// was created by an older render.",
+            " * A canvas where the renderer draws its output. This is automatically created by the renderer",
+            "  owner: task.debugOwner,",
+            "  owner: null | ReactComponentInfo,",
+        ],
+    ),
+    "csharp": (
+        ["/// <author>Jane Doe</author>", "// Created by: Jane Doe", "// Author: Jane"],
+        [
+            "/// Get a ModuleSymbol that refers to the module being created by compiling all of the code.",
+            "// Created by keyword-rosetta generator",
+        ],
+    ),
+    "go": (
+        ["// Owner: Jane Doe", "// Author: Jane"],
+        ["// owner as the given ReplicaSet.", "    Owner: owner,", "// Authorized by"],
+    ),
+    "python": (
+        [
+            '__author__ = "Jane Doe"',
+            ".. moduleauthor:: Pierre Gerard-Marchant",
+            ":author: Pierre Gerard-Marchant",
+            "# Author: Jane",
+            "Maintainer: Glyph Lefkowitz",
+        ],
+        [
+            "owner: UserDB",
+            "owner: Mapped[str] = mapped_column(String(500))",
+            "contact: Annotated[",
+            "authorized = True",
+        ],
+    ),
+    "embedded_python": (['__author__ = "Jane Doe"', "# Author: Jane"], ["owner: User", "author_note = 1"]),
+    "zig": (["// Author: Jane", "//! Maintainer: Jane"], ["    owner: *Package.Module,", "Owner: x,"]),
+    "dart": (["// Author: Jane Doe", "/// @author Jane"], ["      owner: owner.renderObject.owner!.semanticsOwner!,"]),
+    "objective-c": (
+        ["// @author Jane Doe", "//  Created by Joe Esquibel on 9/8/26.", "// Author: Jane"],
+        [
+            "// TBL\t\tTim Berners-Lee CERN/CN",
+            "// Reviewed by: Jane Doe",
+            "// Copyright (c) 2020 Apple Inc.",
+            "// Created by keyword-rosetta generator",
+        ],
+    ),
+    "swift": (
+        ["/// - Author: Jane Doe", "// Created by: Jane Doe", "//  Created by Joe on 1/2/20."],
+        ["// Reviewed by: Jane Doe", "// Copyright © 2020 Apple"],
+    ),
+    "abap": (["* AUTHOR: Jane Doe", '" Maintainer: Jane'], ["* Tim Berners-Lee", "AUTHORITY-CHECK OBJECT 'X'"]),
+    "apex": (["/** @author Joe */", "// Author: Jane"], ["the Author of this module", "// Tim Berners-Lee"]),
+    "scala": (["/** @author Jane Doe */", "// Created by: Jane"], ["// Copyright: 2026 Acme", "// Tim Berners-Lee"]),
+    "fortran": (
+        ["!Author: Jane Doe", "   ! Author: Jane Doe", "C Author: Jane Doe", "! Developer: Jane"],
+        ["! authored 2020", "      CALL AUTHOR(x)"],
+    ),
+    "cobol": (
+        ["       AUTHOR. Jane Doe.", "      *> @author Jane", "      * Author     : ALDV"],
+        ["       AUTHORIZED-USER PIC X.", "      * just a note"],
+    ),
+    "matlab": (
+        ["% Author: Jane Doe", "% Authors: Arnaud Delorme and Scott Makeig"],
+        ["% Copyright: 2020 Jane", "% authored in 2005"],
+    ),
+    # --- the metadata-field forms --------------------------------------------------------
+    "dockerfile": (
+        [
+            "MAINTAINER Jane Doe",
+            'LABEL maintainer="jane@x.org"',
+            'LABEL org.opencontainers.image.authors="Jane"',
+            "# Maintainer: @jhowardmsft",
+        ],
+        ["LABEL description=x", "# Usage: docker build ."],
+    ),
+    "yaml": (
+        ["author: Jane Doe <jane@example.com>", "contact:\n  email: support@example.com\n"],
+        ["name: My Job", "author_note: x", "contact_form: https://x/contact\n"],
+    ),
+    "html": (
+        ['<meta name="author" content="Jane Doe">', "<!-- Author: Jane -->", '<link rev="made" href="mailto:j@x">'],
+        ['<meta name="viewport" content="x">', "<p>Created by the team</p>"],
+    ),
+    "agc_assembly": (
+        ["# MOD BY - GAUNTT", "# Contact:\tRon Burkey <info@sandroid.org>.", "# AUTHOR: J S MILLER"],
+        ["# THIS IS THE RESUME ROUTINE", "\tTC\tAUTHOR"],
+    ),
+    "powershell": (
+        ["# Author: Jane Doe", ".AUTHOR Jane Doe", "Maintainer: PowerShell Team <x@y>"],
+        ["# Reviewed by: Jane Doe", "$author = 'x'"],
+    ),
+    "css": (
+        ["/* Author: keyword-rosetta corpus */", "/* @author Jane Doe */"],
+        ["/** @param --color The theme color */", "/* just a note */"],
+    ),
+    "sqlite": (
+        ["-- Author: Jane Doe", " * @author Qiang Xue <qiang.xue@gmail.com>"],
+        ["-- Copyright: 2020 Jane", "SELECT author FROM books;"],
+    ),
+    "scheme": (
+        [";;; Authors: R. Kent Dybvig, Oscar Waddell", ";; Author: Jane"],
+        [";; Copyright: 2020 Jane", "(define author 1)"],
+    ),
+    "java": (["/** @author Phillip Webb */", "// Maintainer: Jane"], ["// Written by Jane Doe", "String author = x;"]),
+    "groovy": (["/** @author Peter Niederwieser */", "// Author: Jane"], ["def author = 'x'"]),
+    "rust": (["// Author: Jane", "//! Maintainer: Jane"], ["// Copyright: 2020 Jane", "let owner = x;"]),
+    "ruby": (["# Author: Jane Doe", "# @author Jane"], ["# Copyright: 2020 Jane", "author = 'x'"]),
+    "tcl": (["# Author: Jane Doe"], ["# Copyright: 2020 Jane", "set author x"]),
+    "jcl": (["//* Author: Jane Doe"], ["//* Copyright: 2020 Jane", "//STEP1 EXEC PGM=AUTHOR"]),
+    "livecode": (["-- Author: Jane Doe", "# Maintainer: Jane"], ["-- Copyright: 2020 Jane", "put author into x"]),
+    "makefile": (
+        ["# author: keyword-rosetta generator", "# Maintainer: Jane"],
+        ["# Copyright: 2020 Jane", "AUTHOR := x", "AUTHOR:=x", "OWNER = me"],
+    ),
+    "ada": (["-- Author: Jane Doe"], ["-- Copyright: 2020 Jane", "Author : String;"]),
+    "assembly": (["; Author: Jane Doe", "; @author Jane"], ["; Copyright: 2020 Jane", "author db 0"]),
+}
+
+# (lang, text, expected value): C3 -- the last group is the name
+CAPTURES = [
+    ("solidity", "/// @author Jane Doe", "Jane Doe"),
+    ("css", "/* Author: keyword-rosetta corpus */", "keyword-rosetta corpus"),
+    ("html", "<!-- Author: Jane -->", "Jane"),
+    ("html", '<link rev="made" href="mailto:j@x">', "j@x"),
+    ("haskell", "-- Maintainer  :  libraries@haskell.org", "libraries@haskell.org"),
+    ("objective-c", "//  Created by Joe Esquibel on 9/8/26.", "Joe Esquibel"),
+    ("python", ".. moduleauthor:: Pierre Gerard-Marchant", "Pierre Gerard-Marchant"),
+    ("perl", "=head1 AUTHORS\n\nJane Doe <j@x>", "Jane Doe <j@x>"),
+    ("agc_assembly", "# MOD BY - GAUNTT", "GAUNTT"),
+    ("yaml", "contact:\n  email: support@example.com\n", "support@example.com"),
+    ("m4", "dnl Author: Jane Doe", "Jane Doe"),
+    ("makefile", "# author: keyword-rosetta generator", "keyword-rosetta generator"),
+    ("cobol", "      * Author     : ALDV", "ALDV"),
+]
+
+COUNTS = [
+    ("java", "/**\n * @author Jane\n * @author Joe\n */", 2),
+    ("c", "/* Author: Jane\n   Maintainer: Joe */", 2),
+    ("shell", "# Author: Jane\n# Copyright 2020 Jane\n# License: MIT", 1),
+    ("solidity", "// SPDX-License-Identifier: MIT\n// Author: Jane\n", 1),
+    ("python", ":author: Pierre\n:contact: p@x\nowner: User\n", 2),
+    ("yaml", "author: Jane\ncontact:\n  name: Support\n  email: s@x\n", 2),
+]
+
+# (lang, text, other_signal): a token that belongs to another signal alone
+# (C4), or to no signal (C2) -- it must never fire ownership.
+DUALS = [
+    ("assembly", "; @author Jane", None),  # doc released it: ownership's alone, checked below
+    ("m4", "AC_COPYRIGHT([Copyright (C) 2026 Jane Doe])", "doc"),
+    ("dockerfile", 'LABEL description="x"', "doc"),
+    ("kotlin", "@since 1.2", None),
+    ("perl", "=head1 LICENSE", None),
+    ("lua", "-- License: MIT", None),
+    ("shell", "# Copyright 2017 The Kubernetes Authors.", None),
+    ("solidity", "// SPDX-License-Identifier: MIT", None),
+]
+
+# C4: the author tag has one owner -- doc must not count it where it used to.
+DOC_RELEASED = [
+    ("assembly", "; @author Jane"),
+    ("cobol", "      *> @author Joe"),
+    ("css", "/* @author Jane Doe */"),
+    ("dockerfile", 'LABEL maintainer="dev@example.com"'),
+    ("dockerfile", "# Author: Jane"),
+    ("haskell", "-- @author Jane"),
+    ("html", '<meta name="author" content="Jane Doe">'),
+]
+
+PAYLOADS = [
+    "Author:" + " " * 100000,
+    "Author: " + "a" * 100000,
+    "Author: " + "a " * 50000,
+    "Author: " + "a" * 50000 + " */",
+    "Author: " + "a" * 50000 + " -->",
+    "Author" + " " * 50000 + ":",
+    "Author:\n" * 20000,
+    "Created" + " " * 50000 + "by: x",
+    "Created by " + "a" * 50000 + " on ",
+    "//  Created by " + "a " * 25000,
+    "@author" + " " * 100000,
+    "@author " + "a" * 100000,
+    "=head1 AUTHORS" + "\n" * 50000,
+    "=head1 AUTHORS\n" + " " * 100000,
+    "__author__" + " " * 50000 + "=",
+    ".. moduleauthor::" + " " * 100000,
+    "contact:\n" + " \n" * 20000,
+    "MOD BY " + "-" * 100000,
+    '<meta name="author" content="' + "a" * 100000,
+    "AUTHOR. " + " " * 100000,
+    "*" * 50000 + " Author:",
+    "-" * 50000 + " Author:",
+    "#" * 50000 + " Author:",
+    "Owner: " + "a" * 50000 + ",",
+    "=head1 AUTHORS\n" + " " * 100000,
+    "-- " + " " * 100000,
+    "-- |" + " " * 100000,
+    "/// -" + " " * 100000,
+    "      *" + " " * 100000,
+    "#" + " " * 100000 + "MOD BY",
+    " " * 100000 + "Author:",
+]
+
+
+@pytest.mark.parametrize("lang", sorted(CASES))
+def test_ownership_contract_positive_and_negative(lang):
+    rule = _rule(lang)
+    positives, negatives = CASES[lang]
+    for text in positives:
+        assert rule.search(text), f"{lang}: contract positive did not match: {text!r}"
+    for text in negatives:
+        hits = [m.group(0) for m in rule.finditer(text)]
+        assert not hits, f"{lang}: contract negative matched {hits!r} in {text!r}"
+
+
+@pytest.mark.parametrize("lang,text,expected", CAPTURES)
+def test_ownership_value_is_the_name(lang, text, expected):
+    """C3: the detector reads `m.group(m.lastindex)` as the file's dominant author."""
+    m = _rule(lang).search(text)
+    assert m and m.lastindex, f"{lang}: no capture on {text!r}"
+    assert m.group(m.lastindex).strip() == expected
+
+
+@pytest.mark.parametrize("lang", sorted(CASES))
+def test_ownership_every_alternative_captures(lang):
+    """C3: no alternative may match without a group (solidity's SPDX did)."""
+    rule = _rule(lang)
+    positives, _ = CASES[lang]
+    for text in positives:
+        m = rule.search(text)
+        assert m and m.lastindex and m.group(m.lastindex).strip(), f"{lang}: {text!r} matched without a value"
+
+
+@pytest.mark.parametrize("lang,text,expected", COUNTS)
+def test_ownership_one_tag_is_one_hit(lang, text, expected):
+    hits = [m.group(0) for m in _rule(lang).finditer(text)]
+    assert len(hits) == expected, f"{lang}: expected {expected} hits, got {hits!r}"
+
+
+@pytest.mark.parametrize("lang,text,other_signal", DUALS)
+def test_ownership_never_fires_on_another_owners_token(lang, text, other_signal):
+    if other_signal is None and text.startswith("; @author"):
+        assert _rule(lang).search(text)  # the one positive in this list: released BY doc TO ownership
+        return
+    hits = [m.group(0) for m in _rule(lang).finditer(text)]
+    assert not hits, f"{lang}: ownership fired on {text!r}: {hits!r}"
+    if other_signal is not None:
+        assert _rule(lang, other_signal).search(text), f"{lang}: expected {other_signal!r} to own {text!r}"
+
+
+@pytest.mark.parametrize("lang,text", DOC_RELEASED)
+def test_ownership_author_tag_has_one_owner(lang, text):
+    """C4: doc counts the block; the author tag is ownership's alone."""
+    assert not _rule(lang, "doc").search(text), f"{lang}: doc still claims {text!r}"
+    assert _rule(lang).search(text), f"{lang}: ownership does not claim {text!r}"
+
+
+def test_ownership_markdown_has_no_rule():
+    """C5: markdown has no comment surface and no metadata field; the row is absent."""
+    assert LANGUAGE_DEFINITIONS["markdown"]["rules"].get("ownership") is None
+
+
+@pytest.mark.parametrize("lang", sorted(CASES))
+def test_ownership_contract_rules_are_redos_immune(lang):
+    rule = _rule(lang)
+    for payload in PAYLOADS:
+        assert_redos_immune(rule, payload, timeout_sec=3.0)

--- a/tests/extraction/languages/test_scala_strict.py
+++ b/tests/extraction/languages/test_scala_strict.py
@@ -188,7 +188,7 @@ def test_scala_ownership_scaladoc_author_no_colon_regression():
     pattern = SCALA_RULES["ownership"]
     assert pattern.search("@author Jane Doe"), "the real, colon-less @author form still didn't match"
     assert pattern.search("Created by: Jane Doe")
-    assert pattern.search("Copyright: 2026 Acme")
+    assert not pattern.search("Copyright: 2026 Acme")  # #2882 C2: rights are not responsibility
 
 
 def test_scala_test_signature_boundary_regression():

--- a/tests/extraction/languages/test_solidity_strict.py
+++ b/tests/extraction/languages/test_solidity_strict.py
@@ -46,7 +46,7 @@ _SOLIDITY_SIMPLE_CASES = [
     ("scientific", "keccak256(abi.encodePacked(x));", "sha256Hash = compute();"),
     ("reflection_metaprogramming", "fallback() external payable {}", "callingConvention = 1;"),
     ("import", 'import "./Token.sol";', "// import legacy code, no longer used"),
-    ("ownership", "// SPDX-License-Identifier: MIT", "// SPDX-FileCopyrightText: 2024 Acme"),
+    ("ownership", "/// @author Jane Doe", "// SPDX-License-Identifier: MIT"),  # #2882 C2: a license is not an owner
     ("planned_debt", "// TODO: optimize gas", "// See our TODOS backlog for details"),
     ("fragile_debt", "// HACK: workaround for reentrancy", "// this approach is a bit hacky"),
     ("spec_exposure", "// ERC-20 compliant", "ERC721 compliant"),

--- a/tests/signal_contract_audit_baseline.json
+++ b/tests/signal_contract_audit_baseline.json
@@ -37,7 +37,6 @@
   "draft:memory_alloc",
   "draft:memory_scraping",
   "draft:ml_traditional",
-  "draft:ownership",
   "draft:panics_and_aborts",
   "draft:planned_debt",
   "draft:pointers",

--- a/tests/tools/rule_probe.py
+++ b/tests/tools/rule_probe.py
@@ -43,6 +43,13 @@ CORPORA
 WHAT IT MEASURES
     Raw rule hits over `Prism.split_streams(...)["code_stream"]` -- comments
     stripped, string literals kept, exactly the text detector.py hands the rule.
+    The six comment-stream rules (`dead_code`, `doc`, `ownership`, `planned_debt`,
+    `fragile_debt`, `spec_exposure`; detector.comment_analysis) are run over the
+    code stream AND the comment stream, because that is what the detector does:
+    coding_analysis applies every non-underscore rule to the code stream, then
+    comment_analysis adds a second pass over the comments (#2882). `--stream`
+    picks one stream explicitly; the default is `auto` (both for those six, code
+    for everything else). The per-stream split is in the JSON and the samples.
     NOT the recorded count: scope filters (`_scope_filters`, e.g. matlab's return
     channel) and the per-function slicer run after the regex, so a language with a
     filter reads higher here than in a manifest. That is the right thing for a
@@ -87,6 +94,14 @@ ROSETTA = _sibling("KEYWORD_ROSETTA_PATH", "keyword-rosetta") / "data"
 # registry key -> corpus directory name, where they differ
 CORPUS_DIR = {"objectivec": "objective-c"}
 MAX_FILE_BYTES = 2_000_000
+# detector.comment_analysis's list: these rules read the comment surface too.
+COMMENT_STREAM_RULES = frozenset({"dead_code", "doc", "ownership", "planned_debt", "fragile_debt", "spec_exposure"})
+
+
+def streams_for(rule_name: str, stream: str) -> tuple[str, ...]:
+    if stream == "auto":
+        stream = "both" if rule_name in COMMENT_STREAM_RULES else "code"
+    return ("code_stream", "comment_stream") if stream == "both" else (f"{stream}_stream",)
 
 
 def _extensions(lang: str) -> set[str]:
@@ -121,28 +136,45 @@ def compile_override(pattern: str, flags: str) -> re.Pattern:
     return re.compile(pattern, fl)
 
 
-def probe(rule_name: str, lang: str, corpus: str, samples: int, override: re.Pattern | None, prism: Prism):
+def probe(
+    rule_name: str,
+    lang: str,
+    corpus: str,
+    samples: int,
+    override: re.Pattern | None,
+    prism: Prism,
+    stream: str = "auto",
+):
     rule = override or LANGUAGE_DEFINITIONS[lang]["rules"].get(rule_name)
     if rule is None or not hasattr(rule, "finditer"):
         return None
+    streams = streams_for(rule_name, stream)
     per: dict[str, dict] = {}
     for name, root, path in corpus_files(lang, corpus):
         try:
             src = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        code = prism.split_streams(src, lang)["code_stream"]
-        hits = list(rule.finditer(code))
-        c = per.setdefault(name, {"files": 0, "hits": 0, "by_file": {}, "samples": collections.Counter()})
+        split = prism.split_streams(src, lang)
+        c = per.setdefault(
+            name,
+            {"files": 0, "hits": 0, "by_stream": dict.fromkeys(streams, 0), "by_file": {}, "samples": collections.Counter()},
+        )
         c["files"] += 1
-        c["hits"] += len(hits)
-        if hits:
-            c["by_file"][str(path.relative_to(root))] = len(hits)
-        for m in hits:
-            ls = code.rfind("\n", 0, m.start()) + 1
-            le = code.find("\n", m.end())
-            line = code[ls : len(code) if le < 0 else le].strip()
-            c["samples"][(m.group(0).strip()[:40], line[:120])] += 1
+        rel = str(path.relative_to(root))
+        for sname in streams:
+            text = split[sname]
+            hits = list(rule.finditer(text))
+            c["hits"] += len(hits)
+            c["by_stream"][sname] += len(hits)
+            if hits:
+                c["by_file"][rel] = c["by_file"].get(rel, 0) + len(hits)
+            for m in hits:
+                ls = text.rfind("\n", 0, m.start()) + 1
+                le = text.find("\n", m.end())
+                line = text[ls : len(text) if le < 0 else le].strip()
+                tag = "" if len(streams) == 1 else f"{sname[:4]} "
+                c["samples"][(tag + m.group(0).strip()[:40], line[:120])] += 1
     for c in per.values():
         c["samples"] = [(tok, line, n) for (tok, line), n in c["samples"].most_common(samples)]
     return per
@@ -152,7 +184,12 @@ def print_probe(lang: str, per: dict | None, samples: int) -> None:
     if per is None:
         print(f"{lang:16s} rule is None")
         return
-    summary = "  ".join(f"{k}:{v['hits']}/{v['files']}f" for k, v in per.items())
+    def _cell(v: dict) -> str:
+        by = v.get("by_stream") or {}
+        split = f" ({', '.join(f'{k[:4]} {n}' for k, n in by.items())})" if len(by) > 1 else ""
+        return f"{v['hits']}/{v['files']}f{split}"
+
+    summary = "  ".join(f"{k}:{_cell(v)}" for k, v in per.items())
     print(f"{lang:16s} {summary}")
     for k, v in per.items():
         for tok, line, n in v["samples"][:samples]:
@@ -183,6 +220,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("rule")
     ap.add_argument("lang", help="a registry key, or `all`")
     ap.add_argument("--corpus", choices=("crucible", "rosetta", "both"), default="both")
+    ap.add_argument(
+        "--stream",
+        choices=("auto", "code", "comment", "both"),
+        default="auto",
+        help="which Prism stream(s) to run the rule over; auto = both for the comment-stream rules, code otherwise",
+    )
     ap.add_argument("--samples", type=int, default=6, help="matched lines to show per corpus (most frequent first)")
     ap.add_argument("--override", help="probe this regex instead of the registry's rule")
     ap.add_argument("--flags", default="", help="flags for --override, e.g. IM")
@@ -200,7 +243,7 @@ def main(argv: list[str] | None = None) -> int:
     prism = Prism(LEXICAL_FAMILY_HEURISTICS, LANGUAGE_DEFINITIONS)
     out: dict[str, dict | None] = {}
     for lang in langs:
-        per = probe(args.rule, lang, args.corpus, args.samples, override, prism)
+        per = probe(args.rule, lang, args.corpus, args.samples, override, prism, args.stream)
         out[lang] = per
         print_probe(lang, per, args.samples)
     if args.json:


### PR DESCRIPTION
Phase 3 of #2812: the sheet row `ownership` goes `draft` → `stated` (13 of 68). Closes #2882.

## The contract

> **One hit is a tag naming who is responsible for the unit — an author, creator, maintainer, owner, developer or contact — with its value, in the form the language's tooling or header convention reads as metadata: a doc-comment tag, a keyed header line, or the language's own metadata field.**

`docs/ownership_rule_contract.md` has the five corollaries, the audit table and the verdicts. In short: **C1** the tag, not the word (the keyed line is anchored to the comment line and needs its separator; prose `created by the renderer`, fields `owner: User`, and a person's name as a rule are not hits); **C2** rights are not responsibility (license identifiers and copyright notices out in every form — the solidity cell); **C3** one tag one hit, and every alternative captures the value (the detector's ghost meta reads the last group: solidity's group-less SPDX alternative named `// SPDX-License-Identifier:` as every file's architect); **C4** the author tag has one owner (six doc rules release it); **C5** markdown absent.

## What moved

- **46 ownership rules** rewritten to one shared shape by a replacement script (doc-tag form, keyed line on the language's own markers, metadata field, bare capitalised continuation line, every alternative capturing). **6 doc rules** release the author tag (C4).
- **Crucible** (`rule_probe.py --stream auto`, both Prism streams): c 51→0, cpp 62→1, yacc 6→0, shell 131→5 (copyright notices and the MIT license's own prose, C2); typescript 11→0, javascript 4→0, csharp 1→0, go 1→0 (`created by`/`owner` in sentences, C1); m4 2→0, perl 2→1, php 17→16 (C2); haskell 0→7 (the GHC header's `Maintainer  :`), cobol 61→79, sqlite 0→8, python 2→5, matlab 3→5, fortran 1→3, scheme 0→2, powershell 0→1, dockerfile 0→1 (forms the family already counted elsewhere). doc on the crucible: dockerfile 7→6 only.
- **`tests/tools/rule_probe.py` gains `--stream auto|code|comment|both`.** The detector runs the six comment-stream rules over the code stream *and* the comment stream; the probe measured only the code stream, so c read 0 where the truth was 51. `auto` = both for those six.
- Sheet row stated; `how_to_add_a_language.md` schema comment carries the sentence; `signal_contract_audit` baseline 57 → 56, `--ci` clean.
- Tests: `tests/extraction/languages/test_ownership_contract_2882.py` (CASES over 44 languages, CAPTURES, COUNTS, DUALS, DOC_RELEASED, ReDoS detonation incl. the optional-marker whitespace-run shape that hung two first drafts); nine strict pins flipped (solidity's SPDX positive, haskell's doc-owns-@author, m4's AC_COPYRIGHT "intentional dual", fortran's column-1 anchor, scala's `Copyright:`, dockerfile's doc positive, three `group(1)` → `group(lastindex)`).

## Bless scope (`bless_scope.py`)

489 differences, **0 topological**, newly parsed/excluded none. Leaf keys: `Authorship Metadata` 198, `Architect` 194 (doom's `(C) 1993-1996 by id Software, Inc` and haiku's `(c) 2010-2012 Haiku, Inc` become `Unknown Architect` — nobody signed those files; moby's `windows.Dockerfile` gains `@jhowardmsft`), `Documentation Exposure`/`documentation` 91 (the 0.5-weight defense), one dockerfile file's `Structured Documentation Blocks` 2→1 with the `Cognitive Load Exposure` that reads doc. By language: shell 181, c 68, cpp 59, cobol 49, solidity 16, haskell 14, sqlite 10.

## Verification

strict suites green; contract module green; `rosetta_audit.py` 46/46 clean against the corpus branch; `verify_language` 46/46 on the corpus branch; ruff/mypy/dead-key audits no new findings; `audit_check.py` all clear; `signal_contract_audit --ci` clean.

## Cross-repo

Label `rosetta:rebless-owed`. Corpus PR: keyword-rosetta `rebless/gitgalaxy-2882-ownership` (solidity a/b/c 1→0 + `// Author:` plant in main; csharp/objective-c `Created by:` re-plants; ledger `ownership-contract-2882`; `batch5-tier2-morphology-shapes` loses `ownership`, solidity and html). It is stacked on keyword-rosetta#103 (the #2878 re-bless, still open) and goes green when engine main carries this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
