### PR TITLE
docs: risk_documentation score contract goes stated (#2908 Phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,11 @@ The chart colours each deviation by *cause*, not size: red is an open engine
 defect (a rule matching the wrong construct, or a scoring weight sitting inside
 a count); grey is a documented variation the ledger has validated — the language
 cannot express the construct, a deliberate scoring choice, or an echo of another
-row. Current answer: 90% of language × metric cells sit within ±25% of the
-cross-language median across 48 gated metrics, and **2.7% (62 of 2,303) are
-open defects** — concentrated in the orphan census (`raw_state_unreferenced`,
-28% of its cells) and `branch` (27%), named on the chart rather than hidden.
+row. Current answer: on average 95% of languages sit within ±25% of the
+cross-language median per gated metric (55 chartable metrics, 54 holding ≥80%),
+and **0.1% (3 of 2,633 comparable cells) are open defects** — what remains is
+named on the chart rather than hidden: `raw_arch_api` (2 cells) and
+`func_complexity_gini` (1), the next score contracts' territory.
 Every deviation is recorded in a validated ledger, the open defects are worked
 by cause family under the [contract roadmap](docs/contract_roadmap.md), and
 the defect classes found this way are

--- a/docs/contract_roadmap.md
+++ b/docs/contract_roadmap.md
@@ -191,6 +191,11 @@ units come from the sheet.
 
 ### Phase 4 — Score contracts + the commensurability audit
 
+- **done (first formula)** `risk_documentation` (#2908): equation replaced by the per-unit
+  coverage ratio (#2938), corpus re-blessed and the report reads the per-unit inputs
+  (keyword-rosetta#120/#121), D5 confirmed on real code, sheet row `stated` — the first entry
+  in `signal_contracts.py`'s score-contract section. `risk_api_exposure`, `risk_tech_debt` and
+  `func_complexity_gini` copy #2908's phase list; #2771 answered by its D2 per-unit name set.
 - **repo** gitgalaxy: one tooling PR, then one PR per formula
 - **change** `tests/tools/audit_commensurability.py`: walks each `_calc_*` AST (the corpus's
   `_SignalUses` approach in `_registry.py`), reads units from the sheet, flags `+`/`−` between

--- a/docs/risk_documentation_contract.md
+++ b/docs/risk_documentation_contract.md
@@ -5,9 +5,12 @@
 > that a public unit counts double and a unit doing runtime-decided work counts more. It is a
 > ratio over units, never a density over lines. A file with no extracted units has no value.**
 
-**Status: `draft`** — D1–D6 approved on #2908 (2026-09-09); Phase 3 landed the §1 equation in
-`signal_processor.py`, so §2 now describes the *retired* density formula, kept as the record of
-why it was replaced. This document flips to `stated` when Phase 4 re-blesses the corpus.
+**Status: `stated`** (2026-09-11) — D1–D6 approved on #2908 (2026-09-09); Phase 3 landed the
+§1 equation in `signal_processor.py` (#2938); Phase 4 pointed the corpus report at the per-unit
+inputs, declared the D6 n/a class and turned the length-leak row into the invariance proof
+(keyword-rosetta#120); Phase 5 confirmed D5 on real code (curl, cics-genapp, the crucible). §2
+describes the *retired* density formula, kept as the record of why it was replaced. The sheet
+row is the first entry in `signal_contracts.py`'s score-contract section.
 
 This is the first **score** contract (roadmap Phase 4, `docs/contract_roadmap.md` §4). The count
 contracts it builds on: `docs/api_rule_contract.md` (#2730, the public surface),

--- a/docs/signal_contracts.md
+++ b/docs/signal_contracts.md
@@ -64,7 +64,7 @@ written.** Corollaries every audited contract has needed so far:
 
 ## Signals
 
-15 stated, 40 declared, 13 draft. A **draft** row is the schema comment transcribed as-is; a **declared** row has a fixed language-independent sentence, kind and unit, measured incidence and its disagreeing rules filed but not edited (#2897, `docs/domain_sensor_contracts.md`); a **stated** row has been audited across the corpus languages, its rules edited to agree, and has a contract doc. `planted` = the keyword-rosetta corpus plants a known count of it (so the cross-language gate can hold it equal); unplanted signals that feed a risk formula are the ones the roadmap's Phase 3 must plant or declare absent.
+16 stated, 40 declared, 12 draft. A **draft** row is the schema comment transcribed as-is; a **declared** row has a fixed language-independent sentence, kind and unit, measured incidence and its disagreeing rules filed but not edited (#2897, `docs/domain_sensor_contracts.md`); a **stated** row has been audited across the corpus languages, its rules edited to agree, and has a contract doc. `planted` = the keyword-rosetta corpus plants a known count of it (so the cross-language gate can hold it equal); unplanted signals that feed a risk formula are the ones the roadmap's Phase 3 must plant or declare absent.
 
 | signal | phase | kind | status | planted | contract | doc |
 |---|---|---|---|---|---|---|
@@ -107,7 +107,7 @@ written.** Corollaries every audited contract has needed so far:
 | `bitwise_ops` | resources | `site` | declared |  | A bitwise operator applied between value operands -- shift, and, or, xor, or the unary complement -- in operator position | [domain_sensor_contracts.md](../docs/domain_sensor_contracts.md) #2897 |
 | `cleanup` | resources | `site` | stated | yes | A SITE THAT EXPLICITLY DESTROYS STATE OR RELEASES A HELD RESOURCE -- a deallocation or finalization call, a handle or connection close, removal of an entry from a live container or of external state the program owns, or the opener of a guaranteed-teardown region -- in call or statement form. | [cleanup_rule_contract.md](../docs/cleanup_rule_contract.md) #2888 |
 | `debug_prints` | resources | `site` | draft |  | Ad-hoc, temporary debug statements |  |
-| `encapsulation` | resources | `annotation` | draft |  | Explicitly hiding logic from the rest of the application | #2766 |
+| `encapsulation` | resources | `annotation` | stated |  | One hit is a declaration-position marker that excludes a name from the public surface, in the language's own morphology | [encapsulation_rule_contract.md](../docs/encapsulation_rule_contract.md) #2766 |
 | `explicit_casts` | resources | `site` | declared |  | A site that converts a value's type explicitly -- a cast expression, a conversion call or a cast keyword -- in cast form | [domain_sensor_contracts.md](../docs/domain_sensor_contracts.md) #2897 |
 | `immutability_locks` | resources | `annotation` | stated |  | AN ADDED MARKER OR LOCK CALL THAT PREVENTS A BINDING OR VALUE FROM BEING CHANGED AFTER INITIALISATION, WHERE THE LANGUAGE'S DEFAULT WOULD PERMIT IT -- a modifier or qualifier on an otherwise-mutable declaration, a restricted constant-declaration form distinct from the general-purpose binding, a runtime lock call, or an immutable reference pin; the language's ordinary binding keyword is a binding choice, not a lock, and a language whose bindings are immutable by default records the stated absence. | [immutability_locks_rule_contract.md](../docs/immutability_locks_rule_contract.md) #2772 |
 | `listeners` | resources | `site` | declared |  | A registration to receive from an external broadcast -- an event-listener, subscription or handler-binding call -- at its invocation | [domain_sensor_contracts.md](../docs/domain_sensor_contracts.md) #2897 |
@@ -136,6 +136,14 @@ written.** Corollaries every audited contract has needed so far:
 | `lit_diagrams` | literate | `site` | declared |  | A fence line that opens an embedded diagram block by its info string -- one hit per diagram | [domain_sensor_contracts.md](../docs/domain_sensor_contracts.md) #2897 |
 | `lit_headers` | literate | `declaration` | declared |  | An ATX heading line -- one to six `#` at the margin followed by a space -- one hit per heading | [domain_sensor_contracts.md](../docs/domain_sensor_contracts.md) #2897 |
 | `lit_links` | literate | `site` | declared |  | An inline link or image target `[text](target)` -- one hit per link | [domain_sensor_contracts.md](../docs/domain_sensor_contracts.md) #2897 |
+
+## Score contracts (the formulas over these units)
+
+1 stated, 0 draft -- contract roadmap Phase 4 (#2812). A **stated** score contract pins what the 0-100 number MEANS as one language-independent sentence over the units above; its equation, decisions and acceptance table live in the doc, and `tests/tools/audit_score_inputs.py <metric>` keeps it honest (every recorded score reproduced from its recorded inputs). The method is the `score-contract-audit` skill; #2908 is the worked precedent the remaining formulas copy.
+
+| score | status | contract | doc |
+|---|---|---|---|
+| `risk_documentation` | stated | Of the units extracted from a file (functions, methods, paragraphs, steps), the weight-share a reader cannot recover from documentation: a public unit counts double, a unit's own reflection hits raise its weight, and a folder-level documentation umbrella shields the whole file multiplicatively. A ratio over units, never a density over lines; a file with no extracted units has no value (n/a), not zero | [risk_documentation_contract.md](../docs/risk_documentation_contract.md) #2908 |
 
 ## Helper keys (not signals)
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -168,11 +168,12 @@ intent is identical by construction.
 
 Current results
 ([bias report](https://github.com/squid-protocol/keyword-rosetta/blob/main/docs/bias_report.md)):
-across 33 comparable metrics, on average **75% of languages land within ±25% of
-the cross-language median** — but under the strict gate (no language beyond ±50%
-of the median), only **3 of 33 metrics pass** cross-language validation today.
-The weakest metrics are named, not hidden: `risk_cognitive_load` holds only 15%
-of languages in the ±25% band, `risk_api_exposure` 43%, `state_mutation` 46%. Every known
+across 59 gated metrics, on average **95% of languages land within ±25% of the
+cross-language median** (54 of 55 chartable metrics hold at least 80% of
+languages in band), and under the cause-based gate **0.1% of comparable cells
+(3 of 2,633) are open engine defects**. The weakest metrics are named, not
+hidden: `raw_arch_api` holds 76% of languages in the ±25% band,
+`reflection_metaprogramming` 82%, `avg_func_args` and `cog_raw` 83%. Every known
 deviation is recorded in a validated
 [deviation ledger](https://github.com/squid-protocol/keyword-rosetta/blob/main/deviation_ledger.json),
 and the defect classes found this way are filed as GitGalaxy issues — see the

--- a/gitgalaxy/standards/signal_contracts.py
+++ b/gitgalaxy/standards/signal_contracts.py
@@ -736,6 +736,54 @@ HELPER_KEYS: dict[str, str] = {
 }
 
 
+# ------------------------------------------------------------------------------
+# Score contracts (contract roadmap Phase 4, #2812; first entry #2908).
+# One gated `risk_<metric>` formula, stated the way a signal is: one
+# language-independent sentence saying what the 0-100 SCORE means, over units
+# the sheet above defines -- so the equation can be checked for adding like to
+# like, not just for running. The full contract (equation, D-decisions,
+# acceptance table, what left the formula and why) lives in the doc; the audit
+# that keeps it honest is `tests/tools/audit_score_inputs.py <metric>` (every
+# recorded score reproduced from its recorded inputs, exit 1 on residual). The
+# method for taking one from draft to stated is the `score-contract-audit`
+# skill; #2908 (risk_documentation) is the worked precedent whose phase list
+# the next contracts (risk_api_exposure, risk_tech_debt, func_complexity_gini)
+# copy.
+# ------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoreContract:
+    name: str  # the risk vector column, "risk_<metric>"
+    contract: str  # what the score MEANS, one language-independent sentence
+    status: str = "draft"  # "draft" | "stated"
+    doc: str | None = None  # repo-relative path to docs/risk_<metric>_contract.md
+    issue: int | None = None  # the epic that stated it
+
+
+_SCORE_ROWS = [
+    ScoreContract(
+        "risk_documentation",
+        "Of the units extracted from a file (functions, methods, paragraphs, steps), "
+        "the weight-share a reader cannot recover from documentation: a public unit "
+        "counts double, a unit's own reflection hits raise its weight, and a "
+        "folder-level documentation umbrella shields the whole file multiplicatively. "
+        "A ratio over units, never a density over lines; a file with no extracted "
+        "units has no value (n/a), not zero",
+        status="stated",
+        doc="docs/risk_documentation_contract.md",
+        issue=2908,
+    ),
+]
+
+SCORE_CONTRACTS: dict[str, ScoreContract] = {row.name: row for row in _SCORE_ROWS}
+if len(SCORE_CONTRACTS) != len(_SCORE_ROWS):
+    raise RuntimeError("signal_contracts: duplicate score name in _SCORE_ROWS")
+for _srow in _SCORE_ROWS:
+    if _srow.status not in ("draft", "stated"):
+        raise RuntimeError(f"signal_contracts: {_srow.name} has unknown status {_srow.status}")
+
+
 def unit_of(signal: str) -> str | None:
     """The unit a formula may treat this signal's count as, or None if unknown."""
     row = CONTRACTS.get(signal)

--- a/tests/signal_contract_audit.py
+++ b/tests/signal_contract_audit.py
@@ -201,6 +201,27 @@ def render() -> str:
             doc = (doc + " " if doc else "") + f"#{c.issue}"
         planted = "yes" if c.planted else ""
         lines.append(f"| `{name}` | {c.phase} | `{c.kind}` | {c.status} | {planted} | {c.contract} | {doc} |")
+    score_stated = sum(1 for c in sc.SCORE_CONTRACTS.values() if c.status == "stated")
+    lines += [
+        "",
+        "## Score contracts (the formulas over these units)",
+        "",
+        f"{score_stated} stated, {len(sc.SCORE_CONTRACTS) - score_stated} draft -- contract roadmap "
+        "Phase 4 (#2812). A **stated** score contract pins what the 0-100 number MEANS as one "
+        "language-independent sentence over the units above; its equation, decisions and acceptance "
+        "table live in the doc, and `tests/tools/audit_score_inputs.py <metric>` keeps it honest "
+        "(every recorded score reproduced from its recorded inputs). The method is the "
+        "`score-contract-audit` skill; #2908 is the worked precedent the remaining formulas copy.",
+        "",
+        "| score | status | contract | doc |",
+        "|---|---|---|---|",
+    ]
+    for name, c in sorted(sc.SCORE_CONTRACTS.items()):
+        doc = f"[{Path(c.doc).name}]({Path('..') / c.doc})" if c.doc else ""
+        if c.issue:
+            doc = (doc + " " if doc else "") + f"#{c.issue}"
+        lines.append(f"| `{name}` | {c.status} | {c.contract} | {doc} |")
+
     lines += ["", "## Helper keys (not signals)", "", "| key | purpose |", "|---|---|"]
     for k, v in sorted(sc.HELPER_KEYS.items()):
         lines.append(f"| `{k}` | {v} |")


### PR DESCRIPTION
#2908 **Phase 6 — closure.** No engine behavior changes; four documentation surfaces:

- **The sheet**: `signal_contracts.py` gains the score-contract section the epic promised — `ScoreContract` / `SCORE_CONTRACTS`, first entry `risk_documentation` **stated**, rendered into `docs/signal_contracts.md` (`--render`). The audit gate is untouched and green (score contracts add no findings).
- **Roadmap**: `contract_roadmap.md` §4 marks the first formula done; `risk_api_exposure`, `risk_tech_debt`, `func_complexity_gini` copy #2908's phase list.
- **Live numbers**: README "Accuracy, measured" and `docs/validation.md` retire the 2026-09-06 figures (90% / 2.7% open-defect cells; 75% / 3-of-33 strict gate) for the current corpus report: **95% average in-band share across the gated metrics, 0.1% open-defect cells (3 of 2,633)**, weakest metrics named (`raw_arch_api` 76%, `reflection_metaprogramming` 82%).
- **The contract doc** flips `draft` → `stated` with the full phase record (#2938, keyword-rosetta#120/#121, D5 confirmed).

Checks: `signal_contract_audit --ci` no new findings; `test_signal_contract_sheet.py` 10 passed; ruff baseline clean; `audit_check` all clear.

Done-when: open-defect cells attributable to `risk_documentation` = 0 (corpus report: the 3 remaining are `raw_arch_api` ×2 + `func_complexity_gini`), the sheet row is `stated`, and the next score contract can copy this epic's phase list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLztFhLH42oxWBKEvwfdBb