### PR TITLE
fix(rules): stop counting unconditional transfers & non-decision tokens as branch — closes #2832, #2833

### DIFF
--- a/docs/branch_rule_contract.md
+++ b/docs/branch_rule_contract.md
@@ -67,13 +67,19 @@ corollary-4 question from the other side). They moved to
   runtime decisions *and* defensive idioms; they count `branch` and may count
   `safety` (typescript `??`, zig `orelse`). This is a stated exception to
   corollary 4, recorded here.
-- **The break/continue family is deferred** (`break`, `continue`, perl
-  `next`/`last`/`redo`, fortran `EXIT`/`CYCLE`, go `fallthrough`, livecode
-  `next repeat`, …) along with the two-keyword loop headers (C-family
-  `do…while` counts 2; ada `while … loop` counts 2): **#2832**. Uniform across
-  the family today, so no corpus cell reads out of band on them.
-- **Measured but out of scope:** ruby's bare `?` (predicate method names),
-  java's bare `:` (`::` method references), python's `with`: **#2833**.
+- **The break/continue family moved to `structural_boundaries` (#2832).** The
+  single-token unconditional transfers (`break`, `continue`, ruby `next`/`redo`,
+  go `fallthrough`) were relocated out of `branch` into `structural_boundaries`,
+  beside `return`, in the 12 languages whose rule listed them (c, go, java,
+  javascript, kotlin, lua, objectivec, ruby, shell, solidity, typescript, zig) —
+  matching corollary 3. Python already carried `break`/`continue` in its
+  boundaries, so it needed no move. **Still deferred:** the two-keyword loop
+  headers (C-family `do…while` counts 2; ada `while … loop` counts 2), which the
+  regex slicer cannot collapse with the condition sitting between the keywords.
+- **Non-decision token bleed fixed (#2833):** ruby's bare `?` now excludes
+  predicate-method names via `(?<!\w)\?` and drops the `=>` hash-rocket; java's
+  bare `:` excludes `::` method references via `(?<!:):(?!:)`; python's `with`
+  (a resource scope, not a decision) moved to `structural_boundaries`.
 - go's `range` rides the `for` it continues (removed, boundaries); fortran's
   `WHILE` only ever follows `DO` (removed, boundaries).
 
@@ -90,46 +96,46 @@ the four control files, target 3 + 0 + 0 + 0). "—" = no crucible presence.
 | agc_assembly | 398 | 3 | clean since #2779 |
 | apex | 23 → 12 | 3 | try/catch/finally |
 | assembly | 1213 | 3 | clean since #2779 |
-| c | 10093 → 9720 | 3 | goto (reflection owns it) |
+| c | 10093 → 9310 | 3 | goto (reflection owns it); break/continue → boundaries (#2832) |
 | cobol | 21549 → 10087 | 3 | END-IF/END-EVALUATE re-matches; bare PERFORM |
 | cpp | 8346 → 8256 | 4 → 3 | catch; goto relocated |
 | css | 774 | 3 | clean |
 | csharp | 3941 → 3849 | 4 → 3 | try/catch/finally; goto (high_risk owns it) |
 | dart | 6809 → 6729 | 3 | try/catch/finally |
 | dockerfile | 91 → 88 | 3 | fi/esac/done/do; re-plant added the else arm |
-| embedded_python | 772 → 659 | 3 | try/finally |
+| embedded_python | 772 → 588 | 3 | try/finally; with → boundaries (#2833) |
 | fortran | 5457 → 4177 | 4 → 3 | END-rematches guarded; GOTO (high_risk); WHILE rides DO |
-| go | 3552 → 3378 | 3 | goto, range relocated |
+| go | 3552 → 3271 | 3 | goto, range relocated; break/continue/fallthrough → boundaries (#2832) |
 | groovy | 552 → 533 | 3 | try/catch/finally |
 | haskell | 252 → 174 | 3 | then/of; re-plant added a case |
 | html | 11 | 3 | clean |
-| java | 487 → 428 | 3 | try/catch/finally |
-| javascript | 5235 → 5105 | 3 | try/catch/finally |
+| java | 487 → 351 | 3 | try/catch/finally; break/continue → boundaries, `::` method-refs excluded (#2832/#2833) |
+| javascript | 5235 → 4957 | 3 | try/catch/finally; break/continue → boundaries (#2832) |
 | jcl | 81 → 52 | 3 | ENDIF; re-plant added a second IF |
-| kotlin | 45 | 3 | try/catch/finally relocated |
+| kotlin | 45 → 43 | 3 | try/catch/finally relocated; break/continue → boundaries (#2832) |
 | livecode | 8329 → 4407 | 5 → 3 | then/while/until/times, throw, end-rematches; re-plant added a repeat |
-| lua | 6090 → 4036 | 3 | then/do/until/in/goto; re-plant added a while |
+| lua | 6090 → 3973 | 3 | then/do/until/in/goto; re-plant added a while; break → boundaries (#2832) |
 | m4 | 50 | 3 | clean |
 | makefile | — | 4 → 3 | endif; recipe-prefix run bounded (ReDoS) |
 | matlab | 1078 → 1014 | 3 | try/catch |
-| objective-c | 311 | 3 | @try/@catch/@finally; goto relocated |
+| objective-c | 311 → 309 | 3 | @try/@catch/@finally; goto relocated; break/continue → boundaries (#2832) |
 | perl | 8808 → 8771 | 3 | try/catch/finally/defer; goto relocated |
 | php | 6365 → 6240 | 3 | try/catch/finally; goto relocated |
 | powershell | 6400 → 5761 | 5 → 3 | try/catch/finally/trap/throw; trap plant body |
-| python | 8371 → 8177 | 3 | try/finally |
-| ruby | 207 → 205 | 4 → 3 | rescue/ensure; begin/retry relocated |
+| python | 8371 → 7757 | 3 | try/finally; with → boundaries (#2833) |
+| ruby | 207 → 132 | 4 → 3 | rescue/ensure; begin/retry relocated; break/next/redo → boundaries, bare `?` & `=>` fixed (#2832/#2833) |
 | rust | 2749 | 3 | already contract-clean |
 | scala | 2064 → 1850 | 3 | try/catch/finally/throw/then relocated |
 | scheme | 4105 | 3 | clean |
-| shell | 9737 → 3502 | 5 → 3 | then/fi/esac/done/do, test brackets; re-plant added else + while |
-| solidity | 69 | 3 | try/catch relocated |
+| shell | 9737 → 3411 | 5 → 3 | then/fi/esac/done/do, test brackets; re-plant added else + while; break/continue → boundaries (#2832) |
+| solidity | 69 | 3 | try/catch relocated; break/continue → boundaries, no corpus incidence (#2832) |
 | sqlite | 161 → 45 | 5 → 3 | THEN/END relocated; one CASE = CASE + its arms |
 | swift | 871 → 781 | 4 → 3 | catch/try/throws/defer/do; else anchored on `}` |
 | tcl | 2330 → 2124 | 4 → 3 | catch/try/trap/finally |
-| typescript | 14879 → 14751 | 3 | try/catch/finally (+ safety mirror) |
+| typescript | 14879 → 14137 | 3 | try/catch/finally (+ safety mirror); break/continue → boundaries (#2832) |
 | yacc | 93 | 3 | clean (`\|` is yacc's real alternation decision) |
 | yaml | 0 | 3 | fi/esac/do/done; re-plant added the elif arm |
-| zig | 25311 → 16340 | 3 | try/catch (zig safety owns both) |
+| zig | 25311 → 14157 | 3 | try/catch (zig safety owns both); break/continue → boundaries (#2832) |
 
 Every rosetta cell above lands on its plant with no residue; the corpus
 re-bless (keyword-rosetta, branch `rebless/gitgalaxy-2822-branch`) carries the

--- a/gitgalaxy/standards/language_standards/languages/c.py
+++ b/gitgalaxy/standards/language_standards/languages/c.py
@@ -55,7 +55,7 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch (Control Flow / Branching)
         # Decisions and jumps. EXCLUDES exit/abort (bailout_hits).
-        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do|break|continue)\b|&&|\|\||\?"),
+        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do)\b|&&|\|\||\?"),
         # 2. args (Parameters / Coupling)
         # Parameter blocks. Bounded negation [^)]* to prevent ReDoS on massive param lists.
         "args": re.compile(
@@ -92,7 +92,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries. EXCLUDES: Access modifiers (encapsulation) and const (freeze_hits).
         "structural_boundaries": re.compile(
-            r"\b(struct|union|enum|typedef|return|void|restrict|auto|bool|true|false|_BitInt|alignas|alignof)\b"
+            r"\b(struct|union|enum|typedef|return|break|continue|void|restrict|auto|bool|true|false|_BitInt|alignas|alignof)\b"
         ),
         "func_start": re.compile(
             # =====================================================================

--- a/gitgalaxy/standards/language_standards/languages/embedded_python.py
+++ b/gitgalaxy/standards/language_standards/languages/embedded_python.py
@@ -41,7 +41,7 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch (Control Flow / Branching)
         # Decisions and logical jumps. EXCLUDES raise (bailout_hits).
-        "branch": re.compile(r"\b(if|elif|else|for|while|with|match|case|and|or)\b"),
+        "branch": re.compile(r"\b(if|elif|else|for|while|match|case|and|or)\b"),
         # 2. args (Parameters / Coupling)
         # Parameter blocks of functions/lambdas. Bounded negation to prevent ReDoS.
         # #1199: the parameter list is now captured in its own group
@@ -64,7 +64,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries. EXCLUDES: _private (encapsulation) and Final (freeze_hits).
         "structural_boundaries": re.compile(
-            r"\b(def|class|return|import|from|as|pass|continue|break|yield|await|assert|del|global|nonlocal|type)\b"
+            r"\b(def|class|return|import|from|as|with|pass|continue|break|yield|await|assert|del|global|nonlocal|type)\b"
         ),
         # 4. func_start (Executable Logic Anchors)
         # ONLY executable logic blocks. EXCLUDES classes. Steps safely over hardware decorators.

--- a/gitgalaxy/standards/language_standards/languages/go.py
+++ b/gitgalaxy/standards/language_standards/languages/go.py
@@ -38,7 +38,7 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch (Control Flow / Branching)
         # Includes select/case and range-based loops. EXCLUDES panic (bailout_hits).
-        "branch": re.compile(r"\b(if|else|switch|case|default|for|select|break|continue|fallthrough)\b|&&|\|\|"),
+        "branch": re.compile(r"\b(if|else|switch|case|default|for|select)\b|&&|\|\|"),
         # 2. args (Parameters / Coupling)
         # Parameter blocks for functions and methods. Bounded generics [^\]]* and params [^)]*.
         # #1209: parameter-list span wrapped in its own capture group (was
@@ -55,7 +55,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries. EXCLUDES: const/var (freeze_hits) and Capitalization (encapsulation).
         "structural_boundaries": re.compile(
-            r"\b(package|import|return|type|go|defer|chan|map|interface|struct|goto|range)\b"
+            r"\b(package|import|return|break|continue|fallthrough|type|go|defer|chan|map|interface|struct|goto|range)\b"
         ),
         # 4. func_start (Executable Logic Anchors)
         # ONLY executable logic blocks.

--- a/gitgalaxy/standards/language_standards/languages/java.py
+++ b/gitgalaxy/standards/language_standards/languages/java.py
@@ -48,7 +48,7 @@ DEFINITION: dict[str, Any] = {
         # 1. branch (Control Flow / Branching)
         # Includes modern switch expressions (yield) and pattern guards (when).
         # EXCLUDES: Exceptions (throw) - moved to bailout_hits.
-        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do|continue|break|yield|when)\b|\?|:"),
+        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do|yield|when)\b|\?|(?<!:):(?!:)"),
         # 2. args (Parameters / Coupling)
         # Captures method/constructor params and lambdas. Bounded to prevent ReDoS.
         "args": re.compile(
@@ -114,7 +114,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries. EXCLUDES: Access modifiers (encapsulation) and final (freeze_hits).
         "structural_boundaries": re.compile(
-            r"\b(void|return|import|package|class|interface|enum|record|extends|implements|var|sealed|non-sealed|permits|new|throws|module|requires|exports|opens|provides|uses)\b"
+            r"\b(void|return|break|continue|import|package|class|interface|enum|record|extends|implements|var|sealed|non-sealed|permits|new|throws|module|requires|exports|opens|provides|uses)\b"
         ),
         # 4. func_start (Executable Logic Anchors)
         # ONLY executable logic blocks. EXCLUDES classes/interfaces. Steps over annotations.

--- a/gitgalaxy/standards/language_standards/languages/javascript.py
+++ b/gitgalaxy/standards/language_standards/languages/javascript.py
@@ -70,7 +70,7 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch (Control Flow / Branching)
         # Decisions and logical jumps. EXCLUDES throw (bailout_hits).
-        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do|continue|break)\b|&&|\|\||\?|\?\?"),
+        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do)\b|&&|\|\||\?|\?\?"),
         # 2. args (Parameters / Coupling)
         # Parameter blocks. Bounded to prevent ReDoS on massive positional/destructured sets.
         "args": re.compile(
@@ -125,7 +125,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural declaration boundaries. EXCLUDES: Access modifiers (encapsulation) and const (freeze_hits).
         "structural_boundaries": re.compile(
-            r"\b(let|var|import|export|return|class|extends|super|await|delete|yield)\b|=>"
+            r"\b(let|var|import|export|return|break|continue|class|extends|super|await|delete|yield)\b|=>"
         ),
         # 4. func_start (Executable Logic Anchors)
         # Uses positive lookaheads (?=) to stop the match exactly at the identifier name.

--- a/gitgalaxy/standards/language_standards/languages/kotlin.py
+++ b/gitgalaxy/standards/language_standards/languages/kotlin.py
@@ -49,7 +49,7 @@ DEFINITION: dict[str, Any] = {
         # idiom). `return` is already tracked under `structural_boundaries` below, matching
         # java/c/rust/go/csharp's convention -- removing it here is a pure de-duplication,
         # not a signal loss. Corpus impact: kotlin branch 19 (planted 3, +280%) -> exact.
-        "branch": re.compile(r"\b(if|else|when|for|while|do|break|continue)\b|\?:|&&|\|\|"),
+        "branch": re.compile(r"\b(if|else|when|for|while|do)\b|\?:|&&|\|\|"),
         # 2. args (Parameters / Coupling)
         # OPTIMIZED: Removed overlapping whitespace quantifiers to fix Regex Sludge.
         "args": re.compile(
@@ -86,7 +86,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries defining file architecture and control returns.
         "structural_boundaries": re.compile(
-            r"\b(package|import|return|class|interface|object|fun|typealias|try|catch|finally)\b"
+            r"\b(package|import|return|break|continue|class|interface|object|fun|typealias|try|catch|finally)\b"
         ),
         # 4. func_start (Executable Logic Anchors)
         # OPTIMIZED: Bound annotation parenthesis scanning to prevent multi-line bleeding.

--- a/gitgalaxy/standards/language_standards/languages/lua.py
+++ b/gitgalaxy/standards/language_standards/languages/lua.py
@@ -38,7 +38,7 @@ DEFINITION: dict[str, Any] = {
     "rules": {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch: decisions that split flow. Includes standard loops and Lua 5.2+ goto.
-        "branch": re.compile(r"\b(if|elseif|else|for|while|repeat|break|continue|and|or|not)\b"),
+        "branch": re.compile(r"\b(if|elseif|else|for|while|repeat|and|or|not)\b"),
         # 2. args: Parameters / Coupling. Captures parameters in named and anonymous function signatures.
         # #1209: parameter-list span wrapped in its own capture group (was
         # only reachable via group(0), the whole match including the
@@ -52,7 +52,7 @@ DEFINITION: dict[str, Any] = {
         ),
         # 3. linear: Sequential I/O & Network Boundaries. Structural boundaries defining scope and data definitions.
         "structural_boundaries": re.compile(
-            r"\b(local|end|require|module|return|export\s+type|type|then|in|do|until|goto)\b|<\s*(?:const|close|toclose)\s*>"
+            r"\b(local|end|require|module|return|break|export\s+type|type|then|in|do|until|goto)\b|<\s*(?:const|close|toclose)\s*>"
         ),
         # 4. func_start: Executable Logic Anchors. Anchors executable logic blocks (named functions).
         "func_start": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/objectivec.py
+++ b/gitgalaxy/standards/language_standards/languages/objectivec.py
@@ -64,7 +64,7 @@ DEFINITION: dict[str, Any] = {
         # java/c/rust/go/csharp/kotlin/apex/powershell/zig all use -- not just deleted,
         # since objc had no other rule tracking it. Corpus impact: objective-c branch 18
         # (planted 3, +260%) -> exact.
-        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do|break|continue)\b|&&|\|\||\?"),
+        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do)\b|&&|\|\||\?"),
         # 2. args: Parameters / Coupling. Captures method parameters (colons), C-style args, and Blocks (^).
         "args": re.compile(
             # =====================================================================
@@ -203,7 +203,7 @@ DEFINITION: dict[str, Any] = {
         # java/c/rust/go/csharp/kotlin/apex/powershell/zig convention of tracking `return`
         # as a structural boundary, not a branch.
         "structural_boundaries": re.compile(
-            r"@(interface|implementation|protocol|end|synthesize|dynamic|class|import)\b|\b(typedef|struct|enum|union|__block|__weak|__strong|return|goto)\b"
+            r"@(interface|implementation|protocol|end|synthesize|dynamic|class|import)\b|\b(typedef|struct|enum|union|__block|__weak|__strong|return|break|continue|goto)\b"
         ),
         # 4. func_start: Executable Logic Anchors. Anchors executable logic.
         # The Critical Fix: Compiled with re.M and optional return types for TBL / NeXTSTEP syntax

--- a/gitgalaxy/standards/language_standards/languages/python.py
+++ b/gitgalaxy/standards/language_standards/languages/python.py
@@ -83,7 +83,7 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch (Control Flow / Branching)
         # Includes match/case (3.10+) and logical short-circuits. EXCLUDES exceptions.
-        "branch": re.compile(r"\b(if|elif|else|for|while|with|match|case|and|or)\b"),
+        "branch": re.compile(r"\b(if|elif|else|for|while|match|case|and|or)\b"),
         # 2. args (Parameters / Coupling)
         # Signatures for def/lambda. Bounded generics and params [^)]*.
         # RULE 11 FIX (epic #813/#818): the PEP 695 (3.12+) generic-parameter step-over was a
@@ -115,7 +115,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries. EXCLUDES: _private (encapsulation) and Final (freeze_hits).
         "structural_boundaries": re.compile(
-            r"\b(def|class|return|import|from|as|pass|continue|break|await|assert|del|global|nonlocal|type)\b"
+            r"\b(def|class|return|import|from|as|with|pass|continue|break|await|assert|del|global|nonlocal|type)\b"
         ),
         # 4. func_start (Executable Logic Anchors)
         # Anchors executable logic. Steps safely over decorators.

--- a/gitgalaxy/standards/language_standards/languages/ruby.py
+++ b/gitgalaxy/standards/language_standards/languages/ruby.py
@@ -65,7 +65,7 @@ DEFINITION: dict[str, Any] = {
     "rules": {
         # 1. branch (Control Flow / Branching)
         # Decisions and logical jumps. EXCLUDES raise/throw (bailout_hits).
-        "branch": re.compile(r"\b(if|unless|elsif|else|case|when|in|for|while|until|break|next|redo)\b|&&|\|\||\?|=>"),
+        "branch": re.compile(r"\b(if|unless|elsif|else|case|when|in|for|while|until)\b|&&|\|\||(?<!\w)\?"),
         # 2. args (Parameters / Coupling)
         # Parameter blocks of methods, lambdas, and blocks. Bounded to prevent ReDoS.
         # #1209: parameter-list span wrapped in its own capture group in

--- a/gitgalaxy/standards/language_standards/languages/shell.py
+++ b/gitgalaxy/standards/language_standards/languages/shell.py
@@ -53,7 +53,7 @@ DEFINITION: dict[str, Any] = {
         # 1. branch (Control Flow / Branching)
         # Decisions and logic jumps. Includes test constructs [[ ]] and [ ].
         # CRITICAL: Excluded bare '((' and '))' to prevent ReDoS on massive subshell nesting.
-        "branch": re.compile(r"\b(if|else|elif|case|for|while|until|select|break|continue)\b|&&|\|\|"),
+        "branch": re.compile(r"\b(if|else|elif|case|for|while|until|select)\b|&&|\|\|"),
         # 2. args (Parameters / Coupling)
         # Positional parameters and expansion markers.
         # BUG FIX (epic #813/#835): the braced form only matched a bare
@@ -86,7 +86,7 @@ DEFINITION: dict[str, Any] = {
         # `_dependency_capture` below. Pulled out into its own statement-boundary
         # anchored alternative instead of sitting inside the `\b(...)\b` group.
         "structural_boundaries": re.compile(
-            r"\b(local|readonly|export|declare|typeset|return|exit|source|read|cd|pwd|ls|cp|mv|rm|mkdir|touch|then|fi|esac|done|do)\b|(?<!\|)\|(?!\s*\|)|(?:^|[ \t;|&])\.(?=[ \t])|\[\[|\]\]|(?:^|(?<=\s|;|\||&))\[(?=\s)|(?<=\s)\](?=\s|;|\||&|$)",
+            r"\b(local|readonly|export|declare|typeset|return|break|continue|exit|source|read|cd|pwd|ls|cp|mv|rm|mkdir|touch|then|fi|esac|done|do)\b|(?<!\|)\|(?!\s*\|)|(?:^|[ \t;|&])\.(?=[ \t])|\[\[|\]\]|(?:^|(?<=\s|;|\||&))\[(?=\s)|(?<=\s)\](?=\s|;|\||&|$)",
             re.M,
         ),
         # Anchors executable logic blocks. Captures `function foo` or `foo()`.

--- a/gitgalaxy/standards/language_standards/languages/solidity.py
+++ b/gitgalaxy/standards/language_standards/languages/solidity.py
@@ -46,7 +46,7 @@ DEFINITION: dict[str, Any] = {
         # java/c/rust/go/csharp/kotlin/apex/powershell/zig convention -- not just deleted,
         # since solidity had no other rule tracking it. Corpus impact: solidity branch 19
         # (planted 3, +280%) -> exact.
-        "branch": re.compile(r"\b(if|else|for|while|do|break|continue)\b|\?"),
+        "branch": re.compile(r"\b(if|else|for|while|do)\b|\?"),
         # 2. args: Parameters / Coupling. Captures parameters for functions, errors, events, and modifiers.
         # Bounded `{0,50}` to prevent ReDoS on massive tuple returns or complex signatures.
         # #1209: parameter-list span wrapped in its own capture group in
@@ -65,7 +65,7 @@ DEFINITION: dict[str, Any] = {
         # java/c/rust/go/csharp/kotlin/apex/powershell/zig convention of tracking `return`
         # as a structural boundary, not a branch.
         "structural_boundaries": re.compile(
-            r"\b(pragma|import|contract|interface|library|struct|enum|type|mapping|address|uint\d*|int\d*|bytes\d*|bool|string|return|try|catch)\b"
+            r"\b(pragma|import|contract|interface|library|struct|enum|type|mapping|address|uint\d*|int\d*|bytes\d*|bool|string|return|break|continue|try|catch)\b"
         ),
         # 4. func_start: Executable Logic Anchors. Anchors executable logic (Functions, Modifiers, Custom Errors, Events).
         # LOOKAHEAD MANDATE APPLIED: Stops exactly at the identifier name before the parenthesis.

--- a/gitgalaxy/standards/language_standards/languages/typescript.py
+++ b/gitgalaxy/standards/language_standards/languages/typescript.py
@@ -61,7 +61,7 @@ DEFINITION: dict[str, Any] = {
         # --- PHASE 1: LOGIC TOPOLOGY & STRUCTURE ---
         # 1. branch (Control Flow / Branching)
         # EXCLUDES: Exceptions (throw). Includes control flow and logical short-circuits.
-        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do|continue|break)\b|&&|\|\||\?|\?\?"),
+        "branch": re.compile(r"\b(if|else|switch|case|default|for|while|do)\b|&&|\|\||\?|\?\?"),
         # 2. args (Parameters / Coupling)
         # CRITICAL FIX: Added negative lookahead for control flow, and `[^=;{]*` to support TypeScript return types.
         # QUADRATIC BLOWUP FIX: the bare-identifier-before-arrow branch's
@@ -131,7 +131,7 @@ DEFINITION: dict[str, Any] = {
         # 3. linear (Sequential Boundaries)
         # Structural boundaries. EXCLUDES: Access modifiers (public/private) and Immutability (const).
         "structural_boundaries": re.compile(
-            r"\b(var|return|class|interface|type|enum|import|export|await|satisfies|using|namespace|module|implements|extends|declare|unknown|never|void)\b|=>"
+            r"\b(var|return|break|continue|class|interface|type|enum|import|export|await|satisfies|using|namespace|module|implements|extends|declare|unknown|never|void)\b|=>"
         ),
         # 4. func_start (Executable Logic Anchors)
         # Captures standard functions, assignments, object properties, and class methods.

--- a/gitgalaxy/standards/language_standards/languages/zig.py
+++ b/gitgalaxy/standards/language_standards/languages/zig.py
@@ -39,7 +39,7 @@ DEFINITION: dict[str, Any] = {
         # same error-propagation-via-return idiom, doesn't count it either. Already tracked
         # under `structural_boundaries` below, so this is a pure de-duplication. Corpus
         # impact: zig branch 19 (planted 3, +280%) -> exact.
-        "branch": re.compile(r"(?<!@\")\b(if|else|switch|while|for|orelse|break|continue)\b(?!\")|&&|\|\|"),
+        "branch": re.compile(r"(?<!@\")\b(if|else|switch|while|for|orelse)\b(?!\")|&&|\|\|"),
         # 2. args: Parameters / Coupling. Captures parameters in function signatures.
         "args": re.compile(
             r"\bfn[ \t\n]*(?:@\"[^\"]+\"|[a-zA-Z_]\w*[ \t\n]*)?\(((?:[^)(]|\((?:[^)(]|\((?:[^)(]|\((?:[^)(]|\([^)(]*\))*\))*\))*\))*)\)"
@@ -59,7 +59,7 @@ DEFINITION: dict[str, Any] = {
         "_args_bare_body_groups": {1},
         # 3. linear: Sequential I/O & Network Boundaries. Structural boundaries. EXCLUDES access modifiers and const (freeze_hits).
         "structural_boundaries": re.compile(
-            r"(?<!@\")\b(var|return|defer|errdefer|unreachable|resume|suspend|await|nosuspend|usingnamespace)\b(?!\")"
+            r"(?<!@\")\b(var|return|break|continue|defer|errdefer|unreachable|resume|suspend|await|nosuspend|usingnamespace)\b(?!\")"
         ),
         # 4. func_start: Executable Logic Anchors. Anchors logic blocks (fn). EXCLUDES struct/enum/union headers.
         "func_start": re.compile(

--- a/tests/extraction/languages/test_embedded_python_strict.py
+++ b/tests/extraction/languages/test_embedded_python_strict.py
@@ -102,10 +102,10 @@ _EMBEDDED_PYTHON_SIMPLE_CASES = [
     ("branch", "for i in range(10):", "foraging"),
     # 2822 corollary 1: try/finally are safety's
     ("branch", "elif x:", "try:"),
-    ("branch", "with open(f) as fh:", "finally:"),
+    ("structural_boundaries", "with open(f) as fh:", "finally:"),  # 2833: with is resource scope, not a branch
     ("branch", "a and b", "random"),
     ("branch", "a or b", "oracle"),
-    ("branch", 'with open("f") as f:', "without"),
+    ("structural_boundaries", 'with open("f") as f:', "without"),  # 2833: with is resource scope, not a branch
     ("args", 'def foo(a="bar)", b=2):', 'foo(a="bar)", b=2)'),
     ("args", "async def fetch(url):", "async fetch(url)"),
     ("args", "lambda: 5", "lambda_func: 5"),

--- a/tests/extraction/languages/test_go_strict.py
+++ b/tests/extraction/languages/test_go_strict.py
@@ -40,7 +40,7 @@ _GO_SIMPLE_CASES = [
     ("branch", "case <-ch:", "mycase := 1"),
     ("branch", "for k, v := range m {", "for_loop"),
     ("branch", "select {", "goto L"),  # 2822 corollary 3
-    ("branch", "fallthrough", "fallthrough_var := 1"),
+    ("structural_boundaries", "fallthrough", "fallthrough_var := 1"),  # 2832: unconditional transfer, not a branch
     ("class_start", "type Foo struct {", "Foo struct {}"),
     ("class_start", "type Foo[T map[string]int] struct {", "type Foo[T map[string]int] func()"),
     ("class_start", "type \n Foo \n [T map[string]int] \n struct {", "type \n Foo \n int"),

--- a/tests/extraction/languages/test_lua_strict.py
+++ b/tests/extraction/languages/test_lua_strict.py
@@ -83,7 +83,7 @@ _LUA_SIMPLE_CASES = [
 _LUA_DEEP_CASES = [
     # --- branch ---
     ("branch", "repeat", "goto skip_label"),  # 2822 corollary 3: goto moved to boundaries
-    ("branch", "continue", "local continue_flag = true"),
+    ("structural_boundaries", "break", "breakfast = true"),  # 2832: unconditional transfer, not a branch
     ("branch", "elseif\n  condition\nthen", "local if_true = 1"),
     ("branch", "for i, v in ipairs(t) do", "local format = 1"),
     ("branch", "repeat\nuntil x == 0", "local until_now = 0"),

--- a/tests/extraction/languages/test_python_strict.py
+++ b/tests/extraction/languages/test_python_strict.py
@@ -96,7 +96,7 @@ _PY_SIMPLE_CASES = [
     ("branch", "if (x := 1):", "iffy = True"),
     ("branch", "match x:\n    case 1:", "def case_func():"),
     ("branch", "while True:", "while_loop = False"),
-    ("branch", "with open('f.txt') as f:", "without = True"),
+    ("structural_boundaries", "with open('f.txt') as f:", "without = True"),  # 2833: with is resource scope, not a branch
     ("branch", "for i in range(10):", "format_string"),
     # args (generics, newlines, edge-case lambdas)
     ("args", "def foo[T, U](x, y):", "define_foo = 1"),

--- a/tests/extraction/languages/test_solidity_strict.py
+++ b/tests/extraction/languages/test_solidity_strict.py
@@ -88,7 +88,7 @@ _SOLIDITY_ADVERSARIAL_CASES = [
     ("branch", "do { x--; } while (x > 0);", "try feed.getData(token) returns (uint v) {"),  # 2822 corollary 1
     ("branch", "if\n(x)\n{", "assembly { let x := 5 }"),
     ("branch", "while(true){}", 'string memory name = "foo:bar";'),
-    ("branch", "continue;", "catch Error(string memory reason) {"),  # 2822 corollary 1
+    ("structural_boundaries", "continue;", "amount = 5;"),  # 2832: unconditional transfer, relocated to boundaries
     # --- args ---
     ("args", "function\ntransfer\n(address to) public", "transfer(to, amount);"),
     ("args", "modifier onlyOwner\n() {", "emit Transfer(msg.sender);"),


### PR DESCRIPTION
## What
The `branch` rule was still counting tokens that aren't runtime decisions. This resolves the two deferred residue issues from the #2822 branch-contract audit:
- **#2832** — the unconditional-transfer family (`break`, `continue`, ruby `next`/`redo`, go `fallthrough`)
- **#2833** — measured non-decision bleed (ruby bare `?`, java bare `:`, python `with`)

## How
Per corollary 3 (*an unconditional transfer is not a decision*), the transfers are **relocated `branch` → `structural_boundaries`** (beside `return`), matching how `return`/`goto` were already handled — not deleted. Applied to the 12 languages whose rule listed them: c, go, java, javascript, kotlin, lua, objectivec, ruby, shell, solidity, typescript, zig. (python/embedded_python already carried break/continue in boundaries.)

#2833 token fixes:
| lang | was | now |
|---|---|---|
| ruby | `\?\|=>` matched `valid?`, hash rockets | `(?<!\w)\?` (excludes predicate methods), `=>` dropped |
| java | `:` matched `Collection::stream` | `(?<!:):(?!:)` (excludes `::` method refs) |
| python / embedded_python | `with` counted as branch | moved to `structural_boundaries` (resource scope) |

**Still deferred:** the two-keyword loop headers (C-family `do…while`, ada `while … loop`) — the regex slicer can't collapse them with the condition between the keywords. Documented in the contract.

## Verification
- `rule_probe.py` before/after confirms the false positives are gone while real branch keywords still match: **ruby 266→132, java 428→351, python 8177→7757, c 9720→9310** (full per-language table in `docs/branch_rule_contract.md`).
- **Golden masters re-blessed** (`crucible_check.py --update --yes`, both full + zero-dep modes). The diff is large because branch counts and the ratios derived from them (Control Flow Ratio, Cognitive Density, Structural Magnitude) shift across the affected languages — an intentional precision improvement, **not** a parser regression.
- Strict tests for the moved tokens updated to assert `structural_boundaries`. Full extraction + detector suite: **7672 passed, 0 failed**. `ruff_audit --ci` clean.

## Note
Found and scoped via a per-issue agent analysis pass over the actual rule code + crucible incidence; every claim was verified against `rule_probe` before implementing.

Closes #2832, closes #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBL6TAMVXRUY7iQyy9Ysvi
