### PR TITLE
docs(skill): score-contract lesson — correct total can hide a wrong per-unit distribution (closes #2948)

### DIFF
--- a/.claude/skills/score-contract-audit/SKILL.md
+++ b/.claude/skills/score-contract-audit/SKILL.md
@@ -34,6 +34,12 @@ $PY tests/tools/audit_score_inputs.py <metric> --corpus $KEYWORD_ROSETTA_PATH/da
 - Hold four things from the digest: the CLUSTER table's dominant input, the SENSITIVITY
   points-per-unit, the open-defect cells the bias report pins on this metric, and the
   formula's consumers (`grep -n "risk_<metric>\|_calc_<metric>" gitgalaxy/ -r`).
+- A distribution/inequality metric (gini and kin) that is the lone red cell while its
+  underlying count TOTAL sits on the median is a wrong per-unit DISTRIBUTION, not a slicing
+  or inherency question -- one probe planted in the wrong unit, or double-counted across two
+  contracts, skews the per-unit spread behind a correct total. Read the per-file values
+  before reclassifying the cell (makefile `func_complexity_gini`, #2918 -> keyword-rosetta#123:
+  a correct branch total of 3 hid a per-unit gini of 0.667 through three mis-diagnoses).
 
 ### Phase 1 -- the equation contract (orchestrator only; the irreducible reasoning)
 Write, in the template's sections: the equation sentence (what the score MEANS, one


### PR DESCRIPTION
Implements the method-lesson follow-up filed from the #2918 close-out (#2948).

Adds one bullet to Phase 0 ("decomposition before opinion") of the `score-contract-audit` skill:

> A distribution/inequality metric (gini and kin) that is the lone red cell while its underlying count TOTAL sits on the median is a wrong per-unit DISTRIBUTION, not a slicing or inherency question — read per-file values before reclassifying the cell.

Context: makefile `func_complexity_gini` (#2918 → keyword-rosetta#123) was mis-diagnosed three times (branch echo → slicing question → inherency) because a correct branch total of 3 hid a per-unit gini of 0.667. The lesson steers future score-contract work to check the per-unit distribution when a gini-type cell is the lone outlier behind a healthy total.

Docs-only (`.claude/skills/…`); no engine change. Opened as a draft per the repo's gating convention.

Closes #2948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)