### PR TITLE
feat(tools): the score-contract tooling batch — closes #2916

### DIFF
--- a/.claude/agents/contract-audit-scout.md
+++ b/.claude/agents/contract-audit-scout.md
@@ -17,14 +17,23 @@ caller decides against them.
 
 ## Environment (get this right or everything lies)
 
+**Start with `tests/tools/worktree_env.sh <name> [--corpus]` (#2916)** -- it creates/re-detaches
+the engine (and corpus) worktrees at the machine's real worktree roots and prints the five
+exports (`PYTHONPATH GITGALAXY_PATH GALAXYSCOPE_BIN LANGUAGE_CRUCIBLE_PATH
+KEYWORD_ROSETTA_PATH`) as copy-paste lines. Every past environment trap (wrong-path worktree,
+background job from a drifted cwd, stale corpus worktree) is a run that skipped this step.
+
 Two gotchas cost real time; bake them in:
 
-- **Engine tools** (`rule_probe`, `rosetta_audit`, `crucible_check`, `bless_scope`, the audits)
-  run from the engine worktree with `PYTHONPATH=$PWD GITGALAXY_PATH=$PWD`. The venv is
-  `/srv/storage_16tb/projects/gitgalaxy/v6/.venv/bin/python` (call it `$PY`). The baseline-gated
-  audits (`tests/ruff_audit.py`, `tests/mypy_audit.py`, `tests/tools/audit_check.py`) shell out to
-  bare `ruff`/`mypy` -- **prefix `PATH=/srv/storage_16tb/projects/gitgalaxy/v6/.venv/bin:$PATH`**
-  or they die `FileNotFoundError`.
+- **Engine tools** (`rule_probe`, `rosetta_audit`, `crucible_check`, `bless_scope`,
+  `audit_score_inputs`, the audits) run from the engine worktree with
+  `PYTHONPATH=$PWD GITGALAXY_PATH=$PWD`. The interpreter is the PRIMARY checkout's venv --
+  `~/nyx_projects/gitgalaxy/.venv/bin/python` on the primary box (full precision:
+  `.crucible_venvs/full_precision`); wherever the checkout lives, it is
+  `<primary>/.venv/bin/python` (call it `$PY`; `worktree_env.sh` prints the matching
+  `GALAXYSCOPE_BIN`). The baseline-gated audits (`tests/ruff_audit.py`, `tests/mypy_audit.py`,
+  `tests/tools/audit_check.py`) shell out to bare `ruff`/`mypy` -- **prefix
+  `PATH=<primary>/.venv/bin:$PATH`** or they die `FileNotFoundError`.
 - **Corpus tools** (`bias_report.py`, `na_check`, `decoy_check`, `ledger_orphan_check`,
   `verify_language`) run from the keyword-rosetta worktree and default `GITGALAXY_PATH` to the v6
   primary checkout -- which lags your feature branch. **Always pass
@@ -69,6 +78,11 @@ $PY tests/tools/rule_probe.py <signal> all --compare /tmp/<signal>-before.json /
 Return the compare table verbatim (it is already compact -- one row per language), plus a one-line
 call-out for any language that moved in an unexpected direction (widened when it should narrow, or
 vice versa) with its top sample line. That call-out is a flag for the caller, not a diagnosis.
+
+When a language's count moved and the caller asks WHICH lines, run
+`$PY tests/tools/rule_probe.py <signal> <lang> --diff-lines /tmp/<signal>-before.json
+/tmp/<signal>-after.json --context 2` (#2916) and return the LOST/GAINED listing verbatim --
+it is the evidence a candidate silently dropped real definitions (the #2907 Doom K&R case).
 
 ## Job 3 -- the verification sequence
 
@@ -124,6 +138,18 @@ each check's verdict line. **`decoy_check` failing "under the 2-keyword floor" i
 not noise -- a rule change can leave a comment decoy unable to fire any gated signal; surface it
 loudly. Run `verify_language.py <lang>` for any language whose plant you changed and report
 `PASS/FAIL: N assertions`.
+
+## Job 6 -- score-contract legs (#2916)
+
+For a SCORE contract (epic #2812 Phase 4 / #2908), two more tools join the sequence:
+
+- `$PY tests/tools/audit_score_inputs.py <risk_metric> [--summary]` -- reproduces every recorded
+  `risk_<metric>` from its recorded inputs. Return the `--summary` paragraph plus the CLUSTER
+  table; on exit 1 return the residual rows verbatim (a residual means the adapter or the formula
+  drifted -- the caller decides which).
+- `PATH=<venv>/bin:$PATH $PY tests/tools/contract_pr_check.py [--rules|--score] --corpus
+  <kr worktree>` -- the whole PR gauntlet in one command; return its PR-body block verbatim
+  (Measured / Corpus / Golden masters / Tests) and nothing else unless a leg failed.
 
 ## When you're unsure
 

--- a/.claude/skills/score-contract-audit/SKILL.md
+++ b/.claude/skills/score-contract-audit/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: score-contract-audit
+description: Run one SCORE-layer contract (epic #2812 Phase 4 / #2908 shape) end to end -- decompose a gated risk_<metric> into its recorded inputs, state its equation contract with D-decisions and an acceptance table, edit the formula, re-price, and land the engine + corpus PR pair. The score-layer twin of rule-contract-audit; same tier table and never-delegate list.
+---
+
+# Score-contract audit (one `risk_<metric>` family)
+
+The score-layer twin of `rule-contract-audit` (read its "Run it cheap" section first --
+**the tier table and never-delegate list there apply verbatim**: fable orchestrates and owns
+every sentence/decision/go-no-go, the `contract-audit-scout` (haiku) runs the megabyte legs
+and returns digests, a sonnet build agent applies exact specs, `gemini-analyzer` adversary-
+reviews the draft equation and the final diff). The differences are the phases and the
+evidence artifacts, which are score-shaped: a formula and its recorded inputs, not a regex
+and its matched lines.
+
+The worked precedent is `docs/risk_documentation_contract.md` (#2908) -- your contract doc
+follows `docs/_score_contract_template.md`, which mirrors its sections.
+
+## Session shape (exact commands; background every slow leg, delegate every heavy read)
+
+```sh
+# 0. environment -- one command, never the primary checkout (#2916)
+tests/tools/worktree_env.sh score-<N> --corpus     # prints the five exports; eval them
+```
+
+### Phase 0 -- decomposition before opinion (scout runs, orchestrator reads digests)
+```sh
+$PY tests/tools/audit_score_inputs.py <metric> --corpus $KEYWORD_ROSETTA_PATH/data --summary
+```
+- Exit 1 (a residual) means the recorded inputs no longer explain the recorded score --
+  STOP and find out why before any design work; the epic's method rests on this equality.
+  (`verification` warns instead: its per-function `impact` is not persisted -- a known
+  recording gap, not your bug.)
+- Hold four things from the digest: the CLUSTER table's dominant input, the SENSITIVITY
+  points-per-unit, the open-defect cells the bias report pins on this metric, and the
+  formula's consumers (`grep -n "risk_<metric>\|_calc_<metric>" gitgalaxy/ -r`).
+
+### Phase 1 -- the equation contract (orchestrator only; the irreducible reasoning)
+Write, in the template's sections: the equation sentence (what the score MEANS, one
+sentence, language-independent); each input's kind/unit and why adding them is adding like
+to like (the commensurability question Phase 4 exists for); the **D-decisions** -- every
+judgment the new equation forces (denominators, floors, clamps, multiplier semantics) as
+D1/D2/... with the recommendation and the alternative, for maintainer sign-off BEFORE
+implementation; and the **acceptance table** -- expected values on named corpus files,
+computed by hand from the contract, so the implementation has a target that is not itself.
+Adversary-review the draft equation with `gemini-analyzer` before locking it.
+
+### Phase 2 -- edit, then re-price; do not eyeball
+- Build agent applies the formula edit from your exact spec (one `_calc_*`, one layer).
+- Scout re-runs `audit_score_inputs.py <metric>` (must be 0 residuals against the NEW
+  formula) and the acceptance table's named files (must match your hand-computed values).
+- Scout runs the corpus regen (`bias_report.py` under the engine worktree paths) and
+  returns the headline: open-defect share, this metric's cause table.
+
+### Phase 3 -- engine PR
+```sh
+PATH=$PRIMARY/.venv/bin:$PATH $PY tests/tools/contract_pr_check.py --score --corpus $KEYWORD_ROSETTA_PATH
+```
+One command; paste its PR-body block (Measured / Corpus / Golden masters / Tests) into the
+PR. The bless it certifies re-prices a GATED score -- verify the `bless_scope --summary`
+leaf keys are exactly this metric and its declared consumers, nothing else. Label
+`rosetta:rebless-owed` if corpus cells move; merge order engine-first (ROSETTA_AUDIT.md).
+
+### Phase 4 -- corpus PR (keyword-rosetta)
+`tools/rebless.py <lang> --engine <worktree> --note "<dated sentence> (gitgalaxy#N): ..."`
+per moved language + ledger entries per its GATING.md; retire any ledgered cell the new
+equation resolves (`--retire <id> --resolved-by gitgalaxy#N --verdict "..."`).
+
+## Done criterion
+The metric's row in the score sheet carries the equation sentence and doc; the bias
+report's cause table shows no unledgered cell for it; `audit_score_inputs.py <metric>`
+exits 0 on the corpus; the acceptance table's values are asserted in a
+`tests/metrics/test_<metric>_contract.py` the build agent wrote from your table.

--- a/docs/_score_contract_template.md
+++ b/docs/_score_contract_template.md
@@ -1,0 +1,66 @@
+# The `risk_<metric>` score contract (#<N>)
+
+<!-- Template (#2916): the score-layer twin of a rule-contract doc, mirroring
+docs/risk_documentation_contract.md (#2908). One file per gated metric; every
+section below is load-bearing -- delete none, mark n/a explicitly. -->
+
+Phase 4 of the contract roadmap (`docs/contract_roadmap.md`, epic #2812): the
+score row `risk_<metric>` goes from formula-by-accretion to a stated equation
+contract. Decomposition evidence: `tests/tools/audit_score_inputs.py <metric>`
+(#2916) reproduces every recorded score from its recorded inputs (0 residuals
+on <date>, <n> corpus files).
+
+## 1. The equation
+
+> **<one sentence: what the score MEANS, stated without reference to any
+> language or to the current implementation.>**
+
+```
+risk_<metric> = <the equation, in input names -- not code>
+```
+
+Inputs, each with the kind/unit from `signal_contracts.py`, so the sum adds
+like to like (the commensurability audit's question):
+
+| input | source (file_data column / constant) | kind/unit | role |
+|---|---|---|---|
+| | | | |
+
+## 2. What the current formula measures, and why it is replaced
+
+<The audit_score_inputs CLUSTER + SENSITIVITY digest: which input dominates,
+points-per-unit, the open-defect cells the bias report pins on this metric,
+the length leak or granularity mismatch if any.>
+
+## 3. What leaves the equation, and why
+
+<Each term removed, with the corollary-style one-liner: where it moved, or why
+it was never this metric's to carry.>
+
+## 4. Decisions (approve on #<N> before Phase 2)
+
+- **D1 -- <name>**: <the judgment the equation forces>. Recommendation: <x>.
+  Alternative: <y>. <consequence of each>.
+- **D2 -- ...**
+
+## 5. Expected values (acceptance)
+
+Hand-computed from the contract BEFORE implementation; asserted afterward in
+`tests/metrics/test_<metric>_contract.py`.
+
+| corpus file | inputs | expected `risk_<metric>` | note |
+|---|---|---|---|
+| | | | |
+
+## 6. Consumers
+
+<Every reader of `risk_<metric>` / `_calc_<metric>`: score aggregates,
+security_auditor features (note the #96 retrain if a trained input shifts),
+recorders, report sections -- one line each with the file:line.>
+
+## 7. Phase map
+
+<Which phase of the parent epic each piece lands in; the engine/corpus PR
+pair; merge order (engine first); the bless scope expected
+(`bless_scope --from-head --summary` leaf keys = this metric + section 6's
+consumers, nothing else).>

--- a/tests/tools/audit_score_inputs.py
+++ b/tests/tools/audit_score_inputs.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+"""
+Per-file input decomposition for the gated `_calc_*` risk formulas (#2916,
+generalising tests/tools/audit_documentation_inputs.py / #2910).
+
+For every scanned file it reads the inputs a formula consumes straight out of
+the galaxyscope database (the SHORT_KEY_MAP column names), calls the
+`SignalProcessor._calc_<metric>` directly with them, and compares the result to
+the recorded `risk_<metric>`. A residual means the decomposition no longer
+explains the score -- the fact every score contract rests on -- so the tool
+exits 1 (except `verification`, see its adapter note).
+
+One adapter per formula in ADAPTERS: which `file_data` columns feed which call
+arguments, how `fid`/`irc`/`ot` are obtained (`_language_constants`), how `mp`
+is obtained (`_get_locational_multipliers(file_path)`). Like the #2910 template,
+the popularity multiplier is tried both on and off per file and the reading that
+reproduces is reported (popularity 0 cannot tell them apart).
+
+Outputs: one row per file; a CLUSTER table keyed by the metric's dominant input;
+a SENSITIVITY table (score vs that input over its corpus range); `--summary`
+(one paragraph: n files, residuals, dominant input, points-per-unit).
+
+Usage:
+    python tests/tools/audit_score_inputs.py documentation --db path/to/x_galaxy_master.db
+    python tests/tools/audit_score_inputs.py api_exposure --corpus /path/to/keyword-rosetta/data
+    python tests/tools/audit_score_inputs.py tech_debt --corpus ... --languages c,python --summary
+
+Adapters shipped (the five carrying open-defect cells or a length leak):
+documentation, api_exposure, tech_debt, cognitive_load, verification.
+
+KNOWN LIMIT (verification): the per-function `impact` the formula's function
+loop consumes is computed in detector.py and NEVER persisted (function_data has
+complexity/loc/hit columns but no impact). The adapter therefore reproduces the
+FILE-level terms with `functions=[]`; any file whose score carries a function
+term shows as a residual tagged `function-term`, reported but not exit-failing
+-- stating the recording gap loudly instead of faking a reconstruction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from gitgalaxy.metrics.signal_processor import SignalProcessor
+
+EPSILON_DEFAULT = 0.01
+IGNORED_BASENAMES = {"expected_signals.json", "pyproject.toml"}
+
+
+# ---------------------------------------------------------------------------
+# adapters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Adapter:
+    recorded_col: str
+    # formula signal key -> file_data column
+    signal_cols: dict[str, str]
+    # other file_data columns the repro reads (guarded at load time)
+    extra_cols: tuple[str, ...]
+    repro: Callable[[SignalProcessor, dict, int], float]  # (p, row, popularity) -> score
+    cluster_label: str
+    cluster_key: Callable[[dict], int]
+    sens_label: str
+    sens: Callable[[SignalProcessor, str], list[tuple[int, float]]]
+    uses_popularity: bool = True
+    exit_on_residual: bool = True
+    note: str = ""
+    row_cols: tuple[str, ...] = field(default_factory=tuple)  # compact per-file columns
+
+
+def _signals(row: dict, cols: dict[str, str]) -> dict[str, int]:
+    return {k: int(row.get(c) or 0) for k, c in cols.items()}
+
+
+def _mp(p: SignalProcessor, row: dict, which: str) -> float:
+    return p._get_locational_multipliers(row["file_path"] or row["file_name"]).get(which, 1.0)
+
+
+def _consts(p: SignalProcessor, row: dict):
+    return p._language_constants(row["language"])  # (irc, ot, fid)
+
+
+def _repro_documentation(p: SignalProcessor, row: dict, popularity: int) -> float:
+    _irc, _ot, fid = _consts(p, row)
+    return float(
+        p._calc_documentation(
+            max(int(row["coding_loc"] or 0), 1),
+            int(row["doc_loc"] or 0),
+            _signals(row, ADAPTERS["documentation"].signal_cols),
+            fid,
+            _mp(p, row, "doc"),
+            None,
+            doc_umbrella=0.0,
+            popularity=popularity,
+            silo_exposure=float(row.get("silo_risk") or 0.0),
+        )
+    )
+
+
+def _repro_api_exposure(p: SignalProcessor, row: dict, popularity: int) -> float:
+    return float(
+        p._calc_api_exposure(
+            _signals(row, ADAPTERS["api_exposure"].signal_cols),
+            max(int(row.get("total_loc") or row["coding_loc"] or 0), 1),
+            popularity,
+        )
+    )
+
+
+def _repro_tech_debt(p: SignalProcessor, row: dict, popularity: int) -> float:
+    irc, _ot, _fid = _consts(p, row)
+    return float(
+        p._calc_tech_debt(
+            max(int(row["coding_loc"] or 0), 1),
+            _signals(row, ADAPTERS["tech_debt"].signal_cols),
+            irc,
+            _mp(p, row, "debt"),
+        )
+    )
+
+
+def _repro_cognitive_load(p: SignalProcessor, row: dict, popularity: int) -> float:
+    _irc, _ot, fid = _consts(p, row)
+    score, _density = p._calc_cog_load(
+        max(int(row["coding_loc"] or 0), 1),
+        _signals(row, ADAPTERS["cognitive_load"].signal_cols),
+        fid,
+        _mp(p, row, "cog"),
+        float(row.get("func_complexity_gini") or 0.0),
+    )
+    return float(score)
+
+
+def _repro_verification(p: SignalProcessor, row: dict, popularity: int) -> float:
+    _irc, ot, fid = _consts(p, row)
+    return float(
+        p._calc_verification(
+            max(int(row["coding_loc"] or 0), 1),
+            False,  # is_protected is not persisted per file
+            _signals(row, ADAPTERS["verification"].signal_cols),
+            ot,
+            fid,
+            _mp(p, row, "test"),
+            [],  # per-function impact is not persisted -- see KNOWN LIMIT above
+            {},
+            umbrella_bonus=0.0,
+            popularity=popularity,
+        )
+    )
+
+
+def _sens_generic(calc: Callable[[SignalProcessor, int], float]) -> Callable:
+    def go(p: SignalProcessor, language: str) -> list[tuple[int, float]]:
+        return [(x, float(calc(p, x))) for x in range(0, 8)]
+
+    return go
+
+
+ADAPTERS: dict[str, Adapter] = {
+    "documentation": Adapter(
+        recorded_col="risk_documentation",
+        signal_cols={
+            "api": "arch_api",
+            "doc": "def_doc",
+            "ownership": "def_ownership",
+            "reflection_metaprogramming": "state_heat_triggers",
+        },
+        extra_cols=("coding_loc", "doc_loc", "raw_arch_api", "silo_risk"),
+        repro=_repro_documentation,
+        cluster_label="adjusted api per file",
+        cluster_key=lambda r: int(r.get("arch_api") or 0),
+        sens_label="score vs adjusted api (doc_loc 2, others 0, loc 15)",
+        sens=lambda p, lang: [
+            (api, float(p._calc_documentation(15, 2, {"api": api}, p._language_constants(lang)[2], 1.0, None)))
+            for api in range(0, 8)
+        ],
+        row_cols=("coding_loc", "doc_loc", "raw_arch_api", "arch_api", "def_doc", "def_ownership"),
+    ),
+    "api_exposure": Adapter(
+        recorded_col="risk_api_exposure",
+        signal_cols={"api": "arch_api", "encapsulation": "def_encapsulation"},
+        extra_cols=("coding_loc", "total_loc"),
+        repro=_repro_api_exposure,
+        cluster_label="adjusted api per file",
+        cluster_key=lambda r: int(r.get("arch_api") or 0),
+        sens_label="score vs api (encapsulation 0, total_loc 15, popularity 0)",
+        sens=lambda p, lang: [(api, float(p._calc_api_exposure({"api": api}, 15, 0))) for api in range(0, 8)],
+        row_cols=("total_loc", "arch_api", "def_encapsulation"),
+    ),
+    "tech_debt": Adapter(
+        recorded_col="risk_tech_debt",
+        signal_cols={
+            "planned_debt": "state_planned_debt",
+            "fragile_debt": "state_fragile_debt",
+            "unreferenced_by_name": "state_unreferenced",
+            "duplicate_logic": "state_slop_duplicates",
+        },
+        extra_cols=("coding_loc",),
+        repro=_repro_tech_debt,
+        cluster_label="planned+fragile debt per file",
+        cluster_key=lambda r: int(r.get("state_planned_debt") or 0) + int(r.get("state_fragile_debt") or 0),
+        sens_label="score vs fragile_debt (planned 0, slop 0, loc 15)",
+        sens=lambda p, lang: [
+            (n, float(p._calc_tech_debt(15, {"fragile_debt": n}, p._language_constants(lang)[0], 1.0)))
+            for n in range(0, 8)
+        ],
+        uses_popularity=False,
+        row_cols=("coding_loc", "state_planned_debt", "state_fragile_debt", "state_unreferenced"),
+    ),
+    "cognitive_load": Adapter(
+        recorded_col="risk_cognitive_load",
+        signal_cols={
+            "branch": "struct_branch",
+            "state_mutation": "state_flux",
+            "concurrency": "arch_concurrency",
+            "reflection_metaprogramming": "state_heat_triggers",
+            "doc": "def_doc",
+        },
+        extra_cols=("coding_loc", "func_complexity_gini"),
+        repro=_repro_cognitive_load,
+        cluster_label="branch hits per file",
+        cluster_key=lambda r: int(r.get("struct_branch") or 0),
+        sens_label="score vs branch (flux 0, doc 0, gini 0, loc 15)",
+        sens=lambda p, lang: [
+            (b, float(p._calc_cog_load(15, {"branch": b}, p._language_constants(lang)[2], 1.0, 0.0)[0]))
+            for b in range(0, 8)
+        ],
+        uses_popularity=False,
+        row_cols=("coding_loc", "struct_branch", "state_flux", "func_complexity_gini"),
+    ),
+    "verification": Adapter(
+        recorded_col="risk_verification",
+        signal_cols={
+            "high_risk_execution": "state_danger",
+            "test": "def_test",
+            "safety": "def_safety",
+            "test_skip": "def_test_skip",
+        },
+        extra_cols=("coding_loc",),
+        repro=_repro_verification,
+        cluster_label="file-level danger hits",
+        cluster_key=lambda r: int(r.get("state_danger") or 0),
+        sens_label="score vs high_risk_execution (functions [], loc 15)",
+        sens=lambda p, lang: [
+            (
+                d,
+                float(
+                    p._calc_verification(
+                        15,
+                        False,
+                        {"high_risk_execution": d},
+                        p._language_constants(lang)[1],
+                        p._language_constants(lang)[2],
+                        1.0,
+                        [],
+                        {},
+                    )
+                ),
+            )
+            for d in range(0, 8)
+        ],
+        exit_on_residual=False,
+        note=(
+            "KNOWN LIMIT: per-function `impact` is not persisted, so the function\n"
+            "term runs with functions=[] -- residuals tagged `function-term` are the\n"
+            "recording gap itself, reported but not exit-failing (#2916)."
+        ),
+        row_cols=("coding_loc", "state_danger", "def_test", "def_safety"),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# reading (SELECT *, guarded)
+# ---------------------------------------------------------------------------
+
+
+def read_db(db_path: pathlib.Path, adapter: Adapter, language_hint: str | None) -> list[dict]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    have = {r[1] for r in conn.execute("PRAGMA table_info(file_data)")}
+    needed = (
+        {"file_name", "file_path", "language", "popularity", adapter.recorded_col}
+        | set(adapter.signal_cols.values())
+        | set(adapter.extra_cols)
+    )
+    missing = sorted(c for c in needed if c not in have)
+    if missing:
+        raise SystemExit(f"{db_path}: file_data lacks {missing}")
+    rows = [dict(r) for r in conn.execute("SELECT * FROM file_data ORDER BY file_name")]
+    conn.close()
+    out = []
+    for r in rows:
+        if r["file_name"] in IGNORED_BASENAMES:
+            continue
+        if language_hint:
+            r["language"] = language_hint
+        out.append(r)
+    return out
+
+
+def scan_folder(folder: pathlib.Path, out_dir: pathlib.Path) -> pathlib.Path:
+    exe = os.environ.get("GALAXYSCOPE_BIN")
+    cmd = [exe] if exe else [sys.executable, "-c", "from gitgalaxy.galaxyscope import main; main()"]
+    before = set(out_dir.rglob("*.db"))
+    result = subprocess.run([*cmd, str(folder), "--db-only"], cwd=out_dir, capture_output=True, text=True, timeout=600)
+    dbs = sorted(p for p in out_dir.rglob("*.db") if p not in before)
+    if result.returncode != 0 or not dbs:
+        sys.stderr.write(result.stdout[-2000:] + result.stderr[-2000:])
+        raise SystemExit(f"galaxyscope failed on {folder} (rc={result.returncode})")
+    return dbs[0]
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+def run(metric: str, files: list[dict], *, epsilon: float, summary: bool) -> int:
+    a = ADAPTERS[metric]
+    p = SignalProcessor()
+    if a.note:
+        print(a.note + "\n")
+    residuals: list[dict] = []
+    pop_on = pop_off = 0
+    hdr = " ".join(f"{c.split('_')[-1][:5]:>5}" for c in a.row_cols)
+    print(f"{'language':16s} {'file':20s} {hdr} | {'recorded':>8} {'repro':>8} {'resid':>7}")
+    by_key: dict[int, list[dict]] = defaultdict(list)
+    for f in files:
+        recorded = float(f.get(a.recorded_col) or 0.0)
+        popularity = int(f.get("popularity") or 0)
+        if a.uses_popularity:
+            w = a.repro(p, f, popularity)
+            wo = a.repro(p, f, 0)
+            distinguishable = abs(w - wo) > epsilon
+            if distinguishable and abs(w - recorded) <= epsilon:
+                repro = w
+                pop_on += 1
+            elif abs(wo - recorded) <= epsilon:
+                repro = wo
+                if distinguishable:
+                    pop_off += 1
+            else:
+                repro = w
+        else:
+            repro = a.repro(p, f, popularity)
+        resid = recorded - repro
+        bad = abs(resid) > epsilon
+        if bad:
+            residuals.append(f)
+        tag = ("   <-- function-term" if metric == "verification" else "   <-- NOT REPRODUCED") if bad else ""
+        vals = " ".join(f"{int(f.get(c) or 0):>5}" for c in a.row_cols)
+        print(f"{f['language']:16s} {f['file_name'][:20]:20s} {vals} | {recorded:>8.2f} {repro:>8.2f} {resid:>7.2f}{tag}")
+        by_key[a.cluster_key(f)].append(f)
+
+    print(f"\n## CLUSTER: files by {a.cluster_label}")
+    print(f"{'key':>4} {'files':>5} {'score min':>9} {'score max':>9}  languages")
+    for k in sorted(by_key):
+        g = by_key[k]
+        scores = [float(x.get(a.recorded_col) or 0.0) for x in g]
+        langs = sorted({x["language"] for x in g})
+        print(f"{k:>4} {len(g):>5} {min(scores):>9.2f} {max(scores):>9.2f}  {', '.join(langs)}")
+
+    steps: list[float] = []
+    if files:
+        print(f"\n## SENSITIVITY: {a.sens_label}")
+        rows = a.sens(p, files[0]["language"])
+        print("  x      " + " ".join(f"{x:>6}" for x, _ in rows))
+        print("  score  " + " ".join(f"{s:>6.1f}" for _, s in rows))
+        steps = [rows[i + 1][1] - rows[i][1] for i in range(1, len(rows) - 1)]
+        if steps:
+            print(f"  points per additional unit (1..7): {min(steps):.1f} to {max(steps):.1f}")
+
+    if a.uses_popularity:
+        print(f"\npopularity multiplier: reproduced with it on {pop_on} file(s), with it off {pop_off} file(s)")
+
+    if summary:
+        dom = a.cluster_label
+        ppu = f"{min(steps):.1f}-{max(steps):.1f}" if steps else "n/a"
+        print(
+            f"\n--summary: {len(files)} files; {len(residuals)} residual(s); dominant input: {dom}; "
+            f"points per unit: {ppu}."
+        )
+
+    if residuals and a.exit_on_residual:
+        print(f"\nFAIL: {len(residuals)} file(s) not reproduced from their recorded inputs (epsilon {epsilon}).")
+        return 1
+    if residuals:
+        print(f"\nWARN: {len(residuals)} residual file(s) -- see the adapter's KNOWN LIMIT note; exit 0 by design.")
+        return 0
+    print(f"\nOK: every recorded {a.recorded_col} reproduced from its inputs ({len(files)} files).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("metric", choices=sorted(ADAPTERS))
+    ap.add_argument("--db", action="append", default=[], help="a galaxyscope *_galaxy_master.db (repeatable)")
+    ap.add_argument("--corpus", help="keyword-rosetta data/ directory: scan each language folder")
+    ap.add_argument("--languages", help="comma-separated subset of --corpus folders")
+    ap.add_argument("--epsilon", type=float, default=EPSILON_DEFAULT)
+    ap.add_argument("--summary", action="store_true", help="one-paragraph digest for the PR body")
+    args = ap.parse_args(argv)
+    if not args.db and not args.corpus:
+        ap.error("give --db or --corpus")
+
+    adapter = ADAPTERS[args.metric]
+    files: list[dict] = []
+    for db in args.db:
+        files.extend(read_db(pathlib.Path(db), adapter, None))
+    if args.corpus:
+        root = pathlib.Path(args.corpus)
+        wanted = set(args.languages.split(",")) if args.languages else None
+        with tempfile.TemporaryDirectory(prefix="score_inputs_") as tmp:
+            for folder in sorted(d for d in root.iterdir() if d.is_dir() and not d.name.startswith(".")):
+                if wanted and folder.name not in wanted:
+                    continue
+                out = pathlib.Path(tmp) / folder.name
+                out.mkdir()
+                files.extend(read_db(scan_folder(folder, out), adapter, folder.name))
+    files.sort(key=lambda f: (f["language"], f["file_name"]))
+    return run(args.metric, files, epsilon=args.epsilon, summary=args.summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/audit_score_inputs.py
+++ b/tests/tools/audit_score_inputs.py
@@ -56,7 +56,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Callable
 
 from gitgalaxy.metrics.signal_processor import SignalProcessor
 

--- a/tests/tools/bless_scope.py
+++ b/tests/tools/bless_scope.py
@@ -56,11 +56,39 @@ def _unparsable(doc: dict) -> dict[str, str]:
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("old")
+    ap.add_argument("old", nargs="?", help="pre-bless fixture (omit with --from-head)")
     ap.add_argument("new")
+    ap.add_argument(
+        "--from-head",
+        action="store_true",
+        help="#2916: take the pre-bless fixture from `git show HEAD:<new>` itself, "
+        "so the whole recipe is one command run after the bless",
+    )
     ap.add_argument("--show", type=int, default=8, help="substantive diff lines to print")
     ap.add_argument("--grep", help="only print diff lines containing this text")
+    ap.add_argument(
+        "--summary",
+        action="store_true",
+        help="#2916: append the PR-body block -- one line per (file x leaf keys)",
+    )
     args = ap.parse_args(argv)
+
+    if args.from_head:
+        if args.old is not None:
+            ap.error("--from-head takes only the NEW fixture path")
+        import subprocess
+        import tempfile
+
+        rel = str(Path(args.new).resolve().relative_to(Path.cwd().resolve()))
+        blob = subprocess.run(
+            ["git", "show", f"HEAD:{rel}"], capture_output=True, text=True, check=True
+        ).stdout
+        tf = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        tf.write(blob)
+        tf.close()
+        args.old = tf.name
+    elif args.old is None:
+        ap.error("old fixture required (or pass --from-head)")
 
     old, new = gd.load_and_sanitize(args.old), gd.load_and_sanitize(args.new)
     diffs = [str(d) for d in gd.deep_compare(old, new)]
@@ -102,6 +130,29 @@ def main(argv: list[str] | None = None) -> int:
         print(f"\nfirst {len(shown)} substantive lines{' matching ' + repr(args.grep) if args.grep else ''}:")
         for d in shown:
             print("  " + d[:240])
+
+    if args.summary:
+        # #2916: the PR-body block -- one line per file, listing the leaf keys that
+        # moved in it, so a reviewer sees the bless's shape without the raw diff.
+        by_file: dict[str, set] = collections.defaultdict(set)
+        for d in rest:
+            m = _AT.search(d)
+            if not m:
+                continue
+            segs = m.group(1).strip("/").split("/")
+            ml = _LANG.search(m.group(1))
+            fname = next(
+                (s for s in segs if re.search(r"\.[A-Za-z0-9]{1,8}$", s) and not s[:1].isdigit()),
+                segs[0],
+            )
+            key = f"{ml.group(1) + '/' if ml else ''}{fname}"
+            by_file[key].add(segs[-1][:40])
+        print(f"\n--summary ({len(by_file)} files moved):")
+        for f in sorted(by_file):
+            keys = sorted(by_file[f])
+            head = ", ".join(keys[:6])
+            more = f" (+{len(keys) - 6} more)" if len(keys) > 6 else ""
+            print(f"  {f}: {head}{more}")
     return 0
 
 

--- a/tests/tools/contract_pr_check.py
+++ b/tests/tools/contract_pr_check.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+"""
+The contract-PR gauntlet in one command (#2916).
+
+From the current worktree, runs the legs a rule- or score-contract PR owes --
+in parallel where they are independent -- and prints a PR-body block with the
+four standard sections (Measured / Corpus / Golden masters / Tests) filled from
+the tools' own output:
+
+  1. extraction strict tests for the TOUCHED languages (`git diff --name-only`
+     against origin/main, mapped language_standards/languages/<lang>.py ->
+     tests/extraction/languages/test_<lang>_strict.py);
+  2. `rosetta_audit.py --allow-regressions --corpus <kr-worktree>`;
+  3. `crucible_check.py` (verification mode -- run your bless FIRST);
+  4. `bless_scope.py --from-head <fixture> --summary` on both fixtures;
+  5. `audit_check.py` (the baseline-gated audit battery).
+
+Usage:
+    PATH=<venv>/bin:$PATH python tests/tools/contract_pr_check.py --corpus <kr-worktree>
+    python tests/tools/contract_pr_check.py --score --corpus ...   # adds no legs today;
+        # --rules/--score label the PR-body header so the block says which contract
+        # family the run certifies (score contracts add audit_score_inputs runs by hand).
+
+Exit: nonzero if any leg failed; the PR-body block prints either way, with
+failed legs marked, so a red run still yields the review artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PY = sys.executable
+
+
+def sh(cmd: list[str], timeout: int = 1800) -> tuple[int, str]:
+    r = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=timeout)
+    return r.returncode, (r.stdout + r.stderr)
+
+
+def touched_languages() -> list[str]:
+    rc, out = sh(["git", "diff", "--name-only", "origin/main...HEAD"])
+    if rc != 0:
+        rc, out = sh(["git", "diff", "--name-only", "origin/main"])
+    langs = set()
+    for line in out.splitlines():
+        p = Path(line.strip())
+        if p.parent.as_posix().endswith("language_standards/languages") and p.suffix == ".py":
+            langs.add(p.stem)
+    return sorted(langs)
+
+
+def leg_extraction(langs: list[str]) -> tuple[str, int, str]:
+    tests = [
+        f"tests/extraction/languages/test_{lang}_strict.py"
+        for lang in langs
+        if (REPO_ROOT / f"tests/extraction/languages/test_{lang}_strict.py").is_file()
+    ]
+    if not tests:
+        return ("extraction (no touched languages)", 0, "skipped: git diff touched no language file")
+    rc, out = sh([PY, "-m", "pytest", *tests, "-q", "-p", "no:cacheprovider"])
+    tail = out.strip().splitlines()[-1] if out.strip() else ""
+    return (f"extraction strict ({len(tests)} languages)", rc, tail)
+
+
+def leg_rosetta(corpus: str | None) -> tuple[str, int, str]:
+    cmd = [PY, "tests/tools/rosetta_audit.py", "--allow-regressions"]
+    if corpus:
+        cmd += ["--corpus", corpus]
+    rc, out = sh(cmd)
+    tail = next((ln for ln in reversed(out.splitlines()) if "rosetta_audit:" in ln), out.strip().splitlines()[-1] if out.strip() else "")
+    return ("rosetta_audit --allow-regressions", rc, tail)
+
+
+def leg_crucible() -> tuple[str, int, str]:
+    rc, out = sh([PY, "tests/tools/crucible_check.py"], timeout=3600)
+    verdicts = [ln.strip() for ln in out.splitlines() if "PASS" in ln or "FAIL" in ln]
+    return ("crucible_check (verify)", rc, "; ".join(verdicts[-2:]) or out.strip().splitlines()[-1])
+
+
+def leg_bless_scope() -> tuple[str, int, str]:
+    chunks = []
+    worst = 0
+    for fixture in ("tests/golden_master_audit.json", "tests/golden_master_zero_dep_audit.json"):
+        rc, out = sh([PY, "tests/tools/bless_scope.py", "--from-head", fixture, "--show", "0", "--summary"])
+        worst = max(worst, rc)
+        lines = out.splitlines()
+        head = lines[0] if lines else ""
+        summ = next((i for i, ln in enumerate(lines) if ln.startswith("--summary")), None)
+        block = "\n".join(lines[summ : summ + 9]) if summ is not None else ""
+        chunks.append(f"{Path(fixture).name}: {head}\n{block}")
+    return ("bless_scope --from-head (both fixtures)", worst, "\n".join(chunks))
+
+
+def leg_audit_check() -> tuple[str, int, str]:
+    rc, out = sh([PY, "tests/tools/audit_check.py"])
+    tail = "\n".join(out.strip().splitlines()[-3:])
+    return ("audit_check (baseline-gated battery)", rc, tail)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    fam = ap.add_mutually_exclusive_group()
+    fam.add_argument("--rules", action="store_true", help="label the block as a rule-contract run (default)")
+    fam.add_argument("--score", action="store_true", help="label the block as a score-contract run")
+    ap.add_argument("--corpus", help="keyword-rosetta worktree for rosetta_audit")
+    args = ap.parse_args(argv)
+
+    langs = touched_languages()
+    with cf.ThreadPoolExecutor(max_workers=4) as ex:
+        futs = {
+            "extraction": ex.submit(leg_extraction, langs),
+            "rosetta": ex.submit(leg_rosetta, args.corpus),
+            "crucible": ex.submit(leg_crucible),
+            "audits": ex.submit(leg_audit_check),
+        }
+        results = {k: f.result() for k, f in futs.items()}
+    # bless_scope reads the same fixtures crucible_check verifies -- run it after.
+    results["bless"] = leg_bless_scope()
+
+    family = "score-contract" if args.score else "rule-contract"
+    failed = [name for name, (_, rc, _) in results.items() if rc != 0]
+    print(f"\n{'=' * 72}\n## PR body -- {family} gauntlet ({'ALL GREEN' if not failed else 'FAILED: ' + ', '.join(failed)})\n")
+    print("### Measured")
+    print(f"- touched languages: {', '.join(langs) or 'none'}")
+    print(f"- {results['extraction'][0]}: {'PASS' if results['extraction'][1] == 0 else 'FAIL'} -- {results['extraction'][2]}")
+    print("\n### Corpus")
+    print(f"- {results['rosetta'][0]}: {'PASS' if results['rosetta'][1] == 0 else 'FAIL'} -- {results['rosetta'][2]}")
+    print("\n### Golden masters")
+    print(f"- {results['crucible'][0]}: {'PASS' if results['crucible'][1] == 0 else 'FAIL'} -- {results['crucible'][2]}")
+    for ln in results["bless"][2].splitlines():
+        print(f"  {ln}")
+    print("\n### Tests")
+    print(f"- {results['audits'][0]}: {'PASS' if results['audits'][1] == 0 else 'FAIL'}")
+    for ln in results["audits"][2].splitlines():
+        print(f"  {ln}")
+    print("=" * 72)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/rule_probe.py
+++ b/tests/tools/rule_probe.py
@@ -188,6 +188,14 @@ def probe(
                 line = text[ls : len(text) if le < 0 else le].strip()
                 tag = "" if len(streams) == 1 else f"{sname[:4]} "
                 c["samples"][(tag + m.group(0).strip()[:40], line[:120])] += 1
+                # --diff-lines (#2916) reads these: every matched span with its
+                # 1-based line number, so two snapshots of the SAME corpus under
+                # different rule candidates can be diffed line-by-line. Line
+                # numbers are stable across snapshots because the corpus doesn't
+                # change between them -- only the rule does.
+                c.setdefault("lines", {}).setdefault(rel, []).append(
+                    [text.count("\n", 0, m.start()) + 1, m.group(0)[:200]]
+                )
     for c in per.values():
         c["samples"] = [(tok, line, n) for (tok, line), n in c["samples"].most_common(samples)]
     return per
@@ -229,6 +237,68 @@ def compare(before: dict, after: dict, langs: list[str]) -> None:
         print(f"| `{lang}` | {cell('crucible')} | {cell('rosetta')} |")
 
 
+def _context_lines(lang: str, rel: str, lineno: int, n: int) -> list[str]:
+    """±n source lines around lineno, re-read from whichever corpus holds rel (best effort)."""
+    d = CORPUS_DIR.get(lang, lang)
+    for root in (CRUCIBLE / d, ROSETTA / d):
+        p = root / rel
+        if p.is_file():
+            try:
+                src = p.read_text(encoding="utf-8", errors="replace").splitlines()
+            except OSError:
+                return []
+            lo, hi = max(0, lineno - 1 - n), min(len(src), lineno + n)
+            return [f"{'>' if i == lineno - 1 else ' '} {i + 1:5d} {src[i]}" for i in range(lo, hi)]
+    return []
+
+
+def diff_lines(before: dict, after: dict, langs: list[str], context: int) -> int:
+    """#2916: list lost and gained matched lines per corpus, with counts.
+
+    The #2907 session wrote this twice by hand; its first rule candidate lost 21
+    Doom K&R definitions that only this listing showed. Keyed on
+    (file, lineno, matched text) as a multiset -- a line matching twice under one
+    rule and once under the other shows up. Multi-line matches print in full
+    (their span IS the context); --context N adds N surrounding source lines
+    re-read from the corpus when it is checked out.
+    """
+    total_lost = total_gained = 0
+    for lang in langs:
+        for corpus in ("crucible", "rosetta"):
+            b = ((before.get(lang) or {}).get(corpus) or {}).get("lines", {})
+            a = ((after.get(lang) or {}).get(corpus) or {}).get("lines", {})
+            bc: collections.Counter = collections.Counter(
+                (rel, ln, txt) for rel, ms in b.items() for ln, txt in ms
+            )
+            ac: collections.Counter = collections.Counter(
+                (rel, ln, txt) for rel, ms in a.items() for ln, txt in ms
+            )
+            lost, gained = bc - ac, ac - bc
+            if not lost and not gained:
+                continue
+            total_lost += sum(lost.values())
+            total_gained += sum(gained.values())
+            print(f"\n{lang} / {corpus}: -{sum(lost.values())} lost, +{sum(gained.values())} gained")
+            for label, bag in (("LOST", lost), ("GAINED", gained)):
+                for (rel, ln, txt) in sorted(bag):
+                    n = bag[(rel, ln, txt)]
+                    mark = f" x{n}" if n > 1 else ""
+                    if "\n" in txt:
+                        print(f"  {label}{mark} {rel}:{ln} (multi-line match)")
+                        for tl in txt.splitlines():
+                            print(f"      | {tl}")
+                    else:
+                        print(f"  {label}{mark} {rel}:{ln}: {txt.strip()[:160]}")
+                    if context:
+                        for cl in _context_lines(lang, rel, ln, context):
+                            print(f"      {cl}")
+    if total_lost == 0 and total_gained == 0:
+        print("no matched-line movement between the snapshots")
+    else:
+        print(f"\ntotal: -{total_lost} lost, +{total_gained} gained")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("rule")
@@ -245,6 +315,13 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--flags", default="", help="flags for --override, e.g. IM")
     ap.add_argument("--json", help="write the per-language snapshot here")
     ap.add_argument("--compare", nargs=2, metavar=("BEFORE", "AFTER"), help="print audit-table rows from two snapshots")
+    ap.add_argument(
+        "--diff-lines",
+        nargs=2,
+        metavar=("BEFORE", "AFTER"),
+        help="list lost and gained matched LINES between two --json snapshots (#2916)",
+    )
+    ap.add_argument("--context", type=int, default=0, help="source lines of context around each --diff-lines entry")
     args = ap.parse_args(argv)
 
     langs = sorted(LANGUAGE_DEFINITIONS) if args.lang == "all" else [args.lang]
@@ -252,6 +329,9 @@ def main(argv: list[str] | None = None) -> int:
         before, after = (json.loads(Path(p).read_text(encoding="utf-8")) for p in args.compare)
         compare(before, after, langs)
         return 0
+    if args.diff_lines:
+        before, after = (json.loads(Path(p).read_text(encoding="utf-8")) for p in args.diff_lines)
+        return diff_lines(before, after, langs, args.context)
 
     override = compile_override(args.override, args.flags) if args.override else None
     prism = Prism(LEXICAL_FAMILY_HEURISTICS, LANGUAGE_DEFINITIONS)

--- a/tests/tools/worktree_env.sh
+++ b/tests/tools/worktree_env.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# GitGalaxy
+# Copyright (c) 2026 Joe Esquibel
+#
+# This source code is licensed under the PolyForm Noncommercial License 1.0.0.
+# You may not use this file except in compliance with the License.
+# A copy of the license can be found in the LICENSE file in the root directory
+# of this project, or at https://polyformproject.org/licenses/noncommercial/1.0.0/
+# ==============================================================================
+# worktree_env.sh <name> [--corpus]   (#2916)
+#
+# Every environment trap of the #2908 session -- wrong-path worktree, background
+# job from a drifted cwd, stale corpus worktree producing a phantom mismatch --
+# is this script not existing. It:
+#   1. refuses to run its checkout steps against the PRIMARY checkout;
+#   2. `git fetch`es, then creates (or re-detaches to origin/main) the engine
+#      worktree at <worktrees-root>/<name>, where <worktrees-root> is
+#      <repo-parent>/gitgalaxy-worktrees -- ~/nyx_projects/gitgalaxy-worktrees on
+#      the primary box, .../projects/gitgalaxy/gitgalaxy-worktrees elsewhere --
+#      overridable via GITGALAXY_WORKTREES;
+#   3. with --corpus, does the same for keyword-rosetta at
+#      <corpus-parent>/keyword-rosetta-worktrees/<name> (KEYWORD_ROSETTA_WORKTREES);
+#   4. prints the five exports as copy-paste lines. PYTHONPATH comes FIRST on
+#      sys.path, so the worktree's engine code wins over the primary venv's
+#      editable install even when GALAXYSCOPE_BIN is the primary venv's stub --
+#      the confirmed-root-cause trap crucible_check.py's docstring documents.
+set -euo pipefail
+
+usage() { echo "usage: tests/tools/worktree_env.sh <name> [--corpus]" >&2; exit 2; }
+[ $# -ge 1 ] || usage
+NAME="$1"; shift
+WANT_CORPUS=0
+[ "${1:-}" = "--corpus" ] && WANT_CORPUS=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMARY="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+WT_ROOT="${GITGALAXY_WORKTREES:-$(dirname "$PRIMARY")/gitgalaxy-worktrees}"
+WT="$WT_ROOT/$NAME"
+
+if [ "$WT" = "$PRIMARY" ] || [ "$(cd "$WT" 2>/dev/null && pwd)" = "$PRIMARY" ]; then
+  echo "refusing: target resolves to the primary checkout ($PRIMARY)" >&2
+  exit 1
+fi
+
+git -C "$PRIMARY" fetch origin --quiet
+mkdir -p "$WT_ROOT"
+if [ -d "$WT/.git" ] || [ -f "$WT/.git" ]; then
+  git -C "$WT" fetch origin --quiet || true
+  git -C "$WT" checkout --detach origin/main --quiet
+  echo "engine worktree re-detached at origin/main: $WT" >&2
+else
+  git -C "$PRIMARY" worktree add --detach "$WT" origin/main >&2
+  echo "engine worktree created: $WT" >&2
+fi
+
+# Corpus roots via the same sibling logic rule_probe.py uses.
+sibling() { # <name>
+  for base in "$(dirname "$PRIMARY")" "$(dirname "$(dirname "$PRIMARY")")"; do
+    if [ -d "$base/$1/data" ]; then echo "$base/$1"; return; fi
+  done
+  echo "$(dirname "$PRIMARY")/$1"
+}
+CRUCIBLE="${LANGUAGE_CRUCIBLE_PATH:-$(sibling language-crucible)}"
+ROSETTA_MAIN="${KEYWORD_ROSETTA_PATH:-$(sibling keyword-rosetta)}"
+ROSETTA="$ROSETTA_MAIN"
+
+if [ "$WANT_CORPUS" = 1 ]; then
+  KR_ROOT="${KEYWORD_ROSETTA_WORKTREES:-$(dirname "$ROSETTA_MAIN")/keyword-rosetta-worktrees}"
+  KR_WT="$KR_ROOT/$NAME"
+  if [ "$KR_WT" = "$ROSETTA_MAIN" ]; then
+    echo "refusing: corpus target resolves to the primary corpus checkout" >&2
+    exit 1
+  fi
+  git -C "$ROSETTA_MAIN" fetch origin --quiet
+  mkdir -p "$KR_ROOT"
+  if [ -d "$KR_WT/.git" ] || [ -f "$KR_WT/.git" ]; then
+    git -C "$KR_WT" fetch origin --quiet || true
+    git -C "$KR_WT" checkout --detach origin/main --quiet
+    echo "corpus worktree re-detached at origin/main: $KR_WT" >&2
+  else
+    git -C "$ROSETTA_MAIN" worktree add --detach "$KR_WT" origin/main >&2
+    echo "corpus worktree created: $KR_WT" >&2
+  fi
+  ROSETTA="$KR_WT"
+fi
+
+echo
+CORPUS_FLAG=""
+[ "$WANT_CORPUS" = 1 ] && CORPUS_FLAG=" --corpus"
+echo "# copy-paste (or: eval \"\$(tests/tools/worktree_env.sh $NAME$CORPUS_FLAG 2>/dev/null)\"):"
+echo "export PYTHONPATH=$WT"
+echo "export GITGALAXY_PATH=$WT"
+echo "export GALAXYSCOPE_BIN=$PRIMARY/.venv/bin/galaxyscope"
+echo "export LANGUAGE_CRUCIBLE_PATH=$CRUCIBLE"
+echo "export KEYWORD_ROSETTA_PATH=$ROSETTA"


### PR DESCRIPTION
The seven items #2908's efficiency assessment asked for, so a score contract
costs a fraction of a session the way a rule contract does. Each verified by
running it on real corpus data before committing:

- tests/tools/audit_score_inputs.py <metric>: generalises the #2910
  documentation-inputs auditor to one adapter per _calc_* (documentation,
  api_exposure, tech_debt, cognitive_load, verification). Reproduces every
  recorded risk_<metric> from its recorded file_data inputs; per-file rows,
  CLUSTER by dominant input, SENSITIVITY, --summary; exit 1 on residual.
  Verified: 4/5 formulas reproduce with 0 residuals on the rosetta corpus.
  verification warns instead of failing: per-function `impact` is computed in
  detector.py and never persisted, so its function term cannot be reproduced
  from the DB -- a recording gap this tool now states loudly.
- tests/tools/rule_probe.py --diff-lines before.json after.json [--context N]:
  lost/gained matched lines per corpus with counts; --json snapshots now carry
  every matched span with its line number. Verified: a dropped ruby `unless`
  showed all 12 lost lines with context (the #2907 Doom-K&R failure mode).
- tests/tools/contract_pr_check.py [--rules|--score] --corpus <kr>: the PR
  gauntlet in one command -- touched-language strict tests, rosetta_audit
  --allow-regressions, crucible_check verify, bless_scope --from-head
  --summary on both fixtures, audit_check -- parallel where independent, then
  the PR-body block (Measured / Corpus / Golden masters / Tests). Verified:
  full run ALL GREEN on this branch.
- tests/tools/bless_scope.py --from-head + --summary: the pre-bless fixture
  from `git show HEAD:` so the recipe is one command; --summary prints one
  line per moved file x leaf keys. Verified against the #2929 bless diff.
- tests/tools/worktree_env.sh <name> [--corpus]: fetch, create-or-redetach
  the engine (and corpus) worktrees at the machine's real worktree roots
  (<repo-parent>/gitgalaxy-worktrees -- resolves correctly on both the
  ~/nyx_projects and the /srv layouts), refuse the primary checkout, print
  the five exports. Verified: created, re-detached idempotently, exports
  drove a live rule_probe from the worktree code.
- .claude/agents/contract-audit-scout.md: machine-neutral venv paths (the
  primary box's ~/nyx_projects/gitgalaxy/.venv named), worktree_env.sh as the
  environment step, --diff-lines in Job 2, and a new Job 6 for the two score
  tools.
- .claude/skills/score-contract-audit/SKILL.md + docs/_score_contract_template.md:
  the score-layer twin of rule-contract-audit -- same tier table and
  never-delegate list by reference, phases with exact commands, the
  D-decision and acceptance-table templates, sections mirroring
  docs/risk_documentation_contract.md.

Closes #2916

## Gauntlet (generated by the new tool itself)
```

========================================================================
## PR body -- rule-contract gauntlet (ALL GREEN)

### Measured
- touched languages: none
- extraction (no touched languages): PASS -- skipped: git diff touched no language file

### Corpus
- rosetta_audit --allow-regressions: PASS -- rosetta_audit: 46 language(s) checked -- 42 regression(s), 0 pre-existing, 0 broken.

### Golden masters
- crucible_check (verify): PASS -- ✅ full_precision: PASS; ✅ zero_dependency: PASS
  golden_master_audit.json: 0 differences: 0 topological (X/Y/Z re-solve), 0 substantive
  --summary (0 files moved):
  golden_master_zero_dep_audit.json: 0 differences: 0 topological (X/Y/Z re-solve), 0 substantive
  --summary (0 files moved):

### Tests
- audit_check (baseline-gated battery): PASS
  [ast-accuracy] ast_accuracy_audit: OK -- matches the committed baseline, no regressions.
  
  audit_check: all clear.
========================================================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBL6TAMVXRUY7iQyy9Ysvi