### PR TITLE
ci: dedupe concurrent runs, parallelise pytest, and de-flake the ReDoS timing asserts (#2901)

### DIFF
--- a/.github/workflows/ast-accuracy-audit.yml
+++ b/.github/workflows/ast-accuracy-audit.yml
@@ -14,9 +14,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ast-accuracy-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,10 +10,23 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dead-key-audit.yml
+++ b/.github/workflows/dead-key-audit.yml
@@ -9,9 +9,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dead-key-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,11 +9,24 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   deploy:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/full-suite-gate.yml
+++ b/.github/workflows/full-suite-gate.yml
@@ -2,14 +2,27 @@ name: Full Suite Gate (All OS x Python)
 
 # Backup safety net for the full OS x Python-version matrix, now that
 # smoke-test.yml only runs the full pytest suite once per push (see that
-# file's comments for why). This workflow restores full 12-way matrix
-# coverage of the entire suite at two checkpoints instead of every push:
+# file's comments for why). This workflow restores matrix coverage of the
+# entire suite at two checkpoints instead of every push:
 #   - Any label added to a pull request (an explicit "give this the full
 #     validation pass" signal -- not filtered to a specific label name, so
 #     applying ANY label triggers it).
 #   - Any release tag push (`v*`), matching publish.yml's own release
 #     trigger, as a pre-release confidence check across every supported
 #     environment.
+#
+# The matrix is sized per checkpoint (see the `matrix` job below). Measured
+# 2026-09-09: the 12-way matrix's jobs RAN for 10-18 min but QUEUED for
+# 23-65 min, because four label events on one PR put 48 jobs (16 of them
+# macOS, the scarcest pool) into the queue for a single SHA. Deduplication
+# is handled by `concurrency` above; this trims what one run costs.
+#
+# On a PR label: all four Python versions still run, on ubuntu; windows and
+# macOS cover the version floor and ceiling only. That keeps the thing the
+# matrix exists to catch -- a version-specific syntax/stdlib break that the
+# every-push ubuntu/3.12 full-suite cannot see -- while cutting macOS from
+# four jobs to two.
+# On a `v*` tag: the untrimmed 12-way matrix, unchanged.
 on:
   pull_request:
     types: [labeled]
@@ -20,17 +33,71 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). A PR that gets four
+  # labels in one `gh pr create` fired four IDENTICAL matrix runs on the same
+  # SHA; superseded runs are now cancelled instead of queueing behind each
+  # other. cancel-in-progress is scoped to pull_request on purpose -- the
+  # push/schedule/tag runs are the ones that commit (docs, history charts,
+  # releases), and killing one mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Emits the matrix for this checkpoint. A tag push gets the full 12-way
+  # grid; a PR label gets the trimmed grid described in the header comment.
+  matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      include: ${{ steps.pick.outputs.include }}
+    steps:
+      - name: Pick matrix for this trigger
+        id: pick
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Release tag: every supported environment, untrimmed.
+            include='[
+              {"os":"ubuntu-latest","python-version":"3.9"},
+              {"os":"ubuntu-latest","python-version":"3.10"},
+              {"os":"ubuntu-latest","python-version":"3.11"},
+              {"os":"ubuntu-latest","python-version":"3.12"},
+              {"os":"windows-latest","python-version":"3.9"},
+              {"os":"windows-latest","python-version":"3.10"},
+              {"os":"windows-latest","python-version":"3.11"},
+              {"os":"windows-latest","python-version":"3.12"},
+              {"os":"macos-latest","python-version":"3.9"},
+              {"os":"macos-latest","python-version":"3.10"},
+              {"os":"macos-latest","python-version":"3.11"},
+              {"os":"macos-latest","python-version":"3.12"}
+            ]'
+          else
+            # PR label: full Python coverage on ubuntu, floor+ceiling elsewhere.
+            include='[
+              {"os":"ubuntu-latest","python-version":"3.9"},
+              {"os":"ubuntu-latest","python-version":"3.10"},
+              {"os":"ubuntu-latest","python-version":"3.11"},
+              {"os":"ubuntu-latest","python-version":"3.12"},
+              {"os":"windows-latest","python-version":"3.9"},
+              {"os":"windows-latest","python-version":"3.12"},
+              {"os":"macos-latest","python-version":"3.9"},
+              {"os":"macos-latest","python-version":"3.12"}
+            ]'
+          fi
+          echo "include=$(echo "$include" | tr -d '\n ')" >> "$GITHUB_OUTPUT"
+
   full-suite-matrix:
+    needs: matrix
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     env:
       PYTHONUTF8: "1"
       GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
 
     steps:
       - name: Check out repository code
@@ -52,8 +119,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install PyYAML networkx tiktoken pandas xgboost pytest
+          pip install PyYAML networkx tiktoken pandas xgboost pytest pytest-xdist
           pip install --no-build-isolation -e .
 
       - name: Full Suite (${{ matrix.os }}, Python ${{ matrix.python-version }})
-        run: pytest tests/ -v
+        run: pytest tests/ -n auto -q -ra --durations=25

--- a/.github/workflows/gitgalaxy.yml
+++ b/.github/workflows/gitgalaxy.yml
@@ -22,6 +22,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================
   # PRE-GATE — runs on every PR, blocks the merge on failure.
@@ -31,6 +43,7 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Vault Sentinel
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -45,6 +58,7 @@ jobs:
     if: github.event_name == 'pull_request'
     name: X-Ray Inspector
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -59,6 +73,7 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Supply Chain Firewall
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -89,6 +104,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Full Report (SARIF, SBOM, LLM Brief)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write
       pull-requests: write   # NEW — required for create-pull-request to open the PR

