### PR TITLE
test(aperture): fix Windows-illegal quote filename in #2555 test (#2961)

### DIFF
--- a/tests/core_engine/test_lang_classification_2555.py
+++ b/tests/core_engine/test_lang_classification_2555.py
@@ -154,8 +154,15 @@ def test_project_scope_stands_down_infra_shield_but_keeps_ignored_dirs(filter_en
 def test_malformed_extension_not_leaked_into_reason(filter_engine, tmp_path):
     """A path carrying a stray quote (quotepath artifact) must not surface a malformed
     extension like `.txt"` in the human-readable exclusion reason."""
+    # #2961: do NOT create the file on disk -- `"` is a legal filename char on
+    # POSIX (where a git quotepath artifact can actually produce this name) but
+    # illegal on Windows, so `write_text` raised OSError: [Errno 22] on the
+    # Windows CI legs before any assertion ran. evaluate_path_integrity is
+    # "Gate 1: Zero-I/O Path Evaluation" -- the malformed-extension sanitization
+    # is pure string analysis of the path and size_bytes falls back to 0 when the
+    # file is absent, so evaluating the constructed Path alone keeps this test
+    # meaningful (and cross-platform) without touching the filesystem.
     bad = tmp_path / 'naive.txt"'
-    bad.write_text("data", encoding="utf-8")
 
     is_valid, _, reason = filter_engine.evaluate_path_integrity(bad, has_intent=False)
     assert is_valid is False


### PR DESCRIPTION
## Summary

`test_malformed_extension_not_leaked_into_reason` (added in #2946 / #2555) failed on the **Windows** legs of the Full Suite Gate (Python 3.9 and 3.12) — Linux/macOS passed. It created a real file named `naive.txt"`; `"` is a legal filename char on POSIX but illegal on Windows, so `write_text` raised `OSError: [Errno 22]` before any assertion ran.

`AperturePolicy.evaluate_path_integrity` is by design **"Gate 1: Zero-I/O Path Evaluation"** — the `no_extension` sanitization (`aperture.py:235-241`) is pure string analysis of the path, and `size_bytes` already falls back to `0` when the file is absent (the `.exists()`/`.stat()` pair is wrapped in `try/except OSError`). So the test never needed the file on disk.

**Fix:** drop `bad.write_text(...)` and evaluate the constructed `Path` directly. Keeps the assertions meaningful and restores Windows coverage (the `Path` string is fine there; only filesystem ops fail).

## Verification

- `pytest tests/core_engine/test_lang_classification_2555.py` → **9 passed** (existence was not load-bearing for reaching the `no_extension` branch).

Separate from the #2933 slicer PR, per the one-layer-per-PR rule.

Closes #2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)