### PR TITLE
docs(high_risk_execution): record remaining #2879 deferred residue — closes #2879

### DIFF
--- a/docs/high_risk_execution_rule_contract.md
+++ b/docs/high_risk_execution_rule_contract.md
@@ -253,10 +253,13 @@ scheme, swift, yacc. Scala gained the `Runtime.getRuntime().exec` spelling and
 
 ## Deferred by design (#2879)
 
-The one-owner call on `eval` in matlab/ruby/shell/tcl (safety_bypasses' contract), the
-non-root `rm -rf` and single-resource deletions now counted by nobody (#2843), and the
-family's forms no rule carries yet (cobol `CALL 'SYSTEM'`/`EXEC CICS ABEND`, ada `abort`,
-swift `Process()`, java `ScriptEngine.eval`).
+The one-owner call on `eval` in matlab/ruby/shell/tcl (safety_bypasses' contract) — and
+the same unmeasured one-owner question for haskell `unsafePerformIO` and ruby
+`instance_eval`/`class_eval` — the non-root `rm -rf` and single-resource deletions now
+counted by nobody (#2843), and the family's forms no rule carries yet (cobol
+`CALL 'SYSTEM'`/`EXEC CICS ABEND`, ada `abort`/`GNAT.OS_Lib.Spawn`, swift `Process()`,
+java `ScriptEngine.eval`, powershell `Remove-Item -Recurse` on a drive root, and sqlite
+`DELETE FROM` without `WHERE` — unreadable by regex, so it stays cleanup's with the rest).
 
 ## Bless scope
 


### PR DESCRIPTION
## What
Completes the documentation of issue **#2879** — the `high_risk_execution` contract's deferred corollary menu. The "Deferred by design (#2879)" section already recorded most of the menu; this adds the three forms it omitted:
- haskell `unsafePerformIO`, ruby `instance_eval`/`class_eval` — same unmeasured one-owner "execute text as code" question as the `eval` case.
- powershell `Remove-Item -Recurse` on a drive root, sqlite `DELETE FROM` without `WHERE` — forms named by the contract that no rule carries yet.

## Why it's doc-only
Every form in #2879 is explicitly *"left in place because no corpus cell moves on them"* — the issue was filed so the contract doc can link the deferrals, not to change any rule. So:
- **No engine change**, no golden-master re-bless.
- **No keyword-rosetta change** — nothing is planted or re-measured.

Closes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBL6TAMVXRUY7iQyy9Ysvi