--- a/.github/workflows/golden-crucible.yml
+++ b/.github/workflows/golden-crucible.yml
@@ -7,9 +7,22 @@ on:
       - v6-dev
     paths-ignore: ["docs/**"]
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   crucible-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/golden-master-guard.yml
+++ b/.github/workflows/golden-master-guard.yml
@@ -15,9 +15,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   flag-golden-master-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/muninn.yml
+++ b/.github/workflows/muninn.yml
@@ -8,9 +8,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   muninn:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/mypy-audit.yml
+++ b/.github/workflows/mypy-audit.yml
@@ -9,9 +9,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   mypy-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/rosetta-audit.yml
+++ b/.github/workflows/rosetta-audit.yml
@@ -37,9 +37,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   rosetta-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout GitGalaxy PR
         uses: actions/checkout@v4

--- a/.github/workflows/ruff-audit.yml
+++ b/.github/workflows/ruff-audit.yml
@@ -9,9 +9,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ruff-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/signal-contract-audit.yml
+++ b/.github/workflows/signal-contract-audit.yml
@@ -12,9 +12,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   signal-contract-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -8,6 +8,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # TRUE smoke test: cheap, OS/Python-version-sensitive checks only (package
   # installs, CLI entry points, syntax floor) across the full matrix. Does
@@ -20,6 +32,7 @@ jobs:
   # (#813) without adding real signal over running it once.
   smoke-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     env:
       PYTHONUTF8: "1"
       GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
@@ -85,6 +98,7 @@ jobs:
   # full-suite-gate.yml.
   full-suite:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       PYTHONUTF8: "1"
       GITGALAXY_LICENSE_KEY: "COMMUNITY_FREE_TIER"
@@ -103,8 +117,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install PyYAML networkx tiktoken pandas xgboost pytest
+          pip install PyYAML networkx tiktoken pandas xgboost pytest pytest-xdist
           pip install --no-build-isolation -e .
 
       - name: Golden Record Integration Test (Pytest)
-        run: pytest tests/ -v
+        run: pytest tests/ -n auto -q -ra --durations=25

--- a/.github/workflows/tree-sitter-accuracy-audit.yml
+++ b/.github/workflows/tree-sitter-accuracy-audit.yml
@@ -26,9 +26,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tree-sitter-accuracy-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout GitGalaxy PR
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tree-sitter-accuracy-history.yml
+++ b/.github/workflows/tree-sitter-accuracy-history.yml
@@ -41,6 +41,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tree-sitter-accuracy-history:
     # Guards against the same infinite-loop shape documented in gitgalaxy.yml's
@@ -50,6 +62,7 @@ jobs:
     if: |
       !startsWith(github.event.head_commit.message, 'docs: auto-update tree-sitter accuracy data')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tri-comparison-audit.yml
+++ b/.github/workflows/tri-comparison-audit.yml
@@ -35,9 +35,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tri-comparison-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout GitGalaxy PR
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tri-comparison-history.yml
+++ b/.github/workflows/tri-comparison-history.yml
@@ -39,6 +39,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # One run per workflow per PR (or per ref outside a PR). Without this, a PR
+  # that picks up several labels in one `gh pr create` starts a separate,
+  # IDENTICAL run per label event on the same SHA (measured 2026-09-09: four
+  # Full Suite Gate runs and five rosetta-audit runs for one commit), and a
+  # re-push leaves the superseded run occupying the queue. cancel-in-progress
+  # is scoped to pull_request on purpose -- the push/schedule/tag runs are the
+  # ones that commit (docs, history charts, releases), and cancelling one
+  # mid-write is how you get a half-written commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   tri-comparison-history:
     # Guards against the same infinite-loop shape tree-sitter-accuracy-history.yml already
@@ -48,6 +60,7 @@ jobs:
     if: |
       !startsWith(github.event.head_commit.message, 'docs: auto-update tri-comparison data')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/tests/core_engine/test_language_standards_strict.py
+++ b/tests/core_engine/test_language_standards_strict.py
@@ -24,7 +24,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent.parent / "extraction" / "la
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 
 # ==============================================================================
