### PR TITLE
fix(ci): restore ruff/mypy audit green after #2555 (format + baseline line-shifts)

### DIFF
--- a/gitgalaxy/metrics/signal_processor.py
+++ b/gitgalaxy/metrics/signal_processor.py
@@ -2124,7 +2124,8 @@ class SignalProcessor:
         # take the impact-argmax over code languages first and only fall back to the
         # full set (docs included) when there is no code language present at all.
         doc_languages = {
-            lang.lower() for lang in self.asset_masks.get("DOCUMENTATION_LANGUAGES", {"markdown", "plaintext", "rst", "text"})
+            lang.lower()
+            for lang in self.asset_masks.get("DOCUMENTATION_LANGUAGES", {"markdown", "plaintext", "rst", "text"})
         }
         code_langs = {lang: stats for lang, stats in composition.items() if lang.lower() not in doc_languages}
         ranked = code_langs or composition

--- a/tests/mypy_audit_baseline.json
+++ b/tests/mypy_audit_baseline.json
@@ -1,4 +1,4 @@
 {
-  "gitgalaxy/galaxyscope.py:368: assignment": "Incompatible types in assignment (expression has type \"TextIOWrapper\", variable has type \"BufferedReader\")",
+  "gitgalaxy/galaxyscope.py:370: assignment": "Incompatible types in assignment (expression has type \"TextIOWrapper[_WrappedBuffer]\", variable has type \"BufferedReader[_BufferedReaderStream]\")",
   "gitgalaxy/tools/network_auditing/full_api_network_map.py:32: assignment": "Incompatible types in assignment (expression has type \"None\", variable has type Module)"
 }

--- a/tests/ruff_audit_baseline.json
+++ b/tests/ruff_audit_baseline.json
@@ -1,5 +1,5 @@
 {
-  "gitgalaxy/core/guidestar_lens.py:139: C401": "Unnecessary generator (rewrite as a set comprehension)",
+  "gitgalaxy/core/guidestar_lens.py:149: C401": "Unnecessary generator (rewrite as a set comprehension)",
   "gitgalaxy/metrics/signal_processor.py:531: RUF046": "Value being cast to `int` is already an integer",
   "gitgalaxy/recorders/audit_recorder.py:293: C416": "Unnecessary dict comprehension (rewrite using `dict()`)",
   "gitgalaxy/recorders/audit_recorder.py:310: C414": "Unnecessary `list()` call within `sorted()`",


### PR DESCRIPTION
## Why

The #2555 merge (`a550042f`) tripped the two **`pull_request`-only** audit workflows — `mypy-audit` and `ruff-audit`. Every other CI leg passed on that same code (muninn, full-suite, both crucible legs, smoke-test on all platforms, CodeQL, …). Because those audits run only on `pull_request` (not on push to `main`) and the repo's auto-merge lands PRs immediately, the change merged before they could gate it.

**Opened as a draft on purpose** so the audit workflows run and gate this fix before it merges.

## What

Two causes, both addressed:

1. **`ruff format` (zero-tolerance):** the new `doc_languages` set comprehension in `_get_dominant_lang` exceeded the line limit — wrapped to be `ruff format`-clean.
2. **Baseline line-shifts (not new findings):** the #2555 edits pushed two pre-existing baselined findings down a few lines. Updated the keys to match:
   - ruff `C401` `guidestar_lens.py` **139 → 149**
   - mypy `assignment` `galaxyscope.py` **368 → 370**

   Baseline keys are `{file}:{line}: {code}` and the audit's CI check is **keys-only**, so these are the exact line numbers CI's pinned ruff 0.16.0 / mypy will compute (line numbers are version-independent). Baselines re-normalized to the documented `json.dump(indent=2, sort_keys=True)` form.

## Verification

- `python tests/ruff_audit.py --ci` → no NEW findings beyond the 26-finding baseline; `ruff format --check` clean.
- `python tests/mypy_audit.py --ci` → no NEW type errors beyond the 2-error baseline.
- `signal_processor` + `#2555` tests pass (75).

Follow-up to #2555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)