### PR TITLE
docs: rosetta open-defect share is now 0.0% (0/2632), 94% in-band

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,17 @@ The chart colours each deviation by *cause*, not size: red is an open engine
 defect (a rule matching the wrong construct, or a scoring weight sitting inside
 a count); grey is a documented variation the ledger has validated — the language
 cannot express the construct, a deliberate scoring choice, or an echo of another
-row. Current answer: on average 95% of languages sit within ±25% of the
-cross-language median per gated metric (55 chartable metrics, 54 holding ≥80%),
-and **0.1% (3 of 2,633 comparable cells) are open defects** — what remains is
-named on the chart rather than hidden: `raw_arch_api` (2 cells) and
-`func_complexity_gini` (1), the next score contracts' territory.
-Every deviation is recorded in a validated ledger, the open defects are worked
-by cause family under the [contract roadmap](docs/contract_roadmap.md), and
+row. Current answer: on average 94% of languages sit within ±25% of the
+cross-language median per gated metric (55 chartable metrics, 53 holding ≥80%),
+and **the open-defect share is 0.0% (0 of 2,632 comparable cells)** — every
+remaining out-of-band cell is a variation the ledger has validated (a strictness
+stratum, a construct the language cannot express, an echo of another row, or a
+deliberate scoring choice), not an open engine defect. The weakest metrics are
+named rather than hidden — `cog_raw` holds 76% of languages in band,
+`raw_arch_api` 78%, `reflection_metaprogramming` 82% — but their sub-band cells
+are documented, not defects.
+Every deviation is recorded in a validated ledger, the work is tracked by cause
+family under the [contract roadmap](docs/contract_roadmap.md), and
 the defect classes found this way are
 [filed as GitGalaxy issues](https://github.com/squid-protocol/keyword-rosetta/blob/main/docs/findings_by_language.md).
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -168,12 +168,15 @@ intent is identical by construction.
 
 Current results
 ([bias report](https://github.com/squid-protocol/keyword-rosetta/blob/main/docs/bias_report.md)):
-across 59 gated metrics, on average **95% of languages land within ±25% of the
-cross-language median** (54 of 55 chartable metrics hold at least 80% of
-languages in band), and under the cause-based gate **0.1% of comparable cells
-(3 of 2,633) are open engine defects**. The weakest metrics are named, not
-hidden: `raw_arch_api` holds 76% of languages in the ±25% band,
-`reflection_metaprogramming` 82%, `avg_func_args` and `cog_raw` 83%. Every known
+across 59 gated metrics, on average **94% of languages land within ±25% of the
+cross-language median** (53 of 55 chartable metrics hold at least 80% of
+languages in band), and under the cause-based gate **the open-defect share is
+0.0% — 0 of 2,632 comparable cells** are open engine defects; every remaining
+out-of-band cell is a ledger-validated variation (a strictness stratum, a
+construct the language cannot express, an echo, or a scoring choice). The
+weakest metrics are named, not hidden: `cog_raw` holds 76% of languages in the
+±25% band, `raw_arch_api` 78%, `reflection_metaprogramming` and
+`risk_state_flux` 82%, `avg_func_args` 83%. Every known
 deviation is recorded in a validated
 [deviation ledger](https://github.com/squid-protocol/keyword-rosetta/blob/main/deviation_ledger.json),
 and the defect classes found this way are filed as GitGalaxy issues — see the


### PR DESCRIPTION
Refreshes the cross-language consistency copy in the root **README** and **docs/validation.md** to the current keyword-rosetta scoreboard — the README copy for epic #2812's **D4 step 2**.

## What changed
| | before | after |
|---|---|---|
| open-defect share | 0.1% (3 of 2,633) | **0.0% (0 of 2,632)** |
| avg in-band | 95% | **94%** |
| metrics ≥80% in-band | 54 of 55 | **53 of 55** |
| weakest callouts | raw_arch_api 76%, reflection 82%, args/cog 83% | cog_raw 76%, raw_arch_api 78%, reflection/state_flux 82%, args 83% |

The old "what remains" clause named `raw_arch_api` / `func_complexity_gini` as open cells — both resolved (#2771, #2918). Replaced with the accurate framing: **every remaining out-of-band cell is a ledger-validated variation** (strictness stratum, language inherency, echo, or scoring choice), not an open engine defect.

Numbers verified against `keyword-rosetta docs/bias_report.md` on `main`. Docs-only; no code paths touched.

Part of #2812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)