@@ -176,27 +176,27 @@ _SPEC_EXPOSURE_REDOS_SWEEP_TARGETS = [
 
 
 @pytest.mark.parametrize(
-    "language,old_pattern_text,extra_positive",
+    "language,_old_pattern_text,extra_positive",
     _SPEC_EXPOSURE_REDOS_SWEEP_TARGETS,
     ids=[t[0] for t in _SPEC_EXPOSURE_REDOS_SWEEP_TARGETS],
 )
-def test_spec_exposure_adjacent_quantifier_redos_sweep(language, old_pattern_text, extra_positive):
-    old_pattern = re.compile(old_pattern_text, re.I)
+def test_spec_exposure_adjacent_quantifier_redos_sweep(language, _old_pattern_text, extra_positive):
+    """#2901: this used to time the PRE-FIX pattern and assert it scaled
+    quadratically (ratio > 2.2 over an 8000 -> 16000 byte doubling) before
+    checking the shipped one. That half measured a regex this repo no
+    longer ships, on a wall clock, on a shared runner -- and it is what
+    went red on macOS runs 34288012477 / 34212533327 with ratios like
+    2.31, on PRs whose diffs touched none of this. A ratio between two
+    sub-100ms samples is inside the scheduling noise of a contended
+    runner, so no threshold makes it both meaningful and stable.
 
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed -- the exact
-    # failure mode of an earlier version of this same style of test in
-    # this file): a payload-size doubling should cost ~4x on the
-    # quadratic OLD pattern, vs ~2x for linear.
-    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
-    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"{language}: sanity check failed -- old pattern was expected to show quadratic (~4x) "
-        f"scaling on a payload doubling, but only scaled {ratio:.2f}x "
-        f"({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
-
+    What is worth pinning is the property of the code that actually
+    ships: `spec_exposure` is immune on a pathological payload. That is
+    asserted below as an ABSOLUTE bound inside an isolated process
+    (`assert_redos_immune`), which is deterministic. The pre-fix pattern
+    for each language is kept in the parametrize table above as a record
+    of the shape that was fixed -- documentation, not a measurement.
+    """
     spec_exposure = LANGUAGE_DEFINITIONS[language]["rules"]["spec_exposure"]
     assert_redos_immune(spec_exposure, "[SPEC-" + "1" * 100000, timeout_sec=3.0)
     assert spec_exposure.search("[SPEC-123]"), f"{language}: lost the basic SPEC-NNN positive case"

--- a/tests/core_engine/test_naming_convention_signatures.py
+++ b/tests/core_engine/test_naming_convention_signatures.py
@@ -28,7 +28,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent.parent / "extraction" / "la
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 
 @pytest.fixture(scope="module")
@@ -169,17 +169,29 @@ def test_var_decl_pattern_redos_immune_many_comparisons(var_decl_pattern):
     assert_redos_immune(var_decl_pattern, ("x == y " * 20000), timeout_sec=2.0)
 
 
-def test_var_decl_pattern_scales_linearly_not_quadratically(var_decl_pattern):
-    """Scale-relative sanity check (not an absolute wall-clock threshold, which
-    is flaky across CI hardware): doubling the payload should cost ~2x
-    (linear), not ~4x (the O(n^2) catastrophic-backtracking signature)."""
-    small = _best_of_timing(var_decl_pattern, "a" + (" " * 8000))
-    large = _best_of_timing(var_decl_pattern, "a" + (" " * 16000))
-    ratio = large / small if small > 0 else 0
-    assert ratio < 3.0, (
-        f"expected roughly linear (~2x) scaling on a payload doubling, got {ratio:.2f}x "
-        f"({small:.5f}s -> {large:.5f}s) -- possible quadratic regression"
-    )
+def test_var_decl_pattern_stays_linear_on_a_long_whitespace_run(var_decl_pattern):
+    """The payload shape that would expose quadratic backtracking in
+    `var_decl`: one identifier followed by a long whitespace run with no
+    `=` ever appearing, so every offset is a near-miss.
+
+    #2901: this was a `_best_of_timing` ratio check (`large / small < 3.0`
+    over an 8000 -> 16000 byte doubling). Both samples were sub-millisecond,
+    which made the ratio a measurement of runner scheduling rather than of
+    the regex -- it is one of the two asserts #2901 reports going red on
+    shared macOS runners for unrelated PRs.
+
+    Replaced with an absolute bound at a payload an order of magnitude
+    larger, inside an isolated process -- what the rest of this file's
+    ReDoS tests already do, and deterministic.
+
+    Verified (2026-09-09) that this still catches the regression it is
+    here for, rather than just being quieter: dropping the `{0,80}` bound
+    on the pre-`=` segment (`[^=\\n]{0,80}` -> `[^=\\n]*`, which restores
+    the adjacent-unbounded-quantifier shape) makes this exact assertion
+    FAIL on the 160k payload, while the shipped pattern passes it in
+    ~1.1s including process spawn.
+    """
+    assert_redos_immune(var_decl_pattern, "a" + (" " * 160000), timeout_sec=2.0)
 
 
 # ==============================================================================

--- a/tests/extraction/languages/test_ada_strict.py
+++ b/tests/extraction/languages/test_ada_strict.py
@@ -413,26 +413,34 @@ def test_ada_redos_immunity_sweep():
     assert ADA_RULES["import"].search("with Ada.Text_IO;")
 
 
-def test_ada_func_start_scaling_is_linear_not_quadratic():
+def test_ada_func_start_stays_linear_on_a_long_with_aspect_run():
     """
-    Explicit geometric-scaling proof (Rule 5, not a single timing) for the
-    bounded `with`-aspect segment between the profile and "is" -- the one
-    genuinely payload-shaped quantifier in func_start.
-    """
-    import time
+    Bounds the one genuinely payload-shaped quantifier in func_start: the
+    `with`-aspect segment between the profile and "is".
 
+    #2901: this was a geometric-scaling ratio (`timings[-1] < timings[0] *
+    8 + 0.05` over n=2000/4000/8000) built from single unrepeated
+    `perf_counter()` samples -- the same wall-clock-ratio-on-a-shared-runner
+    shape as the two asserts #2901 reports flaking on macOS.
+
+    Measured while replacing it (2026-09-09): every sample was
+    sub-millisecond, so the additive 0.05 floor was deciding the result,
+    not the ratio. And the ratio had little to detect here -- the aspect
+    segment is LAZY and this payload has a single start position, so even
+    with the bound removed entirely (`[^;{}]{0,300}?` -> `[^;{}]*?`) the
+    pattern still scales linearly: 0.0002s / 0.0004s / 0.0007s / 0.0014s at
+    n=2000/4000/8000/16000. So this site has no reachable quadratic
+    regression for a ratio to catch.
+
+    What is left worth pinning is a plain ceiling on the cost of a long
+    aspect run, which an absolute bound on a much larger payload states
+    directly and deterministically.
+    """
     func_start = ADA_RULES["func_start"]
-    timings = []
-    for n in (2000, 4000, 8000):
-        payload = "procedure Foo with " + "A" * n
-        start = time.perf_counter()
-        func_start.search(payload)
-        timings.append(time.perf_counter() - start)
+    assert_redos_immune(func_start, "procedure Foo with " + "A" * 200000, timeout_sec=3.0)
 
-    # A roughly-2x-per-doubling ratio is linear; anything approaching 4x
-    # would indicate real quadratic backtracking. Generous margin for CI
-    # scheduling noise.
-    assert timings[-1] < timings[0] * 8 + 0.05, f"suspicious scaling: {timings}"
+    # the bounded segment must not have cost the rule its real positive case
+    assert func_start.search("procedure Foo is")
 
 
 # ==============================================================================

--- a/tests/extraction/languages/test_c_strict.py
+++ b/tests/extraction/languages/test_c_strict.py
@@ -20,7 +20,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 
 # ==============================================================================
@@ -253,20 +253,15 @@ def test_c_spec_exposure_redos_regression():
     tcl, matlab, scheme, typescript, and rust earlier in this epic (the 8th
     language with this exact shape). Bounded both quantifiers.
     """
-    old_pattern = re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I)
-    # Prove the quadratic blowup via a scale-relative comparison (not an
-    # absolute wall-clock threshold, which is flaky across CI hardware of
-    # varying speed): unclosed bracket with digits then padding forces the
-    # engine to re-partition the trailing run between `\d+` and `[^\]]*` on
-    # every failed attempt to find `]`, so a payload-size doubling should
-    # cost ~4x on the quadratic OLD pattern, vs ~2x for linear.
-    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 4000 + " " * 4000)
-    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000 + " " * 8000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
-        f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I
+    # used to run here, asserting it scaled ~quadratically (ratio > 2.2)
+    # over a payload doubling. Removed: it timed a regex this repo no
+    # longer ships, and the ratio between two sub-100ms samples is inside
+    # the scheduling noise of a shared CI runner -- this family of asserts
+    # went red on macOS for PRs that touched none of it. The shipped
+    # pattern's immunity is asserted below as an ABSOLUTE bound inside an
+    # isolated process, which is deterministic.
 
     spec_exposure = C_RULES["spec_exposure"]
     assert_redos_immune(spec_exposure, "[SPEC-" + " " * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_cpp_strict.py
+++ b/tests/extraction/languages/test_cpp_strict.py
@@ -20,7 +20,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 
 # ==============================================================================
@@ -516,18 +516,15 @@ def test_cpp_spec_exposure_redos_regression():
     tcl, matlab, scheme, typescript, rust, and c earlier in this epic (the
     9th hit).
     """
-    old_pattern = re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I)
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed): a payload-size
-    # doubling should cost ~4x on the quadratic OLD pattern, vs ~2x for
-    # linear.
-    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 4000 + " " * 4000)
-    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000 + " " * 8000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
-        f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I
+    # used to run here, asserting it scaled ~quadratically (ratio > 2.2)
+    # over a payload doubling. Removed: it timed a regex this repo no
+    # longer ships, and the ratio between two sub-100ms samples is inside
+    # the scheduling noise of a shared CI runner -- this family of asserts
+    # went red on macOS for PRs that touched none of it. The shipped
+    # pattern's immunity is asserted below as an ABSOLUTE bound inside an
+    # isolated process, which is deterministic.
 
     spec_exposure = CPP_RULES["spec_exposure"]
     assert_redos_immune(spec_exposure, "[SPEC-" + " " * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_csharp_strict.py
+++ b/tests/extraction/languages/test_csharp_strict.py
@@ -20,7 +20,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 
 # ==============================================================================
@@ -566,18 +566,15 @@ def test_csharp_spec_exposure_redos_regression():
     tcl, matlab, scheme, typescript, rust, c, and cpp earlier in this epic
     (the 10th hit).
     """
-    old_pattern = re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I)
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed): a payload-size
-    # doubling should cost ~4x on the quadratic OLD pattern, vs ~2x for
-    # linear.
-    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000 + " " * 8000)
-    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000 + " " * 16000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
-        f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I
+    # used to run here, asserting it scaled ~quadratically (ratio > 2.2)
+    # over a payload doubling. Removed: it timed a regex this repo no
+    # longer ships, and the ratio between two sub-100ms samples is inside
+    # the scheduling noise of a shared CI runner -- this family of asserts
+    # went red on macOS for PRs that touched none of it. The shipped
+    # pattern's immunity is asserted below as an ABSOLUTE bound inside an
+    # isolated process, which is deterministic.
 
     spec_exposure = CSHARP_RULES["spec_exposure"]
     assert_redos_immune(spec_exposure, "[SPEC-" + " " * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_css_strict.py
+++ b/tests/extraction/languages/test_css_strict.py
@@ -20,7 +20,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 # NOTE: this test was originally grouped under a shared "cross-language sweep"
 # section in tests/core_engine/test_language_standards_strict.py (before that file
@@ -305,18 +305,15 @@ def test_css_io_property_anchor_is_a_lookbehind_not_a_match_redos_regression():
     the fix (1.3s / 5.5s / 13.5s / 54s at 10k / 20k / 40k / 80k chars); the
     fixed-width lookbehind the rule ships is linear on the same inputs.
     """
-    quadratic = re.compile(r"[-a-zA-Z_][-\w]*[ \t]*:[^;{}@%<>]{0,200}?\burl\s*\(", re.I)
-    small = "background:" + "a" * 4000
-    large = "background:" + "a" * 8000
-    small_duration = _best_of_timing(quadratic, small)
-    large_duration = _best_of_timing(quadratic, large)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: the match-anchored spelling was expected to show quadratic (~4x) scaling "
-        f"on a payload doubling, but only scaled {ratio:.2f}x "
-        f"({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
-
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"[-a-zA-Z_][-\w]*[ \t]*:[^;{}@%<>]{0,200}?\burl\s*\(", re.I
+    # used to run here, asserting it scaled ~quadratically over a payload
+    # doubling. Removed: it timed a regex this repo no longer ships, and a
+    # ratio between two sub-100ms samples is inside the scheduling noise of
+    # a shared CI runner -- this family of asserts went red on macOS for
+    # PRs that touched none of it. The measured pre-fix numbers are kept in
+    # the docstring above; the shipped pattern's immunity is asserted below
+    # as an ABSOLUTE bound inside an isolated process, which is stable.
     assert_redos_immune(CSS_RULES["io"], "background:" + "a" * 100000, timeout_sec=3.0)
     assert_redos_immune(CSS_RULES["io"], "background:" + "a" * 100000 + "url(data:x)", timeout_sec=3.0)
     assert_redos_immune(CSS_RULES["io"], "x:" * 50000, timeout_sec=3.0)
@@ -399,20 +396,15 @@ def test_css_class_start_lookahead_redos_regression():
     everything it did) -- post-fix scaling at n=2000/8000/32000 is
     0.0001s/0.0004s/0.0016s, clean ~2x per doubling (linear).
     """
-    old_pattern = re.compile(r"^[ \t]*(\.[a-zA-Z_][\w-]*|#[a-zA-Z_][\w-]*)(?=[ \t,>+~:]*[^{]*\{)", re.M)
-
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed): a doubling of
-    # payload size should cost ~4x on the quadratic OLD pattern, vs ~2x for
-    # linear. This is the same discipline used everywhere else in this
-    # epic's ReDoS scaling sweeps.
-    small_duration = _best_of_timing(old_pattern, ".foo" + (" ,>+~:" * 1000))
-    large_duration = _best_of_timing(old_pattern, ".foo" + (" ,>+~:" * 2000))
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
-        f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"^[ \t]*(\.[a-zA-Z_][\w-]*|#[a-zA-Z_][\w-]*)(?=[ \t,>+~:]*[^{]*\{)", re.M
+    # used to run here, asserting it scaled ~quadratically over a payload
+    # doubling. Removed: it timed a regex this repo no longer ships, and a
+    # ratio between two sub-100ms samples is inside the scheduling noise of
+    # a shared CI runner -- this family of asserts went red on macOS for
+    # PRs that touched none of it. The measured pre-fix numbers are kept in
+    # the docstring above; the shipped pattern's immunity is asserted below
+    # as an ABSOLUTE bound inside an isolated process, which is stable.
 
     class_start = CSS_RULES["class_start"]
     assert_redos_immune(class_start, ".foo" + (" ,>+~:" * 200000), timeout_sec=3.0)
@@ -431,19 +423,15 @@ def test_css_spec_exposure_redos_regression():
     bracket before writing this test; bounded `\\d+` to `\\d{1,10}` and
     `[^\\]]*` to `{0,300}`.
     """
-    old_pattern = re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]|\bfigma\.com/file/", re.I)
-
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed): a doubling of
-    # payload size should cost ~4x on the quadratic OLD pattern, vs ~2x for
-    # linear.
-    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
-    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
-        f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]|\bfigma\.com/file/", re.I
+    # used to run here, asserting it scaled ~quadratically over a payload
+    # doubling. Removed: it timed a regex this repo no longer ships, and a
+    # ratio between two sub-100ms samples is inside the scheduling noise of
+    # a shared CI runner -- this family of asserts went red on macOS for
+    # PRs that touched none of it. The measured pre-fix numbers are kept in
+    # the docstring above; the shipped pattern's immunity is asserted below
+    # as an ABSOLUTE bound inside an isolated process, which is stable.
 
     spec_exposure = CSS_RULES["spec_exposure"]
     assert_redos_immune(spec_exposure, "[SPEC-" + "1" * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_embedded_python_strict.py
+++ b/tests/extraction/languages/test_embedded_python_strict.py
@@ -259,24 +259,15 @@ def test_embedded_python_generics_redos_immunity():
     immune and still matches realistic (including one-level-nested, per
     Rule 11) generic annotations.
     """
-    old_buggy_pattern = re.compile(
-        r"\b(?:List|Dict|Set|Tuple|Optional|Union|Any|Callable|Sequence|Iterable)\[[^\]]*\]|->"
-    )
-    import time as _time
-
-    durations = []
-    for n in (2000, 4000, 8000, 16000):
-        payload = "List[" * n
-        start = _time.perf_counter()
-        list(old_buggy_pattern.finditer(payload))
-        durations.append(_time.perf_counter() - start)
-    # Each doubling should show a roughly 4x increase for real O(n^2); assert
-    # the ratio between the last two measurements is well above the ~2x a
-    # linear-time pattern would show, confirming this really is quadratic.
-    assert durations[-1] / durations[-2] > 2.0, (
-        f"expected quadratic scaling on the pre-fix pattern, got durations={durations}"
-    )
-
+    # #2901: the pre-fix pattern
+    #     \b(?:List|Dict|...|Iterable)\[[^\]]*\]|->
+    # measured ~4x per size doubling at n=2000/4000/8000/16000. That
+    # measurement used to run here as a `durations[-1] / durations[-2] > 2.0`
+    # assertion; it is retained as this comment instead. It timed a regex
+    # this repo no longer ships, and a ratio between sub-100ms samples is
+    # inside the scheduling noise of a shared runner -- it went red on
+    # macOS for unrelated PRs. The shipped pattern's immunity is asserted
+    # below as an absolute bound in an isolated process, which is stable.
     pattern = EP_RULES["generics"]
     assert_redos_immune(pattern, "List[" * 40000, timeout_sec=3.0)
     assert pattern.search("def read() -> Optional[int]:")
@@ -302,19 +293,15 @@ def test_embedded_python_spec_exposure_redos_immunity():
     `[^\\]]*` to `{0,300}`; verify the fixed pattern stays immune and still
     matches realistic SPEC/audit tags.
     """
-    old_buggy_pattern = re.compile(r"\[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]", re.I)
-    import time as _time
-
-    durations = []
-    for n in (2000, 4000, 8000, 16000):
-        payload = "[SPEC-" + "1" * n
-        start = _time.perf_counter()
-        list(old_buggy_pattern.finditer(payload))
-        durations.append(_time.perf_counter() - start)
-    assert durations[-1] / durations[-2] > 2.5, (
-        f"expected quadratic scaling on the pre-fix pattern, got durations={durations}"
-    )
-
+    # #2901: the pre-fix pattern
+    #     \[(?:\s*SPEC\s*-\s*\d+|spec|audit)[^\]]*\]
+    # measured ~4x per size doubling (the numbers are in the docstring
+    # above). That measurement used to run here as a
+    # `durations[-1] / durations[-2] > 2.5` assertion and is the specific
+    # assert named in #2901: macOS run 34288012477 produced 2.31 on a PR
+    # that touched none of this. Deleted rather than re-tuned -- it timed
+    # a deleted regex, and no threshold is both meaningful and stable on
+    # a shared runner. The shipped pattern's absolute bound is below.
     pattern = EP_RULES["spec_exposure"]
     assert_redos_immune(pattern, "[SPEC-" + "1" * 80000, timeout_sec=3.0)
     assert pattern.search("# [SPEC-123] implements the boot contract")

--- a/tests/extraction/languages/test_groovy_strict.py
+++ b/tests/extraction/languages/test_groovy_strict.py
@@ -457,14 +457,17 @@ def test_groovy_closures_redos_immunity():
     """
     pattern = GROOVY_RULES["closures"]
 
-    # _best_of_timing (min-of-5) instead of a single perf_counter() sample
-    # per size -- see the explicit_casts test above for why.
-    timings = [_best_of_timing(pattern, "{" + " " * n) for n in (2000, 4000, 8000, 16000, 32000)]
-
     assert_redos_immune(pattern, "{" + " " * 100000, timeout_sec=3.0)
 
-    for earlier, later in zip(timings, timings[1:]):
-        assert later < max(earlier * 2.5, 0.01), f"closures scaling regressed toward O(n^2): {timings}"
+    # #2901: a geometric-scaling loop over
+    #   timings = [_best_of_timing(pattern, ...) for n in (2000 .. 32000)]
+    # used to assert `later < max(earlier * 2.5, 0.01)` here. Removed as
+    # redundant AND unstable: the assert_redos_immune() call above already
+    # pins the same property on the same shipped pattern as an ABSOLUTE
+    # bound, in an isolated process, on a 100k payload -- a strictly
+    # stronger and deterministic check. The ratio form compared sub-100ms
+    # wall-clock samples on shared runners; the comment this replaces
+    # recorded it going red on macos-3.10 under contention.
 
     # Realistic closures must still match after the fix.
     assert pattern.search("list.each { it }")
@@ -492,20 +495,17 @@ def test_groovy_spec_exposure_quadratic_blowup_redos_regression():
     """
     pattern = GROOVY_RULES["spec_exposure"]
 
-    # _best_of_timing (min-of-5) instead of a single perf_counter() sample
-    # per size -- see explicit_casts's own test earlier in this file for
-    # why (this exact test failed in CI this way on macos-3.10 during
-    # #770's PR: [0.0007, 0.0014, 0.0036, 0.0064, 0.0202]s, tripping the
-    # 0.02s floor on the last size by a hair under runner contention).
-    timings = [_best_of_timing(pattern, "[SPEC-" + "1" * n) for n in (2000, 4000, 8000, 16000, 32000)]
-
     assert_redos_immune(pattern, "[SPEC-" + "1" * 100000, timeout_sec=3.0)
 
-    # Generous ceiling (real O(n^2) is ~4x/doubling): absorbs scheduler
-    # noise under a full-suite parallel run while still catching a
-    # regression back to catastrophic backtracking.
-    for earlier, later in zip(timings, timings[1:]):
-        assert later < max(earlier * 3.0, 0.02), f"spec_exposure scaling regressed toward O(n^2): {timings}"
+    # #2901: a geometric-scaling loop over
+    #   timings = [_best_of_timing(pattern, ...) for n in (2000 .. 32000)]
+    # used to assert `later < max(earlier * 3.0, 0.02)` here. Removed as
+    # redundant AND unstable: the assert_redos_immune() call above already
+    # pins the same property on the same shipped pattern as an ABSOLUTE
+    # bound, in an isolated process, on a 100k payload -- a strictly
+    # stronger and deterministic check. The ratio form compared sub-100ms
+    # wall-clock samples on shared runners; the comment this replaces
+    # recorded it going red on macos-3.10 under contention.
 
     assert pattern.search("[SPEC-123] audit trail"), "realistic spec tag regressed"
     assert pattern.search("[audit] traceability tag"), "realistic audit tag regressed"

--- a/tests/extraction/languages/test_makefile_strict.py
+++ b/tests/extraction/languages/test_makefile_strict.py
@@ -20,7 +20,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 # ==============================================================================
 # MAKEFILE: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #596, part of epic #518)
@@ -499,20 +499,15 @@ def test_makefile_hybrid_sensors_redos_immunity():
     the same n=500..32000 sweep against the new pattern comes in at
     0.00003s..0.00151s, a clean ~2x per doubling.
     """
-    old_serialization_parsing = re.compile(r"(?m)^\s*(?:@|-)?(?:tar|unzip|gunzip|jq|sed|awk)\b")
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed -- confirmed by
-    # a real CI failure on an unrelated PR's smoke-test run hitting the
-    # analogous absolute-threshold check in tcl's spec_exposure test): a
-    # payload-size doubling should cost ~4x on the quadratic OLD pattern,
-    # vs ~2x for linear.
-    small_duration = _best_of_timing(old_serialization_parsing, "\n" * 1000)
-    large_duration = _best_of_timing(old_serialization_parsing, "\n" * 2000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old ^\\s* pattern was expected to show quadratic (~4x) scaling on a "
-        f"payload doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"(?m)^\s*(?:@|-)?(?:tar|unzip|gunzip|jq|sed|awk)\b"
+    # used to run here, asserting it scaled ~quadratically over a payload
+    # doubling. Removed: it timed a regex this repo no longer ships, and a
+    # ratio between two sub-100ms samples is inside the scheduling noise of
+    # a shared CI runner -- this family of asserts went red on macOS for
+    # PRs that touched none of it. The measured pre-fix numbers are kept in
+    # the docstring above; the shipped pattern's immunity is asserted below
+    # as an ABSOLUTE bound inside an isolated process, which is stable.
 
     for key in (
         "serialization_parsing",

--- a/tests/extraction/languages/test_tcl_strict.py
+++ b/tests/extraction/languages/test_tcl_strict.py
@@ -20,7 +20,7 @@ _LANGUAGES_DIR = str(Path(__file__).resolve().parent)
 if _LANGUAGES_DIR not in sys.path:
     sys.path.insert(0, _LANGUAGES_DIR)
 
-from _strict_harness import _best_of_timing, assert_redos_immune  # noqa: E402 # type: ignore
+from _strict_harness import assert_redos_immune  # noqa: E402 # type: ignore
 
 # ==============================================================================
 # TCL: STRICT STRUCTURAL SIGNATURE COVERAGE (Issue #614, part of epic #518)
@@ -173,19 +173,15 @@ def test_tcl_spec_exposure_redos_regression():
     independent copies of this pattern. Bounded `\\d+` to `\\d{1,10}` and
     `[^\\]]*` to `{0,300}`.
     """
-    old_pattern = re.compile(r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d+|spec|audit)[^\]]*\]", re.I)
-
-    # Scale-relative sanity check (not an absolute wall-clock threshold,
-    # which is flaky across CI hardware of varying speed -- this exact
-    # test failed on CI for this reason): a payload-size doubling should
-    # cost ~4x on the quadratic OLD pattern, vs ~2x for linear.
-    small_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 8000)
-    large_duration = _best_of_timing(old_pattern, "[SPEC-" + "1" * 16000)
-    ratio = large_duration / small_duration if small_duration > 0 else 0
-    assert ratio > 2.2, (
-        f"sanity check: old pattern was expected to show quadratic (~4x) scaling on a payload "
-        f"doubling, but only scaled {ratio:.2f}x ({small_duration:.4f}s -> {large_duration:.4f}s)"
-    )
+    # #2901: a scale-relative check on the PRE-FIX pattern
+    #     r"\[(?:[ \t]*SPEC[ \t]*-[ \t]*\d+|spec|audit)[^\]]*\]", re.I
+    # used to run here, asserting it scaled ~quadratically (ratio > 2.2)
+    # over a payload doubling. Removed: it timed a regex this repo no
+    # longer ships, and the ratio between two sub-100ms samples is inside
+    # the scheduling noise of a shared CI runner -- this family of asserts
+    # went red on macOS for PRs that touched none of it. The shipped
+    # pattern's immunity is asserted below as an ABSOLUTE bound inside an
+    # isolated process, which is deterministic.
 
     spec_exposure = TCL_RULES["spec_exposure"]
     assert_redos_immune(spec_exposure, "[SPEC-" + "1" * 100000, timeout_sec=3.0)

--- a/tests/extraction/languages/test_yacc_strict.py
+++ b/tests/extraction/languages/test_yacc_strict.py
@@ -206,21 +206,17 @@ def test_yacc_explicit_casts_redos_immunity():
     """
     pattern = YACC_RULES["explicit_casts"]
 
-    # _best_of_timing (min-of-5) instead of a single perf_counter() sample
-    # per size -- a lone scheduling hiccup on any one size (common on
-    # contended CI runners) used to be indistinguishable from a real
-    # regression. Same hardening already applied to the shared
-    # _best_of_timing/ratio checks elsewhere in this file (#800).
-    timings = [_best_of_timing(pattern, "(int" + " " * n) for n in (2000, 4000, 8000, 16000, 32000)]
-
     assert_redos_immune(pattern, "(int" + " " * 100000, timeout_sec=3.0)
 
-    # After bounding, doubling the input must not multiply the runtime by
-    # anywhere near 4x (the O(n^2) signature) -- a generous 2.5x ceiling
-    # comfortably separates fixed-linear/constant behavior from a
-    # regression back to catastrophic backtracking.
-    for earlier, later in zip(timings, timings[1:]):
-        assert later < max(earlier * 2.5, 0.01), f"explicit_casts scaling regressed toward O(n^2): {timings}"
+    # #2901: a geometric-scaling loop over
+    #   timings = [_best_of_timing(pattern, ...) for n in (2000 .. 32000)]
+    # used to assert `later < max(earlier * 2.5, 0.01)` here. Removed as
+    # redundant AND unstable: the assert_redos_immune() call above already
+    # pins the same property on the same shipped pattern as an ABSOLUTE
+    # bound, in an isolated process, on a 100k payload -- a strictly
+    # stronger and deterministic check. The ratio form compared sub-100ms
+    # wall-clock samples on shared runners; the comment this replaces
+    # recorded it going red on macos-3.10 under contention.
 
     # Realistic cast forms must still match after bounding.
     assert pattern.search("$$ = (int)$1;"), "plain cast regressed"


### PR DESCRIPTION
## Why

CI wall clock was measured over the last 400 workflow runs (~27h window, 2026-09-08/09): **2201 min total, of which Full Suite Gate alone was 983 min (45%)**.

The cost is not test execution. It is running the same tests repeatedly, then queueing for runners.

| Workflow | n | median | p90 | total |
|---|---|---|---|---|
| Full Suite Gate (OS x Python) | 26 | **36.4m** | 61.3m | **983m** |
| GitGalaxy Smoke Tests | 17 | 14.1m | 28.1m | 288m |
| rosetta-audit | 40 | 3.2m | 14.0m | 234m |
| Muninn Security Scan | 54 | 2.7m | 3.6m | 168m |

**1. Every PR ran the full matrix 3-4 times on the same commit.** `full-suite-gate.yml` triggers on `pull_request: types: [labeled]` with no label filter, so every label added starts a run. PRs here routinely carry four labels (`bug`, `metrics`, `core-engine`, `rosetta:rebless-owed`). #2915 fired **four identical 12-job matrix runs against one SHA (`56624e7b8`) within 10 seconds**; rosetta-audit fired five. No workflow declared `concurrency`, so nothing superseded anything. ~577 min of the sampled 2201 was redundant.

**2. Queue time dwarfed run time.** In run `34346837647` the jobs *ran* 10-18 min but *queued* 23-65 min:

```
macos-latest, 3.10     queued=65m   ran=14m
macos-latest, 3.9      queued=60m   ran=16m
ubuntu-latest, 3.10    queued=33m   ran=15m
windows-latest, 3.9    queued=36m   ran=12m
```

macOS is the scarcest pool, and the duplicate runs put 16 macOS jobs in a queue that needed 4.

**3. The suite ran single-threaded** and streamed 7946 lines / 1.1 MB to the Actions log per job via `-v`.

## What changed

- **`concurrency` on 18 workflows**, keyed by workflow + PR number (or ref). `cancel-in-progress` is scoped to `pull_request` via an expression on purpose: the push/schedule/tag runs are the ones that **commit** (docs deploy, tri-comparison / tree-sitter history charts, releases), and cancelling one mid-write risks a half-written commit — those serialise on the group instead. `publish.yml` and `release-crucible-archive.yml` are left untouched entirely.

- **`pytest-xdist`, `-n auto -q -ra --durations=25`** on both pytest jobs. `-ra` and `--durations=25` keep the only parts of `-v` that were load-bearing on a green run.

  Measured locally on 6 cores, 8685 tests, all four runs reporting **identical** counts (8685 passed / 4 skipped / 9 xfailed / 3 xpassed):

  | | serial | `-n auto` | speedup |
  |---|---|---|---|
  | `origin/main` (unmodified) | 349.3s | 109.5s | 3.19x |
  | this branch | 323.6s | 104.8s | 3.09x |

  Two things worth reading off that table. The speedup is **parallelism, not this PR's test edits** — it is the same either side. And the #2901 deletions are worth ~26s serial (7%) on their own, which was never the point of them; de-flaking was. CI runners are 4-core, so expect ~2.5x there rather than 3.1x.

- **`timeout-minutes` on every job** across 18 workflows. The default is 6h; a Full Suite Gate run was observed sitting at 78 min mid-flight during this investigation.

- **Per-checkpoint matrix in `full-suite-gate.yml`.** A `v*` tag still gets the untrimmed 12-way grid. A PR label gets 8 jobs: all four Python versions on ubuntu (a version-specific break the every-push ubuntu/3.12 full-suite cannot see is exactly what this gate exists for), windows and macOS at the version floor and ceiling only. Halves the macOS jobs that dominate the queue.

## Closes #2901

The flaky ReDoS timing asserts had to be fixed **as part of this**, not after: `-n auto` raises CPU contention, which would have made every wall-clock ratio assert flakier.

Scope is wider than the two files #2901 names — the same shape appears at 22 timing sites. `_best_of_timing`'s own docstring records this class recurring (#713, #800), and groovy's spec_exposure test carries a comment about it going red on macos-3.10 during #770.

- **6 sites** already assert an absolute bound on the shipped pattern (test_prism, abap, matlab, scheme, yaml, security_lens) — left alone, this is the shape the issue recommends.
- **13 sites** timed the *pre-fix* pattern to prove it was quadratic before checking the shipped one. Removed: they measure a regex this repo no longer ships, and each is redundant with an `assert_redos_immune` already in the same test. Measured pre-fix numbers preserved as comments; `test_language_standards_strict.py` keeps each language's pre-fix pattern in its parametrize table as documentation.
- **3 sites** (groovy x2, yacc) asserted a ratio ceiling on the shipped pattern immediately after an `assert_redos_immune` on a 100k payload — strictly weaker than the bound above it. Removed.
- **2 sites** converted from ratio to absolute bound:
  - `var_decl` — verified the replacement still catches what it is for: restoring `[^=\n]{0,80}` -> `[^=\n]*` makes the new 160k assertion **fail**, while the shipped pattern passes in ~1.1s.
  - ada `func_start` — measured while replacing it, this site has **no reachable quadratic regression**: the aspect segment is lazy, so even fully unbounded it stays linear (0.0002/0.0004/0.0007/0.0014s at n=2000..16000). The old ratio's additive `0.05` floor was deciding the result. Kept as a plain ceiling, and the docstring says so rather than overclaiming.

## Verification

- Suite green both ways on this tree: **8685 passed, 4 skipped, 9 xfailed, 3 xpassed** — identical serial and under `-n auto`.
- `tests/tools/audit_check.py`: ruff (70-finding baseline, format clean), mypy (2-error baseline), dead-key, ast-accuracy — **all clear**.
- Every workflow YAML re-parsed after editing; the per-trigger matrix shell was executed for both event types and its JSON validated (12 jobs on tag, 8 on PR label).

## Reviewer notes

- This changes **when** the 12-way matrix runs, not whether it exists. Release tags are unchanged.
- `concurrency` cancels superseded **PR** runs only. If you want a commit-producing main-push workflow to also cancel, that is a deliberate follow-up, not an oversight here.
- Not done here, as it is a policy call rather than a defect: filtering the gate to one explicit label (`if: github.event.label.name == 'full-matrix'`) so bookkeeping labels like `rosetta:rebless-owed` stop triggering a matrix at all. `concurrency` already collapses the duplicates without changing the documented "any label = full validation pass" intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
