### PR TITLE
Contextual Baseline Fix: case-fold the resolver for case-insensitive-import languages (#2871)

### DIFF
--- a/gitgalaxy/galaxyscope.py
+++ b/gitgalaxy/galaxyscope.py
@@ -30,7 +30,7 @@ from typing import Any, Optional, Union
 from gitgalaxy.core.aperture import ApertureFilter, InaccessibleArtifactError
 from gitgalaxy.core.detector import HAS_TIKTOKEN
 from gitgalaxy.core.guidestar_lens import GuideStarLens
-from gitgalaxy.core.network_risk_sensor import HAS_NETWORKX, NetworkRiskSensor
+from gitgalaxy.core.network_risk_sensor import CASE_INSENSITIVE_IMPORT_LANGS, HAS_NETWORKX, NetworkRiskSensor
 from gitgalaxy.core.prism import Prism
 from gitgalaxy.core.spatial_correlation import correlate_against_ledger
 from gitgalaxy.core.spatial_mapper import SpatialMapper
@@ -1818,11 +1818,29 @@ class Orchestrator:
         suffix_map = {}
         stem_to_paths = {}
 
+        # #2871 (#2540's residue): a case-folded view of the same suffix keys,
+        # held per case-insensitive-resolution language and holding only that
+        # language's own files -- the orchestrator's twin of
+        # network_risk_sensor's `_build_folded_resolution_map`. #2540 taught
+        # the sensor's graph (the one pagerank and the recorded `popularity`
+        # column read) that haskell's necessarily-capitalised `import B` binds
+        # b.hs, but THIS resolver -- the one the Contextual Baseline Fix reads
+        # to decide whether an imported file's orphans are wiped -- kept its
+        # exact-case fast path and a stem fallback whose `len(stem) >= 3`
+        # guard rejects `b`. So every column a reviewer could see said the
+        # chain resolved while the debt wipe never ran (keyword-rosetta
+        # haskell a/b/c: unreferenced_by_name 3 where every other language
+        # reads 0, risk_tech_debt 97 against a stratum median of 30).
+        folded_suffix_map: dict[str, dict[str, list[str]]] = {}
+
         for repo_file in repo_file_paths:
             s = Path(repo_file).stem.lower()
             if s not in stem_to_paths:
                 stem_to_paths[s] = []
             stem_to_paths[s].append(repo_file)
+
+            fold_lang = str(self.ram_cache.get(repo_file, {}).get("lang_id", "")).lower()
+            folded = folded_suffix_map.setdefault(fold_lang, {}) if fold_lang in CASE_INSENSITIVE_IMPORT_LANGS else None
 
             norm_repo = repo_file.replace("\\", "/")
             repo_no_ext = norm_repo.rsplit(".", 1)[0] if "." in Path(norm_repo).name else norm_repo
@@ -1833,6 +1851,8 @@ class Orchestrator:
                 if suffix not in suffix_map:
                     suffix_map[suffix] = []
                 suffix_map[suffix].append(repo_file)
+                if folded is not None:
+                    folded.setdefault(suffix.lower(), []).append(repo_file)
 
             parts_no_ext = repo_no_ext.split("/")
             for i in range(len(parts_no_ext)):
@@ -1841,6 +1861,8 @@ class Orchestrator:
                     suffix_map[suffix] = []
                 if repo_file not in suffix_map[suffix]:
                     suffix_map[suffix].append(repo_file)
+                if folded is not None and repo_file not in folded.setdefault(suffix.lower(), []):
+                    folded[suffix.lower()].append(repo_file)
 
         stop_stems = {
             "text",
@@ -1939,6 +1961,20 @@ class Orchestrator:
                         matched_internal = True
                         for target_path in suffix_map[init_path]:
                             self.popularity_scores[target_path] += 1
+
+                # --- FAST PATH 1c (#2871 / #2540): case-folded retry ---
+                # Only after every exact-case form missed, only for a file
+                # whose language resolves imports case-insensitively, and
+                # only against that language's own files -- the same three
+                # conditions as the sensor's Stage 1c, so the two resolvers
+                # agree on the edge the Contextual Baseline Fix is gated on.
+                if not matched_internal:
+                    fold_lang = str(meta.get("lang_id", "")).lower()
+                    lang_map = folded_suffix_map.get(fold_lang) if fold_lang in CASE_INSENSITIVE_IMPORT_LANGS else None
+                    if lang_map:
+                        for target_path in lang_map.get(clean_path.lower(), ()):
+                            self.popularity_scores[target_path] += 1
+                            matched_internal = True
 
                 # --- THE FALLBACK: Stem Matching ---
                 if not matched_internal:

--- a/tests/core_engine/test_galaxyscope.py
+++ b/tests/core_engine/test_galaxyscope.py
@@ -489,6 +489,50 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
         )
 
     # ==============================================================================
+    # TEST 8.6: THE CONTEXTUAL BASELINE FIX READS A CASE-FOLDED EDGE (#2871)
+    # ==============================================================================
+    @patch("gitgalaxy.galaxyscope.logger")
+    def test_resolver_case_folds_for_case_insensitive_import_languages(self, mock_logger):
+        """
+        Regression for #2871 (#2540's residue). Haskell module names must be
+        capitalised, so `import B` names b.hs. #2540 taught network_risk_sensor's
+        graph that (the one pagerank and the recorded `popularity` column read),
+        but THIS resolver -- the one the Contextual Baseline Fix is gated on --
+        kept an exact-case fast path plus a stem fallback whose `len(stem) >= 3`
+        guard rejects `b`. So b.hs recorded popularity 1 and pagerank identical to
+        java's while its orphans were never wiped: keyword-rosetta haskell a/b/c
+        read unreferenced_by_name 3 and risk_tech_debt 97 against a stratum
+        median of 30, with every visible input on the median.
+
+        The folded retry is scoped exactly like the sensor's Stage 1c: only
+        after the exact-case forms miss, only for a case-insensitive-resolution
+        language, only onto that language's own files.
+        """
+        scope = Orchestrator(".", self.mock_config)
+        scope.ram_cache = {
+            # haskell: `import B` must bind b.hs even though the module name is
+            # one capital letter (the fallback's length guard rejects it).
+            "hs/a.hs": {"lang_id": "haskell", "raw_imports": {"import B"}},
+            "hs/b.hs": {"lang_id": "haskell", "raw_imports": set()},
+            # go is case-sensitive: `import "B"` must NOT fold onto b.go.
+            "go/a.go": {"lang_id": "go", "raw_imports": {"B"}},
+            "go/b.go": {"lang_id": "go", "raw_imports": set()},
+            # a haskell import must not fold across languages onto a same-named
+            # file of another language. One letter, so the long-standing
+            # language-agnostic stem fallback (`len(stem) >= 3`) cannot reach
+            # it either and only the folded path is under test.
+            "hs/c.hs": {"lang_id": "haskell", "raw_imports": {"import Q"}},
+            "py/q.py": {"lang_id": "python", "raw_imports": set()},
+        }
+        scope.stem_map = {k: k for k in scope.ram_cache.keys()}
+
+        scope._resolve_dependency_graph()
+
+        self.assertEqual(scope.popularity_scores["hs/b.hs"], 1, "haskell `import B` must resolve to b.hs case-folded")
+        self.assertEqual(scope.popularity_scores["go/b.go"], 0, "a case-sensitive language must not gain folding")
+        self.assertEqual(scope.popularity_scores["py/q.py"], 0, "folding never invents a cross-language edge")
+
+    # ==============================================================================
     # TEST 9: INCREMENTAL DELTA SHIFT (State Rehydration)
     # ==============================================================================
     @patch("gitgalaxy.galaxyscope.Orchestrator._extract_features_parallel")
@@ -1445,7 +1489,9 @@ class TestGalaxyScopeOrchestrator(unittest.TestCase):
 
         # 1. Adjusted behavior is byte-identical to before: orphans folded into api.
         self.assertEqual(lib["equations"]["api"], 5, "Contextual Baseline Fix no longer folds orphans into api!")
-        self.assertEqual(lib["equations"]["unreferenced_by_name"], 0, "Contextual Baseline Fix no longer wipes orphans!")
+        self.assertEqual(
+            lib["equations"]["unreferenced_by_name"], 0, "Contextual Baseline Fix no longer wipes orphans!"
+        )
 
         # 2. The raw pre-adjustment values survive on the snapshot, and the
         #    invariant adjusted api == raw_api + raw_unreferenced_by_name holds.


### PR DESCRIPTION
Closes #2871. Phase 1 of #2908 (child of #2812).

## What

Two dependency resolvers disagreed. `network_risk_sensor`'s graph (pagerank, the recorded `popularity` column) learned in #2540 that haskell's necessarily-capitalised `import B` binds `b.hs`. The orchestrator's own `_resolve_dependency_graph` — the resolver the **Contextual Baseline Fix** is gated on — did not: its suffix fast path is exact-case (key `b`, token `B`) and its stem fallback's `len(stem) >= 3` guard rejects `b`. So every visible column said the chain resolved while the orphan wipe never ran.

This adds the orchestrator's twin of the sensor's Stage 1c: a per-language lowercase view of the suffix keys, built only for `CASE_INSENSITIVE_IMPORT_LANGS` (fortran, cobol, haskell — the registry flag #2540 introduced) and holding only that language's own files, consulted only after both exact-case fast paths miss. Case-sensitive languages gain nothing, folding never invents a cross-language edge, and the language-agnostic stem fallback is untouched.

## Measured

haskell corpus folder, full precision, before → after:

| file | CBF popularity | `state_unreferenced` | `risk_tech_debt` |
|---|---|---|---|
| a.hs | 0 → 1 | 3 → 0 | 97.07 → 0.00 |
| b.hs | 0 → 1 | 3 → 0 | 97.07 → 0.00 |
| c.hs | 0 → 1 | 3 → 0 | 100.00 → 81.76 |
| main.hs | 0 → 0 | 1 → 1 | 37.75 → 37.75 |

java, rust and swift (same stratum, same layout) read exactly 0 / 0 / 81.76. This clears the `risk_tech_debt` open-defect cell and takes haskell's `risk_documentation` input onto the right footing for Phase 2.

- `rosetta_audit.py`, 46 languages against keyword-rosetta at origin/main: **no gated cell moves** (haskell PASS, 80 assertions; the one reported regression is c's `a.c`, #2907's re-bless in keyword-rosetta#110). The manifest gate cannot see `unreferenced_by_name` after the wipe, which is why this was ledgered rather than asserted.
- `crucible_check.py`: **both golden masters PASS unchanged** — no crucible file carries a short capitalised import that this path decides.
- `test_galaxyscope.py` 60 passed, incl. the new regression (haskell `import B` → `b.hs`; go `B` does not fold; haskell `import Q` does not fold onto `q.py`). `audit_check.py` all clear.

## Corpus

Label **`rosetta:rebless-owed`** for the ledger only: `haskell-module-name-invisible-to-popularity-tally` retires (`risk_tech_debt` haskell +178% → on the median), and the haskell manifest note's "control for #2827" remark gets the correction the issue names (its `api_orphan_credit` 0 was a suppression that never had a chance to run). No manifest number changes.

## Not done here

The issue's deeper fix — the Contextual Baseline Fix reading the sensor's graph instead of a second resolver — is a refactor of the orchestrator's Phase 1.5 and stays open as a design question. This PR makes the two resolvers agree on the case the corpus proved, with the same scoping rules, so they cannot disagree on it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
