### PR TITLE
docs: rosetta copy — 56 metrics, the secrets expansion proof, temporal fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ defect (a rule matching the wrong construct, or a scoring weight sitting inside
 a count); grey is a documented variation the ledger has validated — the language
 cannot express the construct, a deliberate scoring choice, or an echo of another
 row. Current answer: on average 94% of languages sit within ±25% of the
-cross-language median per gated metric (55 chartable metrics, 53 holding ≥80%),
+cross-language median per gated metric (56 chartable metrics, 54 holding ≥80%),
 and **the open-defect share is 0.0% (0 of 2,632 comparable cells)** — every
 remaining out-of-band cell is a variation the ledger has validated (a strictness
 stratum, a construct the language cannot express, an echo of another row, or a
@@ -164,6 +164,14 @@ deliberate scoring choice), not an open engine defect. The weakest metrics are
 named rather than hidden — `cog_raw` holds 76% of languages in band,
 `raw_arch_api` 78%, `reflection_metaprogramming` 82% — but their sub-band cells
 are documented, not defects.
+The claim also survives expansion: when the corpus planted its first
+security-lens probe — one identical hardcoded secret in every language —
+`risk_secrets_risk` read a **uniform score across all 44 languages the lens
+covers**, and the two exceptions (the engine deliberately skips its security
+lens on data formats) and the formula's measured length dependence were
+ledgered and filed the same day
+([#2978](https://github.com/squid-protocol/gitgalaxy/issues/2978),
+[#2979](https://github.com/squid-protocol/gitgalaxy/issues/2979)).
 Every deviation is recorded in a validated ledger, the work is tracked by cause
 family under the [contract roadmap](docs/contract_roadmap.md), and
 the defect classes found this way are

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -169,14 +169,32 @@ intent is identical by construction.
 Current results
 ([bias report](https://github.com/squid-protocol/keyword-rosetta/blob/main/docs/bias_report.md)):
 across 59 gated metrics, on average **94% of languages land within ±25% of the
-cross-language median** (53 of 55 chartable metrics hold at least 80% of
+cross-language median** (54 of 56 chartable metrics hold at least 80% of
 languages in band), and under the cause-based gate **the open-defect share is
 0.0% — 0 of 2,632 comparable cells** are open engine defects; every remaining
 out-of-band cell is a ledger-validated variation (a strictness stratum, a
 construct the language cannot express, an echo, or a scoring choice). The
 weakest metrics are named, not hidden: `cog_raw` holds 76% of languages in the
 ±25% band, `raw_arch_api` 78%, `reflection_metaprogramming` and
-`risk_state_flux` 82%, `avg_func_args` 83%. Every known
+`risk_state_flux` 82%, `avg_func_args` 83%.
+
+The consistency claim also survives expansion on demand. When the corpus
+planted its first **security-lens probe** — one identical comment-form
+hardcoded secret in every language's shell — `risk_secrets_risk` went from
+inert to a scored metric reading a **uniform value across all 44 languages
+the lens covers**, in one screened change. The two languages reading 0
+(markdown, yaml) are not misses: the engine deliberately skips its security
+lens on inert data formats, a boundary now ledgered and filed as a design
+question ([#2978](https://github.com/squid-protocol/gitgalaxy/issues/2978)).
+The same regeneration *measured* the formula's length dependence (Spearman
+ρ = −0.91 against file length with inputs held equal) and filed it as
+score-contract work ([#2979](https://github.com/squid-protocol/gitgalaxy/issues/2979))
+— the instrument finding its next finding on the day it was extended. The
+commit-age context group reads measured git history as well, since the
+chronometer resolves history for subdirectory scans
+([#2976](https://github.com/squid-protocol/gitgalaxy/issues/2976)).
+
+Every known
 deviation is recorded in a validated
 [deviation ledger](https://github.com/squid-protocol/keyword-rosetta/blob/main/deviation_ledger.json),
 and the defect classes found this way are filed as GitGalaxy issues — see the


### PR DESCRIPTION
Post-merge copy refresh for #2977 + keyword-rosetta#130.

- Numbers: 55→**56** chartable metrics, 53→**54** at ≥80% in band; open-defect share stays **0.0% (0/2632)**.
- New proof point in both README and validation.md: the consistency claim **survives expansion on demand** — the first security-lens plant read a uniform `risk_secrets_risk` across all 44 lens-covered languages in one screened change, with the exceptions and the measured ρ=−0.91 length dependence ledgered/filed same-day (#2978, #2979).
- validation.md notes commit-age context now reads measured git history (#2976).

Docs-only. Numbers verified against keyword-rosetta `docs/bias_report.md` on main (engine f2f2bdf regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaGQfW7WGbGXg54iyBg23j