### PR TITLE
risk_documentation score contract (draft) + per-file input decomposition audit (#2908 Phase 0)

### DIFF
--- a/docs/risk_documentation_contract.md
+++ b/docs/risk_documentation_contract.md
@@ -1,0 +1,165 @@
+# The `risk_documentation` score contract (#2908)
+
+> **`risk_documentation` is the share of a file's extracted units — functions, methods,
+> paragraphs, steps — whose meaning a reader cannot recover from documentation, weighted so
+> that a public unit counts double and a unit doing runtime-decided work counts more. It is a
+> ratio over units, never a density over lines. A file with no extracted units has no value.**
+
+**Status: `draft`** — epic #2908 Phase 0. The sentence, the equation and the decisions below are
+proposed; the formula in `signal_processor.py` is still the one §2 describes. This document
+flips to `stated` when Phase 3 lands the equation and Phase 4 re-blesses the corpus.
+
+This is the first **score** contract (roadmap Phase 4, `docs/contract_roadmap.md` §4). The count
+contracts it builds on: `docs/api_rule_contract.md` (#2730, the public surface),
+`docs/unreferenced_by_name_contract.md` (#2806, the orphan census), and the `doc` row of
+`gitgalaxy/standards/signal_contracts.py`. The audit that keeps §2 honest is
+`tests/tools/audit_documentation_inputs.py`.
+
+## 1. The equation
+
+```
+for each extracted unit u:
+    weight(u)  = (public_weight if public(u) else 1) + reflection_hits_inside(u)
+    exposed(u) = weight(u) if not documented(u) else 0
+
+risk_documentation = 100 × Σ exposed(u) / Σ weight(u) × (1 − umbrella_shield × doc_umbrella)
+                   = n/a when Σ weight(u) = 0
+```
+
+Tuning: `public_weight` 2.0, `umbrella_shield` 0.5. Nothing else.
+
+Three definitions carry the contract:
+
+- **public(u)** — the unit's name is in the file's *public name set*: names the `api` rule matched
+  on the unit's own header ∪ names in an export list (`_visibility_export`,
+  `_visibility_export_list`; the #2823 machinery) ∪ units left uncalled in a file that something
+  imports (the orphans the Contextual Baseline Fix converts). A **union of names**: a unit cannot
+  be public twice, and a name the overlap test misses costs one unit instead of doubling the
+  file. This is the per-unit form of #2771 (a per-file declaration count banded against a
+  per-function median).
+- **documented(u)** — a `doc`-rule match whose span ends inside the unit's *header window*: the
+  few lines immediately before `start_line`, or the leading lines of the body (docstring
+  position). **Not** the slicer's `docstring` field. That field is a per-language "preceding
+  comment" heuristic: on the corpus it captures python's planted `# HACK:` comment as a
+  docstring, reads 13 of 13 for jcl, and 0 for fortran, haskell and scheme. Reading it would
+  import a fresh language bias into the one score this epic exists to make language-neutral.
+- **reflection inside the unit** — #2719's dynamism kept where it belongs. Runtime-decided
+  behaviour is what most needs documenting and what a reader cannot recover from the text; it
+  raises the weight of *that* unit instead of adding a hit to a file total.
+
+The umbrella is `doc_umbrella` exactly as today (GuideStar folder coverage, README-upgraded in
+`galaxyscope.py`): the one file-level defence that survives, because a folder README genuinely
+documents every unit in the folder a little.
+
+**Weights are counts, not lengths.** Per-function `impact` is
+`(branch + 1) × sqrt(args + 1) + 0.05 × effective_loc` (`detector.py`); weighting units by it
+would put length back through the side door. Impact stays the hitlist's ranking key, beside
+the score, not inside it.
+
+## 2. What the current formula measures, and why it is replaced
+
+`_calc_documentation` (`signal_processor.py`) is a per-LOC density:
+
+```
+defense  = doc + 0.5 × ownership + 0.33 × doc_loc + 50 × doc_umbrella
+risk     = opaque_execution + 2 × api            (returns 0 when this is 0)
+hits     = risk + reflection_metaprogramming
+density  = max(0, hits − defense / 2) / (max(coding_loc, 50) + 20) × 100
+score    = 100 / (1 + e^(−0.2 × (density − 10))) × (1 + popularity/10) × silo × mp
+```
+
+On the keyword-rosetta corpus every term but one is flat, measured per file by
+`audit_documentation_inputs.py` (46 languages, 2026-09-09, engine `81b895cc`; every recorded
+score reproduced from its recorded inputs):
+
+- `opaque_execution` needs a function with impact above 50 and no docstring. No corpus function
+  has impact above 50. The term is dead on small functions, which is most functions.
+- Every corpus file is under the 50-line evidence floor (#2655), so the denominator is the
+  constant 70. Length does not enter here — but on a 500-line real file it does, and the same
+  three undocumented public functions score ≈15 instead of 40. That is the −0.83 length leak
+  the bias report flags for this metric, seen from the other side.
+- The popularity multiplier never fires: `meta["popularity"]` is not populated when
+  `calculate_risk_vector` runs (#2909). `silo` is 0 and `mp` is 1 on the corpus.
+- `doc`, `ownership` and `doc_loc` together move a file by about 2 points.
+
+What remains is a sigmoid over the **adjusted api count**, and that is the whole spread:
+
+| adjusted api per file | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+|---|---|---|---|---|---|---|---|---|
+| `risk_documentation` | 0 | 17.9 | 27.9 | 40.6 | 54.8 | 68.2 | 79.2 | 87.1 |
+
+One api hit per file is worth 8 to 14 points on a 0–100 scale. The adjusted count is assembled
+from two sources — the language's `api` rule plus the orphan-census credit, minus a
+tokenizer-dependent overlap — and every way that assembly can fail lands in its own cluster:
+
+| adjusted api / file | corpus files (a/b/c) | mechanism |
+|---|---|---|
+| 6 | makefile, m4, scheme, cobol → 77–79 | raw 3 + credit 3: the declared-orphan overlap test never recognises the names (#2827; m4/makefile re-plant owed after #2902) |
+| 5 | c (a.c only) → 68 | the `globals` plants match c's api rule as top-level declarations (#2907) |
+| 4 | css, agc_assembly, yacc → 55–62 | raw 1 + credit 3; yacc adds 4 reflection hits |
+| 3 | the mainstream pack → 38–41; objective-c via credit alone (raw 0) | intended |
+| 1 | dockerfile, html, yaml (census n/a), haskell (#2871) → 18 | raw 1, no credit |
+| 0 | jcl, sqlite, objective-c main → 0 | the zero-evidence guard |
+
+Four of the scoreboard's eleven open-defect cells and the corpus's one confirmed length leak
+are this one formula. The equation in §1 removes each mechanism by construction: a unit is
+public or it is not (no double count), the score is a ratio (no length regime), and there is
+no sigmoid to turn a ±1 count into ±13 points.
+
+## 3. What leaves the equation, and why
+
+| term | why it goes |
+|---|---|
+| `doc_loc × 0.33` | a comment-line count is not coverage, and it is one of the two length terms |
+| `ownership × 0.5` | *who* maintains a file is a different question, already carried by the silo and authorship views |
+| `opaque_execution` | dead on small functions; its intent — load-bearing undocumented code — is what public weighting expresses |
+| `/ (_mass_loc(loc) + 20)` and the sigmoid | the length regime; a ratio is already 0–100 |
+| popularity and silo multipliers, path modifier `mp` | blast radius sits beside the score in the same report row; a coverage ratio does not change because the file lives in a config folder. The popularity term is dead today anyway (#2909), so its removal is score-neutral |
+| `doc_weight` `ownership_weight` `doc_loc_weight` `loc_smoothing` `threshold_base` `sigmoid_slope` | six knobs become two |
+
+## 4. Decisions (to approve on #2908 before Phase 2)
+
+- **D1** The score is a ratio over extracted units; no per-LOC term, no sigmoid, no small-file
+  floor. The #2655 floor stays for the density formulas that still need one.
+- **D2** `public(u)` is the name-set union in §1. `risk_api_exposure` should read the same set;
+  that formula's contract is a separate epic sharing #2908's Phases 1–2.
+- **D3** `documented(u)` is the header-anchored `doc` match, not `docstring`. `docstring` is left
+  as is (the brief prints it), not deleted.
+- **D4** Ownership, doc_loc, opaque_execution, the popularity and silo multipliers and `mp` leave
+  the equation. The ledger's `path-and-extension-modifiers` entry drops `risk_documentation`
+  from its signal list when this lands.
+- **D5** No damping for one-unit files (they read 0 or 100). The directory and repository
+  roll-ups are already mass-weighted. Revisit only if Phase 5's real-code check shows hitlist
+  noise.
+- **D6** The engine keeps emitting a float; `n/a` is inferred by the reporting layer from a unit
+  count of 0 — the convention the corpus tooling already uses for rule absence. No `None` in
+  the risk vector.
+
+## 5. Expected values (acceptance)
+
+| file | today | after |
+|---|---|---|
+| rosetta a/b/c, every language | 17.9 → 79.2 depending on api assembly | **100** (3 public units, 0 documented) |
+| rosetta main, `entry` documented | 33.4 | **75** where the api rule sees `entry`, **86** where it does not — an `api` contract cell, surfaced on purpose |
+| css, yaml, html, sqlite, markdown | 0 → 55 | **n/a** |
+| 500-line file, 10 public units, 2 documented | ≈ 15 | 80 |
+| 20-line file, 3 public units, 0 documented | 40.6 | 100 |
+| bias report length-leak row | rho −0.83, **leak** | rho 0 by construction |
+
+## 6. Consumers
+
+`risk_documentation` is one of the 13 `risk_*` columns: it feeds the per-file exposure vector,
+the cumulative-risk hitlist in the architecture brief (`llm_recorder.py`, "12. Documentation
+Risk Exposure"), the SARIF/SQLite recorders, and the corpus's `risk_documentation` gate. The
+GuideStar "documentation bypass" (`blanket_risk_vector[... "documentation"] = 0.0`,
+`signal_processor.py` ~L450) zeroes it for files a manifest declares documented; that shortcut
+is unchanged by this contract.
+
+## 7. Phase map
+
+Phase 0 (this document + the audit tool) → Phase 1 (the name set: #2827, #2871, #2907, the
+m4/makefile re-plant) ∥ Phase 2 (per-unit `is_public` / `is_documented` / `reflection_hits`) →
+Phase 3 (the equation; golden bless; `rosetta:rebless-owed`) → Phase 4 (corpus re-bless; the
+report stops banding this metric within a strictness stratum, which it only did because the
+old formula read the fidelity table) → Phase 5 (real-code before/after; D5) → Phase 6 (`stated`).
+The full list with done-when lines is on #2908.

--- a/tests/tools/audit_documentation_inputs.py
+++ b/tests/tools/audit_documentation_inputs.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+"""
+Per-file input decomposition for `_calc_documentation` (epic #2908, Phase 0).
+
+The bias report says `risk_documentation` is the corpus's most variable gated score
+and its one confirmed length leak. This tool shows WHY, file by file, and keeps that
+explanation honest: for every scanned file it reads the inputs the formula consumes
+straight out of the galaxyscope database, calls `SignalProcessor._calc_documentation`
+directly with them, and compares the result to the `risk_documentation` the engine
+recorded. A residual means the decomposition no longer explains the score -- which is
+the fact the epic's design rests on, so the tool exits nonzero.
+
+What it reads per file (DB column -> formula input):
+
+    arch_api              -> raw_signals["api"]     the ADJUSTED api (rule hits + orphan credit)
+    raw_arch_api                                    the rule's own count; credit = arch_api - raw
+    def_doc               -> raw_signals["doc"]
+    def_ownership         -> raw_signals["ownership"]
+    state_heat_triggers   -> raw_signals["reflection_metaprogramming"]  (_dynamism)
+    doc_loc               -> doc_loc
+    coding_loc            -> loc
+    popularity, silo_risk -> the multipliers
+    file_path             -> the path modifier (`mp`)
+
+`functions` is passed empty: the opaque-execution term needs a function with impact
+above 50 and no docstring, which no corpus file has. If a real repository's file
+carries one, that file shows up as a residual here -- deliberately, so the term's
+contribution is never silently folded into "api".
+
+Three outputs: one row per file; the CLUSTER table (files grouped by adjusted api per
+file, which is the whole story on the corpus); and the SENSITIVITY table (score vs
+adjusted api with every other input held at the corpus values), which is what makes a
++-1 api error a +-13 point score error.
+
+Usage:
+    python tests/tools/audit_documentation_inputs.py --db path/to/<x>_galaxy_master.db [--db ...]
+    python tests/tools/audit_documentation_inputs.py --corpus /path/to/keyword-rosetta/data
+    python tests/tools/audit_documentation_inputs.py --corpus ... --languages c,cpp,makefile
+
+`--corpus` scans each language folder with galaxyscope (`--db-only`) into a temporary
+directory, exactly as keyword-rosetta's `verify_language.py` does. Direct invocation of
+`_calc_documentation` is the same isolation technique `audit_length_invariance.py` and
+`audit_risk_equations.py` use (see their docstrings for the #1055 precedent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass
+
+from gitgalaxy.metrics.signal_processor import SignalProcessor
+
+EPSILON_DEFAULT = 0.01
+IGNORED_BASENAMES = {"expected_signals.json", "pyproject.toml"}
+
+
+@dataclass
+class FileInputs:
+    language: str
+    file_name: str
+    file_path: str
+    coding_loc: int
+    doc_loc: int
+    raw_api: int
+    api: int
+    doc: int
+    ownership: int
+    reflection: int
+    popularity: int
+    silo: float
+    recorded: float
+
+    @property
+    def credit(self) -> int:
+        return self.api - self.raw_api
+
+
+# ---------------------------------------------------------------------------
+# reading
+# ---------------------------------------------------------------------------
+
+
+def read_db(db_path: pathlib.Path, language_hint: str | None = None) -> list[FileInputs]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    have = {r[1] for r in conn.execute("PRAGMA table_info(file_data)")}
+    needed = [
+        "file_name",
+        "file_path",
+        "language",
+        "coding_loc",
+        "doc_loc",
+        "raw_arch_api",
+        "arch_api",
+        "def_doc",
+        "def_ownership",
+        "state_heat_triggers",
+        "popularity",
+        "silo_risk",
+        "risk_documentation",
+    ]
+    missing = [c for c in needed if c not in have]
+    if missing:
+        raise SystemExit(f"{db_path}: file_data lacks {missing}")
+    rows = conn.execute(f"SELECT {', '.join(needed)} FROM file_data ORDER BY file_name").fetchall()
+    out: list[FileInputs] = []
+    for r in rows:
+        if r["file_name"] in IGNORED_BASENAMES:
+            continue
+        out.append(
+            FileInputs(
+                language=language_hint or (r["language"] or "?"),
+                file_name=r["file_name"],
+                file_path=r["file_path"] or r["file_name"],
+                coding_loc=int(r["coding_loc"] or 0),
+                doc_loc=int(r["doc_loc"] or 0),
+                raw_api=int(r["raw_arch_api"] or 0),
+                api=int(r["arch_api"] or 0),
+                doc=int(r["def_doc"] or 0),
+                ownership=int(r["def_ownership"] or 0),
+                reflection=int(r["state_heat_triggers"] or 0),
+                popularity=int(r["popularity"] or 0),
+                silo=float(r["silo_risk"] or 0.0),
+                recorded=float(r["risk_documentation"] or 0.0),
+            )
+        )
+    conn.close()
+    return out
+
+
+def scan_folder(folder: pathlib.Path, out_dir: pathlib.Path) -> pathlib.Path:
+    """galaxyscope --db-only over one folder; returns the produced sqlite path."""
+    exe = os.environ.get("GALAXYSCOPE_BIN")
+    cmd = [exe] if exe else [sys.executable, "-c", "from gitgalaxy.galaxyscope import main; main()"]
+    before = set(out_dir.rglob("*.db"))
+    result = subprocess.run(
+        [*cmd, str(folder), "--db-only"],
+        cwd=out_dir,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    dbs = sorted(p for p in out_dir.rglob("*.db") if p not in before)
+    if result.returncode != 0 or not dbs:
+        sys.stderr.write(result.stdout[-2000:] + result.stderr[-2000:])
+        raise SystemExit(f"galaxyscope failed on {folder} (rc={result.returncode})")
+    return dbs[0]
+
+
+# ---------------------------------------------------------------------------
+# reproduction
+# ---------------------------------------------------------------------------
+
+
+def reproduce(p: SignalProcessor, f: FileInputs, *, popularity: int, umbrella: float) -> float:
+    _irc, _ot, fid = p._language_constants(f.language)
+    mp = p._get_locational_multipliers(f.file_path).get("doc", 1.0)
+    signals = {
+        "api": f.api,
+        "doc": f.doc,
+        "ownership": f.ownership,
+        "reflection_metaprogramming": f.reflection,
+    }
+    return float(
+        p._calc_documentation(
+            max(f.coding_loc, 1),
+            f.doc_loc,
+            signals,
+            fid,
+            mp,
+            None,
+            doc_umbrella=umbrella,
+            popularity=popularity,
+            silo_exposure=f.silo,
+        )
+    )
+
+
+def sensitivity(p: SignalProcessor, language: str, *, doc_loc: int = 2, loc: int = 15) -> list[tuple[int, float]]:
+    """score vs adjusted api with every other input at the corpus a/b/c values."""
+    _irc, _ot, fid = p._language_constants(language)
+    rows = []
+    for api in range(0, 8):
+        s = p._calc_documentation(loc, doc_loc, {"api": api}, fid, 1.0, None)
+        rows.append((api, float(s)))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+def run(files: list[FileInputs], *, epsilon: float, umbrella: float) -> int:
+    p = SignalProcessor()
+    residuals = 0
+    popularity_applied = 0
+    popularity_ignored = 0
+    print(
+        f"{'language':16s} {'file':18s} {'loc':>4} {'dloc':>4} {'raw':>3} {'api':>3} {'crd':>3} "
+        f"{'doc':>3} {'own':>3} {'rfl':>3} {'pop':>3} | {'recorded':>8} {'repro':>8} {'resid':>7}"
+    )
+    by_api: dict[int, list[FileInputs]] = defaultdict(list)
+    for f in files:
+        with_pop = reproduce(p, f, popularity=f.popularity, umbrella=umbrella)
+        without = reproduce(p, f, popularity=0, umbrella=umbrella)
+        # The formula multiplies by (1 + popularity / 10), but the per-file
+        # `popularity` the DB records is only what `meta` carried at scoring
+        # time. Report which reading reproduced, counting only files where the
+        # two readings differ (popularity 0 cannot tell them apart).
+        distinguishable = abs(with_pop - without) > epsilon
+        if distinguishable and abs(with_pop - f.recorded) <= epsilon:
+            repro = with_pop
+            popularity_applied += 1
+        elif abs(without - f.recorded) <= epsilon:
+            repro = without
+            if distinguishable:
+                popularity_ignored += 1
+        else:
+            repro = with_pop
+        resid = f.recorded - repro
+        flag = "" if abs(resid) <= epsilon else "   <-- NOT REPRODUCED"
+        if flag:
+            residuals += 1
+        print(
+            f"{f.language:16s} {f.file_name:18s} {f.coding_loc:>4} {f.doc_loc:>4} {f.raw_api:>3} {f.api:>3} "
+            f"{f.credit:>3} {f.doc:>3} {f.ownership:>3} {f.reflection:>3} {f.popularity:>3} | "
+            f"{f.recorded:>8.2f} {repro:>8.2f} {resid:>7.2f}{flag}"
+        )
+        by_api[f.api].append(f)
+
+    print("\n## CLUSTER: files by adjusted api per file (the score is a function of this column)")
+    print(
+        f"{'api':>3} {'files':>5} {'score min':>9} {'score max':>9}  languages (a/b/c-style files; main listed as <lang>/main)"
+    )
+    for api in sorted(by_api):
+        group = by_api[api]
+        scores = [g.recorded for g in group]
+        langs = sorted({g.language if not g.file_name.startswith("main") else f"{g.language}/main" for g in group})
+        print(f"{api:>3} {len(group):>5} {min(scores):>9.2f} {max(scores):>9.2f}  {', '.join(langs)}")
+
+    if files:
+        print("\n## SENSITIVITY: score vs adjusted api (doc_loc 2, doc 0, ownership 0, reflection 0, loc 15)")
+        rows = sensitivity(p, files[0].language)
+        print("  api    " + " ".join(f"{api:>6}" for api, _ in rows))
+        print("  score  " + " ".join(f"{s:>6.1f}" for _, s in rows))
+        steps = [rows[i + 1][1] - rows[i][1] for i in range(1, len(rows) - 1)]
+        print(f"  points per additional api hit (api 1..7): {min(steps):.1f} to {max(steps):.1f}")
+
+    print(
+        f"\npopularity multiplier: reproduced with it on {popularity_applied} file(s), "
+        f"with it off {popularity_ignored} file(s)"
+    )
+    if residuals:
+        print(f"\nFAIL: {residuals} file(s) not reproduced from their recorded inputs (epsilon {epsilon}).")
+        return 1
+    print(f"\nOK: every recorded risk_documentation reproduced from its inputs ({len(files)} files).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--db", action="append", default=[], help="a galaxyscope *_galaxy_master.db (repeatable)")
+    ap.add_argument("--corpus", help="keyword-rosetta data/ directory: scan each language folder")
+    ap.add_argument("--languages", help="comma-separated subset of --corpus folders")
+    ap.add_argument("--epsilon", type=float, default=EPSILON_DEFAULT)
+    ap.add_argument("--umbrella", type=float, default=0.0, help="doc_umbrella to assume (corpus folders have none)")
+    args = ap.parse_args(argv)
+    if not args.db and not args.corpus:
+        ap.error("give --db or --corpus")
+
+    files: list[FileInputs] = []
+    for db in args.db:
+        files.extend(read_db(pathlib.Path(db)))
+    if args.corpus:
+        root = pathlib.Path(args.corpus)
+        wanted = set(args.languages.split(",")) if args.languages else None
+        folders = sorted(d for d in root.iterdir() if d.is_dir() and not d.name.startswith("."))
+        with tempfile.TemporaryDirectory(prefix="doc_inputs_") as tmp:
+            for folder in folders:
+                if wanted and folder.name not in wanted:
+                    continue
+                out = pathlib.Path(tmp) / folder.name
+                out.mkdir()
+                files.extend(read_db(scan_folder(folder, out), language_hint=folder.name))
+    files.sort(key=lambda f: (f.language, f.file_name))
+    return run(files, epsilon=args.epsilon, umbrella=args.umbrella)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Phase 0 of #2908 (child of #2812, Phase 4 score contracts). Docs and a read-only audit tool; no engine behaviour changes, no golden-master or corpus movement.

## What

- **`docs/risk_documentation_contract.md`** (status `draft`) — the contract sentence, the proposed equation (a per-unit coverage ratio: public units weigh double, reflection raises a unit's weight, a folder umbrella shields the file, `n/a` when a file has no units), the leave-list table with a reason per dropped term, decisions D1–D6 for review on the epic, the acceptance table, and §2: what `_calc_documentation` measures **today** on the corpus and why that is replaced.
- **`tests/tools/audit_documentation_inputs.py`** — reads each scanned file's formula inputs out of the galaxyscope DB (`arch_api`, `raw_arch_api`, `def_doc`, `def_ownership`, `state_heat_triggers`, `doc_loc`, `coding_loc`, `popularity`, `silo_risk`, path), calls `_calc_documentation` directly with them (the `audit_length_invariance.py` isolation technique), and compares to the recorded `risk_documentation`. Prints one row per file, the CLUSTER table (files by adjusted api per file) and the SENSITIVITY table (score vs api). Exits 1 on any residual, so the decomposition the epic rests on stays checkable. `--db` for existing DBs, `--corpus <keyword-rosetta>/data` scans each language folder like `verify_language.py`.

## What it found

- On the corpus every term but the adjusted api count is flat: no function has impact > 50 (opaque-execution term dead), every file is under the 50-line floor (denominator constant 70), doc/ownership/doc_loc move a file ≈2 points. One api hit per file = **8 to 14 points**. The clusters: api 6 → 77–79 (makefile, m4, scheme, cobol: double count, #2827 / re-plant owed after #2902), api 5 → 68 (c a.c: globals plants match the api rule, **#2907**, new), api 4 → 55–62 (css, agc, yacc: partial credit), api 3 → 38–41 (intended), api 1 → 18 (dockerfile, html, yaml, haskell #2871), api 0 → 0.
- **The popularity multiplier never fires** — `meta["popularity"]` is not populated when `calculate_risk_vector` runs; the fan-in only ever lands in `meta["telemetry"]`, thirty lines later. Same for `_calc_verification`, `_calc_api_exposure` and the threat vector. Filed as **#2909**; makes D4's removal of the term score-neutral.

## Verification

- `audit_documentation_inputs.py --corpus keyword-rosetta/data` at engine `81b895cc`: **46/46 languages, 185 files, every recorded score reproduced** (epsilon 0.01); with the multiplier on, 0 files reproduce.
- `tests/tools/audit_check.py`: all clear (ruff 70-finding baseline, mypy 2-error baseline, dead-key, ast-accuracy, format).
- No parsing or scoring code touched → no crucible bless, no `rosetta:rebless-owed`.

## Cross-repo

None for this phase. Phase 1 pairs with keyword-rosetta (the m4/makefile re-plant); Phase 3 will carry `rosetta:rebless-owed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
