### PR TITLE
fix(rules): align the domain sensors with their declared contracts — closes #2898, #2899

### DIFF
--- a/docs/domain_sensor_contracts.md
+++ b/docs/domain_sensor_contracts.md
@@ -159,3 +159,29 @@ python tests/tools/rule_probe.py panics_and_aborts zig --samples 8
 # the literate pack, on the stream the detector uses:
 python tests/tools/rule_probe.py lit_headers markdown --stream both
 ```
+
+## Resolution (#2898 / #2899)
+
+The filed one-layer fixes landed in one PR (2026-09-09); the table above remains the
+batch's measurement record — these are the deltas against it:
+
+- **Cross-sensor double-counts removed** (the receiving rule already counts the token):
+  zig `return` (7538), lua `assert` + the `coroutine.*` family, swift `DispatchQueue`,
+  solidity `emit Event(`, embedded_python's peripheral handles (a socket remains its one
+  bridge), fortran `READ(`/`WRITE(`/`OPEN(`, shell `sed`/`awk`.
+- **Registry-consistent narrowing**: javascript/typescript `memory_alloc` now counts
+  unmanaged forms only (`ArrayBuffer`/`SharedArrayBuffer`/`WebAssembly.Memory`/
+  `Buffer.alloc*`), joining the java/kotlin/scala/dart reading; perl `decorators` no
+  longer counts `::`; dart `closures`/`comprehensions` anchor to expression position;
+  zig `bitwise_ops` requires zig-fmt operator spacing; python `vectorized_math`'s `@`
+  gap no longer crosses newlines; python `cryptography` gains `hashlib`/`hmac`.
+- **Contract-level absences declared** (`None`): fortran `regex_execution`,
+  agc_assembly `explicit_casts`, scheme `memory_alloc`, perl `pointers`.
+- **String/bare-word anchors** (#2899): fortran/scheme `scientific` call/head anchors,
+  c `memory_alloc` call anchor, cpp `signal(`/`on(`/`callback(`, typescript `.emit(`,
+  swift/perl `ssr_boundaries` type/call anchors, dart `ui_framework` exact case,
+  php `&` entity guard, perl `|` spacing, perl `skip`/`time` shapes, perl `<%` POD guard.
+- **Parked**: markdown `lit_headers` fence-awareness is a stream-level change
+  (`detector.comment_analysis`), not a regex anchor — still open on #2898's margin;
+  typescript `.emit(` is best-effort, the compiler's own `emit` calls remain
+  by-name indistinguishable.

--- a/gitgalaxy/standards/language_standards/languages/agc_assembly.py
+++ b/gitgalaxy/standards/language_standards/languages/agc_assembly.py
@@ -254,7 +254,9 @@ DEFINITION: dict[str, Any] = {
         # 39. debug_prints (Debug Artifacts / Unstructured Outputs)
         "debug_prints": re.compile(r"\b(?:FLASH|PINBALL|OUT\d+)\b", re.I),
         # 40. explicit_casts (Explicit Type Casting)
-        "explicit_casts": re.compile(r"\bEXTEND\b", re.I),
+        # #2898: contract-level absence. EXTEND is an opcode-mode prefix, not a type
+        # conversion -- AGC assembly has no cast construct.
+        "explicit_casts": None,
         # 41. panics_and_aborts (Execution Interrupts / Fatal Aborts)
         "panics_and_aborts": re.compile(r"\b(POODOO|BAILOUT|TC\s+ALARM|ABORT)\b", re.I),
         # 42. thread_sleeps (Thread Blocking / Synchronous Pauses)

--- a/gitgalaxy/standards/language_standards/languages/c.py
+++ b/gitgalaxy/standards/language_standards/languages/c.py
@@ -345,7 +345,9 @@ DEFINITION: dict[str, Any] = {
             r"->|\b(?:uintptr_t|intptr_t|ptrdiff_t|size_t)\b|(?<=[=\s,(])&\w+|(?<=[=\s,(])\*(?:\s*const\s*)?\w+"
         ),
         # 36. memory_alloc (Manual Memory Management)
-        "memory_alloc": re.compile(r"\b(malloc|calloc|realloc|free|aligned_alloc|mmap|alloca)\b"),
+        # #2899: anchored to the call form -- bare names matched `"malloc failed"`
+        # inside strings and `free` as an ordinary identifier (freefunc free).
+        "memory_alloc": re.compile(r"\b(malloc|calloc|realloc|free|aligned_alloc|mmap|alloca)\s*\("),
         # 37. inline_asm (The Bare Metal)
         "inline_asm": re.compile(
             r"\b(?:__asm__|asm|__asm)\b(?:\s+(?:volatile|__volatile__))?\s*\(|\b(?:__asm__|asm|__asm)\b[ \t]*\{"

--- a/gitgalaxy/standards/language_standards/languages/cpp.py
+++ b/gitgalaxy/standards/language_standards/languages/cpp.py
@@ -420,7 +420,9 @@ DEFINITION: dict[str, Any] = {
         # 31. ssr_boundaries (Server-Side Rendering)
         "ssr_boundaries": re.compile(r"\b(FCGI_Accept|render_template|Inja::|ctemplate::)\b"),
         # 32. events (Event Emitters / Pub-Sub)
-        "events": re.compile(r"\b(emit|signal|slot|notify|publish|subscribe|boost::signals2)\b"),
+        # #2899: `signal` anchored to its call form so the word inside prose strings
+        # no longer counts.
+        "events": re.compile(r"\b(emit|slot|notify|publish|subscribe|boost::signals2)\b|\bsignal\s*\("),
         # 33. dependency_injection (Dependency Injection / IoC)
         "dependency_injection": re.compile(r"\b(boost\.di|fruit::|[I]nject|IServiceCollection)\b"),
         # 34. macros (Preprocessor Directives / Macros)
@@ -497,7 +499,9 @@ DEFINITION: dict[str, Any] = {
         # unambiguous.
         "encapsulation": re.compile(r"\b(?:private|protected|internal):"),
         # 48. listeners (Event Listeners / Observers)
-        "listeners": re.compile(r"\b(on|addEventListener|subscribe|connect|handler|callback)\b"),
+        # #2899: `on` and `callback` anchored to their call form -- bare, they matched
+        # prose in strings and ordinary identifiers.
+        "listeners": re.compile(r"\bon\s*\(|\bcallback\s*\(|\b(addEventListener|subscribe|connect|handler)\b"),
         # 49. test_skip (Bypassed Tests / Ignored Specs)
         # BUG FIX (Rule 10): `mock\(`/`fake\(` end in a literal `(` but
         # shared a trailing `\b` with word-ending siblings -- broke on

--- a/gitgalaxy/standards/language_standards/languages/dart.py
+++ b/gitgalaxy/standards/language_standards/languages/dart.py
@@ -320,9 +320,10 @@ DEFINITION: dict[str, Any] = {
             re.I,
         ),
         # 16. ui_framework: UI / View Components. Flutter Component trees and DOM nodes (Includes TBL triggers).
+        # #2899: re.I dropped -- flutter's types are exact-case, and the fold made
+        # `widget`/`text` inside prose strings count.
         "ui_framework": re.compile(
-            r"\b(Widget|BuildContext|StatefulWidget|Scaffold|Container|Text|HtmlElementView|RichText|Hyperlink|SGML|HyperText|Browser)\b",
-            re.I,
+            r"\b(Widget|BuildContext|StatefulWidget|Scaffold|Container|Text|HtmlElementView|RichText|Hyperlink|SGML|HyperText|Browser)\b"
         ),
         # 17. closures: Closures / Anonymous Functions. Fat-arrows and anonymous function blocks.
         # BUG FIX (ReDoS): `[^)]*` was unbounded. Confirmed quadratic
@@ -334,7 +335,10 @@ DEFINITION: dict[str, Any] = {
         # across the whole remaining length -- O(n) work at each of
         # O(n) positions. Bounded to `{0,300}`, the same fix shape used
         # elsewhere in this sweep.
-        "closures": re.compile(r"=>|\(\s*[^)]{0,300}\)\s*(?:async\*?|sync\*?)?[ \t]*\{"),
+        # #2898: the paren-block arm matched `if (...) {` and every parameter list
+        # (3282 crucible hits). An anonymous function's list sits in expression
+        # position -- directly after `(`/`,`/`=`/`:`/`[` -- a statement keyword's never does.
+        "closures": re.compile(r"=>|(?:^|(?<=[,(=:\[]))\s*\(\s*[^)]{0,300}\)\s*(?:async\*?|sync\*?)?[ \t]*\{"),
         # 18. globals: Global / Shared State. Static class fields and environmental bindings.
         # BUG FIX (#2651): Anchored to true column-0 (no indentation) to prevent
         # function-local var/const declarations from being incorrectly counted as globals.
@@ -348,7 +352,10 @@ DEFINITION: dict[str, Any] = {
         "generics": re.compile(r"<\s*[A-Z][^>]*>"),
         # 21. comprehensions: Iterators / Comprehensions. Collection for/if and functional pipelines.
         "comprehensions": re.compile(
-            r"\[\s*(?:for|if)\s*\([^)]*\)|\{\s*(?:for|if)\s*\([^)]*\)|\.(?:map|where|reduce|fold|expand|every|any)\s*\("
+            # #2898: the `{` arm matched statement blocks (`{ if (...)`) -- a set/map
+            # literal's brace sits in expression position (after =/,/(/:/[), a block's
+            # never does. `[` needs no guard: it can't open a code block.
+            r"\[\s*(?:for|if)\s*\([^)]*\)|(?:^|(?<=[=,(:\[]))\s*\{\s*(?:for|if)\s*\([^)]*\)|\.(?:map|where|reduce|fold|expand|every|any)\s*\("
         ),
         # 22. scientific: Numerical / Compute Libraries. math.pi, typed binary arrays, and Matrix4 vectors.
         "scientific": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/embedded_python.py
+++ b/gitgalaxy/standards/language_standards/languages/embedded_python.py
@@ -285,8 +285,9 @@ DEFINITION: dict[str, Any] = {
         "serialization_parsing": re.compile(r"\b(ujson\.loads?|ujson\.dumps?|ustruct\.pack|ustruct\.unpack)\b"),
         "regex_execution": re.compile(r"\b(ure\.compile|ure\.search|ure\.match|ure\.sub)\b"),
         "time_date_logic": re.compile(r"\b(utime\.sleep_ms|utime\.ticks_ms|utime\.ticks_diff|machine\.RTC)\b"),
-        "ipc_rpc_bridges": re.compile(
-            r"\b(machine\.Pin|machine\.I2C|machine\.UART|network\.WLAN|usocket\.socket|busio\.I2C)\b"
-        ),
+        # #2898: the peripheral handles (machine.Pin/I2C/UART, network.WLAN, busio.I2C)
+        # removed -- io's tokens (its rule already counts them). A socket is the one
+        # genuine process/host boundary this dialect has.
+        "ipc_rpc_bridges": re.compile(r"\busocket\.socket\b"),
     },
 }

--- a/gitgalaxy/standards/language_standards/languages/fortran.py
+++ b/gitgalaxy/standards/language_standards/languages/fortran.py
@@ -334,8 +334,10 @@ DEFINITION: dict[str, Any] = {
         "comprehensions": re.compile(r"\b(?:FORALL|DO\s+CONCURRENT)\b|\[[^\]]+\]|\(\/[^/]+\/\)", re.I),
         # 22. scientific (Numerical / Compute Libraries)
         # Native Fortran superpower: Vectorized matrix operations, tensor reductions, and strict scientific primitive typing.
+        # #2899: intrinsics anchored to their call form -- with re.I, bare `sum`, `exp`,
+        # `mod` etc. matched ordinary variable names (fortran's top bleed, 28/file).
         "scientific": re.compile(
-            r"\b(MATMUL|DOT_PRODUCT|TRANSPOSE|SUM|PRODUCT|MAXVAL|MINVAL|MAXLOC|MINLOC|RESHAPE|SQRT|EXP|LOG|LOG10|SIN|COS|TAN|ASIN|ACOS|ATAN|ATAN2|SINH|COSH|TANH|KIND=|CEILING|FLOOR|MOD|MODULO)\b",
+            r"\b(MATMUL|DOT_PRODUCT|TRANSPOSE|SUM|PRODUCT|MAXVAL|MINVAL|MAXLOC|MINLOC|RESHAPE|SQRT|EXP|LOG|LOG10|SIN|COS|TAN|ASIN|ACOS|ATAN|ATAN2|SINH|COSH|TANH|CEILING|FLOOR|MOD|MODULO)\s*\(|KIND\s*=",
             re.I,
         ),
         # 23. heat_triggers (Metaprogramming & Reflection)
@@ -442,10 +444,12 @@ DEFINITION: dict[str, Any] = {
         # Framework code that explicitly bypasses verification.
         "test_skip": None,
         # --- PHASE 3: HYBRID DOMAIN SENSORS (Fortran Specifics) ---
-        "serialization_parsing": re.compile(r"(?i)\b(NAMELIST|READ\s*\(|WRITE\s*\(|FORMAT|OPEN\s*\()\b"),
-        "regex_execution": re.compile(
-            r"(?i)\b(SCAN|INDEX|VERIFY|ADJUSTL|ADJUSTR)\b"
-        ),  # Relies on intrinsic string processing
+        # #2898: READ(/WRITE(/OPEN( removed -- formatted record I/O is io's (its rule
+        # already counts them). NAMELIST and FORMAT are fortran's serialization formats.
+        "serialization_parsing": re.compile(r"(?i)\b(NAMELIST|FORMAT)\b"),
+        # #2898: contract-level absence. SCAN/INDEX/VERIFY/ADJUSTL/ADJUSTR are string
+        # intrinsics that take no pattern -- standard fortran has no regex engine.
+        "regex_execution": None,
         "time_date_logic": re.compile(r"(?i)\b(DATE_AND_TIME|SYSTEM_CLOCK|CPU_TIME)\b"),
         # BUG FIX: the shared trailing `\b` made the `OMP_` prefix alternative
         # unreachable -- `OMP_` ends in `_` (a word char), and real OpenMP

--- a/gitgalaxy/standards/language_standards/languages/javascript.py
+++ b/gitgalaxy/standards/language_standards/languages/javascript.py
@@ -289,7 +289,8 @@ DEFINITION: dict[str, Any] = {
         "comprehensions": re.compile(r"\.(?:map|filter|reduce|flatMap|some|every|find|forEach|groupBy)\s*\("),
         "scientific": re.compile(r"\b(?:import|require|from)\b.*?(?:numpy|pandas|scipy|matplotlib|opencv|cv2)\b"),
         "hardware_bridge": re.compile(
-            r"\b(?:import|require|from)\b.*?(?:serialport|usb|bluetooth|socket\.io|websocket|printer|webgl)\b"
+            # #2898: webgl removed -- a renderer, not a hardware peripheral.
+            r"\b(?:import|require|from)\b.*?(?:serialport|usb|bluetooth|socket\.io|websocket|printer)\b"
         ),
         "cryptography": re.compile(
             r"\b(?:import|require|from)\b.*?(?:crypto|bcrypt|x509|tls|ssl|jsonwebtoken|argon2)\b"
@@ -367,7 +368,12 @@ DEFINITION: dict[str, Any] = {
         # 35. pointers
         "pointers": None,
         # 36. memory_alloc
-        "memory_alloc": re.compile(r"\bnew\s+[A-Z]\w*"),
+        # #2898: `new <AnyCapitalized>` counted every object construction (new Error,
+        # new Promise). The registry reads memory_alloc as UNMANAGED allocation only
+        # (java/kotlin/scala/dart precedent: Arena/memScoped/ffi.Allocator, honest 0s).
+        "memory_alloc": re.compile(
+            r"\bnew\s+(?:ArrayBuffer|SharedArrayBuffer|WebAssembly\.Memory)\b|\bBuffer\.alloc(?:Unsafe(?:Slow)?)?\s*\("
+        ),
         # 37. inline_asm
         "inline_asm": None,
         # --- PHASE 5: RESOURCE MANAGEMENT & STABILITY ---

--- a/gitgalaxy/standards/language_standards/languages/lua.py
+++ b/gitgalaxy/standards/language_standards/languages/lua.py
@@ -237,7 +237,8 @@ DEFINITION: dict[str, Any] = {
         # 40. explicit_casts (Explicit Type Casting): "Trust Me" Tax.
         "explicit_casts": re.compile(r"\b(ffi\.cast|tonumber|tostring)\b"),
         # 41. panics_and_aborts (Execution Interrupts / Fatal Aborts)
-        "panics_and_aborts": re.compile(r"\b(error|assert|os\.exit)\b"),
+        # #2898: `assert` removed -- safety's token (its rule already counts it).
+        "panics_and_aborts": re.compile(r"\b(error|os\.exit)\b"),
         # 42. thread_sleeps (Thread Blocking / Synchronous Pauses)
         "thread_sleeps": re.compile(r'\b(task\.wait|os\.execute\s*\(?[\'"]sleep)\b'),
         # 43. bitwise_ops (Bitwise Operations)
@@ -264,8 +265,9 @@ DEFINITION: dict[str, Any] = {
         "serialization_parsing": re.compile(r"\b(string\.dump|loadstring|load|cjson\.decode|cjson\.encode)\b"),
         "regex_execution": re.compile(r"\b(string\.match|string\.gmatch|string\.find|string\.gsub)\b"),
         "time_date_logic": re.compile(r"\b(os\.time|os\.clock|os\.date|os\.difftime)\b"),
-        "ipc_rpc_bridges": re.compile(
-            r"\b(os\.execute|io\.popen|coroutine\.create|coroutine\.resume|coroutine\.yield)\b"
-        ),
+        # #2898: the coroutine.* family removed -- in-process control transfer is
+        # concurrency's (its rule already counts `coroutine`); a bridge crosses a
+        # process boundary, which os.execute/io.popen do.
+        "ipc_rpc_bridges": re.compile(r"\b(os\.execute|io\.popen)\b"),
     },
 }

--- a/gitgalaxy/standards/language_standards/languages/perl.py
+++ b/gitgalaxy/standards/language_standards/languages/perl.py
@@ -261,7 +261,10 @@ DEFINITION: dict[str, Any] = {
         ),
         # 16. ui_framework: UI / View Components. GUI libraries and template engines.
         "ui_framework": re.compile(
-            r"\b(Tk::|Wx::|Gtk2::|Gtk3::|Prima::|Template|HTML::Mason|Mojolicious::Plugin::TagHelpers)\b|\brender(?:_to_string)?\b|<%|%>|\[%|%\]"
+            # #2898: `<%` no longer fires inside POD formatting codes (C<%Y>) -- an
+            # uppercase letter directly before `<` is POD's C<>/B<>/L<> shape, never a
+            # Mason/embedded-template tag.
+            r"\b(Tk::|Wx::|Gtk2::|Gtk3::|Prima::|Template|HTML::Mason|Mojolicious::Plugin::TagHelpers)\b|\brender(?:_to_string)?\b|(?<![A-Z])<%|%>|\[%|%\]"
         ),
         # 17. closures: Closures / Anonymous Functions. Anonymous subroutines.
         "closures": re.compile(r"\bsub\s*(?:\([^)]*\))?[ \t]*\{"),
@@ -282,7 +285,10 @@ DEFINITION: dict[str, Any] = {
             re.M,
         ),
         # 19. decorators: Decorators / Annotations. Subroutine and variable attributes.
-        "decorators": re.compile(r":\s*[a-zA-Z_]\w*(?:\([^)]*\))?"),
+        # #2898: `::` package separators no longer count (2760 crucible hits) -- the
+        # double-colon guards leave only the single-colon attribute form (:shared,
+        # :SpamAssassin), which is what the sentence names.
+        "decorators": re.compile(r"(?<!:):(?!:)\s*[a-zA-Z_]\w*(?:\([^)]*\))?"),
         # 20. generics: Generics / Type Parameters. Parameterized types (via Type::Tiny/Moose).
         "generics": re.compile(r"\b(?:ArrayRef|HashRef|Map|Tuple|Dict|Maybe|InstanceOf|ConsumerOf|Enum)\[[^\]]*\]"),
         # 21. comprehensions: Iterators / Comprehensions. Map and Grep.
@@ -335,7 +341,9 @@ DEFINITION: dict[str, Any] = {
         "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
         # 31. ssr_boundaries: View Horizon. Server-Side Rendering computation boundaries.
         "ssr_boundaries": re.compile(
-            r"\b(Mojolicious::Controller|Dancer2|Catalyst::Controller|render|template|reply->|to_app)\b"
+            # #2899: bare `render`/`template` matched ordinary words; anchored to the
+            # call form a server handler actually uses.
+            r"\b(Mojolicious::Controller|Dancer2|Catalyst::Controller|reply->|to_app)\b|\b(?:render|template)\s*\("
         ),
         # 32. events: Pub/Sub Network. Event-driven architecture signatures and message brokers.
         "events": re.compile(
@@ -350,7 +358,10 @@ DEFINITION: dict[str, Any] = {
         ),
         # 35. pointers: Memory Map. Explicit tracking of memory addressing or references.
         # UPDATED: Removed '\\[$@%&*]\w+' to stop flagging standard pass-by-reference variables.
-        "pointers": re.compile(r"->(?:\[[^\]]*\]|\{[^\}]*\})|@\$|%\$|\$\$|\&\$"),
+        # #2898: contract-level absence. ->{key}/->[i] and the sigil-derefs ($$, @$,
+        # %$, &$) are all GC-managed reference operations; perl exposes no raw memory
+        # address the way c/cpp/zig (which read the sentence) do.
+        "pointers": None,
         # 36. memory_alloc: Manual Memory Management. Explicit heap manipulations or reference count controls.
         "memory_alloc": re.compile(
             r"\b(Scalar::Util::weaken|Scalar::Util::isweak|Internals::SvREFCNT|Internals::SvREADONLY|undef|Devel::Peek)\b"
@@ -374,7 +385,9 @@ DEFINITION: dict[str, Any] = {
         "thread_sleeps": re.compile(r"\bsleep\b"),
         # 43. bitwise_ops (Bitwise Operations) Manipulating raw bytes and memory registers.
         # UPDATED: Added negative lookbehinds '(?<![=!])~' to ignore Perl regex operators.
-        "bitwise_ops": re.compile(r"(?<!&)&(?!&)|(?<!\|)\|(?!\|)|<<|>>|\^|(?<![=!])~"),
+        # #2899: binary `|` requires spacing so regex-literal alternation (m/a|b/) no
+        # longer counts; perl bitwise-or is conventionally written spaced.
+        "bitwise_ops": re.compile(r"(?<!&)&(?!&)|(?<= )\|(?= )|<<|>>|\^|(?<![=!])~"),
         # 44. sync_locks (Resource Management & Stability)
         "sync_locks": re.compile(r"\b(lock|threads::shared|Thread::Semaphore)\b"),
         # 45. immutability_locks (Immutability Constraints) Explicitly locking data so it cannot be mutated.
@@ -394,7 +407,9 @@ DEFINITION: dict[str, Any] = {
         # follows the paren. Both never matched at all.
         "listeners": re.compile(r"\bon\s*\(|\bsubscribe\s*\(|\badd_listener\b"),
         # 49. test_skip (Bypassed Tests / Ignored Specs) Code that bypasses test verification.
-        "test_skip": re.compile(r"\b(skip|todo_skip)\b"),
+        # #2899: `skip` anchored to Test::More's call shapes (skip(..., skip "why", n,
+        # skip $why, n) so a hash key or POD item spelling the word no longer counts.
+        "test_skip": re.compile(r"\bskip\s*(?:\(|[\"'\$])|\btodo_skip\b"),
         # --- PHASE 3: HYBRID DOMAIN SENSORS (Perl Specifics) ---
         "serialization_parsing": re.compile(
             r"\b(Storable::(?:thaw|fd_retrieve)|JSON::(?:decode_json|from_json)|YAML::(?:Load|LoadFile))\b"
@@ -414,7 +429,8 @@ DEFINITION: dict[str, Any] = {
         "regex_execution": re.compile(
             r"(=~|!~|\b(?:qr|m|s|tr|y)\b[/{}\[\]()<>!|#~^])"
         ),  # Catches Perl's native binding operators and regex quotes
-        "time_date_logic": re.compile(r"\b(localtime|gmtime|Time::HiRes|sleep|time)\b"),
+        # #2899: `time` no longer matches sigil-carrying variables ($time[5], @time).
+        "time_date_logic": re.compile(r"\b(localtime|gmtime|Time::HiRes|sleep)\b|(?<![\$@%\w])time\b(?!\s*[\[{])"),
         # BUG FIX: the whole alternation used to be wrapped in \b(...)\b.
         # \b requires a word/non-word transition; `system\s*\(` and
         # `exec\s*\(` both END in a literal `(` (non-word), so the

--- a/gitgalaxy/standards/language_standards/languages/php.py
+++ b/gitgalaxy/standards/language_standards/languages/php.py
@@ -357,7 +357,9 @@ DEFINITION: dict[str, Any] = {
         # 42. thread_sleeps (Thread Blocking / Synchronous Pauses)
         "thread_sleeps": re.compile(r"\b(sleep|usleep|time_nanosleep|time_sleep_until)\b"),
         # 43. bitwise_ops (Bitwise Operations)
-        "bitwise_ops": re.compile(r"<<|>>|(?<!&)&(?!&)|(?<!\|)\|(?!\|)|\^|~"),
+        # #2899: `&` no longer matches HTML entities (&amp;, &#123;) inside the string
+        # stream -- 12316 of php's 15137 crucible hits were entity ampersands.
+        "bitwise_ops": re.compile(r"<<|>>|(?<!&)&(?!&)(?![a-zA-Z#]\w*;)|(?<!\|)\|(?!\|)|\^|~"),
         # 44. sync_locks (Resource Management & Stability)
         "sync_locks": re.compile(r"\b(mutex|lock|synchronized|Semaphore|flock|sem_acquire)\b", re.I),
         # 45. immutability_locks (Immutability Constraints)

--- a/gitgalaxy/standards/language_standards/languages/python.py
+++ b/gitgalaxy/standards/language_standards/languages/python.py
@@ -269,7 +269,9 @@ DEFINITION: dict[str, Any] = {
             r"\b(?:import|require|from)\b.*?(?:serialport|usb|bluetooth|socket\.io|websocket|printer|webgl)\b"
         ),
         "cryptography": re.compile(
-            r"\b(?:import|require|from)\b.*?(?:crypto|bcrypt|x509|tls|ssl|jsonwebtoken|argon2)\b"
+            # #2898: hashlib/hmac added -- the stdlib's own crypto modules were missing
+            # from the name list, so files importing them read 0.
+            r"\b(?:import|require|from)\b.*?(?:crypto|bcrypt|x509|tls|ssl|jsonwebtoken|argon2|hashlib|hmac)\b"
         ),
         # 23. heat_triggers (Metaprogramming & Reflection)
         # Metaprogramming and class-level binding.
@@ -370,7 +372,10 @@ DEFINITION: dict[str, Any] = {
         # --- NEW: ADVANCED ALGORITHMIC SENSORS ---
         "lazy_evaluation": re.compile(r"\b(yield|yield\s+from|Generator|AsyncGenerator|Iterator|AsyncIterator)\b"),
         "vectorized_math": re.compile(
-            r"\b(einsum|matmul|tensordot|vdot|bmm)\b|\.dot\s*\(|(?<=[a-zA-Z0-9_\]\)])\s*@\s*(?=[a-zA-Z0-9_\[\(])"
+            # #2898: the matrix-multiply `@` operand gap must stay on one line --
+            # `\s*` crossed newlines, so a decorator under any expression counted
+            # (892 of the 898 crucible hits were decorator lines).
+            r"\b(einsum|matmul|tensordot|vdot|bmm)\b|\.dot\s*\(|(?<=[a-zA-Z0-9_\]\)])[ \t]*@[ \t]*(?=[a-zA-Z0-9_\[\(])"
         ),
         # --- PHASE 3: HYBRID DOMAIN SENSORS (Python Specifics) ---
         "serialization_parsing": re.compile(

--- a/gitgalaxy/standards/language_standards/languages/scheme.py
+++ b/gitgalaxy/standards/language_standards/languages/scheme.py
@@ -223,8 +223,10 @@ DEFINITION: dict[str, Any] = {
         ),
         # 22. scientific (Numerical / Compute Libraries)
         # Scheme's native mathematical tower.
+        # #2899: anchored to head (operator) position -- directly after `(`/`[` -- so
+        # `exp` as a field/variable name in operand position no longer counts.
         "scientific": re.compile(
-            r"(?<![^ \t\n\r(\[])(sin|cos|tan|asin|acos|atan|exp|log|sqrt|expt|abs|gcd|lcm|numerator|denominator|floor|ceiling|truncate|round|exact->inexact)(?![^ \t)\]\n\r])"
+            r"(?<=[(\[])(sin|cos|tan|asin|acos|atan|exp|log|sqrt|expt|abs|gcd|lcm|numerator|denominator|floor|ceiling|truncate|round|exact->inexact)(?![^ \t)\]\n\r])"
         ),
         # 23. heat_triggers (Metaprogramming & Reflection)
         # Metaprogramming and syntactic abstractions.
@@ -280,9 +282,10 @@ DEFINITION: dict[str, Any] = {
         "pointers": None,
         # 36. memory_alloc
         # Explicit heap instantiations.
-        "memory_alloc": re.compile(
-            r"(?<![^ \t\n\r(\[])(make-vector|make-string|make-bytevector|make-hash-table|cons|list)(?![^ \t)\]\n\r])"
-        ),
+        # #2898: contract-level absence. cons/list/make-* are all GC-managed allocation
+        # (cons alone was 150/file); the registry reads memory_alloc as UNMANAGED
+        # allocation only, and portable scheme has no unmanaged form.
+        "memory_alloc": None,
         # 37. inline_asm
         "inline_asm": None,
         # --- PHASE 5: RESOURCE MANAGEMENT & STABILITY ---

--- a/gitgalaxy/standards/language_standards/languages/shell.py
+++ b/gitgalaxy/standards/language_standards/languages/shell.py
@@ -382,7 +382,9 @@ DEFINITION: dict[str, Any] = {
         # group with the leading `\b` dropped (the `#` is self-delimiting).
         "test_skip": re.compile(r"\b(test\.skip|bats_skip|mock|stub)\b|#\s*SKIP\b"),
         # --- PHASE 3: HYBRID DOMAIN SENSORS (Shell Specifics) ---
-        "serialization_parsing": re.compile(r"\b(jq|yq|awk|sed|xmlstarlet)\b"),
+        # #2898: sed/awk removed -- general text processors, not format codecs
+        # (sed alone was 529 crucible hits); jq/yq/xmlstarlet parse a format.
+        "serialization_parsing": re.compile(r"\b(jq|yq|xmlstarlet)\b"),
         "regex_execution": re.compile(r"\b(grep|egrep|sed|awk)\b|=~"),
         # BOUNDARY FIX: the trailing `\s+` before the shared closing `\b`
         # required a word char to immediately follow the whitespace --

--- a/gitgalaxy/standards/language_standards/languages/solidity.py
+++ b/gitgalaxy/standards/language_standards/languages/solidity.py
@@ -249,7 +249,9 @@ DEFINITION: dict[str, Any] = {
         #   failed for every event name longer than one letter, which
         #   is effectively all of them.
         "ipc_rpc_bridges": re.compile(
-            r"\b(?:delegatecall|staticcall|selfdestruct)\b|\.call\{value:|\bemit\s+[A-Z]\w*\b"
+            # #2898: `emit Event(` removed -- events' token (its rule already counts
+            # emit); what stays are genuine cross-contract call boundaries.
+            r"\b(?:delegatecall|staticcall|selfdestruct)\b|\.call\{value:"
         ),
     },
 }

--- a/gitgalaxy/standards/language_standards/languages/swift.py
+++ b/gitgalaxy/standards/language_standards/languages/swift.py
@@ -271,7 +271,11 @@ DEFINITION: dict[str, Any] = {
         "spec_exposure": re.compile(r"\[(?:\s*SPEC\s*-\s*\d{1,10}|spec|audit)[^\]]{0,300}\]", re.I),
         # 31. ssr_boundaries (Server-Side Rendering)
         "ssr_boundaries": re.compile(
-            r"\b(Vapor|Hummingbird|Request|Response|Route|app\.get|app\.post|EventLoopFuture)\b"
+            # #2899: bare `Request`/`Response` matched ordinary identifiers and prose;
+            # anchored to the type-annotation (`: Request`) and initializer (`Request(`)
+            # forms, the shapes a server handler actually uses.
+            r"\b(Vapor|Hummingbird|Route|app\.get|app\.post|EventLoopFuture)\b"
+            r"|:\s*(?:Request|Response)\b|\b(?:Request|Response)\("
         ),
         # 32. events (Event Emitters / Pub-Sub)
         # BUG FIX: `@Published` is `@`-prefixed -- same leading-\b bug.
@@ -353,7 +357,9 @@ DEFINITION: dict[str, Any] = {
         ),
         # BUG FIX: `Process\(\)` ends on `)` -- same bug. Never matched.
         "ipc_rpc_bridges": re.compile(
-            r"\b(?:URLSession|NSXPCConnection|NotificationCenter|DispatchQueue)\b|\bProcess\(\)"
+            # #2898: DispatchQueue removed -- in-process dispatch is concurrency's
+            # (its rule already counts it); a bridge crosses a process boundary.
+            r"\b(?:URLSession|NSXPCConnection|NotificationCenter)\b|\bProcess\(\)"
         ),
     },
 }

--- a/gitgalaxy/standards/language_standards/languages/typescript.py
+++ b/gitgalaxy/standards/language_standards/languages/typescript.py
@@ -610,7 +610,10 @@ DEFINITION: dict[str, Any] = {
         ),
         # 16. ui_framework (UI / View Components)
         "ui_framework": re.compile(
-            r'<[A-Z]\w+|className=|use(?:State|Effect|Context|Reducer|Ref|Memo|Callback|Transition|Id)|props\.|this\.state|@Component|@Injectable|document\.(?:getElementById|querySelector)|["\']use\s+(?:client|server)["\']'
+            # #2898: `<[A-Z]\w+` also matched generic type arguments (Array<Foo>,
+            # <ModifierLike>). A generic always follows an identifier; a JSX element
+            # never does -- the not-word lookbehind separates them.
+            r'(?<!\w)<[A-Z]\w+|className=|use(?:State|Effect|Context|Reducer|Ref|Memo|Callback|Transition|Id)|props\.|this\.state|@Component|@Injectable|document\.(?:getElementById|querySelector)|["\']use\s+(?:client|server)["\']'
         ),
         # 17. closures (Closures / Anonymous Functions)
         "closures": re.compile(r"=>[ \t]*\{|\(\)[ \t]*=>|function\s*\([^)]*\)[ \t]*\{"),
@@ -711,7 +714,10 @@ DEFINITION: dict[str, Any] = {
             r"\b(getServerSideProps|getStaticProps|generateStaticParams|LoaderFunction|ActionFunction)\b"
         ),
         # 32. events (Event Emitters / Pub-Sub)
-        "events": re.compile(r"\b(emit|on|once|off|dispatchEvent|EventEmitter|EventTarget)\b"),
+        # #2899: the short generic words anchored to their method-call form -- bare
+        # `emit` was the typescript compiler's own emit pipeline (9/file), and bare
+        # on/once/off matched prose and identifiers.
+        "events": re.compile(r"\.(?:emit|on|once|off)\s*\(|\b(dispatchEvent|EventEmitter|EventTarget)\b"),
         # 33. dependency_injection (Dependency Injection / IoC)
         "dependency_injection": re.compile(r"\b(Inject|Injectable|Container|resolve|register|tsyringe|inversify)\b"),
         # 34. macros
@@ -719,7 +725,12 @@ DEFINITION: dict[str, Any] = {
         # 35. pointers
         "pointers": None,  # Managed memory environment.
         # 36. memory_alloc
-        "memory_alloc": re.compile(r"\bnew\s+[A-Z]\w*"),
+        # #2898: `new <AnyCapitalized>` counted every object construction (new Error,
+        # new Promise). The registry reads memory_alloc as UNMANAGED allocation only
+        # (java/kotlin/scala/dart precedent: Arena/memScoped/ffi.Allocator, honest 0s).
+        "memory_alloc": re.compile(
+            r"\bnew\s+(?:ArrayBuffer|SharedArrayBuffer|WebAssembly\.Memory)\b|\bBuffer\.alloc(?:Unsafe(?:Slow)?)?\s*\("
+        ),
         # 37. inline_asm
         "inline_asm": None,
         # --- PHASE 5: RESOURCE MANAGEMENT & STABILITY ---

--- a/gitgalaxy/standards/language_standards/languages/zig.py
+++ b/gitgalaxy/standards/language_standards/languages/zig.py
@@ -217,11 +217,15 @@ DEFINITION: dict[str, Any] = {
         "explicit_casts": re.compile(r"@ptrCast\b|@intCast\b|@alignCast\b|@bitCast\b|@as\b"),
         # 41. panics_and_aborts (Execution Interrupts / Fatal Aborts) Aborting context.
         # BUG FIX: `@panic` is `@`-prefixed -- same leading-\b bug.
-        "panics_and_aborts": re.compile(r"\b(?:unreachable|return)\b|@panic"),
+        # #2898: `return` removed -- an unconditional transfer is structural_boundaries'
+        # (7538 crucible hits, none of them a panic/abort).
+        "panics_and_aborts": re.compile(r"\bunreachable\b|@panic"),
         # 42. thread_sleeps (Thread Blocking / Synchronous Pauses) (Forced waits/sleep).
         "thread_sleeps": re.compile(r"\b(std\.time\.sleep)\b"),
         # 43. bitwise_ops (Bitwise Operations)
-        "bitwise_ops": re.compile(r"(?<!&)&(?!&)|(?<!\|)\|(?!\|)|<<|>>|\^|~"),
+        # #2898: binary `&`/`|` require the zig-fmt spacing (` a & b `) so the prefix
+        # address-of `&x` and payload captures `|err|` no longer count.
+        "bitwise_ops": re.compile(r"(?<= )&(?= )|(?<= )\|(?= )|<<|>>|\^|~"),
         # 44. sync_locks (Resource Management & Stability) Coordinated threading.
         "sync_locks": re.compile(r"\b(Mutex|RwLock|Semaphore|lock|unlock)\b"),
         # 45. immutability_locks (Immutability Constraints) Immutability.

--- a/tests/extraction/languages/test_agc_assembly_strict.py
+++ b/tests/extraction/languages/test_agc_assembly_strict.py
@@ -109,7 +109,8 @@ _AGC_SIMPLE_CASES = [
     ("memory_alloc", "\tERASABLE", "\tCA\tBAR"),
     ("telemetry", "\tDOWNLINK", "\tCA\tBAR"),
     ("debug_prints", "\tFLASH", "\tCA\tBAR"),
-    ("explicit_casts", "\tEXTEND", "\tCA\tBAR"),
+    # explicit_casts is None since #2898 -- EXTEND is an opcode-mode prefix, not a
+    # type conversion; tested in test_agc_assembly_explicit_casts_vs_pointers_no_false_collision.
     ("panics_and_aborts", "\tTC\tBAILOUT", "\tCA\tBAR"),
     ("thread_sleeps", "\tVARDELAY", "\tCA\tBAR"),
     ("bitwise_ops", "\tMASK\tBAR", "\tTC\tBAR"),
@@ -218,10 +219,14 @@ def test_agc_assembly_explicit_casts_vs_pointers_no_false_collision():
     explicit_casts = AGC_RULES["explicit_casts"]
     pointers = AGC_RULES["pointers"]
 
+    # #2898: explicit_casts is a contract-level absence -- EXTEND is an
+    # opcode-mode prefix, not a type conversion, and AGC assembly has no cast
+    # construct. The old EXTEND/INDEX co-occurrence scenario now belongs to
+    # pointers alone.
+    assert explicit_casts is None
+
     combined = "\tEXTEND\n\tINDEX\tA"
-    cast_match = explicit_casts.search(combined)
     ptr_match = pointers.search(combined)
-    assert cast_match and cast_match.group(0).upper() == "EXTEND"
     assert ptr_match and ptr_match.group(0).upper() == "INDEX"
 
 

--- a/tests/extraction/languages/test_embedded_python_strict.py
+++ b/tests/extraction/languages/test_embedded_python_strict.py
@@ -186,7 +186,7 @@ _EMBEDDED_PYTHON_SIMPLE_CASES = [
     ("serialization_parsing", "data = ujson.loads(raw)", "data = 1"),
     ("regex_execution", "m = ure.match(r'^boot', line)", "m = 1"),
     ("time_date_logic", "now = utime.ticks_ms()", "now = 1"),
-    ("ipc_rpc_bridges", "i2c = machine.I2C(0)", "i2c = 0"),
+    ("ipc_rpc_bridges", "s = usocket.socket()", "i2c = machine.I2C(0)"),  # 2898: peripherals are io's
 ]
 
 

--- a/tests/extraction/languages/test_fortran_strict.py
+++ b/tests/extraction/languages/test_fortran_strict.py
@@ -142,7 +142,8 @@ _FORTRAN_SIMPLE_CASES = [
     ("cleanup", "DEALLOCATE(x)", "X = 1"),
     ("encapsulation", "PRIVATE", "PUBLIC"),
     ("serialization_parsing", "FORMAT(I5)", None),
-    ("regex_execution", "INDEX(str, 'x')", "X = 1"),
+    # regex_execution is None since #2898 -- fortran's string intrinsics take no
+    # pattern; tested explicitly in test_fortran_test_vs_regex_execution_no_false_collision.
     ("time_date_logic", "CALL DATE_AND_TIME(date, time)", "X = 1"),
     ("ipc_rpc_bridges", "CALL MPI_Send(buf, count, dtype)", "X = 1"),
 ]
@@ -524,13 +525,13 @@ def test_fortran_test_vs_regex_execution_no_false_collision():
     test = FORTRAN_RULES["test"]
     regex_execution = FORTRAN_RULES["regex_execution"]
 
+    # #2898: regex_execution is a contract-level absence -- SCAN/INDEX/VERIFY/
+    # ADJUSTL/ADJUSTR are string intrinsics that take no pattern, and standard
+    # fortran has no regex engine. The old collision scenario is moot.
+    assert regex_execution is None
+
     test_line = "call assert_equal(x, y)"
     assert test.search(test_line)
-    assert not regex_execution.search(test_line)
-
-    regex_line = "pos = INDEX(str, 'x')"
-    assert regex_execution.search(regex_line)
-    assert not test.search(regex_line)
 
 
 def test_fortran_func_start_vs_generics_no_false_collision():

--- a/tests/extraction/languages/test_javascript_strict.py
+++ b/tests/extraction/languages/test_javascript_strict.py
@@ -58,7 +58,7 @@ _JS_SIMPLE_CASES = [
     ("ssr_boundaries", "export async function getServerSideProps() {}", "function foo() {}"),
     ("events", "emitter.on('data', handler);", "onData(handler);"),
     ("dependency_injection", "@Injectable()", "let inject = true;"),
-    ("memory_alloc", "const x = new Foo();", "const x = new foo();"),
+    ("memory_alloc", "const buf = new ArrayBuffer(8);", "const e = new Error('x');"),  # 2898: unmanaged only
     ("telemetry", "logger.info('started');", "let logger = info;"),
     ("debug_prints", "console.log('debug value:', x);", "let console = log;"),
     ("explicit_casts", "Number('42');", "let num = 42;"),

--- a/tests/extraction/languages/test_perl_strict.py
+++ b/tests/extraction/languages/test_perl_strict.py
@@ -96,7 +96,8 @@ _PERL_SIMPLE_CASES = [
     ("events", "$bus->emit('event');", "$bus->publish('event');"),
     ("dependency_injection", "my $c = container();", "my $c = factory();"),
     ("macros", "BEGIN { }", "INIT { }"),
-    ("pointers", "$ref->[0];", "$ref->method();"),
+    # pointers is None since #2898 -- perl's derefs are GC-managed references,
+    # not raw memory addresses (c/cpp/zig read the sentence).
     ("memory_alloc", "undef $x;", "delete $h{$x};"),
     ("inline_asm", "use Inline 'C';", "use Inline::Python;"),
     ("telemetry", "$logger->info('msg');", "$logger->format('msg');"),

--- a/tests/extraction/languages/test_python_strict.py
+++ b/tests/extraction/languages/test_python_strict.py
@@ -71,7 +71,7 @@ _PY_SIMPLE_CASES = [
     ("bitwise_ops", "x = a << 2", "result = base ** exponent"),
     ("closures", "f = lambda x: x + 1", "def f(x):\n    return x + 1"),
     ("comprehensions", "[x**2 for x in range(10)]", "for x in range(10):\n    print(x)"),
-    ("cryptography", "import bcrypt", "import hashlib"),
+    ("cryptography", "import hashlib", "import os"),  # 2898: stdlib crypto modules now count
     ("dl_frameworks", "import torch", "import sklearn"),
     ("encapsulation", "self._private_value = 1", "self.public_value = 1"),
     (

--- a/tests/extraction/languages/test_scheme_strict.py
+++ b/tests/extraction/languages/test_scheme_strict.py
@@ -68,7 +68,8 @@ _SCHEME_SIMPLE_CASES = [
     ("spec_exposure", "[SPEC-123]", "; just a note"),
     ("events", "(add-hook! my-hook proc)", "(+ x 1)"),
     ("macros", "(define-syntax my-macro (syntax-rules () ((_ x) x)))", "(+ x 1)"),
-    ("memory_alloc", "(make-vector 10)", "(+ x 1)"),
+    # memory_alloc is None since #2898 -- cons/list/make-* are GC-managed allocation
+    # and the registry reads memory_alloc as unmanaged only.
     ("telemetry", '(log-info "msg")', '(display "msg")'),
     ("debug_prints", '(display "hello")', '(log-info "msg")'),
     ("explicit_casts", "(number->string 5)", "(+ x 1)"),

--- a/tests/extraction/languages/test_solidity_strict.py
+++ b/tests/extraction/languages/test_solidity_strict.py
@@ -194,7 +194,8 @@ def test_solidity_ipc_rpc_bridges_boundary_regressions():
         "the idiomatic spaced .call{value: ...} form still didn't match"
     )
     assert pattern.search('target.call{value:amount}("");')
-    assert pattern.search("emit Transfer(from, to, amount);"), "a real multi-character event name still didn't match"
+    # #2898: `emit Event(` is events' token alone now -- the ipc arm was removed.
+    assert not pattern.search("emit Transfer(from, to, amount);")
     assert pattern.search("target.delegatecall(data);")
     assert pattern.search("target.staticcall(data);")
     assert pattern.search("selfdestruct(payable(owner));")

--- a/tests/extraction/languages/test_typescript_strict.py
+++ b/tests/extraction/languages/test_typescript_strict.py
@@ -64,9 +64,9 @@ _TYPESCRIPT_SIMPLE_CASES = [
     ("fragile_debt", "// HACK: workaround", "// clean"),
     ("spec_exposure", "[SPEC-123]", "// just a note"),
     ("ssr_boundaries", "getServerSideProps", "const x = 1;"),
-    ("events", "emit('event')", "const x = 1;"),
+    ("events", "bus.emit('event')", "function emit(node) {"),  # 2899: method-call anchored
     ("dependency_injection", "@Injectable()", "const x = 1;"),
-    ("memory_alloc", "new Foo()", "const x = 1;"),
+    ("memory_alloc", "new ArrayBuffer(8)", "new Foo()"),  # 2898: unmanaged only
     ("telemetry", "logger.info('msg')", "console.log('msg')"),
     ("debug_prints", "console.log('msg')", "logger.info('msg')"),
     ("explicit_casts", "x as Foo", "const x = 1;"),
@@ -415,8 +415,11 @@ def test_typescript_intentional_double_classification_sweep():
     assert TYPESCRIPT_RULES["sync_locks"].search(atomics_wait)
     assert TYPESCRIPT_RULES["thread_sleeps"].search(atomics_wait)
 
+    # #2898 retires the memory_alloc half of this dual: the registry reads
+    # memory_alloc as UNMANAGED allocation only (java/kotlin/scala/dart precedent),
+    # so a managed object construction is regex_execution's alone.
     new_regexp = "new RegExp(x)"
-    assert TYPESCRIPT_RULES["memory_alloc"].search(new_regexp)
+    assert not TYPESCRIPT_RULES["memory_alloc"].search(new_regexp)
     assert TYPESCRIPT_RULES["regex_execution"].search(new_regexp)
 
     # #2888 retires the cleanup half of the `.delete(` dual: the container

--- a/tests/extraction/languages/test_zig_strict.py
+++ b/tests/extraction/languages/test_zig_strict.py
@@ -319,8 +319,11 @@ def test_zig_structural_boundaries_and_panics_and_aborts_shared_literals_intenti
     structural_boundaries = ZIG_RULES["structural_boundaries"]
     panics_and_aborts = ZIG_RULES["panics_and_aborts"]
 
+    # #2898 retires the `return` half of the dual: an unconditional transfer is
+    # structural_boundaries' alone. `unreachable` keeps both readings (it is a
+    # boundary AND a trap).
     assert structural_boundaries.search("return;")
-    assert panics_and_aborts.search("return;")
+    assert not panics_and_aborts.search("return;")
     assert structural_boundaries.search("unreachable;")
     assert panics_and_aborts.search("unreachable;")
 


### PR DESCRIPTION
## What
Lands the one-layer domain-sensor fixes that the **#2897 declared batch** (`docs/domain_sensor_contracts.md`) filed under #2898 and #2899. Every edit follows a ruling that document already made — **one owner per construct, family-consistent readings, honest zeros over fabricated matches**. 26 rule edits across 17 languages.

## #2898 — structural overlap & registry alignment
- **Double-counts removed** (receiving rule already owns the token): zig `return` (7538 hits → structural_boundaries'), lua `assert` (safety's) + `coroutine.*` (concurrency's), swift `DispatchQueue` (concurrency's), solidity `emit Event(` (events'), embedded_python peripheral handles (io's — `usocket.socket` remains its one true bridge), fortran `READ(`/`WRITE(`/`OPEN(` (io's), shell `sed`/`awk` (text processors, not codecs).
- **Registry-consistent narrowing**: js/ts `memory_alloc` → **unmanaged allocation only** (joins the java/kotlin/scala/dart reading); perl `decorators` drops `::` (2760 hits); dart `closures`/`comprehensions` anchor to expression position; zig `bitwise_ops` requires zig-fmt spacing (kills address-of `&x` and `|err|` captures); python `vectorized_math`'s `@` stays on one line (892/898 hits were decorators); python `cryptography` gains `hashlib`/`hmac`.
- **Contract-level absences (`None`)**: fortran `regex_execution`, agc `explicit_casts`, scheme `memory_alloc`, perl `pointers` — per the established 233-`None` pattern; "a zero is usually honest."

## #2899 — string/bare-word bleed anchored out
fortran/scheme `scientific` call/head anchors, c `memory_alloc` call anchor (`"malloc failed"`), cpp `signal(`/`on(`/`callback(`, ts `.emit(`, swift/perl `ssr_boundaries` type/call anchors, dart `ui_framework` exact case, php `&`-entity guard (12316/15137 hits were HTML entities), perl `|` spacing / `skip` / `time` shapes / `<%` POD guard.

**Parked:** markdown `lit_headers` fence-awareness — a stream-level change (`detector.comment_analysis`), not a regex anchor; stays open on #2898's margin.

## Verification
| rule | before → after |
|---|---|
| php `bitwise_ops` | 15137 → 727 |
| python `vectorized_math` | 898 → 42 |
| perl `decorators` | ~2760+ → 536 |
| zig `panics_and_aborts` | −7538 `return` hits |
| dart `closures` | −3282 `if (...) {` hits |
| c `memory_alloc` | 58 → 19 (rosetta `free(0)` plant **preserved**) |

- **No keyword-rosetta cell moves** — all 40 sensors are unplanted/ungated (no companion PR).
- Strict tests updated to pin the new ownership (incl. flipping the zig `return` dual and the ts `new RegExp` memory_alloc half, both retired by the registry decision). Extraction + detector suite: **7900+ green, 0 failed**.
- Golden masters re-blessed (both modes) — `memory_alloc` feeds the `mitigated_memory_allocs` proximity telemetry, and the sensor counts shift.
- `ruff_audit --ci` clean.
- `docs/domain_sensor_contracts.md` gains a **Resolution** section recording the deltas against the batch's measurement.

Closes #2898, closes #2899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBL6TAMVXRUY7iQyy9Ysvi
